### PR TITLE
fix(audio): increase scsynth boot timeout from 3s to 30s

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,21 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.48 Issue #82: Fix scsynth boot timeout (February 27, 2026)
+
+**Date**: February 27, 2026
+**Status**: ✅ COMPLETE
+**Branch**: `82-fix-scsynth-boot-timeout`
+**Issue**: #82
+
+**Work Content**: supercolliderjs の `Server.boot()` に3秒のハードコードタイムアウトがあり、scynthのデバイス初期化に3秒以上かかるとエンジンがクラッシュする問題を修正。
+
+**Changes**:
+- `scripts/patch-supercolliderjs.sh` を作成（タイムアウト 3s → 30s にパッチ）
+- `package.json` に `postinstall` スクリプトを追加（`npm install` 時に自動パッチ）
+
+---
+
 ### 6.47 Issue #80: Fix hardcoded input device in scsynth boot (February 27, 2026)
 
 **Date**: February 27, 2026

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier . --write",
     "telemetry:max": "node tools/max-telemetry-server.js",
+    "postinstall": "bash scripts/patch-supercolliderjs.sh",
     "prepare": "husky"
   },
   "version": "1.0.1",

--- a/scripts/patch-supercolliderjs.sh
+++ b/scripts/patch-supercolliderjs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Patch supercolliderjs boot timeout from 3s to 30s
+# The library hardcodes a 3000ms timeout for scsynth startup,
+# which is too short when audio device initialization takes longer.
+
+SERVER_JS="node_modules/@supercollider/server/lib/server.js"
+
+if [ ! -f "$SERVER_JS" ]; then
+  echo "⏭️  supercolliderjs not installed yet, skipping patch"
+  exit 0
+fi
+
+# Check if already patched
+if grep -q "30000ms" "$SERVER_JS"; then
+  echo "✅ supercolliderjs already patched"
+  exit 0
+fi
+
+# Patch timeout: 3000ms -> 30000ms
+if sed -i '' 's/Server failed to start in 3000ms/Server failed to start in 30000ms/; s/}, 3000);/}, 30000);/' "$SERVER_JS"; then
+  echo "✅ supercolliderjs patched: boot timeout 3s -> 30s"
+else
+  echo "⚠️  Failed to patch supercolliderjs"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- supercolliderjs の `Server.boot()` にハードコードされた3秒タイムアウトを30秒に延長
- postinstall スクリプトでライブラリをパッチする形で対応

## 問題

scynthのデバイス初期化に3秒以上かかるとエンジンが `Server failed to start in 3000ms` エラーでクラッシュしていた。

## 変更内容

- `scripts/patch-supercolliderjs.sh` を新規作成
- `package.json` に `postinstall` スクリプトを追加

## Test plan

- [x] `npm test` - 225 passed, 23 skipped
- [x] `npm run build` - 成功
- [x] CLIからエンジン起動テスト - `Live coding mode` まで到達確認
- [ ] VS Code拡張での動作確認（手動テスト）

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)