### PR TITLE
feat(daemon): Phase 1b-3 StreamStats 1Hz + DaemonError warning

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,34 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.60 Issue #107: orbit-audio-daemon Phase 1b-3 StreamStats / DaemonError (April 17, 2026)
+
+**Date**: April 17, 2026
+**Status**: ✅ COMPLETE (Phase 1b-3: StreamStats 1 Hz + DaemonError warning path)
+**Branch**: `107-daemon-stream-events`
+**Issue**: #107（Phase 1b-3 の一部）
+
+**Work Content**: orbit-audio-daemon に StreamStats イベントの 1 Hz 周期送信と、cpal `err_fn` からの xrun 検知を経由する DaemonError (severity=warning, code=STREAM_XRUN) 通知を実装。Phase 1b-2 で導入した mpsc writer task 経路を再利用し、接続ごとに ticker task を起動する。
+
+**実装**:
+- `orbit-audio-native/src/output.rs` に `StreamStats { xruns, buffer_underruns }` atomic counter を追加、`start_default_output` の戻り値を `(Engine, OutputStream, Arc<StreamStats>)` に拡張
+- `err_fn` を factory 化し xrun 発生時に atomic increment
+- `engine_wrap.rs` に `stream_stats_snapshot()` を追加
+- `session.rs` に 1 Hz ticker task を追加。前回値と比較して xrun 増分があれば DaemonError warning を先に送出、続けて StreamStats を送出
+- session 終了時に `stats_task.abort()` で cleanup
+
+**スコープ外（次フェーズ）**:
+- `cpu_load` 実測（現状は 0.0 stub、コールバック timing 計測基盤が未整備）
+- `buffer_underruns` の個別集計（cpal `StreamError` が underrun を区別しないため 0 stub）
+- DaemonError severity=fatal（DEVICE_LOST / FATAL_PANIC） — panic hook と cpal device lost 検出が必要
+
+**検証**:
+- `cargo build --workspace` clean
+- `cargo test -p orbit-audio-daemon` 1 pass（smoke test）
+- 既存 PlayStarted/PlayEnded 経路への影響なし
+
+---
+
 ### 6.59 Issue #107: orbit-audio-daemon Phase 1b-2 events (April 17, 2026)
 
 **Date**: April 17, 2026

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use orbit_audio_core::{Engine, Sample};
 use orbit_audio_native::{
     load_sample_resampled, start_default_output, LoaderError, OutputError, OutputStream,
-    ResampleError,
+    ResampleError, StreamStats, StreamStatsSnapshot,
 };
 use uuid::Uuid;
 
@@ -38,6 +38,7 @@ pub struct EngineWrap {
     samples: Mutex<HashMap<String, Sample>>,
     started_at: std::time::Instant,
     active_play_count: std::sync::atomic::AtomicUsize,
+    stream_stats: Arc<StreamStats>,
 }
 
 /// `cpal::Stream` を保持する guard。drop されるとストリーム停止。`!Send`。
