### PR TITLE
feat(rust): sample rate conversion on load via rubato

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,50 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.55 Issue #100: Sample rate conversion on load via rubato (April 17, 2026)
+
+**Date**: April 17, 2026
+**Status**: ✅ COMPLETE
+**Branch**: `100-sample-rate-conversion`
+**Issue**: #100
+
+**Work Content**: PoC #91 で明示された既知の制限「サンプリング周波数変換 (SRC) なし」を解消。rubato 2.0 を使って**ロード時**に Project SR へ一度だけ変換する方式（Pro Tools / Logic Pro 方式）を採用。再生時（リアルタイム）は従来通り 1:1 マッピングで低レイテンシを維持。
+
+**追加モジュール**:
+- `rust/src/native/resampler.rs` (新規)
+  - `resample_to(sample, target_sr)` — rubato の FftFixedSync::Both で高品質変換
+  - `ResampleError` (Init / Process / ZeroChannels)
+
+**API 追加**:
+- `rust/src/native/loader.rs`: `load_sample_at(path, target_sr)` を公開
+  - ソース SR と target_sr が一致する場合はコピーせずそのまま返す
+  - 異なる場合のみ resampler を呼ぶ
+
+**依存追加**:
+- `rubato = "2"` (optional, native feature)
+- `audioadapter-buffers = "3"` (optional, native feature)
+
+**テスト追加** (4 件、合計 12 tests):
+- same_sample_rate_passes_through — パススルーの確認
+- upsample_44100_to_48000_preserves_duration — 持続時間 ±5ms
+- downsample_96000_to_48000_halves_frames — フレーム数半減
+- zero_channel_sample_returns_error — 不正入力の早期エラー
+
+**example 更新**:
+- `poc_play.rs` が `load_sample_at(path, stream.sample_rate)` を使用
+- 異なる SR の WAV を渡しても正しいピッチ・テンポで再生できる
+
+**ドキュメント**:
+- `rust/README.md` Known Limitations から SRC 項目を削除
+- WORK_LOG に本エントリ追加
+
+**検証**:
+- cargo check / clippy -D warnings / fmt --check すべて clean
+- cargo test --lib: 12 passed, 0 failed
+- PoC (examples/poc_play) 動作確認 OK
+
+---
+
 ### 6.54 Issue #91: Rust audio engine proof of concept (April 17, 2026)
 
 **Date**: April 17, 2026

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -32,7 +32,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
   - `ResampleError` (Init / Process / ZeroChannels)
 
 **API 追加**:
-- `rust/src/native/loader.rs`: `load_sample_at(path, target_sr)` を公開
+- `rust/src/native/loader.rs`: `load_sample_resampled(path, target_sr)` を公開
   - ソース SR と target_sr が一致する場合はコピーせずそのまま返す
   - 異なる場合のみ resampler を呼ぶ
 
@@ -47,7 +47,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 - zero_channel_sample_returns_error — 不正入力の早期エラー
 
 **example 更新**:
-- `poc_play.rs` が `load_sample_at(path, stream.sample_rate)` を使用
+- `poc_play.rs` が `load_sample_resampled(path, stream.sample_rate)` を使用
 - 異なる SR の WAV を渡しても正しいピッチ・テンポで再生できる
 
 **ドキュメント**:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -40,6 +40,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "audio-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
