### PR TITLE
feat(daemon): Phase 1b-2 PlayStarted/PlayEnded events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ credentials*
 # Slack MCP cache files (not used in OrbitScore)
 .channels_cache.json
 .users_cache.json
+.claude/scheduled_tasks.lock

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,37 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.59 Issue #107: orbit-audio-daemon Phase 1b-2 events (April 17, 2026)
+
+**Date**: April 17, 2026
+**Status**: ✅ COMPLETE (Phase 1b-2 小スコープ: PlayStarted / PlayEnded events)
+**Branch**: `107-daemon-events`
+**Issue**: #107（Phase 1b-2 の一部）
+
+**Work Content**: orbit-audio-daemon に Phase 1 event 発行を追加。`PlayStarted` を PlayAt 応答直後に送り、`PlayEnded` を `start_sec + duration_sec` で遅延送信する。writer task 分離構造 (mpsc) で、今後の StreamStats / DaemonError も同一経路で発行可能になった。
+
+**設計変更**:
+- session.rs を reader / writer 2 task 構造にリファクタ (`tokio::sync::mpsc` で合流)
+- PlayHandle に `sample_id` / `start_sec` / `duration_sec` を追加
+- `schedule_play_ended` ヘルパで遅延送信タスクを spawn
+- back pressure 用 channel capacity = 128
+
+**Changes**:
+- `rust/crates/orbit-audio-daemon/src/session.rs` を mpsc ベースに書き換え
+- `rust/crates/orbit-audio-daemon/src/engine_wrap.rs` PlayHandle 拡張
+
+**検証**:
+- cargo check / clippy / fmt / test clean、18 tests pass 継続
+- WebSocket 往復は smoke test と手動検証
+
+**非対応（将来）**:
+- StreamStats 1 Hz: 同じ mpsc 経路で追加可能、Phase 1b-3 で実装
+- DaemonError 経路: cpal err_fn からの通知経路が必要
+- 個別 Stop / SetGlobalGain の実動作: Engine API 追加が必要
+- lock-free ringbuf 化
+
+---
+
 ### 6.58 Issue #107: orbit-audio-daemon Phase 1b-1 (April 17, 2026)
 
 **Date**: April 17, 2026

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -106,6 +106,8 @@ impl EngineWrap {
     /// sample を現在時刻 + offset でスケジュール。
     ///
     /// `time_sec` は daemon 起動からの経過秒（Engine transport 基準）。
+    /// 戻り値にサンプル再生時間を含めるので、呼び出し側は PlayEnded を
+    /// 遅延送信するためのタイマーを組める。
     pub fn play_at(
         &self,
         sample_id: &str,
@@ -117,6 +119,7 @@ impl EngineWrap {
             .get(sample_id)
             .cloned()
             .ok_or_else(|| WrapError::SampleNotFound(sample_id.to_string()))?;
+        let duration_sec = sample.duration_secs();
         self.engine
             .schedule_with_gain(time_sec, gain, sample)
             .map_err(|e| WrapError::Scheduler(e.to_string()))?;
@@ -124,6 +127,9 @@ impl EngineWrap {
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(PlayHandle {
             play_id: format!("p-{}", short_uuid()),
+            sample_id: sample_id.to_string(),
+            start_sec: time_sec,
+            duration_sec,
         })
     }
 
@@ -161,6 +167,9 @@ pub struct LoadedSample {
 
 pub struct PlayHandle {
     pub play_id: String,
+    pub sample_id: String,
+    pub start_sec: f64,
+    pub duration_sec: f64,
 }
 
 fn short_uuid() -> String {

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -127,7 +127,6 @@ impl EngineWrap {
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(PlayHandle {
             play_id: format!("p-{}", short_uuid()),
-            sample_id: sample_id.to_string(),
             start_sec: time_sec,
             duration_sec,
         })
@@ -167,7 +166,6 @@ pub struct LoadedSample {
 
 pub struct PlayHandle {
     pub play_id: String,
-    pub sample_id: String,
     pub start_sec: f64,
     pub duration_sec: f64,
 }

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -58,8 +58,9 @@ pub async fn run(
             Message::Text(t) => t,
             Message::Close(_) => break,
             Message::Ping(_) => {
-                // tungstenite が自動で Pong を返すが、handshake 後はアプリ層 Ping
-                // (method="Ping") を使うことを想定しているため無視。
+                // split 後は read/write が分離しており auto-Pong は走らない。
+                // プロトコル上は application 層 method="Ping" を keepalive に使う想定で、
+                // ws-layer Ping は現状未サポート (Phase 1c で write 経由の Pong 対応検討)。
                 continue;
             }
             _ => continue,
@@ -87,7 +88,9 @@ pub async fn run(
 
     // drop で channel を閉じると writer は rx.recv() の None で exit する
     drop(tx);
-    let _ = writer_task.await;
+    if let Err(e) = writer_task.await {
+        warn!("writer task terminated abnormally: {e}");
+    }
     Ok(())
 }
 
@@ -208,7 +211,12 @@ async fn handle_command(
                                 "time_sec": handle.start_sec,
                             }),
                         );
-                        let _ = tx.send(to_json_or_fallback(&started_evt)).await;
+                        if tx.send(to_json_or_fallback(&started_evt)).await.is_err() {
+                            warn!(
+                                "PlayStarted event drop: writer gone (play_id={})",
+                                handle.play_id
+                            );
+                        }
 
                         ok(&id, json!({"play_id": handle.play_id}))
                     }
@@ -255,8 +263,9 @@ fn schedule_play_ended(
     duration_sec: f64,
 ) {
     tokio::spawn(async move {
-        // 現在時刻 (daemon 起動からの経過秒) を求めて、終了予定までの実時間を計算
-        let now = engine.uptime_sec();
+        // transport 時刻 (audio callback 駆動) を優先し、未起動時のみ wall-clock にフォールバック。
+        // これにより start_sec が transport 基準で指定された場合も正しく待機できる。
+        let now = engine.now_sec().unwrap_or_else(|| engine.uptime_sec());
         let delay = (start_sec + duration_sec - now).max(0.0);
         if delay > 0.0 {
             tokio::time::sleep(std::time::Duration::from_secs_f64(delay)).await;
@@ -274,11 +283,14 @@ fn schedule_play_ended(
 }
 
 fn ok(id: &str, result: Value) -> Value {
+    // OkResponse は String/Value のみ含む固定スキーマ。
+    // シリアライズ失敗はプログラマエラー (新フィールドの Serialize 実装不備) として
+    // expect で早期失敗させ、"null" をクライアントに silent 送信する事態を避ける。
     serde_json::to_value(OkResponse {
         id: id.to_string(),
         result,
     })
-    .unwrap_or(serde_json::Value::Null)
+    .expect("OkResponse must be serializable")
 }
 
 fn err(id: &str, error: ProtocolError) -> Value {
@@ -286,7 +298,7 @@ fn err(id: &str, error: ProtocolError) -> Value {
         id: id.to_string(),
         error,
     })
-    .unwrap_or(serde_json::Value::Null)
+    .expect("ErrorResponse must be serializable")
 }
 
 fn wrap_err_to_protocol(e: &WrapError) -> ProtocolError {

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -22,6 +22,9 @@ use crate::protocol::{Command, ErrorResponse, Event, Handshake, OkResponse, Prot
 /// writer task のキュー容量。過大に積まれると back pressure をかける。
 const EVENT_CHANNEL_CAPACITY: usize = 128;
 
+const EVENT_PLAY_STARTED: &str = "PlayStarted";
+const EVENT_PLAY_ENDED: &str = "PlayEnded";
+
 pub async fn run(
     ws: WebSocketStream<TcpStream>,
     engine: Arc<EngineWrap>,
@@ -34,17 +37,14 @@ pub async fn run(
         .send(Message::Text(to_json_or_fallback(&Handshake::current())))
         .await?;
 
-    // writer task: mpsc から受けた message を書き出す
     let writer_task = tokio::spawn(async move {
         while let Some(msg) = rx.recv().await {
             if write.send(Message::Text(msg)).await.is_err() {
                 break;
             }
         }
-        // remaining drain (close handshake 等) は tungstenite 側で行われる
     });
 
-    // reader task: WebSocket 受信 → command → tx へ送る
     while let Some(msg) = read.next().await {
         let msg = match msg {
             Ok(m) => m,
@@ -85,7 +85,7 @@ pub async fn run(
         }
     }
 
-    // tx を drop して writer が exit
+    // drop で channel を閉じると writer は rx.recv() の None で exit する
     drop(tx);
     let _ = writer_task.await;
     Ok(())
@@ -191,18 +191,7 @@ async fn handle_command(
             match params.get("sample_id").and_then(|v| v.as_str()) {
                 Some(sid) => match engine.play_at(sid, time_sec, gain) {
                     Ok(handle) => {
-                        // PlayStarted event を即時送信
-                        let started_evt = Event::new(
-                            "PlayStarted",
-                            json!({
-                                "play_id": handle.play_id,
-                                "sample_id": handle.sample_id,
-                                "time_sec": handle.start_sec,
-                            }),
-                        );
-                        let _ = tx.send(to_json_or_fallback(&started_evt)).await;
-
-                        // PlayEnded event をサンプル長 + 起動時刻からの経過で遅延送信
+                        // 遅延タスクを先に spawn して await コストを避ける
                         schedule_play_ended(
                             tx.clone(),
                             engine.clone(),
@@ -210,6 +199,16 @@ async fn handle_command(
                             handle.start_sec,
                             handle.duration_sec,
                         );
+
+                        let started_evt = Event::new(
+                            EVENT_PLAY_STARTED,
+                            json!({
+                                "play_id": handle.play_id,
+                                "sample_id": sid,
+                                "time_sec": handle.start_sec,
+                            }),
+                        );
+                        let _ = tx.send(to_json_or_fallback(&started_evt)).await;
 
                         ok(&id, json!({"play_id": handle.play_id}))
                     }
@@ -264,7 +263,7 @@ fn schedule_play_ended(
         }
         let ended_at_sec = start_sec + duration_sec;
         let evt = Event::new(
-            "PlayEnded",
+            EVENT_PLAY_ENDED,
             json!({
                 "play_id": play_id,
                 "ended_at_sec": ended_at_sec,

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -74,14 +74,17 @@ pub async fn run(
                     error: ProtocolError::new("MALFORMED_REQUEST", e.to_string()),
                 };
                 if tx.send(to_json_or_fallback(&err)).await.is_err() {
+                    warn!("MALFORMED_REQUEST reply send failed; closing session");
                     break;
                 }
                 continue;
             }
         };
 
+        let method = cmd.method.clone();
         let reply = handle_command(cmd, &engine, &tx).await;
         if tx.send(to_json_or_fallback(&reply)).await.is_err() {
+            warn!("reply send failed for method={method}; closing session");
             break;
         }
     }

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -1,27 +1,50 @@
 //! 1 WebSocket 接続あたりのメッセージループ。
+//!
+//! writer task と reader task を分離した構造:
+//! - reader: WebSocket 受信 → Command dispatch → Response を mpsc へ送る
+//! - writer: mpsc から受信 → WebSocket へ書き込む
+//! - 遅延イベント (PlayEnded 等) も mpsc で writer に合流する
+//!
+//! これにより、handle_command の非同期待ち中にもイベントを送れる。
 
 use std::sync::Arc;
 
 use futures_util::{SinkExt, StreamExt};
 use serde_json::{json, Value};
 use tokio::net::TcpStream;
+use tokio::sync::mpsc;
 use tokio_tungstenite::{tungstenite::Message, WebSocketStream};
 use tracing::warn;
 
 use crate::engine_wrap::{EngineWrap, WrapError};
 use crate::protocol::{Command, ErrorResponse, Event, Handshake, OkResponse, ProtocolError};
 
+/// writer task のキュー容量。過大に積まれると back pressure をかける。
+const EVENT_CHANNEL_CAPACITY: usize = 128;
+
 pub async fn run(
     ws: WebSocketStream<TcpStream>,
     engine: Arc<EngineWrap>,
 ) -> Result<(), tokio_tungstenite::tungstenite::Error> {
     let (mut write, mut read) = ws.split();
+    let (tx, mut rx) = mpsc::channel::<String>(EVENT_CHANNEL_CAPACITY);
 
-    // 最初の handshake フレーム送信
+    // 最初の handshake フレーム
     write
         .send(Message::Text(to_json_or_fallback(&Handshake::current())))
         .await?;
 
+    // writer task: mpsc から受けた message を書き出す
+    let writer_task = tokio::spawn(async move {
+        while let Some(msg) = rx.recv().await {
+            if write.send(Message::Text(msg)).await.is_err() {
+                break;
+            }
+        }
+        // remaining drain (close handshake 等) は tungstenite 側で行われる
+    });
+
+    // reader task: WebSocket 受信 → command → tx へ送る
     while let Some(msg) = read.next().await {
         let msg = match msg {
             Ok(m) => m,
@@ -34,8 +57,9 @@ pub async fn run(
         let text = match msg {
             Message::Text(t) => t,
             Message::Close(_) => break,
-            Message::Ping(p) => {
-                write.send(Message::Pong(p)).await?;
+            Message::Ping(_) => {
+                // tungstenite が自動で Pong を返すが、handshake 後はアプリ層 Ping
+                // (method="Ping") を使うことを想定しているため無視。
                 continue;
             }
             _ => continue,
@@ -48,17 +72,22 @@ pub async fn run(
                     id: String::new(),
                     error: ProtocolError::new("MALFORMED_REQUEST", e.to_string()),
                 };
-                write.send(Message::Text(to_json_or_fallback(&err))).await?;
+                if tx.send(to_json_or_fallback(&err)).await.is_err() {
+                    break;
+                }
                 continue;
             }
         };
 
-        let reply = handle_command(cmd, &engine).await;
-        write
-            .send(Message::Text(to_json_or_fallback(&reply)))
-            .await?;
+        let reply = handle_command(cmd, &engine, &tx).await;
+        if tx.send(to_json_or_fallback(&reply)).await.is_err() {
+            break;
+        }
     }
 
+    // tx を drop して writer が exit
+    drop(tx);
+    let _ = writer_task.await;
     Ok(())
 }
 
@@ -82,7 +111,13 @@ fn to_json_or_fallback<T: serde::Serialize>(v: &T) -> String {
 }
 
 /// Command を dispatch し、Response JSON を組み立てる。
-async fn handle_command(cmd: Command, engine: &Arc<EngineWrap>) -> Value {
+///
+/// `tx` は event 送信用チャンネル（PlayEnded 等の遅延通知に使う）。
+async fn handle_command(
+    cmd: Command,
+    engine: &Arc<EngineWrap>,
+    tx: &mpsc::Sender<String>,
+) -> Value {
     let Command { id, method, params } = cmd;
     match method.as_str() {
         "Ping" => ok(&id, Value::String("pong".to_string())),
@@ -155,7 +190,29 @@ async fn handle_command(cmd: Command, engine: &Arc<EngineWrap>) -> Value {
             }
             match params.get("sample_id").and_then(|v| v.as_str()) {
                 Some(sid) => match engine.play_at(sid, time_sec, gain) {
-                    Ok(handle) => ok(&id, json!({"play_id": handle.play_id})),
+                    Ok(handle) => {
+                        // PlayStarted event を即時送信
+                        let started_evt = Event::new(
+                            "PlayStarted",
+                            json!({
+                                "play_id": handle.play_id,
+                                "sample_id": handle.sample_id,
+                                "time_sec": handle.start_sec,
+                            }),
+                        );
+                        let _ = tx.send(to_json_or_fallback(&started_evt)).await;
+
+                        // PlayEnded event をサンプル長 + 起動時刻からの経過で遅延送信
+                        schedule_play_ended(
+                            tx.clone(),
+                            engine.clone(),
+                            handle.play_id.clone(),
+                            handle.start_sec,
+                            handle.duration_sec,
+                        );
+
+                        ok(&id, json!({"play_id": handle.play_id}))
+                    }
                     Err(e) => err(&id, wrap_err_to_protocol(&e)),
                 },
                 None => err(
@@ -185,6 +242,36 @@ async fn handle_command(cmd: Command, engine: &Arc<EngineWrap>) -> Value {
             ProtocolError::new("MALFORMED_REQUEST", format!("unknown method: {other}")),
         ),
     }
+}
+
+/// PlayEnded event を遅延発行するタスクを spawn する。
+///
+/// 現在の transport 時刻を基準に `start_sec + duration_sec` まで待機し、
+/// mpsc 経由で writer task に送る。コネクションが閉じていたら silently drop。
+fn schedule_play_ended(
+    tx: mpsc::Sender<String>,
+    engine: Arc<EngineWrap>,
+    play_id: String,
+    start_sec: f64,
+    duration_sec: f64,
+) {
+    tokio::spawn(async move {
+        // 現在時刻 (daemon 起動からの経過秒) を求めて、終了予定までの実時間を計算
+        let now = engine.uptime_sec();
+        let delay = (start_sec + duration_sec - now).max(0.0);
+        if delay > 0.0 {
+            tokio::time::sleep(std::time::Duration::from_secs_f64(delay)).await;
+        }
+        let ended_at_sec = start_sec + duration_sec;
+        let evt = Event::new(
+            "PlayEnded",
+            json!({
+                "play_id": play_id,
+                "ended_at_sec": ended_at_sec,
+            }),
+        );
+        let _ = tx.send(to_json_or_fallback(&evt)).await;
+    });
 }
 
 fn ok(id: &str, result: Value) -> Value {
@@ -222,18 +309,4 @@ fn wrap_err_to_protocol(e: &WrapError) -> ProtocolError {
         WrapError::Output(o) => ProtocolError::new("DEVICE_CONFIG_ERROR", o.to_string()),
         WrapError::Scheduler(msg) => ProtocolError::new("INTERNAL_ERROR", msg.clone()),
     }
-}
-
-/// Stream stats 通知（Phase 1b-2 で定期送信を実装、現状はヘルパのみ提供）。
-#[allow(dead_code)]
-pub fn make_stream_stats_event(now_sec: f64) -> Event {
-    Event::new(
-        "StreamStats",
-        json!({
-            "cpu_load": 0.0,
-            "xruns": 0,
-            "buffer_underruns": 0,
-            "now_sec": now_sec,
-        }),
-    )
 }


### PR DESCRIPTION
## 概要

Epic #105 Phase 1b-2 のサブセット。orbit-audio-daemon の session を reader/writer 2 task 構造にリファクタし、**PlayStarted / PlayEnded イベント**を発行する。

Part of #107
Part of #105

## 実装

### Session 構造
- **reader**: WebSocket 受信 → command dispatch → mpsc へ送る
- **writer**: mpsc から受信 → WebSocket 書き込み
- mpsc capacity = 128（back pressure）

### イベント
- `PlayStarted`: PlayAt 応答直後に即時送信
- `PlayEnded`: `start_sec + duration_sec` で `tokio::spawn` + `sleep` による遅延送信

### PlayHandle 拡張
`sample_id` / `start_sec` / `duration_sec` を追加（ended_at 計算用）

## 変更
- `rust/crates/orbit-audio-daemon/src/session.rs` 大幅リファクタ
- `rust/crates/orbit-audio-daemon/src/engine_wrap.rs` PlayHandle 拡張
- `.gitignore` に `.claude/scheduled_tasks.lock` を追加
- `docs/development/WORK_LOG.md` 6.59 エントリ追加

## 検証

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --workspace`: 18 passed (core 8 + native 9 + daemon smoke 1)

## 非対応（Phase 1b-3 以降）

- `StreamStats` 1 Hz 定期送信（同 mpsc 経路で追加可能）
- `DaemonError` event（cpal err_fn からの経路設計が必要）
- 個別 `Stop` の実動作（Engine API 追加要）
- `SetGlobalGain` の実動作（Engine API 追加要）
- lock-free ringbuf 化