@@ -47,7 +48,7 @@ impl EngineWrap {
     /// Engine とストリーム guard を起動する。
     /// guard は caller（通常は main）が drop されるまで保持すること。
     pub fn start() -> Result<(Arc<Self>, StreamGuard), WrapError> {
-        let (engine, stream) = start_default_output()?;
+        let (engine, stream, stream_stats) = start_default_output()?;
         let sample_rate = stream.sample_rate;
         let channels = stream.channels;
         let wrap = Arc::new(Self {
@@ -57,6 +58,7 @@ impl EngineWrap {
             samples: Mutex::new(HashMap::new()),
             started_at: std::time::Instant::now(),
             active_play_count: std::sync::atomic::AtomicUsize::new(0),
+            stream_stats,
         });
         Ok((wrap, StreamGuard(stream)))
     }
@@ -141,9 +143,14 @@ impl EngineWrap {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn now_sec(&self) -> Option<f64> {
-        self.engine.now_sec()
+    /// transport 時刻（audio callback 駆動）を優先し、未起動時のみ wall-clock にフォールバック。
+    pub fn transport_or_uptime_sec(&self) -> f64 {
+        self.engine.now_sec().unwrap_or_else(|| self.uptime_sec())
+    }
+
+    /// audio stream の稼働統計スナップショット（StreamStats event 用）。
+    pub fn stream_stats_snapshot(&self) -> StreamStatsSnapshot {
+        self.stream_stats.snapshot()
     }
 
     /// `samples` Mutex を poisoned-safe に取得する。

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -30,7 +30,7 @@ const EVENT_DAEMON_ERROR: &str = "DaemonError";
 const ERROR_SEVERITY_WARNING: &str = "warning";
 const ERROR_CODE_STREAM_XRUN: &str = "STREAM_XRUN";
 
-/// StreamStats の送出間隔。プロトコル仕様 v0.1 で 1 Hz 固定。
+/// StreamStats の送出間隔。protocol 仕様で 1 Hz 固定。
 const STREAM_STATS_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
 
 pub async fn run(
@@ -60,8 +60,8 @@ pub async fn run(
         let tx = tx.clone();
         let engine = engine.clone();
         tokio::spawn(async move {
-            // interval_at で最初の tick も 1 s 後に揃える。プロトコル仕様 (1 Hz 固定) に
-            // 則り、接続直後の即時イベントは送出しない。
+            // 1 Hz 固定仕様に合わせ、最初の tick も INTERVAL 後に揃える
+            // （tokio::time::interval のデフォルトは即時発火）。
             let start = tokio::time::Instant::now() + STREAM_STATS_INTERVAL;
             let mut ticker = tokio::time::interval_at(start, STREAM_STATS_INTERVAL);
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -150,9 +150,14 @@ pub async fn run(
         }
     }
 
-    // drop で channel を閉じると writer は rx.recv() の None で exit する。
-    // stats_task は tx clone を保持しているため、ここで先に中止する。
+    // stats_task は自身の tx clone を保持するため、drop(tx) では exit しない。
+    // abort してから join を待ち、cancelled 以外の終了（panic 等）があれば warn する。
     stats_task.abort();
+    match stats_task.await {
+        Ok(()) => {}
+        Err(e) if e.is_cancelled() => {}
+        Err(e) => warn!("stats task terminated abnormally: {e}"),
+    }
     drop(tx);
     if let Err(e) = writer_task.await {
         warn!("writer task terminated abnormally: {e}");

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -60,9 +60,11 @@ pub async fn run(
         let tx = tx.clone();
         let engine = engine.clone();
         tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(STREAM_STATS_INTERVAL);
+            // interval_at で最初の tick も 1 s 後に揃える。プロトコル仕様 (1 Hz 固定) に
+            // 則り、接続直後の即時イベントは送出しない。
+            let start = tokio::time::Instant::now() + STREAM_STATS_INTERVAL;
+            let mut ticker = tokio::time::interval_at(start, STREAM_STATS_INTERVAL);
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            // 最初の tick は即時発火し、接続直後の baseline として送出する。
             let mut last_xruns: u64 = 0;
             loop {
                 ticker.tick().await;

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -24,6 +24,14 @@ const EVENT_CHANNEL_CAPACITY: usize = 128;
 
 const EVENT_PLAY_STARTED: &str = "PlayStarted";
 const EVENT_PLAY_ENDED: &str = "PlayEnded";
+const EVENT_STREAM_STATS: &str = "StreamStats";
+const EVENT_DAEMON_ERROR: &str = "DaemonError";
+
+const ERROR_SEVERITY_WARNING: &str = "warning";
+const ERROR_CODE_STREAM_XRUN: &str = "STREAM_XRUN";
+
+/// StreamStats の送出間隔。プロトコル仕様 v0.1 で 1 Hz 固定。
+const STREAM_STATS_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
 
 pub async fn run(
     ws: WebSocketStream<TcpStream>,
@@ -44,6 +52,57 @@ pub async fn run(
             }
         }
     });
+
+    // StreamStats 1 Hz ticker。mpsc の送信が失敗（= writer/reader 終了）した
+    // 時点で自然に exit する。reader 側が閉じる tx の clone を持つため、
+    // session が終わると tx が全て drop され、この task も最後は送信失敗で抜ける。
+    let stats_task = {
+        let tx = tx.clone();
+        let engine = engine.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(STREAM_STATS_INTERVAL);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            // 最初の tick は即時発火し、接続直後の baseline として送出する。
+            let mut last_xruns: u64 = 0;
+            loop {
+                ticker.tick().await;
+                let snapshot = engine.stream_stats_snapshot();
+                let now_sec = engine.transport_or_uptime_sec();
+
+                if snapshot.xruns > last_xruns {
+                    let warn_evt = Event::new(
+                        EVENT_DAEMON_ERROR,
+                        json!({
+                            "severity": ERROR_SEVERITY_WARNING,
+                            "code": ERROR_CODE_STREAM_XRUN,
+                            "message": format!(
+                                "buffer underrun or stream error occurred ({} total)",
+                                snapshot.xruns
+                            ),
+                        }),
+                    );
+                    if tx.send(to_json_or_fallback(&warn_evt)).await.is_err() {
+                        break;
+                    }
+                    last_xruns = snapshot.xruns;
+                }
+
+                let stats_evt = Event::new(
+                    EVENT_STREAM_STATS,
+                    json!({
+                        // cpu_load: audio callback の計測基盤が未整備のため 0.0 固定。
+                        "cpu_load": 0.0,
+                        "xruns": snapshot.xruns,
+                        "buffer_underruns": snapshot.buffer_underruns,
+                        "now_sec": now_sec,
+                    }),
+                );
+                if tx.send(to_json_or_fallback(&stats_evt)).await.is_err() {
+                    break;
+                }
+            }
+        })
+    };
 
     while let Some(msg) = read.next().await {
         let msg = match msg {
@@ -89,7 +148,9 @@ pub async fn run(
         }
     }
 
-    // drop で channel を閉じると writer は rx.recv() の None で exit する
+    // drop で channel を閉じると writer は rx.recv() の None で exit する。
+    // stats_task は tx clone を保持しているため、ここで先に中止する。
+    stats_task.abort();
     drop(tx);
     if let Err(e) = writer_task.await {
         warn!("writer task terminated abnormally: {e}");
@@ -266,9 +327,7 @@ fn schedule_play_ended(
     duration_sec: f64,
 ) {
     tokio::spawn(async move {
-        // transport 時刻 (audio callback 駆動) を優先し、未起動時のみ wall-clock にフォールバック。
-        // これにより start_sec が transport 基準で指定された場合も正しく待機できる。
-        let now = engine.now_sec().unwrap_or_else(|| engine.uptime_sec());
+        let now = engine.transport_or_uptime_sec();
         let delay = (start_sec + duration_sec - now).max(0.0);
         if delay > 0.0 {
             tokio::time::sleep(std::time::Duration::from_secs_f64(delay)).await;

--- a/rust/crates/orbit-audio-native/examples/poc_play.rs
+++ b/rust/crates/orbit-audio-native/examples/poc_play.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // デバイス config に一致する Engine を自動構築
-    let (engine, stream) = start_default_output()?;
+    let (engine, stream, _stats) = start_default_output()?;
     println!(
         "output stream: sr={}, ch={}",
         stream.sample_rate, stream.channels

--- a/rust/crates/orbit-audio-native/src/lib.rs
+++ b/rust/crates/orbit-audio-native/src/lib.rs
@@ -11,5 +11,5 @@ mod output;
 mod resampler;
 
 pub use loader::{load_sample_from_file, load_sample_resampled, LoaderError};
-pub use output::{start_default_output, OutputError, OutputStream};
+pub use output::{start_default_output, OutputError, OutputStream, StreamStats, StreamStatsSnapshot};
 pub use resampler::ResampleError;

--- a/rust/crates/orbit-audio-native/src/output.rs
+++ b/rust/crates/orbit-audio-native/src/output.rs
@@ -1,10 +1,43 @@
 //! cpal を使った既定出力デバイスへのストリーム設定。
 
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{Device, SampleFormat, Stream, StreamConfig};
 use thiserror::Error;
 
 use orbit_audio_core::Engine;
+
+/// cpal ストリームから得られる稼働統計。
+///
+/// err_fn は audio スレッドから呼ばれるため atomic で更新する。
+/// `buffer_underruns` は cpal の `StreamError` が underrun を個別に示さないため
+/// 常に 0。将来 backend-specific な判別ができるようになれば増分経路を追加する。
+#[derive(Debug, Default)]
+pub struct StreamStats {
+    xruns: AtomicU64,
+    buffer_underruns: AtomicU64,
+}
+
+impl StreamStats {
+    pub fn snapshot(&self) -> StreamStatsSnapshot {
+        StreamStatsSnapshot {
+            xruns: self.xruns.load(Ordering::Relaxed),
+            buffer_underruns: self.buffer_underruns.load(Ordering::Relaxed),
+        }
+    }
+
+    fn record_xrun(&self) {
+        self.xruns.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct StreamStatsSnapshot {
+    pub xruns: u64,
+    pub buffer_underruns: u64,
+}
 
 #[derive(Error, Debug)]
 pub enum OutputError {
@@ -27,7 +60,7 @@ pub struct OutputStream {
 
 /// 既定の出力デバイスを使い、デバイス config に合う [`Engine`] とストリームを
 /// 同時に初期化する。呼び出し側は config ミスマッチを意識しなくてよい。
-pub fn start_default_output() -> Result<(Engine, OutputStream), OutputError> {
+pub fn start_default_output() -> Result<(Engine, OutputStream, Arc<StreamStats>), OutputError> {
     let host = cpal::default_host();
     let device = host.default_output_device().ok_or(OutputError::NoDevice)?;
     let supported = device
@@ -39,8 +72,9 @@ pub fn start_default_output() -> Result<(Engine, OutputStream), OutputError> {
     let sample_rate = config.sample_rate.0;
     let channels = config.channels;
 
+    let stats = Arc::new(StreamStats::default());
     let engine = Engine::new(sample_rate, channels);
-    let stream = build_stream(&device, &config, sample_format, engine.clone())?;
+    let stream = build_stream(&device, &config, sample_format, engine.clone(), stats.clone())?;
     stream
         .play()
         .map_err(|e| OutputError::PlayStream(e.to_string()))?;
@@ -52,6 +86,7 @@ pub fn start_default_output() -> Result<(Engine, OutputStream), OutputError> {
             sample_rate,
             channels,
         },
+        stats,
     ))
 }
 
@@ -60,8 +95,15 @@ fn build_stream(
     config: &StreamConfig,
     sample_format: SampleFormat,
     engine: Engine,
+    stats: Arc<StreamStats>,
 ) -> Result<Stream, OutputError> {
-    let err_fn = |err| eprintln!("stream error: {err}");
+    let make_err_fn = || {
+        let stats = stats.clone();
+        move |err| {
+            stats.record_xrun();
+            eprintln!("stream error: {err}");
+        }
+    };
 
     /// scratch バッファを事前に 1 秒分確保してクロージャにムーブするヘルパー。
     /// cpal のコールバック buffer_size は通常数百フレームなので十分余裕がある。
@@ -75,7 +117,7 @@ fn build_stream(
             .build_output_stream(
                 config,
                 move |data: &mut [f32], _| engine.render(data),
-                err_fn,
+                make_err_fn(),
                 None,
             )
             .map_err(|e| OutputError::BuildStream(e.to_string()))?,
@@ -95,7 +137,7 @@ fn build_stream(
                             data[i] = (s.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
                         }
                     },
-                    err_fn,
+                    make_err_fn(),
                     None,
                 )
                 .map_err(|e| OutputError::BuildStream(e.to_string()))?
@@ -116,7 +158,7 @@ fn build_stream(
                             data[i] = (s.clamp(-1.0, 1.0) * i32::MAX as f32) as i32;
                         }
                     },
-                    err_fn,
+                    make_err_fn(),
                     None,
                 )
                 .map_err(|e| OutputError::BuildStream(e.to_string()))?
@@ -137,7 +179,7 @@ fn build_stream(
                             data[i] = v as u16;
                         }
                     },
-                    err_fn,
+                    make_err_fn(),
                     None,
                 )
                 .map_err(|e| OutputError::BuildStream(e.to_string()))?

--- a/rust/crates/orbit-audio-native/src/output.rs
+++ b/rust/crates/orbit-audio-native/src/output.rs
@@ -98,10 +98,11 @@ fn build_stream(
     stats: Arc<StreamStats>,
 ) -> Result<Stream, OutputError> {
     let make_err_fn = || {
+        // audio thread から呼ばれるため blocking I/O を避け、atomic increment のみ行う。
+        // 上位 (daemon session) が StreamStats / DaemonError 経由で可視化する責務を持つ。
         let stats = stats.clone();
-        move |err| {
+        move |_err| {
             stats.record_xrun();
-            eprintln!("stream error: {err}");
         }
     };
 
@@ -191,4 +192,37 @@ fn build_stream(
         }
     };
     Ok(stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_stats_starts_at_zero() {
+        let stats = StreamStats::default();
+        let snap = stats.snapshot();
+        assert_eq!(snap.xruns, 0);
+        assert_eq!(snap.buffer_underruns, 0);
+    }
+
+    #[test]
+    fn record_xrun_increments_only_xruns() {
+        let stats = StreamStats::default();
+        stats.record_xrun();
+        stats.record_xrun();
+        stats.record_xrun();
+        let snap = stats.snapshot();
+        assert_eq!(snap.xruns, 3);
+        assert_eq!(snap.buffer_underruns, 0);
+    }
+
+    #[test]
+    fn snapshot_is_monotonic() {
+        let stats = StreamStats::default();
+        let s1 = stats.snapshot();
+        stats.record_xrun();
+        let s2 = stats.snapshot();
+        assert!(s2.xruns > s1.xruns);
+    }
 }


### PR DESCRIPTION
## Summary
- orbit-audio-daemon に StreamStats イベントの 1 Hz 周期送信を追加
- cpal err_fn 経由で xrun を検知し、DaemonError (severity=warning, code=STREAM_XRUN) を通知
- Phase 1b-2 の mpsc writer task 経路を再利用し、接続ごとに ticker task を spawn

## 変更内容
- `orbit-audio-native`: `StreamStats { xruns, buffer_underruns }` atomic counter を追加、`start_default_output` の戻り値を `(Engine, OutputStream, Arc<StreamStats>)` に拡張
- `err_fn` を factory 化し xrun 発生時に atomic increment
- `EngineWrap` に `stream_stats_snapshot` / `transport_or_uptime_sec` を追加
- `session.rs` に 1 Hz ticker task。`interval_at` で最初の tick も 1 s 後に揃え、プロトコル仕様 (1 Hz 固定) に厳密準拠
- xrun 増分を検知したら DaemonError warning を先に送出、続けて StreamStats を送出
- セッション終了時に `stats_task.abort()` で cleanup

## スコープ外（次フェーズ）
- `cpu_load` 実測（現状は 0.0 固定、callback timing 計測基盤が未整備）
- `buffer_underruns` 個別集計（cpal `StreamError` が underrun を区別しないため常に 0）
- DaemonError severity=fatal (DEVICE_LOST / FATAL_PANIC) — panic hook / device lost 検出が必要

## Test plan
- [x] cargo build --workspace clean
- [x] cargo clippy --workspace --all-targets -- -D warnings clean
- [x] cargo test -p orbit-audio-daemon (1 pass, 既存 smoke test)
- [x] 既存 PlayStarted/PlayEnded 経路への影響なし

Refs #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)