### PR TITLE
chore: gitignore .claude/settings.local.json for per-developer overrides

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,17 +1,4 @@
 {
-  "permissions": {
-    "allow": [
-      "Bash(npm audit)",
-      "Bash(npm audit --json)",
-      "Bash(swiftlint *)",
-      "Bash(cargo check *)",
-      "Bash(cargo clippy *)",
-      "Bash(cargo fmt --check *)",
-      "Bash(cargo test *)",
-      "mcp__plugin_context7_context7__query-docs",
-      "mcp__plugin_context7_context7__resolve-library-id"
-    ]
-  },
   "hooks": {
     "SessionStart": [
       {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(npm audit)",
+      "Bash(npm audit --json)",
+      "Bash(swiftlint *)",
+      "Bash(cargo check *)",
+      "Bash(cargo clippy *)",
+      "Bash(cargo fmt --check *)",
+      "Bash(cargo test *)",
+      "mcp__plugin_context7_context7__query-docs",
+      "mcp__plugin_context7_context7__resolve-library-id"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ logs/
 *.tsbuildinfo
 .orbitscore.json
 
+# Claude Code local settings (per-developer overrides)
+.claude/settings.local.json
+
 # Rust build artifacts (Cargo)
 rust/target/
 


### PR DESCRIPTION
## 概要

\`.gitignore\` に \`.claude/settings.local.json\` を追加し、各開発者がローカル固有の permissions / 設定を追跡対象外で持てるようにする。

## 変更

\`.gitignore\` に 3 行追加:

\`\`\`
# Claude Code local settings (per-developer overrides)
.claude/settings.local.json
\`\`\`

## 方針

- **共有ベースライン**: \`.claude/settings.json\` に残す（PR #102 で追加済みの permissions はそのまま）
- **ローカル上書き**: \`.claude/settings.local.json\` が個人設定置き場。Claude Code が自動マージ

## 変更ファイル

| ファイル | 変更 |
|---|---|
| \`.gitignore\` | \`.claude/settings.local.json\` の除外エントリ 3 行追加 |

(当初 \`settings.json\` から permissions を外す構想もあったが、共有ベースを維持する方針に戻した。コミット \`revert: keep permissions in settings.json as shared baseline\` 参照)

## Test plan

- [x] \`git check-ignore\` で \`.claude/settings.local.json\` が無視されることを確認