### PR TITLE
feat(engine): per-play Stop implementation

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,34 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.62 Issue #107: orbit-audio-daemon Stop 個別停止実装 (April 18, 2026)
+
+**Date**: April 18, 2026
+**Status**: ✅ COMPLETE (Phase 1b-5: per-play Stop)
+**Branch**: `107-daemon-stop`
+**Issue**: #107
+
+**Work Content**: これまで常に `not_found` を返す no-op だった `Stop` コマンドを実装。`Scheduler::stop(play_id)` で events から対象を削除、`Engine` / `EngineWrap` 経由で daemon session が呼び出す。protocol v0.1 の `stopped` / `not_found` 返却を満たす。
+
+**実装**:
+- `ScheduledSample` / `ActiveSample` に `play_id: Option<String>` を追加
+- `Scheduler::stop(&str) -> bool` で events retain 経由の削除
+- `Engine::schedule_with_play_id` / `Engine::stop` を公開
+- `EngineWrap::play_at` は生成した `play_id` を `schedule_with_play_id` 経由で渡す
+- `EngineWrap::stop(play_id) -> Result<bool, _>` を追加
+- `Stop` handler を実装に置き換え、`play_id` 欠落を `MALFORMED_REQUEST` で返却
+
+**テスト**:
+- scheduler: 一致 id で削除 / 未知 id で no-op — 2 件追加
+- 既存 12 native / 14 core / 1 daemon smoke 全 pass
+- clippy clean
+
+**スコープ外**:
+- `already_stopped` 状態の区別（履歴追跡が必要、現状は `not_found` にまとめる）
+- DaemonError severity=fatal (panic hook / device lost)
+
+---
+
 ### 6.61 Issue #107: orbit-audio-daemon SetGlobalGain 実装 (April 18, 2026)
 
 **Date**: April 18, 2026

--- a/rust/crates/orbit-audio-core/src/engine.rs
+++ b/rust/crates/orbit-audio-core/src/engine.rs
@@ -57,6 +57,29 @@ impl Engine {
         Ok(())
     }
 
+    /// `play_id` 付きでスケジュールする。後で `stop` で個別停止できる。
+    pub fn schedule_with_play_id(
+        &self,
+        start_sec: f64,
+        gain: f32,
+        play_id: String,
+        sample: Sample,
+    ) -> Result<(), EngineError> {
+        let mut s = self.inner.lock().map_err(|_| EngineError::Poisoned)?;
+        s.schedule(
+            ScheduledSample::new(start_sec, sample)
+                .with_gain(gain)
+                .with_play_id(play_id),
+        );
+        Ok(())
+    }
+
+    /// `play_id` に一致するアクティブ再生を停止する。true = 停止成功, false = 見つからず。
+    pub fn stop(&self, play_id: &str) -> Result<bool, EngineError> {
+        let mut s = self.inner.lock().map_err(|_| EngineError::Poisoned)?;
+        Ok(s.stop(play_id))
+    }
+
     /// マスターゲインを設定する。`ramp_sec` が 0 以下なら即時、正なら線形ランプ。
     ///
     /// 正の `ramp_sec` がサブフレーム相当（例: 1/sample_rate 未満）でも、

--- a/rust/crates/orbit-audio-core/src/engine.rs
+++ b/rust/crates/orbit-audio-core/src/engine.rs
@@ -80,6 +80,12 @@ impl Engine {
         Ok(s.stop(play_id))
     }
 
+    /// スケジュール中のイベント数（実時間で active な再生数）。
+    /// ロック競合時は `None` を返す。
+    pub fn active_count(&self) -> Option<usize> {
+        self.inner.try_lock().ok().map(|s| s.active_count())
+    }
+
     /// マスターゲインを設定する。`ramp_sec` が 0 以下なら即時、正なら線形ランプ。
     ///
     /// 正の `ramp_sec` がサブフレーム相当（例: 1/sample_rate 未満）でも、

--- a/rust/crates/orbit-audio-core/src/engine.rs
+++ b/rust/crates/orbit-audio-core/src/engine.rs
@@ -45,18 +45,6 @@ impl Engine {
         Ok(())
     }
 
