### PR TITLE
feat(engine): SetGlobalGain with linear ramp

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,33 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.61 Issue #107: orbit-audio-daemon SetGlobalGain 実装 (April 18, 2026)
+
+**Date**: April 18, 2026
+**Status**: ✅ COMPLETE (Phase 1b-4: SetGlobalGain with ramp)
+**Branch**: `107-global-gain`
+**Issue**: #107
+
+**Work Content**: これまで `accepted` を返すだけの no-op だった `SetGlobalGain` コマンドを実装。`Scheduler` に master gain + 線形ランプ機能を追加し、Engine / EngineWrap / session.rs を経由して protocol v0.1 仕様を満たすようにした。
+
+**実装**:
+- `orbit-audio-core::Scheduler` に `global_gain` / `target_gain` / `ramp_frames_remaining` を追加、`set_global_gain(value, ramp_frames)` を公開
+- `render` 末尾で混合済み出力にマスターゲインを後適用（per-frame 線形ランプ、allocation 無し）
+- `Engine::set_global_gain(value, ramp_sec)` で秒 → frames 変換を担当
+- `EngineWrap::set_global_gain` 経由で daemon session がそのまま呼べる
+- `SetGlobalGain` handler を実装に置き換え、`ramp_sec` バリデーション（負値エラー）を追加
+
+**テスト**:
+- scheduler: 即時セット / 線形ランプ後に target 到達 / 負値クランプ — 3 件追加
+- 既存 12 native tests / 11 core tests 全て pass
+- clippy clean
+
+**非対応（次フェーズ）**:
+- 個別 Stop 実装（Scheduler に play_id 追跡が必要）
+- DaemonError severity=fatal（panic hook / device lost 検出）
+
+---
+
 ### 6.60 Issue #107: orbit-audio-daemon Phase 1b-3 StreamStats / DaemonError (April 17, 2026)
 
 **Date**: April 17, 2026

--- a/rust/crates/orbit-audio-core/src/engine.rs
+++ b/rust/crates/orbit-audio-core/src/engine.rs
@@ -57,6 +57,18 @@ impl Engine {
         Ok(())
     }
 
+    /// マスターゲインを設定する。`ramp_sec` が 0 以下なら即時、正なら線形ランプ。
+    pub fn set_global_gain(&self, value: f32, ramp_sec: f64) -> Result<(), EngineError> {
+        let mut s = self.inner.lock().map_err(|_| EngineError::Poisoned)?;
+        let ramp_frames = if ramp_sec > 0.0 {
+            (ramp_sec * s.output_sample_rate() as f64).round() as u64
+        } else {
+            0
+        };
+        s.set_global_gain(value, ramp_frames);
+        Ok(())
+    }
+
     /// オーディオコールバックから呼び出される。`out` は interleaved f32。
     ///
     /// リアルタイムスレッドで呼ばれるため `try_lock` を用い、ロック競合時は

--- a/rust/crates/orbit-audio-core/src/engine.rs
+++ b/rust/crates/orbit-audio-core/src/engine.rs
@@ -58,10 +58,14 @@ impl Engine {
     }
 
     /// マスターゲインを設定する。`ramp_sec` が 0 以下なら即時、正なら線形ランプ。
