### PR TITLE
chore: add read-only commands to permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(npm audit)",
+      "Bash(npm audit --json)",
+      "Bash(swiftlint *)",
+      "Bash(cargo check *)",
+      "Bash(cargo clippy *)",
+      "Bash(cargo fmt --check *)",
+      "Bash(cargo test *)",
+      "mcp__plugin_context7_context7__query-docs",
+      "mcp__plugin_context7_context7__resolve-library-id"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## 概要

\`/less-permission-prompts\` スキルで直近 50 セッションを解析し、頻出する read-only コマンド 9 件を \`.claude/settings.json\` の \`permissions.allow\` に追加。

Closes #101

## 追加パターン

| # | Pattern | Count | Notes |
|---|---|---|---|
| 1 | \`Bash(npm audit)\` | 8 | 脆弱性スキャン |
| 2 | \`Bash(npm audit --json)\` | 8 | JSON 形式 |
| 3 | \`mcp__plugin_context7_context7__query-docs\` | 5 | Context7 docs |
| 4 | \`Bash(swiftlint *)\` | 4 | read-only lint |
| 5 | \`Bash(cargo check *)\` | 2→急増見込み | Rust 型/コンパイル検証 |
| 6 | \`Bash(cargo clippy *)\` | 2→急増見込み | Rust lint |
| 7 | \`Bash(cargo fmt --check *)\` | 今後 | fmt チェック（読み取りのみ） |
| 8 | \`Bash(cargo test *)\` | 2→急増見込み | Rust テスト |
| 9 | \`mcp__plugin_context7_context7__resolve-library-id\` | 2 | Context7 リゾルバ |

## 意図的に除外したもの

- **自動許可済み**: \`ls / cat / find / git log / git diff / git show / git status / git rev-parse / gh pr view / gh issue view / gh api (GET)\` 等
- **任意コード実行**: \`python3\`(33), \`bash\`(165), \`npm run *\` 等
- **書き込み/副作用**: \`xcodegen\`(44), \`xcodebuild\`(43), \`git push / git commit / git rebase / cp / touch / mkdir / rm\`
- **外部 CLI スクリプト**: \`gemini-search.sh / codex-exec.sh\` など任意コード扱い
- **cargo fmt (無条件) / cargo build**: 書き込み（\`--check\` のみ許可）
- **npm audit fix**: 書き込み（\`npm audit\` exact だけ許可）

## Test plan

- [x] JSON 構文検証 (\`python3 -m json.tool\` 相当)
- [x] 既存の \`hooks\` セクション保持
- [x] \`permissions.deny\` / \`ask\` は追加していない