### PR TITLE
docs: audio engine 3-layer architecture and Phase 1a workspace plan

### DIFF
--- a/docs/core/INDEX.md
+++ b/docs/core/INDEX.md
@@ -84,6 +84,11 @@
    - Engine-as-a-Service アーキテクチャ
    - VST3/CLAP プラグインホスティング、商用展開戦略
 
+5. **[AUDIO_ENGINE_CORE_ARCHITECTURE.md](../planning/AUDIO_ENGINE_CORE_ARCHITECTURE.md)** 🎚️
+   - 3 層分離アーキテクチャ（Core / Plugins / App）
+   - DSL → MIDI 変換戦略、responsibilities 境界
+   - Cargo workspace 構造、Plugin Host MIDI 契約
+
 ### Quick Links
 
 - **User Guide**: [../README.md](../README.md) - Start here for usage

--- a/docs/planning/AUDIO_ENGINE_CORE_ARCHITECTURE.md
+++ b/docs/planning/AUDIO_ENGINE_CORE_ARCHITECTURE.md
@@ -1,0 +1,240 @@
+# Audio Engine Core Architecture
+
+**ステータス**: 設計方針確定（実装は段階的）
+**最終更新**: 2026-04-17
+**関連 Issue**: Epic [#105](https://github.com/signalcompose/orbitscore/issues/105)
+
+---
+
+## 1. 背景と動機
+
+PR #99 / #103 で Rust audio engine の PoC を構築した結果、全機能が単一 crate に入った形になった。今後の拡張（プラグインホスト、Web 版、他プロダクトへの転用）を見据え、**責務を層で分離**する必要がある。
+
+加えて、Signal compose の戦略として **音声スタックを OrbitScore 専用ではなく「汎用 Rust audio engine」として育て、他プロダクト・OSS 貢献・商用プロダクトの基盤とする**ことを目指す。
+
+---
+
+## 2. 目標アーキテクチャ（最終形）
+
+```
+┌──────────────────────────────────────────────┐
+│ App Layer (OrbitScore)                         │
+│  ├─ VS Code Extension                          │
+│  ├─ DSL parser / interpreter                   │
+│  ├─ Musical timing (BPM / 拍子 / polymeter)    │
+│  ├─ Project management                         │
+│  └─ LLM agent / UI                             │
+└──────────────┬───────────────────────────────┘
+               │ IPC (WebSocket + JSON-RPC)
+┌──────────────▼───────────────────────────────┐
+│ Plugins (Rust, 差し替え可能)                   │
+│  ├─ VST3 / CLAP host                           │
+│  ├─ MIDI I/O                                   │
+│  ├─ Time-stretch wrapper (rubberband/SoundTouch)│
+│  └─ Third-party Node impls                     │
+├──────────────────────────────────────────────┤
+│ Audio Engine Core (Rust, 汎用)                 │
+│  ├─ Audio I/O (cpal / AudioWorklet)            │
+│  ├─ Audio graph (Node trait + bus routing)    │
+│  ├─ Sample-accurate scheduler                  │
+│  ├─ Sample management (load, mix, SRC)         │
+│  ├─ Parameter system (automation, timed set)   │
+│  ├─ Realtime-safe primitives (lock-free)       │
+│  └─ Built-in Node types (SamplePlayer, Bus等)  │
+└──────────────────────────────────────────────┘
+```
+
+**橋渡しは "層" ではなく "プロトコル"**: IPC は Core のコマンド型を JSON-RPC on WebSocket で配線する薄い通信路。
+
+---
+
+## 3. 責務の分離原則
+
+### Core は以下を「知らない」
+
+- DSL の構文 / 意味論
+- Musical time (BPM / 拍子 / ポリリズム)
+- ファイル形式（`.osc` 等）
+- ネットワーク / IPC（デーモン化の詳細）
+- UI / エディタ
+
+### Core が扱うのは以下のみ
+
+- **秒（または sample 単位）** の時刻軸
+- 入出力バッファとオーディオグラフ
+- Node trait によるノード抽象
+- `LoadSample` / `PlayAt` / `ConnectNode` 等の **命令**
+
+### Plugins は Core の Node trait を実装
+
+- VST3 host / CLAP host も「Node の一種」
+- MIDI I/O も Node として graph に繋がる
+- サードパーティ拡張も同じ trait を通る
+
+### App（TypeScript）の責務
+
+- DSL parse
+- Musical timing → 秒変換
+- Note 列 → MIDI Event 列への展開
+- UI（VS Code 拡張、将来は Tauri）
+- プロジェクトファイル管理
+
+---
+
+## 4. DSL → MIDI 変換の方針
+
+### ソフトシンセ / VST エフェクト利用時の流れ
+
+```
+TS engine:
+  DSL パース
+  ↓ musical timing 適用（BPM → 秒）
+  ↓ Note sequence → 時刻付き MIDI Event 列
+  ↓ IPC メッセージ生成
+       ├─ LoadPlugin { path }
+       ├─ PluginMidiEvent { plugin_id, time_sec, event }
+       └─ PluginParam { plugin_id, param_id, value }
+
+Rust plugin host:
+  MIDI Event を sample-accurate に plugin へ
+  Plugin が audio を生成
+  Audio graph の bus に合流
+  → 出力
+```
+
+### 重要な契約
+
+- **Plugin host は MIDI Event を受け取る**（DSL を知らない）
+- **TS interpreter が DSL → MIDI 変換を担う**
+- **業界標準の MIDI を IPC メッセージにする**ことで、Plugin 層の universality を確保
+
+---
+
+## 5. Musical timing はどこに置くか
+
+### 結論: **Phase 1〜2 は TypeScript 側に残す**
+
+既存の `packages/engine/` には BPM / 拍子 / polymeter / polytempo / seamless parameter update 等の musical timing ロジックが実装済み。既存テストも通過。**これを活かす**のが合理的。
+
+### Rust に移す判断タイミング
+
+- Web / WASM 版の開発着手時（TS が動かない環境）
+- または複数のフロント（standalone / web / plugin 版）が同じ timing を使う必要が出た時
+
+この時点で初めて `orbit-music-timing` crate を切り出す。それまでは TS 側に留める。
+
+### 今の layering
+
+```
+Phase 1〜2:
+  [TS: DSL + interpreter + musical timing]
+         ↓ IPC (秒ベース)
+  [Rust: audio-core + plugins]
+
+Phase 3 以降（Web 版着手時に検討）:
+  [TS or WASM: DSL + interpreter]
+         ↓
+  [Rust: orbit-music-timing] ← ここで独立 crate 化
+         ↓
+  [Rust: audio-core + plugins]
+```
+
+---
+
+## 6. フェーズ別移行計画
+
+### Phase 1a: Cargo workspace 再構成
+- 現 `rust/` 単一 crate → 複数 crate に分割
+- `orbit-audio-core` / `orbit-audio-native` / `orbit-audio-wasm`
+- Issue [#106](https://github.com/signalcompose/orbitscore/issues/106)
+
+### Phase 1b: IPC ブリッジ
+- IPC プロトコル設計（Issue [#93](https://github.com/signalcompose/orbitscore/issues/93)）
+- `orbit-audio-daemon` binary（Issue [#107](https://github.com/signalcompose/orbitscore/issues/107)）
+- TS 側の rust-engine client（Issue [#108](https://github.com/signalcompose/orbitscore/issues/108)）
+- SuperCollider 経路を段階的に置き換え
+
+### Phase 2: プラグイン段階投入
+- Time-stretch（Issue [#92](https://github.com/signalcompose/orbitscore/issues/92)）
+- VST3 / CLAP plugin host（Issue [#95](https://github.com/signalcompose/orbitscore/issues/95)）
+- MIDI I/O plugin
+
+### Phase 3: スタンドアローン / Web 拡張
+- Tauri standalone（Issue [#94](https://github.com/signalcompose/orbitscore/issues/94)）
+- LLM agent 統合（Issue [#96](https://github.com/signalcompose/orbitscore/issues/96)）
+- Web 版（WAM 対応、ここで musical timing の Rust 化検討）
+
+---
+
+## 7. Cargo workspace 構造（提案）
+
+```
+rust/
+├── Cargo.toml (workspace root)
+└── crates/
+    ├── orbit-audio-core/       # platform-agnostic, publishable
+    ├── orbit-audio-native/     # cpal backend + symphonia + SRC
+    ├── orbit-audio-wasm/       # wasm-bindgen + AudioWorklet
+    ├── orbit-audio-daemon/     # binary with WebSocket server
+    ├── orbit-audio-midi/       # MIDI I/O plugin (Phase 2)
+    ├── orbit-audio-vst3/       # VST3 host plugin (Phase 2)
+    ├── orbit-audio-clap/       # CLAP host plugin (Phase 2)
+    └── orbit-audio-timestretch/# rubberband/soundtouch wrapper (Phase 2)
+```
+
+### 公開戦略
+
+- `orbit-audio-core`: **MIT / Apache 2.0** で OSS 公開候補（Rust audio コミュニティ貢献）
+- Plugins: 各 crate のライセンスに従う（LGPL の SoundTouch 等は別 crate で隔離）
+- `orbit-audio-daemon` / `orbitscore-app`: **Signal compose Source-Available License**（商用戦略）
+
+---
+
+## 8. Plugin Host の MIDI Event 契約
+
+```rust
+pub enum MidiEvent {
+    NoteOn { channel: u8, pitch: u8, velocity: u8 },
+    NoteOff { channel: u8, pitch: u8, velocity: u8 },
+    CC { channel: u8, controller: u8, value: u8 },
+    PitchBend { channel: u8, value: i16 },
+    ProgramChange { channel: u8, program: u8 },
+    Aftertouch { channel: u8, value: u8 },
+    // 必要に応じ拡張
+}
+
+pub trait MidiSink: Node {
+    fn handle_midi(&mut self, time_sec: f64, event: MidiEvent);
+}
+```
+
+この trait を VST3 host / CLAP host / MIDI I/O plugin / 将来のカスタム DSP が**統一的に実装**する。IPC 越しの command はこの形をそのままシリアライズしたもの。
+
+---
+
+## 9. 非目標（本設計で扱わない）
+
+- **DSL 仕様変更**: 実装を真とする。本ドキュメントでは DSL 具体論を書かない
+- **musical timing の Rust 化**: Phase 1〜2 では TS 側に留める
+- **TS engine の既存テスト 220+ を壊すこと**: 既存動作を保ちながら置き換える
+- **特定のシンセや DAW との密結合**: Plugin 層は汎用 MIDI Event を契約とする
+- **リアルタイム MIDI 入力の完全サポート**: まずは内部生成 MIDI から着手（外部入力は MIDI I/O plugin で追加）
+
+---
+
+## 10. Open Questions（Phase 進行中に解決）
+
+- cpal の audio callback と WebSocket 受信スレッド間の lock-free 通信方式（`ringbuf` or `rtrb`）
+- Plugin の process() 呼び出し周期と、MIDI event のサンプル精度 alignment 手法
+- Time-stretch の商用ライセンス判断（Rubberband vs SoundTouch vs 独自）
+- daemon プロセスのライフサイクル管理（VS Code extension から子プロセス管理）
+- `orbit-audio-core` を crates.io に公開するタイミング / 命名の最終決定
+
+---
+
+## 11. 参考
+
+- [docs/planning/RUST_ENGINE_MIGRATION_PLAN.md](./RUST_ENGINE_MIGRATION_PLAN.md) - 全体ロードマップ
+- [docs/research/RUST_POC_FINDINGS.md](../research/RUST_POC_FINDINGS.md) - PoC 所感
+- [Epic #105](https://github.com/signalcompose/orbitscore/issues/105)
+- Node trait の設計参考: JUCE AudioProcessor, Web Audio API AudioNode

--- a/docs/planning/RUST_ENGINE_MIGRATION_PLAN.md
+++ b/docs/planning/RUST_ENGINE_MIGRATION_PLAN.md
@@ -272,19 +272,29 @@ Signal compose Source-Available License により:
 - ✅ Dependabot 警告の安全な修正（Phase 0）— PR #90 (2026-04-17)
 - ✅ Research Issue 群の作成（下記）
 - ✅ ライセンス切り替え（MIT → Signal compose Source-Available License v1.0）— PR #88
+- ✅ Rust audio engine PoC — PR #99 (Issue #91)
+- ✅ Sample rate conversion on load via rubato — PR #103 (Issue #100)
+- ✅ 3-layer architecture 方針確定 — [docs/planning/AUDIO_ENGINE_CORE_ARCHITECTURE.md](./AUDIO_ENGINE_CORE_ARCHITECTURE.md) (Epic #105)
 
 ### 進行中 / 次に取り組む
 
 - [ ] Issue #73: リリース自動化（エンドユーザー向け `.vsix` ワークフロー）
 
-### Research / Design Issues（Phase 1）
+### Research / Design Issues（Phase 1 以降）
 
-- [ ] Issue #91: [spike: Rust audio engine proof of concept](https://github.com/signalcompose/orbitscore/issues/91)
-- [ ] Issue #92: [research: time-stretch DSP library selection for Rust engine](https://github.com/signalcompose/orbitscore/issues/92)
-- [ ] Issue #93: [design: engine daemon IPC protocol (WebSocket + JSON-RPC)](https://github.com/signalcompose/orbitscore/issues/93)
-- [ ] Issue #94: [design: Tauri standalone application architecture](https://github.com/signalcompose/orbitscore/issues/94)
-- [ ] Issue #95: [research: VST3 and CLAP plugin hosting in Rust](https://github.com/signalcompose/orbitscore/issues/95)
-- [ ] Issue #96: [design: LLM agent integration architecture](https://github.com/signalcompose/orbitscore/issues/96)
+- [x] Issue #91: Rust audio engine proof of concept (PR #99 merged)
+- [ ] Issue #92: [research: time-stretch DSP library selection for Rust engine](https://github.com/signalcompose/orbitscore/issues/92) — Phase 2
+- [ ] Issue #93: [design: engine daemon IPC protocol (WebSocket + JSON-RPC)](https://github.com/signalcompose/orbitscore/issues/93) — Phase 1b
+- [ ] Issue #94: [design: Tauri standalone application architecture](https://github.com/signalcompose/orbitscore/issues/94) — Phase 3
+- [ ] Issue #95: [research: VST3 and CLAP plugin hosting in Rust](https://github.com/signalcompose/orbitscore/issues/95) — Phase 2
+- [ ] Issue #96: [design: LLM agent integration architecture](https://github.com/signalcompose/orbitscore/issues/96) — Phase 3
+
+### Phase 1a / 1b 実装 Issues（新規追加）
+
+- [ ] Issue [#105 (Epic)](https://github.com/signalcompose/orbitscore/issues/105) Audio Engine Core 3-layer architecture migration
+- [ ] Issue [#106](https://github.com/signalcompose/orbitscore/issues/106) feat(rust): Cargo workspace split for core/native/wasm separation — Phase 1a
+- [ ] Issue [#107](https://github.com/signalcompose/orbitscore/issues/107) feat(rust): orbit-audio-daemon binary with WebSocket IPC server — Phase 1b
+- [ ] Issue [#108](https://github.com/signalcompose/orbitscore/issues/108) feat(ts): rust-engine client replacing SuperCollider OSC path — Phase 1b
 
 ### 組織タスク
 

--- a/docs/plans/rust-audio-workspace-split.md
+++ b/docs/plans/rust-audio-workspace-split.md
@@ -1,0 +1,163 @@
+# Plan: Rust Audio Workspace Split (Phase 1a)
+
+**対象 Issue**: [#106](https://github.com/signalcompose/orbitscore/issues/106)
+**Epic**: [#105](https://github.com/signalcompose/orbitscore/issues/105)
+**前提**: PR #99, #103 がマージされた状態の main
+**想定 effort**: medium
+**想定 dev-cycle**: 1 cycle で完結
+
+---
+
+## 1. 目的
+
+単一 crate `orbitscore-engine` に入っている Rust コードを **Cargo workspace** に再構成し、`orbit-audio-core` を platform-agnostic な独立 crate として切り出す。将来のプラグイン分離・他プロダクト転用・OSS 公開の**土台**を作る。
+
+**本プランは純粋な構造リファクタであり、新機能の追加は一切行わない。**
+
+---
+
+## 2. 参照すべきドキュメント
+
+作業前に必ず目を通す:
+
+- [docs/planning/AUDIO_ENGINE_CORE_ARCHITECTURE.md](../planning/AUDIO_ENGINE_CORE_ARCHITECTURE.md) — 全体設計方針と責務分離原則
+- [docs/planning/RUST_ENGINE_MIGRATION_PLAN.md](../planning/RUST_ENGINE_MIGRATION_PLAN.md) — 段階的ロードマップ
+- `rust/` の現状コード（17 tests + PoC example が動く状態）
+
+---
+
+## 3. スコープ
+
+### 含む
+
+- `rust/` を Cargo workspace に再構成
+- 3 crates に分割:
+  - `rust/crates/orbit-audio-core/` — 現 `src/core/` 相当（platform-agnostic）
+  - `rust/crates/orbit-audio-native/` — 現 `src/native/` 相当（cpal + symphonia + rubato）
+  - `rust/crates/orbit-audio-wasm/` — 現 `src/wasm/` 相当（スタブ）
+- `rust/Cargo.toml` を workspace root に（`[workspace]` セクション）
+- 各 crate の `Cargo.toml` を適切な dependencies 記述で構成
+- 既存の features (`native` / `wasm`) のポリシーは workspace 全体で整合性を保つ形に移行
+- `rust/examples/poc_play.rs` を `orbit-audio-native` の examples へ移設
+- `rust/target/` gitignore / `rust/Cargo.lock` は workspace 共通で 1 箇所
+- `rust-toolchain.toml` は workspace root に維持
+
+### 含まない（Phase 1b 以降）
+
+- 新機能の追加
+- daemon binary crate の新設
+- IPC / WebSocket の実装
+- TS 側の変更
+- DSL / interpreter / musical timing の改修
+- プラグイン host 実装
+- crates.io への公開
+
+---
+
+## 4. 完了条件
+
+- [ ] `rust/crates/orbit-audio-core/` が作成され、core モジュール相当が移設されている
+- [ ] `rust/crates/orbit-audio-native/` が作成され、native モジュールと poc_play example が移設されている
+- [ ] `rust/crates/orbit-audio-wasm/` が作成され、wasm スタブが移設されている
+- [ ] `rust/Cargo.toml` が workspace root として機能（`[workspace]` members 定義）
+- [ ] `cargo check --workspace --all-targets` が全て成功
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` が成功
+- [ ] `cargo fmt --check` が成功
+- [ ] `cargo test --workspace --lib` で既存 17 tests が全部通る
+- [ ] `cd rust && cargo run --example poc_play -- ../test-assets/audio/kick.wav ../test-assets/audio/snare.wav` が動作（実機再生）
+- [ ] `cargo build --release` 成功
+
+---
+
+## 5. 実装手順（推奨シーケンス）
+
+1. ブランチ `106-rust-workspace-split` を作成
+2. `rust/Cargo.toml` を workspace root に変換（メンバー定義のみ）
+3. `rust/crates/orbit-audio-core/` を作成し `src/core/` を移設
+4. `rust/crates/orbit-audio-native/` を作成し `src/native/` を移設（`orbit-audio-core` に依存）
+5. `rust/crates/orbit-audio-wasm/` を作成し `src/wasm/` を移設（`orbit-audio-core` に依存）
+6. `examples/poc_play.rs` を `crates/orbit-audio-native/examples/` に移動
+7. 旧 `rust/src/`, `rust/Cargo.toml` の残骸を整理
+8. `cargo check` / `clippy` / `fmt` / `test` / `run --example` をすべて確認
+9. PoC を実機再生で動作確認
+
+### crate 命名ポリシー
+
+- パッケージ名は **`orbit-audio-*`** 形式（ハイフン区切り）
+- Rust 内モジュール名は **`orbit_audio_*`**（snake_case 自動変換）
+- version は初期 `0.0.1` に揃える
+- license は `LicenseRef-Signal-compose-FairTrade-1.0`
+- description は Signal compose 由来の汎用 audio crate である旨を明記
+
+### feature flag 方針
+
+- `orbit-audio-core`: 基本は `no_std` 志向だが、まずは `std` ありで spawn。feature なし
+- `orbit-audio-native`: cpal / symphonia / rubato / audioadapter-buffers を直接 require（optional ではなく必須依存）
+- `orbit-audio-wasm`: wasm-bindgen / web-sys を直接 require
+- **旧 `native` / `wasm` feature flag は crate 分割によって不要になるため削除**
+- 旧 `lib.rs` の `compile_error!` は不要になる（crate 単位で選ぶようになるため）
+
+---
+
+## 6. DDD / ドキュメント更新項目
+
+実装 PR に含めるべき更新:
+
+- [ ] `rust/README.md` を **ワークスペース全体の overview** に刷新
+  - 各 crate の役割と依存関係
+  - 主要コマンド（`cargo test --workspace` 等）
+  - 既存の Known Limitations は維持
+- [ ] `docs/development/WORK_LOG.md` に 6.56 エントリ追加（作業内容）
+- [ ] `docs/planning/RUST_ENGINE_MIGRATION_PLAN.md` Phase 1 section の進捗更新（Phase 1a 完了にチェック）
+- [ ] `docs/planning/AUDIO_ENGINE_CORE_ARCHITECTURE.md` の「Cargo workspace 構造」セクションを実装実態に合わせて調整
+- [ ] `CLAUDE.md` の Development Commands 欄に `cargo` 系コマンド（workspace）を追加（任意、対象的なら）
+
+**DSL 仕様については本プランでは言及しない**。実装を唯一の真実とする方針。
+
+---
+
+## 7. 検証項目（PR 作成前チェックリスト）
+
+- [ ] `cargo check --workspace --all-targets` clean
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
+- [ ] `cargo fmt --check` clean
+- [ ] `cargo test --workspace --lib`: 17 passed（PoC / #100 SRC の tests 合計）
+- [ ] `cargo build --release` 成功
+- [ ] `cd rust && cargo run --example poc_play -- ../test-assets/audio/kick.wav ../test-assets/audio/snare.wav` で音が出る
+- [ ] `git diff main..HEAD` を確認し、移設以外の意図しない変更がないこと
+- [ ] `cargo tree --workspace` で依存が正しく解決されているか確認
+
+---
+
+## 8. リスクと注意点
+
+- **Cargo.lock の差し替え**: workspace 化で lock の構造が変わる。再生成すると依存バージョンがズレる可能性があるので、既存の pin を極力維持する
+- **feature flag の消滅**: 旧 `native` / `wasm` features 前提のビルドスクリプトやドキュメントが残っていないか要確認
+- **path dependency**: crate 間依存は **`{ path = "../orbit-audio-core" }`** を使う（未公開段階なので version 指定不可）
+- **example の path**: `test-assets/audio/*.wav` への相対パスが `crates/orbit-audio-native/examples/` からだと変わる。poc_play.rs 内の相対パス or README のコマンド例を調整
+
+---
+
+## 9. 非目標（重要な再確認）
+
+- DSL 仕様への言及は一切行わない（間違いの元になる）
+- musical timing は触らない（TS 側に残す）
+- 新規 Rust コードを書かない（リファクタのみ）
+- daemon / IPC 実装は **Phase 1b (#107) で別途**
+
+---
+
+## 10. 次のステップ（本 PR 完了後）
+
+1. PR マージ後に Epic #105 のチェックリストを更新
+2. Issue #106 クローズ
+3. Phase 1b に進む場合: Issue #93 → #107 → #108 の順で着手
+
+---
+
+## 11. 参考
+
+- [Epic #105](https://github.com/signalcompose/orbitscore/issues/105)
+- [Issue #106](https://github.com/signalcompose/orbitscore/issues/106) ← 本プランが対応する Issue
+- [docs/planning/AUDIO_ENGINE_CORE_ARCHITECTURE.md](../planning/AUDIO_ENGINE_CORE_ARCHITECTURE.md)
+- [Cargo workspace 公式ドキュメント](https://doc.rust-lang.org/cargo/reference/workspaces.html)


### PR DESCRIPTION
## 概要

Epic #105「Audio Engine Core 3-layer architecture migration」の設計方針をドキュメントとして定着させ、実装の最初の一歩（Cargo workspace split）の dev-cycle プランを追加する。

## 追加ドキュメント

### docs/planning/AUDIO_ENGINE_CORE_ARCHITECTURE.md (新規)

3 層分離アーキテクチャの設計方針を定義:

- **Core / Plugins / App** の責務境界
- Core は DSL / musical timing / ネットワークを知らない（秒ベース命令のみ）
- Plugin host は汎用 MIDI Event を受ける（DSL 不知）
- DSL → MIDI 変換は TS interpreter の責務
- **musical timing は Phase 3 まで TS に留める**（Rust 化しない）
- Cargo workspace 構造（`orbit-audio-core/native/wasm/daemon/plugins`）
- 公開戦略: core は OSS 候補、app は Signal compose license

### docs/plans/rust-audio-workspace-split.md (新規)

Issue #106 対応の Phase 1a 実装プラン:

- `/code:dev-cycle docs/plans/rust-audio-workspace-split.md` で実行可能な形式
- 純粋なリファクタ、新機能なし、17 tests 維持
- 完了条件・検証項目・DDD 更新項目を明記
- **DSL 仕様には一切言及しない**（実装を真実とする方針）

## 更新

- `docs/planning/RUST_ENGINE_MIGRATION_PLAN.md`: Phase 区分と新規 Issue #105-108 を追記
- `docs/core/INDEX.md`: アーキテクチャ文書へのリンク追加

## 関連 Issue

- 新規作成: #105 (Epic), #106 (workspace split), #107 (daemon), #108 (TS client)
- 既存へ追記: #93, #95 にアーキテクチャ方針コメント

## 非目標

- 実装コード変更なし（本 PR は 100% ドキュメント）
- DSL 仕様変更なし
- TS engine 側への影響なし

## Test plan

- [x] 文書のリンクが全て解決
- [x] Issue 番号の参照が正確
- [x] CLAUDE.md / 既存 INDEX.md の方針に整合