### PR TITLE
chore: adopt Signal compose Fair Trade License

### DIFF
--- a/.claude/license.local.md
+++ b/.claude/license.local.md
@@ -1,0 +1,7 @@
+# License Configuration (Local)
+
+このファイルは `/sigcomadmin:license-setup` スキルのためのローカル設定。
+
+## Default Email
+
+license@signalcompose.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,11 @@ orbitscore/
 
 ## License
 
-By contributing to OrbitScore, you agree that your contributions will be licensed under the MIT License.
+By contributing to OrbitScore, you agree that your contributions will be licensed under the Signal compose Source-Available License v1.0 — the same license that covers the project as a whole. See [LICENSE](LICENSE) for the full terms.
+
+Note: This license is Apache 2.0-based with Commons Clause and Fair Revenue Clause. It is not an OSI-approved open source license; it is source-available.
+
+For significant contributions, Signal compose Inc. may request a Contributor License Agreement (CLA) to enable commercial redistribution (e.g. Steam, App Store, Gumroad) of the compiled software. This will be communicated on a per-PR basis when applicable.
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -27,6 +27,14 @@ https://www.apache.org/licenses/LICENSE-2.0
 All rights granted under the Apache License 2.0 (use, copy, modify, distribute)
 remain in effect, subject to the following additional conditions.
 
+Note: The Commons Clause and Fair Revenue Clause below modify the rights
+granted by the Apache License 2.0. In the event of a conflict, these
+additional conditions take precedence over the Apache License 2.0. Because
+of these additional conditions, this license does not qualify as an Open
+Source license under the Open Source Definition. The source code is made
+publicly available under the terms below, but the combined license is
+"source-available" rather than "open source".
+
 ================================================================================
 COMMONS CLAUSE (v1.0)
 ================================================================================

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,94 @@
-MIT License
+Signal compose Source-Available License v1.0
 
