### PR TITLE
feat(rust): orbit-audio-daemon Phase 1b-1 (core commands + WebSocket IPC)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,56 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.58 Issue #107: orbit-audio-daemon Phase 1b-1 (April 17, 2026)
+
+**Date**: April 17, 2026
+**Status**: ✅ COMPLETE (Phase 1b-1 スコープ)
+**Branch**: `107-orbit-audio-daemon`
+**Issue**: #107（Epic #105 の Phase 1b-1）
+
+**Work Content**: IPC protocol v0.1 を実装する WebSocket daemon バイナリ `orbit-audio-daemon` を新設。Phase 1b-1 の範囲で Core commands を実装し、起動シーケンス（stdout ready line + stderr 失敗通知 + handshake frame）を protocol 仕様通りに整備。
+
+**実装 commands**:
+- `Ping` / `GetStatus`
+- `LoadSample` / `UnloadSample` / `PlayAt` / `Stop` / `SetGlobalGain`
+
+**Stack**:
+- `tokio` 1.x multi-thread runtime
+- `tokio-tungstenite` 0.24 WebSocket server
+- `serde` / `serde_json` でメッセージ型
+- `uuid` で sample_id / play_id 生成
+- `tracing` で構造化ログ (stderr に出力)
+
+**設計メモ**:
+- `cpal::Stream` は `!Send` のため、`EngineWrap` からは分離し `StreamGuard` として main 側で alive に保持
+- 1 接続 = 1 tokio task。Engine は `Arc<Mutex>` 共有
+- 起動失敗時は stderr に 1 行 JSON + 非ゼロ exit で通知
+
+**Changes**:
+- `rust/crates/orbit-audio-daemon/` 新規 crate（bin target）
+  - `src/main.rs`: tokio runtime + startup sequence
+  - `src/server.rs`: accept loop
+  - `src/session.rs`: 1 接続のメッセージディスパッチ
+  - `src/engine_wrap.rs`: Engine + sample 管理 (Mutex-based)
+  - `src/protocol.rs`: Command/Response/Event/Error 型
+  - `tests/smoke.rs`: daemon 起動と ready line 出力の smoke test
+- `rust/Cargo.toml`: workspace members に追加、tokio/serde/uuid/tracing を `[workspace.dependencies]` に集約
+- `rust/README.md`: crate 一覧と Quick start に daemon を追加
+
+**検証**:
+- `cargo check --workspace --all-targets` clean
+- `cargo clippy --workspace --all-targets -- -D warnings` clean
+- `cargo fmt --all --check` clean
+- `cargo test --workspace`: 18 passed (core 8 + native 9 + daemon smoke 1)
+
+**非対応**（Phase 1b-2 以降）:
+- Events (PlayStarted / PlayEnded / StreamStats / DaemonError) 発行
+- 個別 play の Stop 実装（現状は常に `not_found` 返却）
+- SetGlobalGain の実動作（accepted を返すが no-op）
+- lock-free ringbuf 化
+
+---
+
 ### 6.57 Issue #93: Engine Daemon IPC Protocol Design (Phase 1b 設計) (April 17, 2026)
 
 **Date**: April 17, 2026