+
+[[package]]
+name = "audioadapter"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f87b70b051c5866680ad79f6743a42ccab264c009d1a71f4d33a3872ae60c8"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-buffers"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9097d67933fb083d382ce980430afdb758aada60846010aee6be068c06cef0ca"
+dependencies = [
+ "audioadapter",
+ "audioadapter-sample",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-sample"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ab94f2bc04a14e1f49ee5f222f66460e8a1b51627bdfedf34eed394d747938"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +510,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +527,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -547,9 +602,11 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 name = "orbitscore-engine"
 version = "0.0.1"
 dependencies = [
+ "audioadapter-buffers",
  "console_error_panic_hook",
  "cpal",
  "hound",
+ "rubato",
  "symphonia",
  "thiserror 2.0.18",
  "wasm-bindgen",
@@ -567,6 +624,15 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -602,6 +668,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,10 +706,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rubato"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce96ead1a91f7895704a9f08ea5947dfc8bd7c1f2936a22295b655ec67e5c6ef"
+dependencies = [
+ "audioadapter",
+ "audioadapter-buffers",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
+ "visibility",
+ "windowfunctions",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+]
 
 [[package]]
 name = "rustversion"
@@ -682,6 +787,12 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "symphonia"
@@ -937,10 +1048,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "walkdir"
@@ -1033,6 +1165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windowfunctions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,7 +13,12 @@ path = "src/lib.rs"
 
 [features]
 default = ["native"]
-native = ["dep:cpal", "dep:symphonia"]
+native = [
+  "dep:cpal",
+  "dep:symphonia",
+  "dep:rubato",
+  "dep:audioadapter-buffers",
+]
 wasm = ["dep:wasm-bindgen", "dep:web-sys", "dep:console_error_panic_hook"]
 
 [dependencies]
@@ -21,6 +26,8 @@ thiserror = "2.0"
 
 cpal = { version = "0.15", optional = true }
 symphonia = { version = "0.5", features = ["wav", "mp3", "aac", "isomp4"], optional = true }
+rubato = { version = "2", optional = true }
+audioadapter-buffers = { version = "3", optional = true }
 
 wasm-bindgen = { version = "0.2", optional = true }
 web-sys = { version = "0.3", optional = true, features = [

--- a/rust/README.md
+++ b/rust/README.md
@@ -40,9 +40,6 @@ cargo build --no-default-features --features wasm --target wasm32-unknown-unknow
 
 ## Known Limitations (PoC)
 
-- **サンプリング周波数変換 (SRC) なし** — ソース WAV と出力デバイスの SR が
-  一致するときのみ正しく再生される。異なる場合はピッチ・テンポがずれる。
-  対応 Issue: [#100](https://github.com/signalcompose/orbitscore/issues/100)
 - **タイムストレッチなし** — Phase 2 で `rubato` or SoundTouch 等を検討
   (Issue [#92](https://github.com/signalcompose/orbitscore/issues/92))
 - **モノラル → マルチチャンネル展開は最終チャンネル複製のみ** — モノラル素材を

--- a/rust/examples/poc_play.rs
+++ b/rust/examples/poc_play.rs
@@ -11,7 +11,7 @@ use std::error::Error;
 use std::thread;
 use std::time::Duration;
 
-use orbitscore_engine::native::{load_sample_at, start_default_output};
+use orbitscore_engine::native::{load_sample_resampled, start_default_output};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let paths: Vec<String> = env::args().skip(1).collect();
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .iter()
         .map(|p| {
             println!("loading {p}");
-            load_sample_at(p, stream.sample_rate)
+            load_sample_resampled(p, stream.sample_rate)
         })
         .collect::<Result<Vec<_>, _>>()?;
 

--- a/rust/examples/poc_play.rs
+++ b/rust/examples/poc_play.rs
@@ -11,7 +11,7 @@ use std::error::Error;
 use std::thread;
 use std::time::Duration;
 
-use orbitscore_engine::native::{load_sample_from_file, start_default_output};
+use orbitscore_engine::native::{load_sample_at, start_default_output};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let paths: Vec<String> = env::args().skip(1).collect();
@@ -20,11 +20,19 @@ fn main() -> Result<(), Box<dyn Error>> {
         std::process::exit(1);
     }
 
+    // デバイス config に一致する Engine を自動構築
+    let (engine, stream) = start_default_output()?;
+    println!(
+        "output stream: sr={}, ch={}",
+        stream.sample_rate, stream.channels
+    );
+
+    // Project SR = 出力デバイスの SR。ソースが異なる場合は rubato でリサンプル。
     let samples = paths
         .iter()
         .map(|p| {
             println!("loading {p}");
-            load_sample_from_file(p)
+            load_sample_at(p, stream.sample_rate)
         })
         .collect::<Result<Vec<_>, _>>()?;
 
@@ -37,13 +45,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             s.duration_secs()
         );
     }
-
-    // デバイス config に一致する Engine を自動構築
-    let (engine, stream) = start_default_output()?;
-    println!(
-        "output stream: sr={}, ch={}",
-        stream.sample_rate, stream.channels
-    );
 
     // 500ms 間隔で 10 回スケジュール（ラウンドロビン）
     for i in 0..10 {

--- a/rust/src/core/sample.rs
+++ b/rust/src/core/sample.rs
@@ -34,6 +34,12 @@ impl Sample {
     pub fn duration_secs(&self) -> f64 {
         self.frames() as f64 / self.sample_rate as f64
     }
+
+    /// インターリーブ PCM バッファへの読み取り専用スライス。
+    /// 外部で内部表現（`Arc<Vec<f32>>`）に依存せずデータを参照するためのアクセサ。
+    pub fn as_slice(&self) -> &[f32] {
+        &self.data
+    }
 }
 
 #[cfg(test)]

--- a/rust/src/native/loader.rs
+++ b/rust/src/native/loader.rs
@@ -31,12 +31,13 @@ pub enum LoaderError {
 /// Pro Tools / Logic Pro 方式に倣い、再生時ではなくロード時に一度だけ
 /// 変換することで、再生時のリアルタイム処理を 1:1 マッピングに保つ。
 ///
-/// ソースの SR と target が一致する場合はコピーせずそのまま返す。
-pub fn load_sample_at(path: impl AsRef<Path>, target_sr: u32) -> Result<Sample, LoaderError> {
+/// SR が一致する場合は `resample_to` がコピーせずそのまま返すため、ここでは
+/// 追加のガードは置かない。
+pub fn load_sample_resampled(
+    path: impl AsRef<Path>,
+    target_sr: u32,
+) -> Result<Sample, LoaderError> {
     let raw = load_sample_from_file(path)?;
-    if raw.sample_rate == target_sr {
-        return Ok(raw);
-    }
     Ok(super::resampler::resample_to(raw, target_sr)?)
 }
 

--- a/rust/src/native/loader.rs
+++ b/rust/src/native/loader.rs
@@ -26,13 +26,10 @@ pub enum LoaderError {
     Resample(#[from] super::resampler::ResampleError),
 }
 
-/// 音声ファイルをロードして `target_sr` に合わせてリサンプリングする。
+/// 音声ファイルをロードし、`target_sr`（プロジェクト SR）へ自動で揃える。
 ///
 /// Pro Tools / Logic Pro 方式に倣い、再生時ではなくロード時に一度だけ
 /// 変換することで、再生時のリアルタイム処理を 1:1 マッピングに保つ。
-///
-/// SR が一致する場合は `resample_to` がコピーせずそのまま返すため、ここでは
-/// 追加のガードは置かない。
 pub fn load_sample_resampled(
     path: impl AsRef<Path>,
     target_sr: u32,

--- a/rust/src/native/loader.rs
+++ b/rust/src/native/loader.rs
@@ -22,6 +22,22 @@ pub enum LoaderError {
     Decode(String),
     #[error("unsupported format")]
     Unsupported,
+    #[error("resample error: {0}")]
+    Resample(#[from] super::resampler::ResampleError),
+}
+
+/// 音声ファイルをロードして `target_sr` に合わせてリサンプリングする。
+///
+/// Pro Tools / Logic Pro 方式に倣い、再生時ではなくロード時に一度だけ
+/// 変換することで、再生時のリアルタイム処理を 1:1 マッピングに保つ。
+///
+/// ソースの SR と target が一致する場合はコピーせずそのまま返す。
+pub fn load_sample_at(path: impl AsRef<Path>, target_sr: u32) -> Result<Sample, LoaderError> {
+    let raw = load_sample_from_file(path)?;
+    if raw.sample_rate == target_sr {
+        return Ok(raw);
+    }
+    Ok(super::resampler::resample_to(raw, target_sr)?)
 }
 
 /// 音声ファイルを読み込み、出力サンプルレートに関係なく元のサンプルをそのまま返す。

--- a/rust/src/native/mod.rs
+++ b/rust/src/native/mod.rs
@@ -9,4 +9,4 @@ mod resampler;
 
 pub use loader::{load_sample_from_file, load_sample_resampled, LoaderError};
 pub use output::{start_default_output, OutputError, OutputStream};
-pub use resampler::{resample_to, ResampleError};
+pub use resampler::ResampleError;

--- a/rust/src/native/mod.rs
+++ b/rust/src/native/mod.rs
@@ -7,6 +7,6 @@ mod loader;
 mod output;
 mod resampler;
 
-pub use loader::{load_sample_at, load_sample_from_file, LoaderError};
+pub use loader::{load_sample_from_file, load_sample_resampled, LoaderError};
 pub use output::{start_default_output, OutputError, OutputStream};
 pub use resampler::{resample_to, ResampleError};

--- a/rust/src/native/mod.rs
+++ b/rust/src/native/mod.rs
@@ -5,6 +5,8 @@
 
 mod loader;
 mod output;
+mod resampler;
 
-pub use loader::{load_sample_from_file, LoaderError};
+pub use loader::{load_sample_at, load_sample_from_file, LoaderError};
 pub use output::{start_default_output, OutputError, OutputStream};
+pub use resampler::{resample_to, ResampleError};

--- a/rust/src/native/resampler.rs
+++ b/rust/src/native/resampler.rs
@@ -145,6 +145,57 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn empty_sample_does_not_panic() {
+        // フレーム数 0 の有効なサンプルが panic せず扱えること
+        let s = Sample::new(vec![], 44_100, 2);
+        let r = resample_to(s, 48_000).unwrap();
+        assert_eq!(r.sample_rate, 48_000);
+        assert_eq!(r.channels, 2);
+        // 出力はせいぜいリサンプラの delay 分（または 0）
+        assert!(
+            r.frames() < 2048,
+            "unexpected non-trivial frames: {}",
+            r.frames()
+        );
+    }
+
+    #[test]
+    fn mono_upsample_8000_to_48000_preserves_duration() {
+        // 1:6 という極端な比率で mono source を upsample
+        let in_frames = 8_000;
+        let data = vec![0.5f32; in_frames];
+        let s = Sample::new(data, 8_000, 1);
+        let r = resample_to(s, 48_000).unwrap();
+
+        assert_eq!(r.sample_rate, 48_000);
+        assert_eq!(r.channels, 1);
+        assert!((r.duration_secs() - 1.0).abs() < 0.01);
+        let diff = (r.frames() as i64 - 48_000).abs();
+        assert!(diff < 200, "frames {} far from 48000", r.frames());
+    }
+
+    #[test]
+    fn short_sample_smaller_than_chunk_frames() {
+        // CHUNK_FRAMES (1024) より短いサンプルが panic / 切り捨てなく扱えること
+        let in_frames = 100;
+        let data = vec![0.2f32; in_frames * 2];
+        let s = Sample::new(data, 44_100, 2);
+        let r = resample_to(s, 48_000).unwrap();
+
+        assert_eq!(r.sample_rate, 48_000);
+        assert_eq!(r.channels, 2);
+        // 期待フレーム数: 100 * 48000 / 44100 ≈ 109
+        let expected = (in_frames as f64 * 48_000.0 / 44_100.0) as i64;
+        let diff = (r.frames() as i64 - expected).abs();
+        assert!(
+            diff < 20,
+            "short sample frames {} far from {}",
+            r.frames(),
+            expected
+        );
+    }
+
     /// サイン波で信号品質を検証する。DC だけのテストでは
     /// FFT 処理が壊れていても通ってしまうため、周波数成分を持つ信号で
     /// RMS が概ね保たれることを確認する。

--- a/rust/src/native/resampler.rs
+++ b/rust/src/native/resampler.rs
@@ -11,10 +11,12 @@ use crate::core::Sample;
 
 #[derive(Error, Debug)]
 pub enum ResampleError {
-    #[error("resampler init error: {0}")]
-    Init(String),
+    #[error("resampler construct error: {0}")]
+    Construct(#[from] rubato::ResamplerConstructionError),
     #[error("resampler process error: {0}")]
-    Process(String),
+    Process(#[from] rubato::ResampleError),
+    #[error("buffer setup error: {0}")]
+    Buffer(String),
     #[error("zero-channel sample cannot be resampled")]
     ZeroChannels,
 }
@@ -27,13 +29,14 @@ const SUB_CHUNKS: usize = 2;
 
 /// `sample` を `target_sr` へリサンプリングする。
 ///
-/// source と target の SR が同じ場合はコピー無しでそのまま返す。
+/// - source と target の SR が同じ場合はコピー無しでそのまま返す
+/// - ゼロチャンネルの不正サンプルは SR 比較より先にエラー
 pub fn resample_to(sample: Sample, target_sr: u32) -> Result<Sample, ResampleError> {
-    if sample.sample_rate == target_sr {
-        return Ok(sample);
-    }
     if sample.channels == 0 {
         return Err(ResampleError::ZeroChannels);
+    }
+    if sample.sample_rate == target_sr {
+        return Ok(sample);
     }
 
     let channels = sample.channels as usize;
@@ -47,23 +50,23 @@ pub fn resample_to(sample: Sample, target_sr: u32) -> Result<Sample, ResampleErr
         SUB_CHUNKS,
         channels,
         FixedSync::Both,
-    )
-    .map_err(|e| ResampleError::Init(e.to_string()))?;
+    )?;
 
     let out_len = resampler.process_all_needed_output_len(in_frames);
     let mut out_data = vec![0.0f32; out_len * channels];
 
-    let input = InterleavedSlice::new(&sample.data[..], channels, in_frames)
-        .map_err(|e| ResampleError::Init(e.to_string()))?;
+    let input = InterleavedSlice::new(sample.as_slice(), channels, in_frames)
+        .map_err(|e| ResampleError::Buffer(e.to_string()))?;
     let mut output = InterleavedSlice::new_mut(&mut out_data, channels, out_len)
-        .map_err(|e| ResampleError::Init(e.to_string()))?;
+        .map_err(|e| ResampleError::Buffer(e.to_string()))?;
 
-    let (_nbr_in, nbr_out) = resampler
-        .process_all_into_buffer(&input, &mut output, in_frames, None)
-        .map_err(|e| ResampleError::Process(e.to_string()))?;
+    let (_, nbr_out) = resampler.process_all_into_buffer(&input, &mut output, in_frames, None)?;
 
-    // 実際に書き込まれた frames 分だけに切り詰める
+    // 実際に書き込まれた frames 分だけに切り詰め、余剰キャパシティも解放。
+    // このあと `Sample::new` で `Arc<Vec<f32>>` に包まれると shrink できなくなるため、
+    // 共有前のここが唯一の縮小機会。
     out_data.truncate(nbr_out * channels);
+    out_data.shrink_to_fit();
 
     Ok(Sample::new(out_data, target_sr, sample.channels))
 }
@@ -92,7 +95,6 @@ mod tests {
         assert_eq!(r.channels, 2);
         // 持続時間が ±5ms 以内で保たれること
         assert!((r.duration_secs() - 1.0).abs() < 0.005);
-        // 期待フレーム数付近（48000 ±小誤差）
         let expected = 48_000;
         let diff = (r.frames() as i64 - expected as i64).abs();
         assert!(
@@ -129,5 +131,48 @@ mod tests {
             resample_to(s, 44_100),
             Err(ResampleError::ZeroChannels)
         ));
+    }
+
+    #[test]
+    fn zero_channel_sample_with_same_sr_also_returns_error() {
+        // channels チェックが SR 比較より先に動くことを確認
+        let s = Sample::new(vec![], 48_000, 0);
+        assert!(matches!(
+            resample_to(s, 48_000),
+            Err(ResampleError::ZeroChannels)
+        ));
+    }
+
+    /// サイン波で信号品質を検証する。DC だけのテストでは
+    /// FFT 処理が壊れていても通ってしまうため、周波数成分を持つ信号で
+    /// RMS が概ね保たれることを確認する。
+    #[test]
+    fn sine_wave_rms_is_preserved_through_resampling() {
+        use std::f32::consts::TAU;
+
+        let sr_in: u32 = 44_100;
+        let sr_out: u32 = 48_000;
+        let freq: f32 = 1_000.0;
+        let channels: u16 = 2;
+        let in_frames = sr_in as usize;
+
+        let data: Vec<f32> = (0..in_frames * channels as usize)
+            .map(|i| {
+                let frame = i / channels as usize;
+                (TAU * freq * frame as f32 / sr_in as f32).sin() * 0.5
+            })
+            .collect();
+
+        let rms_in: f32 = (data.iter().map(|x| x * x).sum::<f32>() / data.len() as f32).sqrt();
+
+        let s = Sample::new(data, sr_in, channels);
+        let r = resample_to(s, sr_out).unwrap();
+
+        let rms_out: f32 = (r.data.iter().map(|x| x * x).sum::<f32>() / r.data.len() as f32).sqrt();
+        let db_diff = 20.0 * (rms_out / rms_in).log10();
+        assert!(
+            db_diff.abs() < 0.5,
+            "RMS diff {db_diff:.3} dB outside ±0.5 dB (in={rms_in:.4}, out={rms_out:.4})"
+        );
     }
 }

--- a/rust/src/native/resampler.rs
+++ b/rust/src/native/resampler.rs
@@ -21,9 +21,11 @@ pub enum ResampleError {
     ZeroChannels,
 }
 
-/// チャンクサイズ (frames). オフライン処理なのでそこそこ大きめで可。
-/// rubato は内部でこのサイズ単位で FFT 処理する。
+/// FFT 処理のチャンクサイズ (frames)。
+/// rubato のドキュメントで音声用途の典型値として推奨されている 1024 サンプルを採用。
+/// 2 の冪であることが FFT 効率の前提。
 const CHUNK_FRAMES: usize = 1024;
+
 /// 遅延と品質のトレードオフ。2 は rubato のドキュメント推奨値。
 const SUB_CHUNKS: usize = 2;
 

--- a/rust/src/native/resampler.rs
+++ b/rust/src/native/resampler.rs
@@ -1,0 +1,133 @@
+//! Offline sample rate conversion using `rubato`.
+//!
+//! ロード時に Project SR へ一度だけ変換する用途を想定している。
+//! 再生時（リアルタイム）の変換は行わない。
+
+use audioadapter_buffers::direct::InterleavedSlice;
+use rubato::{Fft, FixedSync, Resampler};
+use thiserror::Error;
+
+use crate::core::Sample;
+
+#[derive(Error, Debug)]
+pub enum ResampleError {
+    #[error("resampler init error: {0}")]
+    Init(String),
+    #[error("resampler process error: {0}")]
+    Process(String),
+    #[error("zero-channel sample cannot be resampled")]
+    ZeroChannels,
+}
+
+/// チャンクサイズ (frames). オフライン処理なのでそこそこ大きめで可。
+/// rubato は内部でこのサイズ単位で FFT 処理する。
+const CHUNK_FRAMES: usize = 1024;
+/// 遅延と品質のトレードオフ。2 は rubato のドキュメント推奨値。
+const SUB_CHUNKS: usize = 2;
+
+/// `sample` を `target_sr` へリサンプリングする。
+///
+/// source と target の SR が同じ場合はコピー無しでそのまま返す。
+pub fn resample_to(sample: Sample, target_sr: u32) -> Result<Sample, ResampleError> {
+    if sample.sample_rate == target_sr {
+        return Ok(sample);
+    }
+    if sample.channels == 0 {
+        return Err(ResampleError::ZeroChannels);
+    }
+
+    let channels = sample.channels as usize;
+    let in_frames = sample.frames();
+
+    // rubato 2.0 の高品質 FFT リサンプラ。オフライン処理には FixedSync::Both が適切。
+    let mut resampler = Fft::<f32>::new(
+        sample.sample_rate as usize,
+        target_sr as usize,
+        CHUNK_FRAMES,
+        SUB_CHUNKS,
+        channels,
+        FixedSync::Both,
+    )
+    .map_err(|e| ResampleError::Init(e.to_string()))?;
+
+    let out_len = resampler.process_all_needed_output_len(in_frames);
+    let mut out_data = vec![0.0f32; out_len * channels];
+
+    let input = InterleavedSlice::new(&sample.data[..], channels, in_frames)
+        .map_err(|e| ResampleError::Init(e.to_string()))?;
+    let mut output = InterleavedSlice::new_mut(&mut out_data, channels, out_len)
+        .map_err(|e| ResampleError::Init(e.to_string()))?;
+
+    let (_nbr_in, nbr_out) = resampler
+        .process_all_into_buffer(&input, &mut output, in_frames, None)
+        .map_err(|e| ResampleError::Process(e.to_string()))?;
+
+    // 実際に書き込まれた frames 分だけに切り詰める
+    out_data.truncate(nbr_out * channels);
+
+    Ok(Sample::new(out_data, target_sr, sample.channels))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_sample_rate_passes_through() {
+        let s = Sample::new(vec![0.1f32; 200], 48_000, 2);
+        let r = resample_to(s.clone(), 48_000).unwrap();
+        assert_eq!(r.sample_rate, 48_000);
+        assert_eq!(r.frames(), s.frames());
+    }
+
+    #[test]
+    fn upsample_44100_to_48000_preserves_duration() {
+        // 1 秒分の 44.1kHz ステレオ
+        let in_frames = 44_100;
+        let data = vec![0.1f32; in_frames * 2];
+        let s = Sample::new(data, 44_100, 2);
+        let r = resample_to(s, 48_000).unwrap();
+
+        assert_eq!(r.sample_rate, 48_000);
+        assert_eq!(r.channels, 2);
+        // 持続時間が ±5ms 以内で保たれること
+        assert!((r.duration_secs() - 1.0).abs() < 0.005);
+        // 期待フレーム数付近（48000 ±小誤差）
+        let expected = 48_000;
+        let diff = (r.frames() as i64 - expected as i64).abs();
+        assert!(
+            diff < 100,
+            "frames {} too far from {}",
+            r.frames(),
+            expected
+        );
+    }
+
+    #[test]
+    fn downsample_96000_to_48000_halves_frames() {
+        let in_frames = 96_000;
+        let data = vec![0.1f32; in_frames];
+        let s = Sample::new(data, 96_000, 1);
+        let r = resample_to(s, 48_000).unwrap();
+
+        assert_eq!(r.sample_rate, 48_000);
+        assert_eq!(r.channels, 1);
+        let expected = 48_000;
+        let diff = (r.frames() as i64 - expected as i64).abs();
+        assert!(
+            diff < 100,
+            "frames {} too far from {}",
+            r.frames(),
+            expected
+        );
+    }
+
+    #[test]
+    fn zero_channel_sample_returns_error() {
+        let s = Sample::new(vec![], 48_000, 0);
+        assert!(matches!(
+            resample_to(s, 44_100),
+            Err(ResampleError::ZeroChannels)
+        ));
+    }
+}


### PR DESCRIPTION
## 概要

Issue #100 対応。PoC #91 の既知の制限「SRC なし」を解消。

Closes #100

## 方式

Pro Tools / Logic Pro 方式（**ロード時オフライン変換**）を採用:

- rubato 2.0 の `Fft<f32>` リサンプラ + `FixedSync::Both`
- 再生時は 1:1 マッピングを維持（低レイテンシ）
- ソース SR == target SR ならコピーなしパススルー

## API

```rust
pub fn load_sample_resampled(
    path: impl AsRef<Path>,
    target_sr: u32,
) -> Result<Sample, LoaderError>;

pub fn resample_to(
    sample: Sample,
    target_sr: u32,
) -> Result<Sample, ResampleError>;
```

## 変更

- `rust/src/native/resampler.rs` 新規
- `rust/src/native/loader.rs` に `load_sample_resampled` 追加
- `rust/src/core/sample.rs` に `as_slice()` アクセサ追加
- `rubato = "2"` / `audioadapter-buffers = "3"` を native feature に追加
- `examples/poc_play.rs` が新 API を使用
- `rust/README.md` Known Limitations から SRC 項目を削除

## レビュー対応

`/simplify`（3 並列）のレビューで Critical/Important を解消:

- `shrink_to_fit` 追加（Arc 共有前の唯一の縮小機会）
- `ResampleError` を型安全化（`#[from]` で rubato エラー保持）
- ゼロチャンネル + 同 SR のバイパスバグ修正（check 順序変更）
- `load_sample_at` → `load_sample_resampled` へリネーム
- `Sample::as_slice()` で内部表現の抽象化

## テスト (14 passing)

- `same_sample_rate_passes_through`
- `upsample_44100_to_48000_preserves_duration`
- `downsample_96000_to_48000_halves_frames`
- `zero_channel_sample_returns_error`
- `zero_channel_sample_with_same_sr_also_returns_error` (バイパスバグ回帰)
- `sine_wave_rms_is_preserved_through_resampling` (信号品質検証、±0.5 dB)
- 既存 core テスト 8 件はそのまま

## Test plan

- [x] `cargo check --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --lib`: 14 passed
- [x] PoC 実機再生確認
- [x] simplify レビュー 7 件対応