-    /// 指定ゲインでサンプルをスケジュールする。
-    pub fn schedule_with_gain(
-        &self,
-        start_sec: f64,
-        gain: f32,
-        sample: Sample,
-    ) -> Result<(), EngineError> {
-        let mut s = self.inner.lock().map_err(|_| EngineError::Poisoned)?;
-        s.schedule(ScheduledSample::new(start_sec, sample).with_gain(gain));
-        Ok(())
-    }
-
     /// `play_id` 付きでスケジュールする。後で `stop` で個別停止できる。
     pub fn schedule_with_play_id(
         &self,

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -11,6 +11,8 @@ pub struct ScheduledSample {
     pub gain: f32,
     /// サンプル本体
     pub sample: Sample,
+    /// Stop 命令での個別停止用識別子。`None` なら停止不可（fire-and-forget）。
+    pub play_id: Option<String>,
 }
 
 impl ScheduledSample {
@@ -19,11 +21,17 @@ impl ScheduledSample {
             start_sec,
             gain: 1.0,
             sample,
+            play_id: None,
         }
     }
 
     pub fn with_gain(mut self, gain: f32) -> Self {
         self.gain = gain;
+        self
+    }
+
+    pub fn with_play_id(mut self, play_id: String) -> Self {
+        self.play_id = Some(play_id);
         self
     }
 }
@@ -59,6 +67,8 @@ struct ActiveSample {
     sample: Sample,
     /// このサンプル内で次に読むフレーム位置
     read_pos: usize,
+    /// 個別停止用識別子
+    play_id: Option<String>,
 }
 
 impl Scheduler {
@@ -104,7 +114,16 @@ impl Scheduler {
             gain: event.gain,
             sample: event.sample,
             read_pos: 0,
+            play_id: event.play_id,
         });
+    }
+
+    /// `play_id` に一致するアクティブ再生を削除する。true = 削除した, false = 見つからず。
+    pub fn stop(&mut self, play_id: &str) -> bool {
+        let before = self.events.len();
+        self.events
+            .retain(|a| a.play_id.as_deref() != Some(play_id));
+        self.events.len() < before
     }
 
     /// 出力バッファにアクティブなサンプル群を加算する。
@@ -311,6 +330,33 @@ mod tests {
         s.render(&mut buf);
         // 50 frames 経過後の global_gain は 0.5 付近
         assert!((s.global_gain() - 0.5).abs() < 0.02, "{}", s.global_gain());
+    }
+
+    #[test]
+    fn stop_removes_matching_play_id() {
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(
+            ScheduledSample::new(1.0, mk_sample_stereo(100))
+                .with_play_id("p-a".to_string()),
+        );
+        s.schedule(
+            ScheduledSample::new(2.0, mk_sample_stereo(100))
+                .with_play_id("p-b".to_string()),
+        );
+        assert_eq!(s.events_len(), 2);
+        assert!(s.stop("p-a"));
+        assert_eq!(s.events_len(), 1);
+        assert!(!s.stop("p-a"));
+        assert!(s.stop("p-b"));
+        assert_eq!(s.events_len(), 0);
+    }
+
+    #[test]
+    fn stop_ignores_unknown_id() {
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(ScheduledSample::new(0.0, mk_sample_stereo(100)));
+        assert!(!s.stop("does-not-exist"));
+        assert_eq!(s.events_len(), 1);
     }
 
     #[test]

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -214,6 +214,11 @@ impl Scheduler {
         self.output_sample_rate
     }
 
+    /// スケジュール中のイベント数（完了前の play_at + まだ開始時刻に到達していないもの）。
+    pub fn active_count(&self) -> usize {
+        self.events.len()
+    }
+
     /// テスト用: 保持しているイベント数
     #[cfg(test)]
     pub(crate) fn events_len(&self) -> usize {

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -214,16 +214,11 @@ impl Scheduler {
         self.output_sample_rate
     }
 
-    /// スケジュール中のイベント数（完了前の play_at + まだ開始時刻に到達していないもの）。
+    /// 現在保持中のイベント数（開始時刻待機中 + 再生中の両方を含む、完了済は除く）。
     pub fn active_count(&self) -> usize {
         self.events.len()
     }
 
-    /// テスト用: 保持しているイベント数
-    #[cfg(test)]
-    pub(crate) fn events_len(&self) -> usize {
-        self.events.len()
-    }
 }
 
 #[cfg(test)]
