### PR TITLE
docs: align test count and link Rust migration research issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,14 +118,14 @@ git branch --show-current
 ### Project Overview
 **OrbitScore** - Audio-based live coding DSL for modern music production
 - DSL Version: v3.0 (SuperCollider Audio Engine)
-- Test Status: 225 passed, 23 skipped (248 total) = 90.7%
+- Test Status: 220 passed, 23 skipped (243 total) = 90.5%
 - Branch Strategy: GitHub Flow (`main` + feature branches)
 
 ### Development Commands
 ```bash
 npm run build            # Build all packages (incremental)
 npm run build:clean      # Clean build (rebuild all files)
-npm test                 # Run all tests (225 tests, 23 skipped)
+npm test                 # Run all tests (220 tests, 23 skipped)
 npm run dev:engine       # Run engine in development mode
 npm run lint             # ESLint + Prettier
 ```

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Project documentation is organized in the [`docs/`](docs/) folder:
 npm test
 ```
 
-**225/248 tests passing (90.7%)**:
+**220/243 tests passing (90.5%)**:
 
 - Parser: ✅ Complete (50 tests)
 - Audio Engine: ✅ Complete (15 tests)

--- a/docs/development/IMPLEMENTATION_PLAN.md
+++ b/docs/development/IMPLEMENTATION_PLAN.md
@@ -42,7 +42,7 @@ Implementation plan for the new audio-based OrbitScore DSL as defined in `INSTRU
 - **DAW Plugin**: VST/AU development (Phase A5)
 
 ### 📊 Testing Coverage
-- **Total Tests**: 225 passed, 23 skipped (248 total) = 90.7%
+- **Total Tests**: 220 passed, 23 skipped (243 total) = 90.5%
 - **Parser Tests**: 50/50
 - **Interpreter Tests**: 83/83
 - **DSL v3.0 Tests**: 56/56 (Unidirectional Toggle, Underscore Prefix, Gain/Pan)

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,40 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.53 Issue #97: Align test count references and link Rust migration research issues (April 17, 2026)
+
+**Date**: April 17, 2026
+**Status**: ✅ COMPLETE
+**Branch**: `97-update-test-count-docs`
+**Issue**: #97
+
+**Work Content**: 複数ドキュメントで古い「225 passed」と記載されていたが、実測値は **220 passed, 23 skipped, 243 total = 90.5%**。現状に合わせて修正。併せて Rust 移行計画に Research Issue 群（#91-#96）へのリンクを追加。
+
+**テスト数更新**:
+- `CLAUDE.md` L121, L128
+- `README.md` L233
+- `docs/testing/TESTING_GUIDE.md` L4 (+ Last Updated を 2026-04-17 に), L71
+- `docs/development/IMPLEMENTATION_PLAN.md` L45
+- `docs/planning/RUST_ENGINE_MIGRATION_PLAN.md` L59
+
+**Rust 移行計画の進捗反映**:
+- `docs/planning/RUST_ENGINE_MIGRATION_PLAN.md` §7「次のアクション」を更新
+  - 完了項目（PR #88 ライセンス、PR #90 Dependabot）にチェック
+  - Research Issue #91-#96 へのリンクを追加
+  - 組織タスク（Rust 経験者確保、メールセットアップ）を追記
+
+**新規作成 Research Issues**:
+- #91: spike: Rust audio engine proof of concept
+- #92: research: time-stretch DSP library selection for Rust engine
+- #93: design: engine daemon IPC protocol
+- #94: design: Tauri standalone application architecture
+- #95: research: VST3 and CLAP plugin hosting in Rust
+- #96: design: LLM agent integration architecture
+
+**Tests**: 220 passed, 23 skipped（変更なし、docs のみ更新）
+
+---
+
 ### 6.52 Issue #89: Fix Dependabot vulnerabilities, excluding supercolliderjs-related (April 17, 2026)
 
 **Date**: April 17, 2026

