### PR TITLE
fix(audio): remove hardcoded input device from scsynth boot options

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,22 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.47 Issue #80: Fix hardcoded input device in scsynth boot (February 27, 2026)
+
+**Date**: February 27, 2026
+**Status**: ✅ COMPLETE
+**Branch**: `80-fix-hardcoded-input-device`
+**Issue**: #80
+
+**Work Content**: `osc-client.ts` の `boot()` で入力デバイス `'MacBook Airの'` がハードコードされており、外付けオーディオインターフェースが使用できない問題を修正。
+
+**Changes**:
+- `bootOptions.device = ['MacBook Airの', outputDevice]` → `bootOptions.device = outputDevice` に変更
+- OrbitScoreは出力のみ使用するため、入力デバイス指定を削除
+- scynthのデフォルト入力デバイスに委任
+
+---
+
 ### 6.46 Issue #78: Migrate from Git Flow to GitHub Flow (February 27, 2026)
 
 **Date**: February 27, 2026

--- a/packages/engine/src/audio/supercollider/osc-client.ts
+++ b/packages/engine/src/audio/supercollider/osc-client.ts
@@ -24,11 +24,8 @@ export class OSCClient {
     }
 
     // Set output device if specified (by name)
-    // SuperCollider device option can be a string or [inputDevice, outputDevice] array
     if (outputDevice) {
-      // Use array format: [inputDevice, outputDevice]
-      // Use default input device (MacBook Airの) and specified output
-      bootOptions.device = ['MacBook Airの', outputDevice]
+      bootOptions.device = outputDevice
       this.currentOutputDevice = outputDevice
       console.log(`🔊 Using output device: ${outputDevice}`)
     }


### PR DESCRIPTION
## Summary

- `osc-client.ts` の `boot()` で入力デバイス `'MacBook Airの'` がハードコードされていた問題を修正
- `bootOptions.device` に出力デバイス名のみを文字列で渡す形に変更
- OrbitScoreは出力のみ使用するため、入力デバイスの指定は不要

## 問題

外付けオーディオインターフェース使用時、存在しない入力デバイス名 `'MacBook Airの'` が渡されscynthがクラッシュしていた。

## 変更内容

```diff
- bootOptions.device = ['MacBook Airの', outputDevice]
+ bootOptions.device = outputDevice
```

## Test plan

- [x] `npm test` - 225 passed, 23 skipped
- [x] `npm run build` - 成功
- [ ] 外付けオーディオインターフェースでの動作確認（手動テスト）

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)