+    ///
+    /// 正の `ramp_sec` がサブフレーム相当（例: 1/sample_rate 未満）でも、
+    /// 呼び出し側の「ランプ要求」意図を尊重して最小 1 フレームのランプとして扱う。
+    /// これにより、意図せず即時切替にフォールバックして pop ノイズが乗ることを防ぐ。
     pub fn set_global_gain(&self, value: f32, ramp_sec: f64) -> Result<(), EngineError> {
         let mut s = self.inner.lock().map_err(|_| EngineError::Poisoned)?;
         let ramp_frames = if ramp_sec > 0.0 {
-            (ramp_sec * s.output_sample_rate() as f64).round() as u64
+            ((ramp_sec * s.output_sample_rate() as f64).round() as u64).max(1)
         } else {
             0
         };

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -44,6 +44,8 @@ pub struct Scheduler {
     target_gain: f32,
     /// 残りランプフレーム数。0 でランプ終了し global_gain = target_gain。
     ramp_frames_remaining: u64,
+    /// ランプ中の定数ステップ（set_global_gain で計算）。線形ランプを保証する。
+    ramp_step: f32,
     // TODO (Phase 2): events を start_frame で BinaryHeap にして、
     // render ごとの線形スキャンを削減する
 }
@@ -69,20 +71,23 @@ impl Scheduler {
             global_gain: 1.0,
             target_gain: 1.0,
             ramp_frames_remaining: 0,
+            ramp_step: 0.0,
         }
     }
 
-    /// マスターゲインを設定する。`ramp_frames == 0` なら即時、それ以外は線形ランプで
-    /// `value` に到達する。負の値は 0.0 にクランプする。
+    /// マスターゲインを設定する。`ramp_frames == 0` なら即時、それ以外は定数ステップで
+    /// 線形に `value` へ到達する。負の値は 0.0 にクランプする。
     pub fn set_global_gain(&mut self, value: f32, ramp_frames: u64) {
         let value = value.max(0.0);
         if ramp_frames == 0 {
             self.global_gain = value;
             self.target_gain = value;
             self.ramp_frames_remaining = 0;
+            self.ramp_step = 0.0;
         } else {
             self.target_gain = value;
             self.ramp_frames_remaining = ramp_frames;
+            self.ramp_step = (value - self.global_gain) / ramp_frames as f32;
         }
     }
 