--- a/docs/planning/RUST_ENGINE_MIGRATION_PLAN.md
+++ b/docs/planning/RUST_ENGINE_MIGRATION_PLAN.md
@@ -56,7 +56,7 @@
 ```
 ・Rust エンジン本実装（デーモン構造）
 ・VS Code 拡張を「エンジンクライアント」として書き換え
-・既存テストスイート（225 tests）の移植
+・既存テストスイート（220 tests）の移植
 ・機能パリティ達成
   └─ WAV/AIFF/MP3/MP4 デコード (symphonia)
   └─ タイムストレッチ (SoundTouch 等)
@@ -265,18 +265,32 @@ Signal compose Source-Available License により:
 
 ---
 
-## 7. 次のアクション（即座）
+## 7. 次のアクション
 
-```
-□ Issue #73 (リリース自動化) 完遂
-□ Dependabot 警告の安全な修正（Phase 0）
-□ 本ドキュメントを基にした Research Issue 群の作成
-  - Issue: Rust engine PoC
-  - Issue: Tauri standalone design
-  - Issue: Plugin hosting architecture
-  - Issue: LLM agent integration
-□ チーム合意形成（Signal compose ミーティングで議論）
-```
+### 完了済み
+
+- ✅ Dependabot 警告の安全な修正（Phase 0）— PR #90 (2026-04-17)
+- ✅ Research Issue 群の作成（下記）
+- ✅ ライセンス切り替え（MIT → Signal compose Source-Available License v1.0）— PR #88
+
+### 進行中 / 次に取り組む
+
+- [ ] Issue #73: リリース自動化（エンドユーザー向け `.vsix` ワークフロー）
+
+### Research / Design Issues（Phase 1）
+
+- [ ] Issue #91: [spike: Rust audio engine proof of concept](https://github.com/signalcompose/orbitscore/issues/91)
+- [ ] Issue #92: [research: time-stretch DSP library selection for Rust engine](https://github.com/signalcompose/orbitscore/issues/92)
+- [ ] Issue #93: [design: engine daemon IPC protocol (WebSocket + JSON-RPC)](https://github.com/signalcompose/orbitscore/issues/93)
+- [ ] Issue #94: [design: Tauri standalone application architecture](https://github.com/signalcompose/orbitscore/issues/94)
+- [ ] Issue #95: [research: VST3 and CLAP plugin hosting in Rust](https://github.com/signalcompose/orbitscore/issues/95)
+- [ ] Issue #96: [design: LLM agent integration architecture](https://github.com/signalcompose/orbitscore/issues/96)
+
+### 組織タスク
+
+- [ ] チーム合意形成（Signal compose ミーティングで議論）
+- [ ] Rust + リアルタイム DSP 経験者の確保（採用 / 外部委託 / 自学）
+- [ ] `license@signalcompose.com` メールアドレスのセットアップ（Google Workspace エイリアス等）
 
 ---
 

--- a/docs/testing/TESTING_GUIDE.md
+++ b/docs/testing/TESTING_GUIDE.md
@@ -1,7 +1,7 @@
 # OrbitScore Testing Guide
 
-**Last Updated**: 2025-10-26
-**Test Status**: 225 passed | 23 skipped (248 total) = 90.7%
+**Last Updated**: 2026-04-17
+**Test Status**: 220 passed | 23 skipped (243 total) = 90.5%
 
 ## 📚 Overview
 
@@ -68,7 +68,7 @@ npm test -- unidirectional-toggle
 
 ### Current Test Coverage
 
-**Total**: 225 passed | 23 skipped (248 total) = 90.7%
+**Total**: 220 passed | 23 skipped (243 total) = 90.5%
 
 **Test Suites**:
 - ✅ Audio Parser: 50/50


### PR DESCRIPTION
## 概要

小規模な doc 整備 PR。

Closes #97

## 変更内容

### 1. テスト数の整合（225 → 220）

複数ドキュメントで古い「225 passed」と記載されていたが、main / 本ブランチともに実測値は **220 passed, 23 skipped, 243 total = 90.5%**。現状に合わせて修正。

| ファイル | 変更前 | 変更後 |
|---|---|---|
| \`CLAUDE.md\` (L121) | 225 passed, 23 skipped (248 total) = 90.7% | 220 passed, 23 skipped (243 total) = 90.5% |
| \`CLAUDE.md\` (L128) | \`Run all tests (225 tests, 23 skipped)\` | \`Run all tests (220 tests, 23 skipped)\` |
| \`README.md\` | **225/248 tests passing (90.7%)** | **220/243 tests passing (90.5%)** |
| \`docs/testing/TESTING_GUIDE.md\` (L4) | 225 passed \| 23 skipped (248 total) = 90.7% | 220 passed \| 23 skipped (243 total) = 90.5%（Last Updated も 2026-04-17 に） |
| \`docs/testing/TESTING_GUIDE.md\` (L71) | 同上 | 同上 |
| \`docs/development/IMPLEMENTATION_PLAN.md\` (L45) | 225 passed, 23 skipped (248 total) = 90.7% | 220 passed, 23 skipped (243 total) = 90.5% |
| \`docs/planning/RUST_ENGINE_MIGRATION_PLAN.md\` (L59) | 既存テストスイート（225 tests）の移植 | 既存テストスイート（220 tests）の移植 |

### 2. Rust 移行計画の進捗反映

\`docs/planning/RUST_ENGINE_MIGRATION_PLAN.md\` §7「次のアクション」を更新:

- ✅ 完了項目（ライセンス PR #88、Dependabot PR #90）にチェック
- 📋 Research Issue 群へのリンクを追加:
  - #91: spike: Rust audio engine proof of concept
  - #92: research: time-stretch DSP library selection
  - #93: design: engine daemon IPC protocol
  - #94: design: Tauri standalone application architecture
  - #95: research: VST3 and CLAP plugin hosting
  - #96: design: LLM agent integration architecture
- 組織タスク（Rust 経験者確保、\`license@signalcompose.com\` セットアップ）を追記

## Test plan

- [x] \`grep -rn "225 passed\\|225/248" --include="*.md"\` で残留なしを確認
- [x] WORK_LOG.md 履歴内の「225」記述は historical context として温存

## Notes

実装コード変更なし。テスト実行は不要（docs のみ）。