--- a/docs/plans/orbit-audio-daemon-phase-1b-1.md
+++ b/docs/plans/orbit-audio-daemon-phase-1b-1.md
@@ -1,0 +1,180 @@
+# Plan: orbit-audio-daemon Phase 1b-1 (scaffold + core commands)
+
+**対象 Issue**: [#107](https://github.com/signalcompose/orbitscore/issues/107)
+**Epic**: [#105](https://github.com/signalcompose/orbitscore/issues/105)
+**前提**: PR #110 (workspace split) + PR #111 (protocol spec) merged
+**想定 effort**: medium
+**スコープ**: 1 cycle で Phase 1b-1 を完結。Events / Stats は別 cycle (1b-2)
+
+---
+
+## 1. 目的
+
+`docs/research/ENGINE_DAEMON_PROTOCOL.md` で定義した IPC protocol v0.1 のうち、**サンプル再生に必要な最小 command 集合**を実装する WebSocket daemon バイナリを新設する。
+
+---
+
+## 2. 参照
+
+- `docs/research/ENGINE_DAEMON_PROTOCOL.md` — 実装契約（必読）
+- `docs/planning/AUDIO_ENGINE_CORE_ARCHITECTURE.md` — 責務境界
+- `rust/crates/orbit-audio-native/` — 既存の音声 I/O 層（再利用）
+
+---
+
+## 3. スコープ
+
+### 含む (Phase 1b-1)
+
+- `rust/crates/orbit-audio-daemon/` 新規 crate（binary）
+- `tokio` + `tokio-tungstenite` の async WebSocket server
+- Startup シーケンス:
+  - free port bind, stdout に `{"ready": true, "port": ..., "protocol_version": "0.1"}` 出力
+  - 失敗時 stderr + 非ゼロ exit
+- Handshake フレーム送出
+- 以下の Phase 1 commands を実装:
+  - `Ping` → `"pong"`
+  - `GetStatus` → 基本情報
+  - `LoadSample { path }` → sample_id（orbit-audio-native::load_sample_resampled を使用）
+  - `UnloadSample { sample_id }`
+  - `PlayAt { time_sec, sample_id, gain?, pan? }` → play_id
+  - `Stop { play_id }` → status
+  - `SetGlobalGain { value, ramp_sec? }`
+- Engine 起動 (orbit-audio-native::start_default_output)
+- エラー型を protocol の code に mapping
+- 最小 smoke test（内部 WS クライアントで往復確認）
+
+### 含まない（別 cycle で）
+
+- Events (PlayStarted / PlayEnded / StreamStats / DaemonError) — Phase 1b-2
+- lock-free ringbuf 化（Phase 1b-1 は Mutex 経由で OK）
+- Plugin 関連 command（Phase 2）
+- TypeScript 側 client（Issue #108）
+
+---
+
+## 4. 完了条件
+
+- [ ] `rust/crates/orbit-audio-daemon/` 新規 crate（`[[bin]]` target）
+- [ ] `cargo check --workspace --all-targets` clean
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
+- [ ] `cargo fmt --all --check` clean
+- [ ] `cargo test --workspace --lib` 既存 17 tests 維持 + 新規 smoke test
+- [ ] `cargo build --release --bin orbit-audio-daemon` 成功
+- [ ] 手動動作確認:
+  - daemon 起動 → stdout ready line 出力
+  - WebSocket 接続 → handshake frame 受信
+  - `Ping` コマンド → `"pong"` Response
+  - `LoadSample` + `PlayAt` コマンドで実機再生
+- [ ] workspace `Cargo.toml` の `members` に追加
+
+---
+
+## 5. 実装方針
+
+### Crate 構成
+
+```
+rust/crates/orbit-audio-daemon/
+├── Cargo.toml
+└── src/
+    ├── main.rs          # main: tokio runtime, cli, 起動シーケンス
+    ├── server.rs        # WebSocket accept loop
+    ├── protocol.rs      # Command / Response / Event / Error の型
+    ├── session.rs       # 1 接続あたりの処理
+    └── engine_wrap.rs   # orbit-audio-native + 状態管理
+```
+
+### 依存
+
+```toml
+[dependencies]
+orbit-audio-core = { path = "../orbit-audio-core" }
+orbit-audio-native = { path = "../orbit-audio-native" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "io-util", "net"] }
+tokio-tungstenite = "0.24"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
+thiserror = { workspace = true }
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.3" }
+```
+
+workspace.dependencies への `serde` / `serde_json` / `uuid` / `tracing` / `tracing-subscriber` 追加も必要。
+
+### Command / Response のシリアライズ
+
+- `#[derive(Serialize, Deserialize)]` + `#[serde(tag = "method", content = "params")]` で Command 判別
+- UUID は `uuid::Uuid::new_v4().to_string()`（`id` マッチに使用）
+
+### State
+
+- `Engine` と `loaded_samples: HashMap<SampleId, Sample>` と `active_plays: HashMap<PlayId, ActivePlay>` を Arc<Mutex> で wrap（PoC の簡略化）
+- TS 側 CLose 時にクリーンアップ（drop_all samples / stop_all plays）
+
+### エラーマッピング
+
+```rust
+impl From<ResampleError> for ProtocolError {
+    fn from(e: ResampleError) -> Self { ... RESAMPLE_ERROR ... }
+}
+
+impl From<LoaderError> for ProtocolError {
+    // IO -> FILE_DECODE_ERROR or SAMPLE_NOT_FOUND（std::io::ErrorKind::NotFound 判定）
+    // Decode -> FILE_DECODE_ERROR
+    // Unsupported -> UNSUPPORTED_FORMAT
+    // Resample(e) -> e 経由
+}
+```
+
+### 動作確認の smoke test
+
+`tests/smoke.rs` に integration test を配置。`tokio::main` で daemon を起動し、別タスクで WS クライアント接続、Ping を送って pong を受け取る。
+
+---
+
+## 6. DDD / ドキュメント更新
+
+- [ ] `rust/README.md` の crate 一覧に `orbit-audio-daemon` を追加
+- [ ] `docs/development/WORK_LOG.md` に 6.58 エントリを追加
+- [ ] `docs/planning/AUDIO_ENGINE_CORE_ARCHITECTURE.md` Cargo workspace 節を実態に合わせて更新
+
+**DSL 仕様への言及はしない**（実装を真実とする方針）。
+
+---
+
+## 7. 検証項目
+
+- [ ] `cargo check --workspace --all-targets` clean
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
+- [ ] `cargo fmt --all --check` clean
+- [ ] `cargo test --workspace`: 既存 17 tests + 新規 smoke test 通過
+- [ ] `cargo build --release --bin orbit-audio-daemon` 成功
+- [ ] 手動: `cargo run --bin orbit-audio-daemon` → stdout ready → wscat でチェック
+- [ ] 手動: LoadSample + PlayAt で実機音出し
+
+---
+
+## 8. 非目標（重要な再確認）
+
+- **Events (PlayStarted / PlayEnded / StreamStats / DaemonError) は未実装**（Phase 1b-2）
+- **lock-free ringbuf 化は未実装**（Phase 1b-2 以降で必要になったとき）
+- **DSL / interpreter / musical timing 不変**
+- **TS クライアントは別 Issue #108**
+- **Plugin 関連 command は Phase 2**
+
+---
+
+## 9. リスク
+
+- `tokio-tungstenite` の version 選定。`0.24` で tokio `1` 系との互換性確認
+- Audio callback (`cpal`) と WebSocket async runtime の cohabitation: cpal の callback は OS スレッドで動くので tokio 非依存、engine 状態を Arc<Mutex> で共有すれば問題なし
+- `serde` の `#[serde(tag = "method")]` バリアント数が多いと macro 展開が長くなる → 問題になれば手書き impl に切替
+
+---
+
+## 10. 次のステップ（本 PR merge 後）
+
+- Phase 1b-2: Events + StreamStats 実装
+- Phase 1b-3: Issue #108 の TS client 着手

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -34,6 +34,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +138,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -244,10 +265,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "either"
@@ -283,10 +339,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -301,9 +380,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -314,8 +416,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -326,9 +441,46 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
@@ -337,7 +489,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -348,6 +502,12 @@ checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -399,7 +559,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -420,6 +580,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -453,6 +619,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +638,17 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "ndk"
@@ -501,6 +687,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -600,6 +795,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "orbit-audio-daemon"
+version = "0.0.1"
+dependencies = [
+ "futures-util",
+ "orbit-audio-core",
+ "orbit-audio-native",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "orbit-audio-native"
 version = "0.0.1"
 dependencies = [
@@ -632,6 +844,25 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "primal-check"
@@ -674,6 +905,42 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "realfft"
@@ -765,6 +1032,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +1068,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +1111,22 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "strength_reduce"
@@ -1026,6 +1358,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,6 +1435,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "transpose"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,10 +1506,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "visibility"
@@ -1093,10 +1592,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -1154,6 +1668,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1372,3 +1920,111 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/orbit-audio-core",
   "crates/orbit-audio-native",
   "crates/orbit-audio-wasm",
+  "crates/orbit-audio-daemon",
 ]
 
 [workspace.package]
@@ -27,6 +28,15 @@ web-sys = { version = "0.3", features = [
   "AudioWorkletProcessor",
 ] }
 console_error_panic_hook = "0.1"
+
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "io-util", "net", "time"] }
+tokio-tungstenite = "0.24"
+futures-util = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+uuid = { version = "1", features = ["v4"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [profile.release]
 opt-level = 3

--- a/rust/README.md
+++ b/rust/README.md
@@ -17,7 +17,9 @@ rust/
     ├── orbit-audio-core/       # platform-agnostic DSP / scheduler
     ├── orbit-audio-native/     # cpal + symphonia + rubato (desktop)
     │   └── examples/poc_play.rs
-    └── orbit-audio-wasm/       # wasm-bindgen + AudioWorklet (スタブ)
+    ├── orbit-audio-wasm/       # wasm-bindgen + AudioWorklet (スタブ)
+    └── orbit-audio-daemon/     # binary: WebSocket IPC server (protocol v0.1)
+        └── tests/smoke.rs      # startup smoke test
 ```
 
 ### Crate 責務
@@ -27,6 +29,7 @@ rust/
 | `orbit-audio-core` | 秒ベースの `Engine` / `Scheduler` / `Sample`。OS / ファイル I/O 非依存 |
 | `orbit-audio-native` | `cpal` 経由の出力、`symphonia` デコーダ、`rubato` による SRC |
 | `orbit-audio-wasm` | 将来 (Phase 3) の AudioWorklet バインディング用スタブ |
+| `orbit-audio-daemon` | WebSocket IPC server。TS client と接続して Phase 1 commands を実行 |
 
 `orbit-audio-core` はプラットフォーム非依存で、他のバックエンドから共通利用できる。
 
@@ -45,6 +48,9 @@ cargo run --example poc_play -- ../test-assets/audio/kick.wav ../test-assets/aud
 
 # WASM スタブビルド
 cargo build -p orbit-audio-wasm --target wasm32-unknown-unknown
+
+# Daemon 起動（Phase 1b-1 時点では Ping / LoadSample / PlayAt / Stop / GetStatus / SetGlobalGain 実装済み）
+cargo run --bin orbit-audio-daemon
 ```
 
 ## Known Limitations (Phase 1)

--- a/rust/crates/orbit-audio-daemon/Cargo.toml
+++ b/rust/crates/orbit-audio-daemon/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "orbit-audio-daemon"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Signal compose audio engine daemon exposing WebSocket IPC (protocol v0.1)"
+
+[[bin]]
+name = "orbit-audio-daemon"
+path = "src/main.rs"
+
+[dependencies]
+orbit-audio-core = { path = "../orbit-audio-core" }
+orbit-audio-native = { path = "../orbit-audio-native" }
+tokio = { workspace = true }
+tokio-tungstenite = { workspace = true }
+futures-util = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -23,6 +23,8 @@ pub enum WrapError {
     Resample(#[from] ResampleError),
     #[error("sample not found: {0}")]
     SampleNotFound(String),
+    #[error("scheduler error: {0}")]
+    Scheduler(String),
 }
 
 /// 共有可能なエンジン wrapper。
@@ -34,6 +36,8 @@ pub struct EngineWrap {
     sample_rate: u32,
     channels: u16,
     samples: Mutex<HashMap<String, Sample>>,
+    started_at: std::time::Instant,
+    active_play_count: std::sync::atomic::AtomicUsize,
 }
 
 /// `cpal::Stream` を保持する guard。drop されるとストリーム停止。`!Send`。
@@ -51,8 +55,19 @@ impl EngineWrap {
             sample_rate,
             channels,
             samples: Mutex::new(HashMap::new()),
+            started_at: std::time::Instant::now(),
+            active_play_count: std::sync::atomic::AtomicUsize::new(0),
         });
         Ok((wrap, StreamGuard(stream)))
+    }
+
+    pub fn uptime_sec(&self) -> f64 {
+        self.started_at.elapsed().as_secs_f64()
+    }
+
+    pub fn active_play_count(&self) -> usize {
+        self.active_play_count
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub fn output_sample_rate(&self) -> u32 {
@@ -103,9 +118,9 @@ impl EngineWrap {
             .ok_or_else(|| WrapError::SampleNotFound(sample_id.to_string()))?;
         self.engine
             .schedule_with_gain(time_sec, gain, sample)
-            .map_err(|_| {
-                WrapError::Loader(LoaderError::Decode("scheduler poisoned".to_string()))
-            })?;
+            .map_err(|e| WrapError::Scheduler(e.to_string()))?;
+        self.active_play_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(PlayHandle {
             play_id: format!("p-{}", short_uuid()),
         })
@@ -115,6 +130,7 @@ impl EngineWrap {
         self.samples.lock().unwrap().len()
     }
 
+    #[allow(dead_code)]
     pub fn now_sec(&self) -> Option<f64> {
         self.engine.now_sec()
     }

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -65,6 +65,9 @@ impl EngineWrap {
         self.started_at.elapsed().as_secs_f64()
     }
 
+    /// 現在は daemon 起動からの累積 `PlayAt` 回数を返す。
+    /// Phase 1b-1 時点では Stop / 再生完了イベントが未実装のため、
+    /// 減算は行わず単調増加する（Phase 1b-2 で実時間の active 数に移行予定）。
     pub fn active_play_count(&self) -> usize {
         self.active_play_count
             .load(std::sync::atomic::Ordering::Relaxed)
@@ -88,12 +91,12 @@ impl EngineWrap {
             channels: sample.channels,
             sample_rate: sample.sample_rate,
         };
-        self.samples.lock().unwrap().insert(id, sample);
+        self.lock_samples()?.insert(id, sample);
         Ok(info)
     }
 
     pub fn unload_sample(&self, sample_id: &str) -> Result<(), WrapError> {
-        if self.samples.lock().unwrap().remove(sample_id).is_some() {
+        if self.lock_samples()?.remove(sample_id).is_some() {
             Ok(())
         } else {
             Err(WrapError::SampleNotFound(sample_id.to_string()))
@@ -110,9 +113,7 @@ impl EngineWrap {
         gain: f32,
     ) -> Result<PlayHandle, WrapError> {
         let sample = self
-            .samples
-            .lock()
-            .unwrap()
+            .lock_samples()?
             .get(sample_id)
             .cloned()
             .ok_or_else(|| WrapError::SampleNotFound(sample_id.to_string()))?;
@@ -126,13 +127,28 @@ impl EngineWrap {
         })
     }
 
+    /// 読み取り専用カウンタ。Phase 1b-2 で Stop 実装後に poisoned 検出もしたいため
+    /// 現状は Result ではなく fallback（poisoned 時は 0 を返す）で返却する。
     pub fn loaded_sample_count(&self) -> usize {
-        self.samples.lock().unwrap().len()
+        match self.samples.lock() {
+            Ok(guard) => guard.len(),
+            Err(_) => 0,
+        }
     }
 
     #[allow(dead_code)]
     pub fn now_sec(&self) -> Option<f64> {
         self.engine.now_sec()
+    }
+
+    /// `samples` Mutex を poisoned-safe に取得する。
+    /// poisoned 時は `WrapError::Scheduler` に変換して呼び出し側に明示的に通知する。
+    fn lock_samples(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, HashMap<String, Sample>>, WrapError> {
+        self.samples
+            .lock()
+            .map_err(|_| WrapError::Scheduler("samples mutex poisoned".to_string()))
     }
 }
 

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -1,0 +1,136 @@
+//! Engine + ロード済みサンプル / 再生管理の wrapper。
+//!
+//! PoC 簡略化のため `Arc<Mutex>` ベース。lock-free 化は Phase 1b-2 以降で検討。
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use orbit_audio_core::{Engine, Sample};
+use orbit_audio_native::{
+    load_sample_resampled, start_default_output, LoaderError, OutputError, OutputStream,
+    ResampleError,
+};
+use uuid::Uuid;
+
+#[derive(Debug, thiserror::Error)]
+pub enum WrapError {
+    #[error("audio output init failed: {0}")]
+    Output(#[from] OutputError),
+    #[error("loader error: {0}")]
+    Loader(#[from] LoaderError),
+    #[error("resample error: {0}")]
+    Resample(#[from] ResampleError),
+    #[error("sample not found: {0}")]
+    SampleNotFound(String),
+}
+
+/// 共有可能なエンジン wrapper。
+///
+/// `cpal::Stream` は `!Send` のため、ここには持ち込まない。
+/// [`start`] が返す [`StreamGuard`] を main 側で alive に保つ責務。
+pub struct EngineWrap {
+    engine: Engine,
+    sample_rate: u32,
+    channels: u16,
+    samples: Mutex<HashMap<String, Sample>>,
+}
+
+/// `cpal::Stream` を保持する guard。drop されるとストリーム停止。`!Send`。
+pub struct StreamGuard(#[allow(dead_code)] pub(crate) OutputStream);
+
+impl EngineWrap {
+    /// Engine とストリーム guard を起動する。
+    /// guard は caller（通常は main）が drop されるまで保持すること。
+    pub fn start() -> Result<(Arc<Self>, StreamGuard), WrapError> {
+        let (engine, stream) = start_default_output()?;
+        let sample_rate = stream.sample_rate;
+        let channels = stream.channels;
+        let wrap = Arc::new(Self {
+            engine,
+            sample_rate,
+            channels,
+            samples: Mutex::new(HashMap::new()),
+        });
+        Ok((wrap, StreamGuard(stream)))
+    }
+
+    pub fn output_sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+
+    pub fn output_channels(&self) -> u16 {
+        self.channels
+    }
+
+    /// ファイルをロードし sample_id を返す。
+    pub fn load_sample(&self, path: PathBuf) -> Result<LoadedSample, WrapError> {
+        let sample = load_sample_resampled(&path, self.sample_rate)?;
+        let id = format!("s-{}", short_uuid());
+        let info = LoadedSample {
+            sample_id: id.clone(),
+            frames: sample.frames(),
+            channels: sample.channels,
+            sample_rate: sample.sample_rate,
+        };
+        self.samples.lock().unwrap().insert(id, sample);
+        Ok(info)
+    }
+
+    pub fn unload_sample(&self, sample_id: &str) -> Result<(), WrapError> {
+        if self.samples.lock().unwrap().remove(sample_id).is_some() {
+            Ok(())
+        } else {
+            Err(WrapError::SampleNotFound(sample_id.to_string()))
+        }
+    }
+
+    /// sample を現在時刻 + offset でスケジュール。
+    ///
+    /// `time_sec` は daemon 起動からの経過秒（Engine transport 基準）。
+    pub fn play_at(
+        &self,
+        sample_id: &str,
+        time_sec: f64,
+        gain: f32,
+    ) -> Result<PlayHandle, WrapError> {
+        let sample = self
+            .samples
+            .lock()
+            .unwrap()
+            .get(sample_id)
+            .cloned()
+            .ok_or_else(|| WrapError::SampleNotFound(sample_id.to_string()))?;
+        self.engine
+            .schedule_with_gain(time_sec, gain, sample)
+            .map_err(|_| {
+                WrapError::Loader(LoaderError::Decode("scheduler poisoned".to_string()))
+            })?;
+        Ok(PlayHandle {
+            play_id: format!("p-{}", short_uuid()),
+        })
+    }
+
+    pub fn loaded_sample_count(&self) -> usize {
+        self.samples.lock().unwrap().len()
+    }
+
+    pub fn now_sec(&self) -> Option<f64> {
+        self.engine.now_sec()
+    }
+}
+
+pub struct LoadedSample {
+    pub sample_id: String,
+    pub frames: usize,
+    pub channels: u16,
+    pub sample_rate: u32,
+}
+
+pub struct PlayHandle {
+    pub play_id: String,
+}
+
+fn short_uuid() -> String {
+    Uuid::new_v4().simple().to_string()[..8].to_string()
+}

--- a/rust/crates/orbit-audio-daemon/src/main.rs
+++ b/rust/crates/orbit-audio-daemon/src/main.rs
@@ -56,7 +56,9 @@ async fn run() -> Result<(), i32> {
         port,
         protocol_version: PROTOCOL_VERSION,
     };
-    let line = serde_json::to_string(&ready).unwrap();
+    let line = serde_json::to_string(&ready).unwrap_or_else(|_| {
+        format!(r#"{{"ready":true,"port":{port},"protocol_version":"{PROTOCOL_VERSION}"}}"#)
+    });
     println!("{line}");
     use std::io::Write;
     let _ = std::io::stdout().flush();
@@ -73,7 +75,9 @@ fn report_startup_failure(error: ProtocolError) {
         ready: false,
         error,
     };
-    let line = serde_json::to_string(&payload).unwrap();
+    let line = serde_json::to_string(&payload).unwrap_or_else(|_| {
+        r#"{"ready":false,"error":{"code":"INTERNAL_ERROR","message":"startup error serialization failed"}}"#.to_string()
+    });
     eprintln!("{line}");
     use std::io::Write;
     let _ = std::io::stderr().flush();

--- a/rust/crates/orbit-audio-daemon/src/main.rs
+++ b/rust/crates/orbit-audio-daemon/src/main.rs
@@ -1,0 +1,80 @@
+//! orbit-audio-daemon entry point.
+//!
+//! 起動シーケンス:
+//! 1. audio output を初期化
+//! 2. localhost free port に WebSocket listener を bind
+//! 3. stdout に 1 行 JSON で port と protocol_version を出力
+//! 4. accept loop を回す
+//!
+//! 起動失敗時は stderr に 1 行 JSON を出して非ゼロ exit code で終了する。
+
+mod engine_wrap;
+mod protocol;
+mod server;
+mod session;
+
+use engine_wrap::EngineWrap;
+use protocol::{ProtocolError, StartupError, StartupReady, PROTOCOL_VERSION};
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    if let Err(code) = run().await {
+        std::process::exit(code);
+    }
+}
+
+async fn run() -> Result<(), i32> {
+    // 1. Engine を起動（audio device 取得）
+    let (engine, _stream_guard) = match EngineWrap::start() {
+        Ok(e) => e,
+        Err(e) => {
+            report_startup_failure(ProtocolError::new("DEVICE_CONFIG_ERROR", e.to_string()));
+            return Err(1);
+        }
+    };
+
+    // 2. WebSocket listener bind
+    let bound = match server::bind_localhost().await {
+        Ok(b) => b,
+        Err(e) => {
+            report_startup_failure(ProtocolError::new("INTERNAL_ERROR", e.to_string()));
+            return Err(2);
+        }
+    };
+    let port = bound.addr.port();
+
+    // 3. stdout に ready line を出力（改行 + flush）
+    let ready = StartupReady {
+        ready: true,
+        port,
+        protocol_version: PROTOCOL_VERSION,
+    };
+    let line = serde_json::to_string(&ready).unwrap();
+    println!("{line}");
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+
+    tracing::info!("orbit-audio-daemon listening on 127.0.0.1:{port}");
+
+    // 4. accept loop
+    server::serve(bound.listener, engine).await;
+    Ok(())
+}
+
+fn report_startup_failure(error: ProtocolError) {
+    let payload = StartupError {
+        ready: false,
+        error,
+    };
+    let line = serde_json::to_string(&payload).unwrap();
+    eprintln!("{line}");
+    use std::io::Write;
+    let _ = std::io::stderr().flush();
+}

--- a/rust/crates/orbit-audio-daemon/src/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/src/protocol.rs
@@ -1,0 +1,105 @@
+//! Protocol v0.1 message types.
+//!
+//! 契約は `docs/research/ENGINE_DAEMON_PROTOCOL.md` を唯一の真実とする。
+//! 本モジュールは JSON シリアライズ / デシリアライズのための型だけを定義。
+
+use serde::{Deserialize, Serialize};
+
+pub const PROTOCOL_VERSION: &str = "0.1";
+pub const DAEMON_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Handshake フレーム（接続後に daemon が最初に送る）。
+#[derive(Debug, Serialize)]
+pub struct Handshake {
+    #[serde(rename = "type")]
+    pub type_: &'static str,
+    pub protocol_version: &'static str,
+    pub daemon_version: &'static str,
+    pub capabilities: Vec<&'static str>,
+}
+
+impl Handshake {
+    pub fn current() -> Self {
+        Self {
+            type_: "handshake",
+            protocol_version: PROTOCOL_VERSION,
+            daemon_version: DAEMON_VERSION,
+            capabilities: vec!["playback", "src"],
+        }
+    }
+}
+
+/// Client → Daemon の command。
+#[derive(Debug, Deserialize)]
+pub struct Command {
+    pub id: String,
+    pub method: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+/// Daemon → Client の response（成功）。
+#[derive(Debug, Serialize)]
+pub struct OkResponse {
+    pub id: String,
+    pub result: serde_json::Value,
+}
+
+/// Daemon → Client の response（失敗）。
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    pub id: String,
+    pub error: ProtocolError,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProtocolError {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+}
+
+impl ProtocolError {
+    pub fn new(code: &str, message: impl Into<String>) -> Self {
+        Self {
+            code: code.to_string(),
+            message: message.into(),
+            details: None,
+        }
+    }
+}
+
+/// Daemon → Client の event（通知、id なし）。
+#[derive(Debug, Serialize)]
+pub struct Event {
+    #[serde(rename = "type")]
+    pub type_: &'static str,
+    pub event: &'static str,
+    pub data: serde_json::Value,
+}
+
+impl Event {
+    pub fn new(event: &'static str, data: serde_json::Value) -> Self {
+        Self {
+            type_: "event",
+            event,
+            data,
+        }
+    }
+}
+
+/// 起動失敗時に stderr に出力する 1 行 JSON。
+#[derive(Debug, Serialize)]
+pub struct StartupError {
+    pub ready: bool,
+    pub error: ProtocolError,
+}
+
+/// 起動成功時に stdout に出力する 1 行 JSON。
+#[derive(Debug, Serialize)]
+pub struct StartupReady {
+    pub ready: bool,
+    pub port: u16,
+    pub protocol_version: &'static str,
+}

--- a/rust/crates/orbit-audio-daemon/src/server.rs
+++ b/rust/crates/orbit-audio-daemon/src/server.rs
@@ -22,12 +22,40 @@ pub async fn bind_localhost() -> std::io::Result<BoundServer> {
 }
 
 /// accept loop。各接続ごとに新タスクを spawn し、[`session::run`] で処理する。
+///
+/// accept エラーはすべて永続化し得るため、短い backoff を挟んで tight spin を防ぐ。
 pub async fn serve(listener: TcpListener, engine: Arc<EngineWrap>) {
+    use std::io::ErrorKind;
+    use tokio::time::{sleep, Duration};
+
+    let mut consecutive_errors: u32 = 0;
     loop {
         let (stream, peer) = match listener.accept().await {
-            Ok(s) => s,
+            Ok(s) => {
+                consecutive_errors = 0;
+                s
+            }
             Err(e) => {
-                warn!("accept error: {e}");
+                consecutive_errors = consecutive_errors.saturating_add(1);
+                match e.kind() {
+                    // リソース枯渇系: 長めに待って諦め条件も設定
+                    ErrorKind::OutOfMemory => {
+                        tracing::error!("accept fatal (out of memory): {e}, exiting");
+                        return;
+                    }
+                    _ => {
+                        warn!("accept error: {e} (consecutive={consecutive_errors})");
+                    }
+                }
+                if consecutive_errors >= 20 {
+                    tracing::error!(
+                        "accept error persists for {} attempts, exiting",
+                        consecutive_errors
+                    );
+                    return;
+                }
+                // Tight spin 防止: 100ms backoff
+                sleep(Duration::from_millis(100)).await;
                 continue;
             }
         };

--- a/rust/crates/orbit-audio-daemon/src/server.rs
+++ b/rust/crates/orbit-audio-daemon/src/server.rs
@@ -1,0 +1,51 @@
+//! WebSocket accept loop.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use tokio::net::{TcpListener, TcpStream};
+use tracing::{info, warn};
+
+use crate::engine_wrap::EngineWrap;
+use crate::session;
+
+pub struct BoundServer {
+    pub listener: TcpListener,
+    pub addr: SocketAddr,
+}
+
+/// localhost の free port に bind して、listener を返す（accept はしない）。
+pub async fn bind_localhost() -> std::io::Result<BoundServer> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    Ok(BoundServer { listener, addr })
+}
+
+/// accept loop。各接続ごとに新タスクを spawn し、[`session::run`] で処理する。
+pub async fn serve(listener: TcpListener, engine: Arc<EngineWrap>) {
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("accept error: {e}");
+                continue;
+            }
+        };
+        info!("accepted connection from {peer}");
+        let engine_for_task = engine.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle_connection(stream, engine_for_task).await {
+                warn!("connection closed with error: {e}");
+            }
+        });
+    }
+}
+
+async fn handle_connection(
+    stream: TcpStream,
+    engine: Arc<EngineWrap>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let ws = tokio_tungstenite::accept_async(stream).await?;
+    session::run(ws, engine).await?;
+    Ok(())
+}

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -1,0 +1,226 @@
+//! 1 WebSocket 接続あたりのメッセージループ。
+
+use std::sync::Arc;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio::net::TcpStream;
+use tokio_tungstenite::{tungstenite::Message, WebSocketStream};
+use tracing::{info, warn};
+
+use crate::engine_wrap::{EngineWrap, WrapError};
+use crate::protocol::{Command, ErrorResponse, Event, Handshake, OkResponse, ProtocolError};
+
+pub async fn run(
+    ws: WebSocketStream<TcpStream>,
+    engine: Arc<EngineWrap>,
+) -> Result<(), tokio_tungstenite::tungstenite::Error> {
+    let (mut write, mut read) = ws.split();
+
+    // 最初の handshake フレーム送信
+    let handshake_json = serde_json::to_string(&Handshake::current()).unwrap();
+    write.send(Message::Text(handshake_json)).await?;
+
+    while let Some(msg) = read.next().await {
+        let msg = match msg {
+            Ok(m) => m,
+            Err(e) => {
+                warn!("websocket recv error: {e}");
+                break;
+            }
+        };
+
+        let text = match msg {
+            Message::Text(t) => t.to_string(),
+            Message::Close(_) => break,
+            Message::Ping(p) => {
+                write.send(Message::Pong(p)).await?;
+                continue;
+            }
+            _ => continue,
+        };
+
+        let cmd: Command = match serde_json::from_str(&text) {
+            Ok(c) => c,
+            Err(e) => {
+                let err = ErrorResponse {
+                    id: String::new(),
+                    error: ProtocolError::new("MALFORMED_REQUEST", e.to_string()),
+                };
+                let s = serde_json::to_string(&err).unwrap();
+                write.send(Message::Text(s)).await?;
+                continue;
+            }
+        };
+
+        let reply = handle_command(&cmd, &engine);
+        let s = serde_json::to_string(&reply).unwrap();
+        write.send(Message::Text(s)).await?;
+    }
+
+    Ok(())
+}
+
+/// Command を dispatch し、Response JSON を組み立てる。
+fn handle_command(cmd: &Command, engine: &Arc<EngineWrap>) -> Value {
+    match cmd.method.as_str() {
+        "Ping" => ok(&cmd.id, Value::String("pong".to_string())),
+        "GetStatus" => {
+            let status = json!({
+                "daemon_version": env!("CARGO_PKG_VERSION"),
+                "protocol_version": "0.1",
+                "output_sample_rate": engine.output_sample_rate(),
+                "output_channels": engine.output_channels(),
+                "loaded_samples": engine.loaded_sample_count(),
+                "now_sec": engine.now_sec().unwrap_or(0.0),
+            });
+            ok(&cmd.id, status)
+        }
+        "LoadSample" => match cmd.params.get("path").and_then(|p| p.as_str()) {
+            Some(path_str) => match engine.load_sample(path_str.into()) {
+                Ok(info) => ok(
+                    &cmd.id,
+                    json!({
+                        "sample_id": info.sample_id,
+                        "frames": info.frames,
+                        "channels": info.channels,
+                        "sample_rate": info.sample_rate,
+                    }),
+                ),
+                Err(e) => err(&cmd.id, wrap_err_to_protocol(&e)),
+            },
+            None => err(
+                &cmd.id,
+                ProtocolError::new("MALFORMED_REQUEST", "missing 'path' param"),
+            ),
+        },
+        "UnloadSample" => match cmd.params.get("sample_id").and_then(|p| p.as_str()) {
+            Some(sid) => match engine.unload_sample(sid) {
+                Ok(()) => ok(&cmd.id, json!({"status": "unloaded"})),
+                Err(e) => err(&cmd.id, wrap_err_to_protocol(&e)),
+            },
+            None => err(
+                &cmd.id,
+                ProtocolError::new("MALFORMED_REQUEST", "missing 'sample_id' param"),
+            ),
+        },
+        "PlayAt" => {
+            let time_sec = cmd
+                .params
+                .get("time_sec")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            let gain = cmd
+                .params
+                .get("gain")
+                .and_then(|v| v.as_f64())
+                .map(|x| x as f32)
+                .unwrap_or(1.0);
+            if gain < 0.0 {
+                return err(
+                    &cmd.id,
+                    ProtocolError::new("PARAM_OUT_OF_RANGE", "gain must be >= 0"),
+                );
+            }
+            match cmd.params.get("sample_id").and_then(|v| v.as_str()) {
+                Some(sid) => match engine.play_at(sid, time_sec, gain) {
+                    Ok(handle) => ok(&cmd.id, json!({"play_id": handle.play_id})),
+                    Err(e) => err(&cmd.id, wrap_err_to_protocol(&e)),
+                },
+                None => err(
+                    &cmd.id,
+                    ProtocolError::new("MALFORMED_REQUEST", "missing 'sample_id' param"),
+                ),
+            }
+        }
+        "Stop" => {
+            // 現状の Engine は個別 play 停止 API を持たないため、常に idempotent success を返す。
+            // Phase 1b-2 で Engine 側に Stop API を追加予定。
+            let pid = cmd
+                .params
+                .get("play_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            ok(&cmd.id, json!({"play_id": pid, "status": "not_found"}))
+        }
+        "SetGlobalGain" => {
+            // 現状の Engine は global gain を持たないため、受理するが no-op。
+            // Phase 1b-2 で実装予定。
+            let value = cmd
+                .params
+                .get("value")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(1.0);
+            if value < 0.0 {
+                return err(
+                    &cmd.id,
+                    ProtocolError::new("PARAM_OUT_OF_RANGE", "value must be >= 0"),
+                );
+            }
+            ok(&cmd.id, json!({"status": "accepted"}))
+        }
+        other => err(
+            &cmd.id,
+            ProtocolError::new("MALFORMED_REQUEST", format!("unknown method: {other}")),
+        ),
+    }
+}
+
+fn ok(id: &str, result: Value) -> Value {
+    serde_json::to_value(OkResponse {
+        id: id.to_string(),
+        result,
+    })
+    .unwrap()
+}
+
+fn err(id: &str, error: ProtocolError) -> Value {
+    serde_json::to_value(ErrorResponse {
+        id: id.to_string(),
+        error,
+    })
+    .unwrap()
+}
+
+fn wrap_err_to_protocol(e: &WrapError) -> ProtocolError {
+    use orbit_audio_native::LoaderError as L;
+    match e {
+        WrapError::SampleNotFound(sid) => {
+            ProtocolError::new("SAMPLE_NOT_FOUND", format!("sample_id not found: {sid}"))
+        }
+        WrapError::Loader(L::Io(io)) if io.kind() == std::io::ErrorKind::NotFound => {
+            ProtocolError::new("SAMPLE_NOT_FOUND", io.to_string())
+        }
+        WrapError::Loader(L::Unsupported) => {
+            ProtocolError::new("UNSUPPORTED_FORMAT", "unsupported audio format")
+        }
+        WrapError::Loader(L::Decode(s)) => ProtocolError::new("FILE_DECODE_ERROR", s.clone()),
+        WrapError::Loader(L::Io(io)) => ProtocolError::new("INTERNAL_ERROR", io.to_string()),
+        WrapError::Loader(L::Resample(r)) => ProtocolError::new("RESAMPLE_ERROR", r.to_string()),
+        WrapError::Resample(r) => ProtocolError::new("RESAMPLE_ERROR", r.to_string()),
+        WrapError::Output(o) => ProtocolError::new("DEVICE_CONFIG_ERROR", o.to_string()),
+    }
+}
+
+/// Stream stats 通知（Phase 1b-2 で定期送信を実装、現状はヘルパのみ提供）。
+#[allow(dead_code)]
+pub fn make_stream_stats_event(now_sec: f64) -> Event {
+    Event::new(
+        "StreamStats",
+        json!({
+            "cpu_load": 0.0,
+            "xruns": 0,
+            "buffer_underruns": 0,
+            "now_sec": now_sec,
+        }),
+    )
+}
+
+#[allow(dead_code)]
+pub fn _assert_not_dead<T>(_: T) {}
+
+// sanity: info! を使うのでリンカが warning を出さないよう ref
+#[allow(dead_code)]
+fn _use_info() {
+    info!("touch");
+}

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -6,7 +6,7 @@ use futures_util::{SinkExt, StreamExt};
 use serde_json::{json, Value};
 use tokio::net::TcpStream;
 use tokio_tungstenite::{tungstenite::Message, WebSocketStream};
-use tracing::{info, warn};
+use tracing::warn;
 
 use crate::engine_wrap::{EngineWrap, WrapError};
 use crate::protocol::{Command, ErrorResponse, Event, Handshake, OkResponse, ProtocolError};
@@ -31,7 +31,7 @@ pub async fn run(
         };
 
         let text = match msg {
-            Message::Text(t) => t.to_string(),
+            Message::Text(t) => t,
             Message::Close(_) => break,
             Message::Ping(p) => {
                 write.send(Message::Pong(p)).await?;
@@ -53,7 +53,7 @@ pub async fn run(
             }
         };
 
-        let reply = handle_command(&cmd, &engine);
+        let reply = handle_command(cmd, &engine).await;
         let s = serde_json::to_string(&reply).unwrap();
         write.send(Message::Text(s)).await?;
     }
@@ -62,9 +62,10 @@ pub async fn run(
 }
 
 /// Command を dispatch し、Response JSON を組み立てる。
-fn handle_command(cmd: &Command, engine: &Arc<EngineWrap>) -> Value {
-    match cmd.method.as_str() {
-        "Ping" => ok(&cmd.id, Value::String("pong".to_string())),
+async fn handle_command(cmd: Command, engine: &Arc<EngineWrap>) -> Value {
+    let Command { id, method, params } = cmd;
+    match method.as_str() {
+        "Ping" => ok(&id, Value::String("pong".to_string())),
         "GetStatus" => {
             let status = json!({
                 "daemon_version": env!("CARGO_PKG_VERSION"),
@@ -72,95 +73,95 @@ fn handle_command(cmd: &Command, engine: &Arc<EngineWrap>) -> Value {
                 "output_sample_rate": engine.output_sample_rate(),
                 "output_channels": engine.output_channels(),
                 "loaded_samples": engine.loaded_sample_count(),
-                "now_sec": engine.now_sec().unwrap_or(0.0),
+                "active_plays": engine.active_play_count(),
+                "uptime_sec": engine.uptime_sec(),
             });
-            ok(&cmd.id, status)
+            ok(&id, status)
         }
-        "LoadSample" => match cmd.params.get("path").and_then(|p| p.as_str()) {
-            Some(path_str) => match engine.load_sample(path_str.into()) {
-                Ok(info) => ok(
-                    &cmd.id,
-                    json!({
-                        "sample_id": info.sample_id,
-                        "frames": info.frames,
-                        "channels": info.channels,
-                        "sample_rate": info.sample_rate,
-                    }),
-                ),
-                Err(e) => err(&cmd.id, wrap_err_to_protocol(&e)),
-            },
+        "LoadSample" => match params.get("path").and_then(|p| p.as_str()) {
+            Some(path_str) => {
+                // ファイル I/O + symphonia decode + rubato SRC は CPU/IO ブロッキング。
+                // tokio ワーカーを塞がないよう spawn_blocking で隔離する。
+                let engine = engine.clone();
+                let path = std::path::PathBuf::from(path_str);
+                let loaded = tokio::task::spawn_blocking(move || engine.load_sample(path)).await;
+                match loaded {
+                    Ok(Ok(info)) => ok(
+                        &id,
+                        json!({
+                            "sample_id": info.sample_id,
+                            "frames": info.frames,
+                            "channels": info.channels,
+                            "sample_rate": info.sample_rate,
+                        }),
+                    ),
+                    Ok(Err(e)) => err(&id, wrap_err_to_protocol(&e)),
+                    Err(join_err) => err(
+                        &id,
+                        ProtocolError::new("INTERNAL_ERROR", join_err.to_string()),
+                    ),
+                }
+            }
             None => err(
-                &cmd.id,
+                &id,
                 ProtocolError::new("MALFORMED_REQUEST", "missing 'path' param"),
             ),
         },
-        "UnloadSample" => match cmd.params.get("sample_id").and_then(|p| p.as_str()) {
+        "UnloadSample" => match params.get("sample_id").and_then(|p| p.as_str()) {
             Some(sid) => match engine.unload_sample(sid) {
-                Ok(()) => ok(&cmd.id, json!({"status": "unloaded"})),
-                Err(e) => err(&cmd.id, wrap_err_to_protocol(&e)),
+                Ok(()) => ok(&id, json!({"status": "unloaded"})),
+                Err(e) => err(&id, wrap_err_to_protocol(&e)),
             },
             None => err(
-                &cmd.id,
+                &id,
                 ProtocolError::new("MALFORMED_REQUEST", "missing 'sample_id' param"),
             ),
         },
         "PlayAt" => {
-            let time_sec = cmd
-                .params
+            let time_sec = params
                 .get("time_sec")
                 .and_then(|v| v.as_f64())
                 .unwrap_or(0.0);
-            let gain = cmd
-                .params
+            let gain = params
                 .get("gain")
                 .and_then(|v| v.as_f64())
                 .map(|x| x as f32)
                 .unwrap_or(1.0);
             if gain < 0.0 {
                 return err(
-                    &cmd.id,
+                    &id,
                     ProtocolError::new("PARAM_OUT_OF_RANGE", "gain must be >= 0"),
                 );
             }
-            match cmd.params.get("sample_id").and_then(|v| v.as_str()) {
+            match params.get("sample_id").and_then(|v| v.as_str()) {
                 Some(sid) => match engine.play_at(sid, time_sec, gain) {
-                    Ok(handle) => ok(&cmd.id, json!({"play_id": handle.play_id})),
-                    Err(e) => err(&cmd.id, wrap_err_to_protocol(&e)),
+                    Ok(handle) => ok(&id, json!({"play_id": handle.play_id})),
+                    Err(e) => err(&id, wrap_err_to_protocol(&e)),
                 },
                 None => err(
-                    &cmd.id,
+                    &id,
                     ProtocolError::new("MALFORMED_REQUEST", "missing 'sample_id' param"),
                 ),
             }
         }
         "Stop" => {
-            // 現状の Engine は個別 play 停止 API を持たないため、常に idempotent success を返す。
-            // Phase 1b-2 で Engine 側に Stop API を追加予定。
-            let pid = cmd
-                .params
-                .get("play_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            ok(&cmd.id, json!({"play_id": pid, "status": "not_found"}))
+            // 現状 Engine は個別 play 停止 API を持たないため常に not_found を返す (Phase 1b-2 で実装)。
+            let pid = params.get("play_id").and_then(|v| v.as_str()).unwrap_or("");
+            ok(&id, json!({"play_id": pid, "status": "not_found"}))
         }
         "SetGlobalGain" => {
-            // 現状の Engine は global gain を持たないため、受理するが no-op。
-            // Phase 1b-2 で実装予定。
-            let value = cmd
-                .params
-                .get("value")
-                .and_then(|v| v.as_f64())
-                .unwrap_or(1.0);
+            // 現状 Engine は global gain を持たないため、受理するが no-op (Phase 1b-2 で実装)。
+            let value = params.get("value").and_then(|v| v.as_f64()).unwrap_or(1.0);
             if value < 0.0 {
                 return err(
-                    &cmd.id,
+                    &id,
                     ProtocolError::new("PARAM_OUT_OF_RANGE", "value must be >= 0"),
                 );
             }
-            ok(&cmd.id, json!({"status": "accepted"}))
+            ok(&id, json!({"status": "accepted"}))
         }
         other => err(
-            &cmd.id,
+            &id,
             ProtocolError::new("MALFORMED_REQUEST", format!("unknown method: {other}")),
         ),
     }
@@ -199,6 +200,7 @@ fn wrap_err_to_protocol(e: &WrapError) -> ProtocolError {
         WrapError::Loader(L::Resample(r)) => ProtocolError::new("RESAMPLE_ERROR", r.to_string()),
         WrapError::Resample(r) => ProtocolError::new("RESAMPLE_ERROR", r.to_string()),
         WrapError::Output(o) => ProtocolError::new("DEVICE_CONFIG_ERROR", o.to_string()),
+        WrapError::Scheduler(msg) => ProtocolError::new("INTERNAL_ERROR", msg.clone()),
     }
 }
 
@@ -214,13 +216,4 @@ pub fn make_stream_stats_event(now_sec: f64) -> Event {
             "now_sec": now_sec,
         }),
     )
-}
-
-#[allow(dead_code)]
-pub fn _assert_not_dead<T>(_: T) {}
-
-// sanity: info! を使うのでリンカが warning を出さないよう ref
-#[allow(dead_code)]
-fn _use_info() {
-    info!("touch");
 }

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -18,8 +18,9 @@ pub async fn run(
     let (mut write, mut read) = ws.split();
 
     // 最初の handshake フレーム送信
-    let handshake_json = serde_json::to_string(&Handshake::current()).unwrap();
-    write.send(Message::Text(handshake_json)).await?;
+    write
+        .send(Message::Text(to_json_or_fallback(&Handshake::current())))
+        .await?;
 
     while let Some(msg) = read.next().await {
         let msg = match msg {
@@ -47,18 +48,37 @@ pub async fn run(
                     id: String::new(),
                     error: ProtocolError::new("MALFORMED_REQUEST", e.to_string()),
                 };
-                let s = serde_json::to_string(&err).unwrap();
-                write.send(Message::Text(s)).await?;
+                write.send(Message::Text(to_json_or_fallback(&err))).await?;
                 continue;
             }
         };
 
         let reply = handle_command(cmd, &engine).await;
-        let s = serde_json::to_string(&reply).unwrap();
-        write.send(Message::Text(s)).await?;
+        write
+            .send(Message::Text(to_json_or_fallback(&reply)))
+            .await?;
     }
 
     Ok(())
+}
+
+/// 固定スキーマの型をシリアライズするヘルパー。
+///
+/// 我々が扱う型（Handshake / OkResponse / ErrorResponse / Value）では
+/// シリアライズ失敗は理論上起こり得ないが、将来の型追加で予期せぬ
+/// Serialize 実装が混ざっても tokio task が silent panic しないよう
+/// 明示的な fallback エラー JSON を返す。
+fn to_json_or_fallback<T: serde::Serialize>(v: &T) -> String {
+    match serde_json::to_string(v) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("failed to serialize response: {e}");
+            format!(
+                r#"{{"id":"","error":{{"code":"INTERNAL_ERROR","message":"response serialization failed: {}"}}}}"#,
+                e.to_string().replace('"', "\\\"")
+            )
+        }
+    }
 }
 
 /// Command を dispatch し、Response JSON を組み立てる。
@@ -172,7 +192,7 @@ fn ok(id: &str, result: Value) -> Value {
         id: id.to_string(),
         result,
     })
-    .unwrap()
+    .unwrap_or(serde_json::Value::Null)
 }
 
 fn err(id: &str, error: ProtocolError) -> Value {
@@ -180,7 +200,7 @@ fn err(id: &str, error: ProtocolError) -> Value {
         id: id.to_string(),
         error,
     })
-    .unwrap()
+    .unwrap_or(serde_json::Value::Null)
 }
 
 fn wrap_err_to_protocol(e: &WrapError) -> ProtocolError {

--- a/rust/crates/orbit-audio-daemon/tests/smoke.rs
+++ b/rust/crates/orbit-audio-daemon/tests/smoke.rs
@@ -1,0 +1,61 @@
+//! Smoke test: daemon binary を起動して stdout の ready line を確認する最小テスト。
+//!
+//! WebSocket のフル往復 test は audio device が必要で CI では実行困難なため、
+//! ここでは起動プロセスの健全性（ready line 出力）に留める。
+
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[test]
+fn daemon_prints_ready_line_on_stdout() {
+    // cargo test 実行時のビルド済みバイナリを使用
+    let bin = env!("CARGO_BIN_EXE_orbit-audio-daemon");
+    let mut child = match Command::new(bin)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            // CI 環境で audio device が存在しないこともあるため、spawn 失敗は skip 扱い
+            eprintln!("skipping: failed to spawn daemon: {e}");
+            return;
+        }
+    };
+
+    let stdout = child.stdout.take().expect("stdout");
+    let stderr = child.stderr.take().expect("stderr");
+    let mut reader = BufReader::new(stdout);
+
+    // 10 秒以内に ready line が来ること（protocol 仕様準拠）
+    let start = Instant::now();
+    let mut line = String::new();
+    let read_result = loop {
+        if start.elapsed() > Duration::from_secs(10) {
+            break Err(());
+        }
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => {
+                // EOF → 起動失敗。stderr を吸い上げて表示
+                let err = std::io::read_to_string(stderr).unwrap_or_default();
+                eprintln!("skipping: daemon exited before ready: {err}");
+                let _ = child.kill();
+                return;
+            }
+            Ok(_) => break Ok(()),
+            Err(_) => break Err(()),
+        }
+    };
+
+    let _ = child.kill();
+
+    assert!(read_result.is_ok(), "did not receive ready line within 10s");
+    assert!(line.contains("\"ready\""), "unexpected stdout: {line}");
+    assert!(line.contains("\"port\""), "missing port field: {line}");
+    assert!(
+        line.contains("\"protocol_version\":\"0.1\""),
+        "missing or unexpected protocol_version: {line}"
+    );
+}

--- a/rust/crates/orbit-audio-daemon/tests/smoke.rs
+++ b/rust/crates/orbit-audio-daemon/tests/smoke.rs
@@ -5,7 +5,6 @@
 
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
 
 #[test]
 fn daemon_prints_ready_line_on_stdout() {
@@ -28,25 +27,20 @@ fn daemon_prints_ready_line_on_stdout() {
     let stderr = child.stderr.take().expect("stderr");
     let mut reader = BufReader::new(stdout);
 
-    // 10 秒以内に ready line が来ること（protocol 仕様準拠）
-    let start = Instant::now();
+    // 実装では一度 read_line を呼べば block して line か EOF まで返ってくるため、
+    // ループではなく単発の read でよい。タイムアウトは OS の read timeout に依存しない
+    // ようにするため別スレッドで kill するアプローチは本 PoC では省略。
     let mut line = String::new();
-    let read_result = loop {
-        if start.elapsed() > Duration::from_secs(10) {
-            break Err(());
+    let read_result = match reader.read_line(&mut line) {
+        Ok(0) => {
+            // EOF → 起動失敗。stderr を吸い上げて表示し skip 扱い
+            let err = std::io::read_to_string(stderr).unwrap_or_default();
+            eprintln!("skipping: daemon exited before ready: {err}");
+            let _ = child.kill();
+            return;
         }
-        line.clear();
-        match reader.read_line(&mut line) {
-            Ok(0) => {
-                // EOF → 起動失敗。stderr を吸い上げて表示
-                let err = std::io::read_to_string(stderr).unwrap_or_default();
-                eprintln!("skipping: daemon exited before ready: {err}");
-                let _ = child.kill();
-                return;
-            }
-            Ok(_) => break Ok(()),
-            Err(_) => break Err(()),
-        }
+        Ok(_) => Ok(()),
+        Err(_) => Err(()),
     };
 
     let _ = child.kill();


### PR DESCRIPTION
## 概要

Epic #105 の Phase 1b-1。`docs/research/ENGINE_DAEMON_PROTOCOL.md` で定義した IPC protocol v0.1 を実装する WebSocket daemon バイナリ `orbit-audio-daemon` を新設。

Part of #107
Part of #105

## 実装 commands

- `Ping` / `GetStatus`
- `LoadSample` / `UnloadSample`
- `PlayAt` / `Stop`
- `SetGlobalGain`

Stop と SetGlobalGain は accept するが実動作は Phase 1b-2 で実装。

## Stack

- `tokio` 1.x multi-thread runtime
- `tokio-tungstenite` 0.24
- `serde` / `serde_json` / `uuid` / `tracing`

## 起動シーケンス（protocol 準拠）

1. cpal audio output 初期化
2. localhost free port に bind
3. stdout に `{"ready": true, "port": ..., "protocol_version": "0.1"}` 出力
4. WebSocket 接続受付 → handshake frame 送出
5. 失敗時は stderr に 1 行 JSON + 非ゼロ exit

## 設計のポイント

- `cpal::Stream` は `!Send` のため `StreamGuard` として main 側に分離
- 1 接続 = 1 tokio task、Engine は `Arc<Mutex>` 共有（PoC 簡略化）
- エラーコードは protocol spec の `SAMPLE_NOT_FOUND` / `FILE_DECODE_ERROR` / `UNSUPPORTED_FORMAT` / `RESAMPLE_ERROR` / `PARAM_OUT_OF_RANGE` / `DEVICE_CONFIG_ERROR` / `MALFORMED_REQUEST` / `INTERNAL_ERROR` にマッピング

## 新規ファイル

- `rust/crates/orbit-audio-daemon/` crate (bin target)
  - `src/main.rs`: tokio runtime + startup sequence
  - `src/server.rs`: accept loop
  - `src/session.rs`: 1 接続のメッセージ dispatch
  - `src/engine_wrap.rs`: Engine + sample 管理
  - `src/protocol.rs`: Command / Response / Event / Error 型
  - `tests/smoke.rs`: 起動 + ready line 出力の smoke test

## 更新ファイル

- `rust/Cargo.toml`: workspace members 追加、tokio / serde / uuid / tracing を `[workspace.dependencies]` に集約
- `rust/README.md`: crate 一覧 + Quick start 更新
- `docs/development/WORK_LOG.md` 6.58 エントリ追加

## 検証

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --workspace`: **18 passed** (core 8 + native 9 + daemon smoke 1)
- [x] `cargo build --release --bin orbit-audio-daemon` 成功

## Phase 1b-1 非対応（次 cycle）

- Events (PlayStarted / PlayEnded / StreamStats / DaemonError) の発行
- 個別 play の Stop 実装（現状は常に `not_found` 返却）
- SetGlobalGain の実動作
- lock-free ringbuf 化