@@ -161,12 +166,12 @@ impl Scheduler {
         // 単調パスで追加 allocation なし。
         for frame in 0..frames_to_render {
             if self.ramp_frames_remaining > 0 {
-                let step =
-                    (self.target_gain - self.global_gain) / self.ramp_frames_remaining as f32;
-                self.global_gain += step;
+                self.global_gain += self.ramp_step;
                 self.ramp_frames_remaining -= 1;
                 if self.ramp_frames_remaining == 0 {
+                    // 浮動小数点誤差対策でターゲットにスナップ
                     self.global_gain = self.target_gain;
+                    self.ramp_step = 0.0;
                 }
             }
             let base = frame * output_channels;
@@ -289,6 +294,23 @@ mod tests {
         let last_r = buf[199];
         assert!(last_l.abs() < 1e-6 && last_r.abs() < 1e-6);
         assert_eq!(s.global_gain(), 0.0);
+    }
+
+    #[test]
+    fn set_global_gain_ramp_is_linear_at_midpoint() {
+        // ランプ 100 フレームで 1.0 → 0.0 の場合、50 フレーム目の直後のゲインは
+        // 約 0.5 であること（線形ランプの検証）。後半 50 フレームで 0 に達する。
+        let mut s = Scheduler::new(48_000, 2);
+        // 定数 0.5 の mono→stereo サンプル 200 フレーム
+        let sample = Sample::new(vec![0.5f32; 200 * 2], 48_000, 2);
+        s.schedule(ScheduledSample::new(0.0, sample));
+        s.set_global_gain(0.0, 100);
+
+        // 最初の 50 フレームを render
+        let mut buf = vec![0.0f32; 100]; // 50 frames
+        s.render(&mut buf);
+        // 50 frames 経過後の global_gain は 0.5 付近
+        assert!((s.global_gain() - 0.5).abs() < 0.02, "{}", s.global_gain());
     }
 
     #[test]

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -38,6 +38,12 @@ pub struct Scheduler {
     events: Vec<ActiveSample>,
     /// 出力ストリーム上の現在位置（サンプルフレーム単位）
     cursor_frames: u64,
+    /// 現在のマスターゲイン（線形、フレーム単位でランプ更新）
+    global_gain: f32,
+    /// ランプ終了時点の目標ゲイン
+    target_gain: f32,
+    /// 残りランプフレーム数。0 でランプ終了し global_gain = target_gain。
+    ramp_frames_remaining: u64,
     // TODO (Phase 2): events を start_frame で BinaryHeap にして、
     // render ごとの線形スキャンを削減する
 }
@@ -60,7 +66,29 @@ impl Scheduler {
             output_channels,
             events: Vec::new(),
             cursor_frames: 0,
+            global_gain: 1.0,
+            target_gain: 1.0,
+            ramp_frames_remaining: 0,
         }
+    }
+
+    /// マスターゲインを設定する。`ramp_frames == 0` なら即時、それ以外は線形ランプで
+    /// `value` に到達する。負の値は 0.0 にクランプする。
+    pub fn set_global_gain(&mut self, value: f32, ramp_frames: u64) {
+        let value = value.max(0.0);
+        if ramp_frames == 0 {
+            self.global_gain = value;
+            self.target_gain = value;
+            self.ramp_frames_remaining = 0;
+        } else {
+            self.target_gain = value;
+            self.ramp_frames_remaining = ramp_frames;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn global_gain(&self) -> f32 {
+        self.global_gain
     }
 
     /// サンプルを予約する。時刻は秒。
@@ -128,6 +156,25 @@ impl Scheduler {
             active.read_pos += frames_to_copy;
         }
 
+        // 混合後の出力バッファにフレーム単位のマスターゲインを適用する。
+        // ランプ中はフレームごとに線形補間で global_gain を更新する。
+        // 単調パスで追加 allocation なし。
+        for frame in 0..frames_to_render {
+            if self.ramp_frames_remaining > 0 {
+                let step =
+                    (self.target_gain - self.global_gain) / self.ramp_frames_remaining as f32;
+                self.global_gain += step;
+                self.ramp_frames_remaining -= 1;
+                if self.ramp_frames_remaining == 0 {
+                    self.global_gain = self.target_gain;
+                }
+            }
+            let base = frame * output_channels;
+            for ch in 0..output_channels {
+                out[base + ch] *= self.global_gain;
+            }
+        }
+
         self.cursor_frames += frames_to_render as u64;
         // 再生完了したもの（= すべてのフレームを読み終えたもの）をドロップ。
         // まだ開始時刻に到達していないイベントは read_pos == 0 のため自然に保持される。
@@ -137,6 +184,10 @@ impl Scheduler {
     /// 現在の出力ストリーム時刻（秒）
     pub fn now_sec(&self) -> f64 {
         self.cursor_frames as f64 / self.output_sample_rate as f64
+    }
+
+    pub fn output_sample_rate(&self) -> u32 {
+        self.output_sample_rate
     }
 
     /// テスト用: 保持しているイベント数
@@ -205,5 +256,45 @@ mod tests {
 
         // 先頭から非ゼロの音が書き込まれているはず
         assert!(buf.iter().any(|&x| x != 0.0));
+    }
+
+    #[test]
+    fn set_global_gain_immediate_scales_output() {
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(ScheduledSample::new(0.0, mk_sample_stereo(100)));
+        s.set_global_gain(0.5, 0);
+
+        let mut buf = vec![0.0f32; 200];
+        s.render(&mut buf);
+
+        // 元々 0.1 のサンプルが 0.5x でスケール → ~0.05。ランプ無しなので一定。
+        let peak = buf.iter().cloned().fold(0.0f32, f32::max);
+        assert!((peak - 0.05).abs() < 1e-5, "peak={peak}");
+    }
+
+    #[test]
+    fn set_global_gain_ramps_linearly_to_target() {
+        let mut s = Scheduler::new(48_000, 2);
+        // 直流 1.0 のモノラルサンプルを想定して 1ch 出力にすると計算が容易。
+        // ここでは 2ch stereo で mk_sample_stereo(.1) を流し、ランプ後の最後の
+        // フレームが target_gain (0.0) で減衰していることだけ検証する。
+        s.schedule(ScheduledSample::new(0.0, mk_sample_stereo(100)));
+        s.set_global_gain(0.0, 100); // 100 フレームで 1.0 → 0.0 へランプ
+
+        let mut buf = vec![0.0f32; 200]; // 100 frames
+        s.render(&mut buf);
+
+        // 最終フレームはランプ完了し target_gain = 0.0 になっているはず
+        let last_l = buf[198];
+        let last_r = buf[199];
+        assert!(last_l.abs() < 1e-6 && last_r.abs() < 1e-6);
+        assert_eq!(s.global_gain(), 0.0);
+    }
+
+    #[test]
+    fn set_global_gain_clamps_negative_to_zero() {
+        let mut s = Scheduler::new(48_000, 2);
+        s.set_global_gain(-0.5, 0);
+        assert_eq!(s.global_gain(), 0.0);
     }
 }

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -148,6 +148,13 @@ impl EngineWrap {
         self.engine.now_sec().unwrap_or_else(|| self.uptime_sec())
     }
 
+    /// マスターゲインを設定する。`ramp_sec` が 0 以下なら即時。
+    pub fn set_global_gain(&self, value: f32, ramp_sec: f64) -> Result<(), WrapError> {
+        self.engine
+            .set_global_gain(value, ramp_sec)
+            .map_err(|e| WrapError::Scheduler(e.to_string()))
+    }
+
     /// audio stream の稼働統計スナップショット（StreamStats event 用）。
     pub fn stream_stats_snapshot(&self) -> StreamStatsSnapshot {
         self.stream_stats.snapshot()

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -305,15 +305,27 @@ async fn handle_command(
             ok(&id, json!({"play_id": pid, "status": "not_found"}))
         }
         "SetGlobalGain" => {
-            // 現状 Engine は global gain を持たないため、受理するが no-op (Phase 1b-2 で実装)。
             let value = params.get("value").and_then(|v| v.as_f64()).unwrap_or(1.0);
+            let ramp_sec = params
+                .get("ramp_sec")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
             if value < 0.0 {
                 return err(
                     &id,
                     ProtocolError::new("PARAM_OUT_OF_RANGE", "value must be >= 0"),
                 );
             }
-            ok(&id, json!({"status": "accepted"}))
+            if ramp_sec < 0.0 {
+                return err(
+                    &id,
+                    ProtocolError::new("PARAM_OUT_OF_RANGE", "ramp_sec must be >= 0"),
+                );
+            }
+            match engine.set_global_gain(value as f32, ramp_sec) {
+                Ok(()) => ok(&id, json!({"status": "accepted"})),
+                Err(e) => err(&id, wrap_err_to_protocol(&e)),
+            }
         }
         other => err(
             &id,


### PR DESCRIPTION
## Summary
- これまで no-op だった `SetGlobalGain` コマンドを実装
- `Scheduler` に master gain + 定数ステップ線形ランプを追加
- sub-frame な正の `ramp_sec` は最小 1 frame にクランプし、pop ノイズを防止

## 変更内容
- `orbit-audio-core::Scheduler` に `global_gain` / `target_gain` / `ramp_frames_remaining` / `ramp_step` を追加
- `set_global_gain(value, ramp_frames)` で step を事前計算（真の線形ランプ）
- `render` 末尾で混合済み出力にマスターゲインを後適用（audio thread 内 allocation なし）
- `Engine::set_global_gain(value, ramp_sec)` で秒 → frames 変換
- `EngineWrap::set_global_gain` 経由で daemon session が呼出
- `SetGlobalGain` handler を実装に置換、`ramp_sec` 負値を PARAM_OUT_OF_RANGE で弾く

## Test plan
- [x] cargo test --workspace (core 12, native 12, daemon 1)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] 即時セット / 線形ランプ / 中間点線形性 / 負値クランプ 4 件の unit test 追加

Refs #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)