@@ -244,7 +239,7 @@ mod tests {
         s.render(&mut buf);
 
         // まだ開始時刻に到達していないので保持されているはず（retain 回帰テスト）
-        assert_eq!(s.events_len(), 1);
+        assert_eq!(s.active_count(), 1);
     }
 
     #[test]
@@ -256,7 +251,7 @@ mod tests {
         let mut buf = vec![0.0f32; 1000];
         s.render(&mut buf);
 
-        assert_eq!(s.events_len(), 0);
+        assert_eq!(s.active_count(), 0);
     }
 
     #[test]
@@ -272,7 +267,7 @@ mod tests {
         s.render(&mut buf); // panic せず完了すること
                             // 次回 render でイベントが掃除される
         s.render(&mut buf);
-        assert_eq!(s.events_len(), 0);
+        assert_eq!(s.active_count(), 0);
     }
 
     #[test]
@@ -348,12 +343,12 @@ mod tests {
             ScheduledSample::new(2.0, mk_sample_stereo(100))
                 .with_play_id("p-b".to_string()),
         );
-        assert_eq!(s.events_len(), 2);
+        assert_eq!(s.active_count(), 2);
         assert!(s.stop("p-a"));
-        assert_eq!(s.events_len(), 1);
+        assert_eq!(s.active_count(), 1);
         assert!(!s.stop("p-a"));
         assert!(s.stop("p-b"));
-        assert_eq!(s.events_len(), 0);
+        assert_eq!(s.active_count(), 0);
     }
 
     #[test]
@@ -361,7 +356,7 @@ mod tests {
         let mut s = Scheduler::new(48_000, 2);
         s.schedule(ScheduledSample::new(0.0, mk_sample_stereo(100)));
         assert!(!s.stop("does-not-exist"));
-        assert_eq!(s.events_len(), 1);
+        assert_eq!(s.active_count(), 1);
     }
 
     #[test]

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -1,6 +1,7 @@
 //! Engine + ロード済みサンプル / 再生管理の wrapper。
 //!
-//! PoC 簡略化のため `Arc<Mutex>` ベース。lock-free 化は Phase 1b-2 以降で検討。
+//! `Arc<Mutex>` ベースで制御スレッドと audio callback を共有する。
+//! audio callback 側は `try_lock` で競合時に無音 fallback する前提（lock-free 化は別 Issue）。
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -136,8 +137,7 @@ impl EngineWrap {
             .map_err(|e| WrapError::Scheduler(e.to_string()))
     }
 