-Copyright (c) 2025 Hiroshi Yamato / dropcontrol
+Copyright (c) 2026 Signal compose Inc.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+================================================================================
+WHY THIS LICENSE
+================================================================================
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+This license exists to:
+- Enable free use for individuals, startups, and small businesses
+- Ensure sustainable development through fair contributions from successful companies
+- Protect the software from being resold as a competing product
+- Support education by providing free access for students and academic institutions
+
+We want to support developers, not restrict them.
+
+================================================================================
+BASE LICENSE
+================================================================================
+
+This software is licensed under the Apache License, Version 2.0 (the "Base
+License"), with the additional conditions below.
+
+You may obtain a copy of the Apache License at:
+https://www.apache.org/licenses/LICENSE-2.0
+
+All rights granted under the Apache License 2.0 (use, copy, modify, distribute)
+remain in effect, subject to the following additional conditions.
+
+================================================================================
+COMMONS CLAUSE (v1.0)
+================================================================================
+
+The grant of rights under this License does not include the right to Sell the
+Software.
+
+"Sell" means providing the Software to third parties for a fee or other
+consideration, where the value derives entirely or substantially from the
+Software's functionality. This includes hosting or consulting services whose
+primary value is the Software itself.
+
+Internal use within your organization is always permitted.
+
+================================================================================
+FAIR REVENUE CLAUSE
+================================================================================
+
+Organizations (individuals, teams, or companies) with annual revenue exceeding
+$250,000 USD are required to obtain a commercial license when they:
+
+- Use the source code to build or operate a product or service, or
+- Distribute derivative works based on this source code, or
+- Otherwise exercise the rights granted by this license in a commercial context.
+
+This is not about restricting use—it's about ensuring that successful
+organizations contribute fairly to the ongoing development of this software.
+
+Grace period: 90 days from exceeding the threshold.
+Contact: license@signalcompose.com
+
+Commercial license options:
+- Perpetual buyout: Contact for pricing (one-time purchase for the current
+  major version; major version upgrades may require a separate upgrade fee).
+
+Note on packaged software:
+This license applies to the SOURCE CODE of this project. Packaged, compiled,
+or distributed binary products (such as those sold on Steam, the App Store,
+Gumroad, or similar storefronts) are distributed under separate end-user
+license terms accompanying each product. Purchasing a packaged product does
+not grant you any rights to the source code beyond those granted by this
+license.
+
+================================================================================
+ACADEMIC EXCEPTION
+================================================================================
+
+Students, faculty, and staff of accredited academic institutions may use this
+Software at no cost, regardless of the annual revenue threshold described in
+the Fair Revenue Clause.
+
+This exception applies to personal projects, coursework, and academic
+research, and is intended to foster learning and academic collaboration.
+Commercial products developed from such use fall under the standard terms of
+this license.
+
+================================================================================
+DISCLAIMER
+================================================================================
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+IMPLIED. See the Apache License 2.0 for the full disclaimer and limitation of
+liability terms.
+
+================================================================================

--- a/README.md
+++ b/README.md
@@ -354,9 +354,19 @@ npm run build
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file for details
+Signal compose Source-Available License v1.0 — see [LICENSE](LICENSE) for details.
 
-Copyright (c) 2025 Hiroshi Yamato / dropcontrol
+Summary:
+- **Base**: Apache License 2.0
+- **Commons Clause**: Reselling the Software as a competing product is not permitted.
+- **Fair Revenue Clause**: Organizations with annual revenue exceeding $250,000 USD require a commercial license when using the source code commercially.
+- **Academic Exception**: Students, faculty, and staff of accredited academic institutions may use the Software at no cost.
+
+Packaged binary products (Steam, App Store, Gumroad, etc.) are distributed under separate end-user license terms accompanying each product.
+
+Commercial licensing inquiries: license@signalcompose.com
+
+Copyright (c) 2026 Signal compose Inc.
 
 ## Contributing
 

--- a/docs/core/INDEX.md
+++ b/docs/core/INDEX.md
@@ -79,6 +79,11 @@
    - Priority-based roadmap
    - Technical enhancements
 
+4. **[RUST_ENGINE_MIGRATION_PLAN.md](../planning/RUST_ENGINE_MIGRATION_PLAN.md)** 🦀
+   - Rust サウンドエンジン移行計画
+   - Engine-as-a-Service アーキテクチャ
+   - VST3/CLAP プラグインホスティング、商用展開戦略
+
 ### Quick Links
 
 - **User Guide**: [../README.md](../README.md) - Start here for usage

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,37 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.51 Issue #87: Adopt Signal compose Fair Trade License (April 17, 2026)
+
+**Date**: April 17, 2026
+**Status**: ✅ COMPLETE
+**Branch**: `87-adopt-fair-trade-license`
+**Issue**: #87
+
+**Work Content**: ソースコードのライセンスを MIT から Signal compose Source-Available License v1.0 へ切り替え。将来の商用展開（Steam / App Store 販売）戦略に合わせた Fair Trade 型ライセンスを採用。
+
+**採用条項**:
+- Apache License 2.0 をベースに
+- Commons Clause（他者による再販制限）
+- Fair Revenue Clause（年商 $250K 超は要商用ライセンス、買い切りモデル、料金は問い合わせベース）
+- Academic Exception（学生・教職員は常に無償）
+
+**Changes**:
+- `LICENSE` を MIT から Signal compose Source-Available License v1.0 へ書き換え
+- `package.json` の `license` を `"SEE LICENSE IN LICENSE"` に更新、`author` を `Signal compose Inc.` に変更
+- `README.md` のライセンスセクションを新規ライセンスに合わせて更新（条項サマリー、連絡先、パッケージ製品との区別を明記）
+- `.claude/license.local.md` に連絡先メール（license@signalcompose.com）を保存
+- `docs/planning/RUST_ENGINE_MIGRATION_PLAN.md` を新規作成（Rust サウンドエンジン移行計画と戦略ロードマップ）
+- `docs/core/INDEX.md` に新規プラン文書へのリンクを追加
+
+**重要な区別**:
+- ソースコード: Signal compose Source-Available License v1.0
+- 完成ソフトウェア（Steam / App Store / Gumroad 販売）: 別途 EULA で配布
+
+**連絡先**: license@signalcompose.com（メールアドレスのセットアップは別途対応予定）
+
+---
+
 ### 6.50 Issue #85: Fix audio relative path resolution (February 27, 2026)
 
 **Date**: February 27, 2026

--- a/docs/planning/ELECTRON_APP_PLAN.md
+++ b/docs/planning/ELECTRON_APP_PLAN.md
@@ -976,7 +976,7 @@ class StatusBar {
 ```yaml
 appId: com.orbitscore.app
 productName: OrbitScore
-copyright: Copyright © 2025
+copyright: Copyright © 2026 Signal compose Inc.
 
 directories:
   output: release

--- a/docs/planning/RUST_ENGINE_MIGRATION_PLAN.md
+++ b/docs/planning/RUST_ENGINE_MIGRATION_PLAN.md
@@ -171,7 +171,7 @@ OrbitScore が SC に依存している機能は**限定的**:
 
 | 用途 | Rust crate | 備考 |
 |---|---|---|
-| VST3 ホスト | `vst3-sys`, `vst3-host` | VST3 SDK バインディング |
+| VST3 ホスト | `vst3-sys`, `nih-plug` | `vst3-sys`: 低レベルバインディング、`nih-plug`: 高レベルホスト/プラグインフレームワーク |
 | CLAP ホスト | `clack-host` | CLAP は Rust 親和性が高い |
 | LV2 ホスト | `lv2-host` (Linux 中心) | Linux ユーザー向け |
 | オーディオ I/O | `cpal` | クロスプラットフォーム |

--- a/docs/planning/RUST_ENGINE_MIGRATION_PLAN.md
+++ b/docs/planning/RUST_ENGINE_MIGRATION_PLAN.md
@@ -1,0 +1,298 @@
+# Rust サウンドエンジン移行計画
+
+**ステータス**: 構想段階（R&D Issue 候補）
+**最終更新**: 2026-04-17
+**関連 Issue**: TBD（Rust 移行研究 Issue を別途作成予定）
+
+---
+
+## 1. 背景と動機
+
+現在の OrbitScore は SuperCollider（`supercolliderjs`）をサウンドエンジンとして利用している。
+この構成には以下の課題がある:
+
+| 課題 | 内容 |
+|---|---|
+| メンテナンス性 | `supercolliderjs` の脆弱性（Dependabot 警告）、依存関係のパッチ運用 |
+| パッケージサイズ | VS Code 拡張の `.vsix` が 3.3 MB（ランタイム同梱のため） |
+| プラットフォーム制約 | デスクトップ限定、Web 展開不可 |
+| 拡張性 | VST3/CLAP 等の商用プラグインホスティング不可 |
+| ライセンス | SC のライセンス体系が商用配布と相性が悪い |
+
+同時に、以下の戦略目標が浮上している:
+
+- 商用プロダクト化（Steam / App Store / Gumroad 販売）
+- Web 版デモによるユーザー獲得
+- VST3/CLAP プラグインホスティング（DAW 統合、外部音源利用）
+- LLM エージェント統合
+
+これらの目標を同時に実現するため、**サウンドエンジンを Rust で再実装**し、**デーモン型アーキテクチャ**へ移行する計画を立てる。
+
+---
+
+## 2. 全体ロードマップ
+
+### Phase 0: 脆弱性対応（即座）
+
+```
+・npm audit fix（非force）で SC 以外の脆弱性を解消
+・SC 関連の脆弱性は実質リスクが低く、将来的に置き換えるため手を出さない
+・Issue #73（リリース自動化）を完遂
+```
+
+### Phase 1: 技術検証 R&D（1〜2ヶ月）
+
+```
+・Rust + Tauri の技術検証 Spike
+  └─ 「WAV 再生 + スケジューリング + cpal 出力」の PoC
+・タイムストレッチ方式の比較検証
+  └─ SoundTouch / Rubato / 独自 Phase Vocoder
+・DSL-to-Engine 通信プロトコルの設計
+  └─ WebSocket + JSON-RPC または MCP ライク
+```
+
+### Phase 2: Rust エンジン本実装（3〜6ヶ月）
+
+```
+・Rust エンジン本実装（デーモン構造）
+・VS Code 拡張を「エンジンクライアント」として書き換え
+・既存テストスイート（225 tests）の移植
+・機能パリティ達成
+  └─ WAV/AIFF/MP3/MP4 デコード (symphonia)
+  └─ タイムストレッチ (SoundTouch 等)
+  └─ ポリメーター対応スケジューラ
+  └─ ゲイン・パン・ループ再生
+```
+
+### Phase 3: スタンドアローンアプリ化（2〜3ヶ月）
+
+```
+・Tauri ベースのスタンドアローンアプリ開発
+・CodeMirror 6 エディタウィジェット組み込み
+・インストーラ（macOS DMG, Windows MSI, Linux AppImage）
+・v2.0 リリース
+```
+
+### Phase 4: プラグイン拡張（6〜12ヶ月、段階リリース）
+
+```
+v2.1: MIDI 出力（midir 経由、1〜2ヶ月）
+v2.2: CLAP ホスティング（clack-host、2〜3ヶ月）
+v2.3: VST3 ホスティング（vst3-sys、3〜4ヶ月）
+v3.0: Web 版（WAM: Web Audio Modules 対応）
+```
+
+---
+
+## 3. アーキテクチャ再フレーミング: Engine-as-a-Service
+
+「VS Code 拡張 vs スタンドアローン」という二択ではなく、**エンジンをデーモン化して複数フロントを持つ**構造に統合する。
+
+```
+                    ┌───────────────────────────────┐
+                    │ orbitscore-engine (Rust バイナリ)│
+                    │ ・DSL Interpreter              │
+                    │ ・Audio I/O (cpal)            │
+                    │ ・Plugin Host (VST3/CLAP)     │
+                    │ ・Scheduler                    │
+                    │ ・WebSocket/gRPC API           │
+                    │ ・スタンドアロン実行 OK         │
+                    └───────────────┬───────────────┘
+                                    │ IPC (LSP-like protocol)
+            ┌───────────┬───────────┼───────────┬──────────┐
+            ▼           ▼           ▼           ▼          ▼
+       ┌────────┐  ┌────────┐  ┌────────┐ ┌────────┐ ┌────────┐
+       │ VS Code│  │ Tauri  │  │ Web    │ │ CLI    │ │ LLM    │
+       │ Ext    │  │ Standa-│  │ Editor │ │ Tool   │ │ Agent  │
+       │ (TS薄) │  │ lone   │  │ (将来) │ │        │ │ (MCP等)│
+       └────────┘  └────────┘  └────────┘ └────────┘ └────────┘
+```
+
+### この構造のメリット
+
+| 項目 | 効果 |
+|---|---|
+| **VS Code 拡張を残せる** | 既存ユーザー・開発者向け UX を維持 |
+| **スタンドアローンも実現** | Tauri で 5〜10MB の軽量ネイティブアプリ |
+| **LLM 統合が自然** | MCP サーバーやエージェント API を直接実装可能 |
+| **プラグインホストが安定** | VS Code プロセスと分離 → クラッシュ隔離 |
+| **ファイルサイズ解決** | 拡張は数百 KB、エンジンは別プロセス |
+| **Web 版への道** | 同じ API を WebSocket で Web 版フロントに |
+| **単一コードベース** | Rust コアを全フロントで共有 |
+
+### 実装スタック推奨
+
+| レイヤー | 技術 | 理由 |
+|---|---|---|
+| Engine Core | Rust | 性能、安全性、DSP 適性 |
+| Engine API | WebSocket + JSON-RPC / MCP | LLM 統合と相性、デバッグ容易 |
+| Standalone Shell | Tauri | Rust 直結、軽量、クロスプラットフォーム |
+| Editor Widget | CodeMirror 6 | 軽量、カスタマイズ容易 |
+| VS Code Ext | TypeScript（薄く） | LSP 的にエンジンと通信するだけ |
+| インストーラ | `cargo-bundle` + GitHub Actions | DMG / MSI / AppImage |
+
+---
+
+## 4. 重要な技術判断
+
+### 4.1 タイムストレッチ実装（最大のライセンス・技術リスク）
+
+| 選択肢 | 品質 | ライセンス | 商用利用 | 実装工数 |
+|---|---|---|---|---|
+| Rubber Band (GPL/商用) | ★★★★★ | GPL or 商用（有料） | 要ライセンス | 小（FFI） |
+| **SoundTouch (LGPL)** | ★★★★ | LGPL-2.1 | 動的リンクで OK | 小（FFI） |
+| Rubato (Rust) | ★★★ | MIT | ◎ | 中 |
+| 独自 Phase Vocoder | 調整次第 | 自由 | ◎ | 大 |
+
+**推奨**: **SoundTouch** で開始。将来の差別化要因として独自実装を検討。
+Rubber Band の商用ライセンスは数千ドル単位で、OSS 戦略と相性が悪い。
+
+### 4.2 Rust 実装の現実的スコープ
+
+OrbitScore が SC に依存している機能は**限定的**:
+
+```
+必須（絶対移植）:
+├── WAV/AIFF/MP3/MP4 デコード (symphonia で解決)
+├── サンプル再生 + リング出力
+├── タイムストレッチ (SoundTouch/独自)
+├── ゲイン・パン
+└── ポリメーター対応のスケジューラ
+
+任意（後回し可）:
+├── リバーブ/ディレイ等の FX
+├── 合成シンセ
+└── 高度なルーティング
+```
+
+**12〜18 週の実装ボリューム**で現状機能パリティに到達できる見込み。
+
+### 4.3 VST3/CLAP ホスティング
+
+| 用途 | Rust crate | 備考 |
+|---|---|---|
+| VST3 ホスト | `vst3-sys`, `vst3-host` | VST3 SDK バインディング |
+| CLAP ホスト | `clack-host` | CLAP は Rust 親和性が高い |
+| LV2 ホスト | `lv2-host` (Linux 中心) | Linux ユーザー向け |
+| オーディオ I/O | `cpal` | クロスプラットフォーム |
+| MIDI ルーティング | `midir`, `coremidi` | デバイス・プラグイン間 |
+
+**実装順序の推奨**: MIDI → CLAP → VST3 → LV2
+（CLAP は API がクリーンなため、VST3 より先に設計パターンを固めやすい）
+
+### 4.4 DSL 拡張イメージ
+
+```
+# MIDI
+sequence.midi([C4, E4, G4])
+  .device("Ableton via IAC")
+  .channel(1)
+  .cc(74, 0.8)
+
+# プラグイン (CLAP/VST3)
+sequence.plugin("Diva.clap")
+  .preset("Analog Lead 3")
+  .midi([C4, E4, G4])
+  .param("filter_cutoff", 0.7)
+  .automate("filter_cutoff", 0.3, 1.0, beats=8)
+
+# サイドチェイン・ルーティング
+kick.send_to(reverb, 0.5)
+bass.sidechain(kick, threshold=-20)
+```
+
+---
+
+## 5. 戦略的意義
+
+### 5.1 競合との差別化
+
+| 言語 | プラグインホスト | シンセ |
+|---|---|---|
+| TidalCycles | ❌（SuperDirt 経由、VST 非対応） | SC のみ |
+| Sonic Pi | ❌ | SC のみ |
+| Strudel | ❌ | WebAudio のみ |
+| **OrbitScore (将来)** | ✅ **VST3/CLAP/LV2** | Rust + 外部プラグイン |
+
+**「ライブコーディングで Serum や Kontakt を叩く」は現時点で事実上空白地帯**。
+
+### 5.2 商業展開パス
+
+```
+[現在]                    [将来]
+OrbitScore (VS Code)  →   OrbitScore (Rust core)
+                          ├─ VS Code Extension (無料 OSS)
+                          ├─ Web Editor (無料 Try)
+                          ├─ Standalone App (Steam/App Store 販売)
+                          ├─ DAW Plugin (VST3/CLAP 有料)
+                          └─ Mobile (iOS/Android 将来)
+```
+
+Signal compose Source-Available License により:
+- ソースコードは公開（コミュニティ成長）
+- 販売される完成品は別 EULA（収益源）
+- 大規模商用利用は別途商用ライセンス要求
+
+---
+
+## 6. 重要な意思決定ポイント
+
+これから決めるべき戦略変数:
+
+### 6.1 ビジネス方針
+
+- [ ] 商用化の具体的時期（v2.0 / v3.0 / それ以降）
+- [ ] 価格設定（Steam 販売価格、App Store 価格、商用ライセンス料金）
+- [ ] モネタイゼーションモデル（買い切り / メジャーアップデート料金）
+
+### 6.2 ターゲットユーザー
+
+- [ ] musician-coder（主に音楽家）向け: スタンドアローン優先
+- [ ] coder-musician（主にプログラマ）向け: VS Code 拡張優先
+- [ ] 両方同時対応（デーモン構造で可能）
+
+### 6.3 チーム体制
+
+- [ ] Rust + リアルタイム DSP 経験者の確保
+  - 採用 / 外部委託 / 自学（大和・森田・大石・池田）
+- [ ] 工数見積もりとタイムライン確定
+
+### 6.4 予算
+
+- [ ] Rubber Band 商用ライセンス（数万〜数十万円）投資可否
+- [ ] VST3 SDK 利用条件確認
+- [ ] Apple Developer Program、Steam Publisher Fee 等の初期費用
+
+---
+
+## 7. 次のアクション（即座）
+
+```
+□ Issue #73 (リリース自動化) 完遂
+□ Dependabot 警告の安全な修正（Phase 0）
+□ 本ドキュメントを基にした Research Issue 群の作成
+  - Issue: Rust engine PoC
+  - Issue: Tauri standalone design
+  - Issue: Plugin hosting architecture
+  - Issue: LLM agent integration
+□ チーム合意形成（Signal compose ミーティングで議論）
+```
+
+---
+
+## 8. 参考リンク
+
+- Rust Audio エコシステム:
+  - `symphonia` (audio decoding): https://github.com/pdeljanov/Symphonia
+  - `cpal` (cross-platform audio I/O): https://github.com/RustAudio/cpal
+  - `rubato` (resampling): https://github.com/HEnquist/rubato
+  - `fundsp` (functional DSP): https://github.com/SamiPerttu/fundsp
+- プラグインホスティング:
+  - `clack` (CLAP bindings): https://github.com/prokopyl/clack
+  - VST3 SDK: https://steinbergmedia.github.io/vst3_doc/
+- Tauri: https://tauri.app/
+- Web Audio Modules (WAM): https://www.w3.org/community/webaudiomodules/
+
+---
+
+**このロードマップは構想段階であり、実装に着手する前にチーム合意形成が必要。**

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "supercollider",
     "performance"
   ],
-  "author": "Hiroshi Yamato / dropcontrol",
-  "license": "MIT",
+  "author": "Signal compose Inc.",
+  "license": "SEE LICENSE IN LICENSE",
   "description": "Audio-based live coding DSL for modern music production",
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -2,6 +2,8 @@
   "name": "@orbitscore/engine",
   "version": "0.0.1",
   "type": "commonjs",
+  "author": "Signal compose Inc.",
+  "license": "SEE LICENSE IN ../../LICENSE",
   "main": "dist/index.js",
   "bin": {
     "orbitscore": "./dist/cli-audio.js"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,6 +3,8 @@
   "displayName": "OrbitScore",
   "publisher": "local",
   "version": "1.0.1",
+  "author": "Signal compose Inc.",
+  "license": "SEE LICENSE IN ../../LICENSE",
   "repository": {
     "type": "git",
     "url": "https://github.com/signalcompose/orbitscore"

--- a/scripts/patch-supercolliderjs.sh
+++ b/scripts/patch-supercolliderjs.sh
@@ -17,7 +17,9 @@ if grep -q "30000ms" "$SERVER_JS"; then
 fi
 
 # Patch timeout: 3000ms -> 30000ms
-if sed -i '' 's/Server failed to start in 3000ms/Server failed to start in 30000ms/; s/}, 3000);/}, 30000);/' "$SERVER_JS"; then
+# `sed -i.bak` is portable across BSD sed (macOS) and GNU sed (Linux).
+if sed -i.bak 's/Server failed to start in 3000ms/Server failed to start in 30000ms/; s/}, 3000);/}, 30000);/' "$SERVER_JS"; then
+  rm -f "$SERVER_JS.bak"
   echo "✅ supercolliderjs patched: boot timeout 3s -> 30s"
 else
   echo "⚠️  Failed to patch supercolliderjs"


### PR DESCRIPTION
## 概要

ソースコードのライセンスを MIT から Signal compose Source-Available License v1.0 へ切り替え。将来の商用展開（Steam / App Store / Gumroad 販売）戦略に合わせた Fair Trade 型ライセンスを採用。

Closes #87

## 採用条項

- **Base**: Apache License 2.0
- **Commons Clause**: 他者による再販制限
- **Fair Revenue Clause**: 年商 \$250,000 USD 超の組織はソースコード利用時に商用ライセンス要
- **Academic Exception**: 学生・教職員は年商閾値に関係なく常に無償

## 料金体系

- **買い切りモデル**（月額サブスクリプションなし）
- 料金は問い合わせベース: license@signalcompose.com
- メジャーアップデートで別途料金の可能性

## 重要な区別

| 対象 | ライセンス |
|---|---|
| ソースコード（本リポジトリ） | Signal compose Source-Available License v1.0 |
| 完成ソフトウェア（Steam / App Store / Gumroad 販売） | 別途 EULA |

## 変更ファイル

- LICENSE — MIT から Signal compose Source-Available License v1.0 へ書き換え、条項の優先関係を明示
- package.json — license を SEE LICENSE IN LICENSE、author を Signal compose Inc. に更新
- README.md — ライセンスセクション刷新
- .claude/license.local.md — 連絡先メール（license@signalcompose.com）をローカル設定として保存
- docs/planning/RUST_ENGINE_MIGRATION_PLAN.md — 商用展開戦略を含む Rust サウンドエンジン移行計画
- docs/core/INDEX.md — 新規プラン文書へのリンクを追加
- docs/development/WORK_LOG.md — 作業ログ（6.51 エントリ）

## コードレビュー対応

\`pr-review-toolkit:code-reviewer\` による事前レビューを実施。Important 問題 2 件を修正:

1. LICENSE に Apache 2.0 と追加条項（Commons / Fair Revenue）の優先関係明示を追加
2. RUST_ENGINE_MIGRATION_PLAN.md の存在しない \`vst3-host\` crate を実在する \`nih-plug\` に修正

## 付随する戦略ドキュメント

\`docs/planning/RUST_ENGINE_MIGRATION_PLAN.md\` には以下を記録:

- SuperCollider → Rust 置換の 4 フェーズロードマップ
- Engine-as-a-Service アーキテクチャ（デーモン + 複数フロント）
- VST3 / CLAP / MIDI プラグインホスティング戦略
- 商業展開パス（VS Code Ext / Standalone / Web / DAW Plugin）

## Test plan

- [ ] LICENSE ファイルの内容を確認（Apache 2.0 ベース + 3 条項 + 優先関係明示）
- [ ] README.md のライセンスセクションが新規ライセンスを反映している
- [ ] package.json の license フィールドが SEE LICENSE IN LICENSE になっている
- [ ] docs/core/INDEX.md から新規プラン文書にリンクが通っている
- [ ] docs/development/WORK_LOG.md に 6.51 エントリが追加されている

## Notes

連絡先メール（license@signalcompose.com）のセットアップ（Google Workspace エイリアス等）は別タスクで対応予定。