-    /// 読み取り専用カウンタ。Phase 1b-2 で Stop 実装後に poisoned 検出もしたいため
-    /// 現状は Result ではなく fallback（poisoned 時は 0 を返す）で返却する。
+    /// 読み取り専用カウンタ。poisoned 時は fallback として 0 を返す。
     pub fn loaded_sample_count(&self) -> usize {
         match self.samples.lock() {
             Ok(guard) => guard.len(),

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -122,16 +122,24 @@ impl EngineWrap {
             .cloned()
             .ok_or_else(|| WrapError::SampleNotFound(sample_id.to_string()))?;
         let duration_sec = sample.duration_secs();
+        let play_id = format!("p-{}", short_uuid());
         self.engine
-            .schedule_with_gain(time_sec, gain, sample)
+            .schedule_with_play_id(time_sec, gain, play_id.clone(), sample)
             .map_err(|e| WrapError::Scheduler(e.to_string()))?;
         self.active_play_count
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(PlayHandle {
-            play_id: format!("p-{}", short_uuid()),
+            play_id,
             start_sec: time_sec,
             duration_sec,
         })
+    }
+
+    /// `play_id` に一致するアクティブ再生を停止する。true = 停止、false = 見つからず。
+    pub fn stop(&self, play_id: &str) -> Result<bool, WrapError> {
+        self.engine
+            .stop(play_id)
+            .map_err(|e| WrapError::Scheduler(e.to_string()))
     }
 
     /// 読み取り専用カウンタ。Phase 1b-2 で Stop 実装後に poisoned 検出もしたいため

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -3,7 +3,7 @@
 //! `Arc<Mutex>` ベースで制御スレッドと audio callback を共有する。
 //! audio callback 側は `try_lock` で競合時に無音 fallback する前提（lock-free 化は別 Issue）。
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -39,6 +39,9 @@ pub struct EngineWrap {
     samples: Mutex<HashMap<String, Sample>>,
     started_at: std::time::Instant,
     stream_stats: Arc<StreamStats>,
+    /// Stop 経由で停止済みの play_id。PlayEnded 遅延タスクが自然発火を抑制するために参照する。
+    /// PlayEnded 発火時に take（remove）されるため、通常ケースでは事後掃除不要。
+    stopped_play_ids: Mutex<HashSet<String>>,
 }
 
 /// `cpal::Stream` を保持する guard。drop されるとストリーム停止。`!Send`。
@@ -58,6 +61,7 @@ impl EngineWrap {
             samples: Mutex::new(HashMap::new()),
             started_at: std::time::Instant::now(),
             stream_stats,
+            stopped_play_ids: Mutex::new(HashSet::new()),
         });
         Ok((wrap, StreamGuard(stream)))
     }
@@ -131,10 +135,31 @@ impl EngineWrap {
     }
 
     /// `play_id` に一致するアクティブ再生を停止する。true = 停止、false = 見つからず。
+    ///
+    /// 停止成功時は `stopped_play_ids` にも記録し、PlayEnded 遅延タスクに
+    /// 自然発火を抑制させる（take_play_ended_suppressed で消費される）。
     pub fn stop(&self, play_id: &str) -> Result<bool, WrapError> {
-        self.engine
+        let stopped = self
+            .engine
             .stop(play_id)
-            .map_err(|e| WrapError::Scheduler(e.to_string()))
+            .map_err(|e| WrapError::Scheduler(e.to_string()))?;
+        if stopped {
+            self.stopped_play_ids
+                .lock()
+                .map_err(|_| WrapError::Scheduler("stopped_play_ids mutex poisoned".to_string()))?
+                .insert(play_id.to_string());
+        }
+        Ok(stopped)
+    }
+
+    /// PlayEnded 送信直前に呼ぶ。Stop によって停止された `play_id` なら true を返し、
+    /// 該当エントリを remove する。呼び出し側は true なら PlayEnded の送出をスキップする。
+    pub fn take_play_ended_suppressed(&self, play_id: &str) -> bool {
+        match self.stopped_play_ids.lock() {
+            Ok(mut s) => s.remove(play_id),
+            // poisoned は非致命的エラー扱い: 抑制されていない前提で PlayEnded を送出する
+            Err(_) => false,
+        }
     }
 
     /// 読み取り専用カウンタ。poisoned 時は fallback として 0 を返す。

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -37,7 +37,6 @@ pub struct EngineWrap {
     channels: u16,
     samples: Mutex<HashMap<String, Sample>>,
     started_at: std::time::Instant,
-    active_play_count: std::sync::atomic::AtomicUsize,
     stream_stats: Arc<StreamStats>,
 }
 
@@ -57,7 +56,6 @@ impl EngineWrap {
             channels,
             samples: Mutex::new(HashMap::new()),
             started_at: std::time::Instant::now(),
-            active_play_count: std::sync::atomic::AtomicUsize::new(0),
             stream_stats,
         });
         Ok((wrap, StreamGuard(stream)))
@@ -67,12 +65,10 @@ impl EngineWrap {
         self.started_at.elapsed().as_secs_f64()
     }
 
-    /// 現在は daemon 起動からの累積 `PlayAt` 回数を返す。
-    /// Phase 1b-1 時点では Stop / 再生完了イベントが未実装のため、
-    /// 減算は行わず単調増加する（Phase 1b-2 で実時間の active 数に移行予定）。
+    /// 現在スケジュール中の（まだ完了していない）再生イベント数。
+    /// audio callback がロックを握っている瞬間は取得できないので、その場合は 0 を返す。
     pub fn active_play_count(&self) -> usize {
-        self.active_play_count
-            .load(std::sync::atomic::Ordering::Relaxed)
+        self.engine.active_count().unwrap_or(0)
     }
 
     pub fn output_sample_rate(&self) -> u32 {
@@ -126,8 +122,6 @@ impl EngineWrap {
         self.engine
             .schedule_with_play_id(time_sec, gain, play_id.clone(), sample)
             .map_err(|e| WrapError::Scheduler(e.to_string()))?;
-        self.active_play_count
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(PlayHandle {
             play_id,
             start_sec: time_sec,

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -357,6 +357,11 @@ fn schedule_play_ended(
         if delay > 0.0 {
             tokio::time::sleep(std::time::Duration::from_secs_f64(delay)).await;
         }
+        // Stop 命令で停止された play_id なら PlayEnded を送出しない。
+        // Stop 応答 + PlayEnded の二重通知を避け、protocol の意味論を保つ。
+        if engine.take_play_ended_suppressed(&play_id) {
+            return;
+        }
         let ended_at_sec = start_sec + duration_sec;
         let evt = Event::new(
             EVENT_PLAY_ENDED,

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -299,11 +299,17 @@ async fn handle_command(
                 ),
             }
         }
-        "Stop" => {
-            // 現状 Engine は個別 play 停止 API を持たないため常に not_found を返す (Phase 1b-2 で実装)。
-            let pid = params.get("play_id").and_then(|v| v.as_str()).unwrap_or("");
-            ok(&id, json!({"play_id": pid, "status": "not_found"}))
-        }
+        "Stop" => match params.get("play_id").and_then(|v| v.as_str()) {
+            Some(pid) => match engine.stop(pid) {
+                Ok(true) => ok(&id, json!({"play_id": pid, "status": "stopped"})),
+                Ok(false) => ok(&id, json!({"play_id": pid, "status": "not_found"})),
+                Err(e) => err(&id, wrap_err_to_protocol(&e)),
+            },
+            None => err(
+                &id,
+                ProtocolError::new("MALFORMED_REQUEST", "missing 'play_id' param"),
+            ),
+        },
         "SetGlobalGain" => {
             let value = params.get("value").and_then(|v| v.as_f64()).unwrap_or(1.0);
             let ramp_sec = params


### PR DESCRIPTION
## Summary
- これまで常に `not_found` を返す no-op だった `Stop` コマンドを実装
- `active_plays` (StreamStats) を Scheduler の events_len 駆動に付け替え、完了/停止で自然減算

## 変更内容
- `ScheduledSample` / `ActiveSample` に `play_id: Option<String>` を追加
- `Scheduler::stop(&str) -> bool` で events retain 経由の削除
- `Scheduler::active_count()` を公開 → `Engine::active_count()` (try_lock)
- `Engine::schedule_with_play_id` / `Engine::stop` を公開
- `EngineWrap::play_at` は生成した `play_id` を渡し、`EngineWrap::stop` を追加
- `EngineWrap` から累積 AtomicUsize を削除、`active_play_count()` を engine ベースに
- `Stop` handler を実装に置き換え、`play_id` 欠落を `MALFORMED_REQUEST` で返却

## Test plan
- [x] cargo test --workspace (core 14, native 12, daemon 1)
- [x] cargo clippy --workspace --all-targets -- -D warnings clean
- [x] scheduler: stop 一致 / 未知 id / events 維持 など 2 件追加

## スコープ外
- `already_stopped` 状態の区別（履歴追跡が必要。現状は `not_found` にまとめる）
- DaemonError severity=fatal (panic hook / device lost)

Refs #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)