### PR TITLE
feat(daemon): Phase 1b-6 fatal DaemonError

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,34 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.63 Issue #107: orbit-audio-daemon fatal DaemonError (April 18, 2026)
+
+**Date**: April 18, 2026
+**Status**: ✅ COMPLETE (Phase 1b-6: fatal DaemonError — DEVICE_LOST / FATAL_PANIC)
+**Branch**: `107-daemon-fatal-errors`
+**Issue**: #107
+
+**Work Content**: Phase 1b の最終 scope として protocol v0.1 の `DaemonError severity=fatal` 2 経路を実装し、daemon 側の Phase 1b 完了。
+
+**実装**:
+- `StreamStats` に `device_lost: AtomicBool` を追加、`record_device_lost()` / snapshot 拡張
+- `make_err_fn` の closure で `cpal::StreamError` を variant で振り分け: `DeviceNotAvailable` → `record_device_lost`、`BackendSpecific` → `record_xrun`
+- `session.rs` stats_task 1 Hz ticker に device_lost 検知ブロックを xrun より前に挿入、1 回だけ fatal DaemonError (`DEVICE_LOST`) 発火
+- `main.rs` に `install_fatal_panic_hook()`: panic 時に DaemonError wire format を stderr に 1 行出力し `process::exit(1)` で確実終了。`StartupError { ready: false }` は pre-ready 失敗専用なので意図的に使わない
+- unit test 4 件追加（device_lost atomic 2件 + err_fn variant dispatch 2件）
+- 既存 test（stream_stats_starts_at_zero / record_xrun_increments_only_xruns）を device_lost フィールド込みに更新
+
+**設計上の既知トレードオフ** (プランで合意、scope 外):
+- 複数 client 同時接続時は各 session が独立に DEVICE_LOST を発火する（broadcast registry は将来拡張）
+- audio thread での DeviceNotAvailable から tokio 側 1 Hz tick 観測まで最大 1 秒の検知遅延（fatal としては許容）
+
+**検証**:
+- cargo build / clippy --workspace --all-targets -D warnings clean
+- cargo test --workspace: core 14 / native 16 / daemon 1 smoke = 31 pass
+- FATAL_PANIC は panic hook が process-global のため unit test では単離困難。Issue #117（統合テスト基盤）で対応
+
+---
+
 ### 6.62 Issue #107: orbit-audio-daemon Stop 個別停止実装 (April 18, 2026)
 
 **Date**: April 18, 2026

--- a/rust/crates/orbit-audio-daemon/src/main.rs
+++ b/rust/crates/orbit-audio-daemon/src/main.rs
@@ -14,7 +14,11 @@ mod server;
 mod session;
 
 use engine_wrap::EngineWrap;
-use protocol::{ProtocolError, StartupError, StartupReady, PROTOCOL_VERSION};
+use protocol::{
+    Event, ProtocolError, StartupError, StartupReady, ERROR_CODE_FATAL_PANIC,
+    ERROR_SEVERITY_FATAL, EVENT_DAEMON_ERROR, PROTOCOL_VERSION,
+};
+use serde_json::json;
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() {
@@ -25,9 +29,38 @@ async fn main() {
         )
         .init();
 
+    install_fatal_panic_hook();
+
     if let Err(code) = run().await {
         std::process::exit(code);
     }
+}
+
+/// panic 時に DaemonError event の wire format を stderr に出力し、
+/// `process::exit(1)` で daemon を確実に終了させる。
+///
+/// WebSocket と stderr で同じ schema を使うため、client は transport
+/// を問わず同じ parser で fatal を扱える。`StartupError { ready: false }`
+/// は pre-ready 失敗専用なので意図的に使わない。
+fn install_fatal_panic_hook() {
+    std::panic::set_hook(Box::new(|info| {
+        let msg = format!("{info}");
+        let evt = Event::new(
+            EVENT_DAEMON_ERROR,
+            json!({
+                "severity": ERROR_SEVERITY_FATAL,
+                "code": ERROR_CODE_FATAL_PANIC,
+                "message": msg,
+            }),
+        );
+        match serde_json::to_string(&evt) {
+            Ok(line) => eprintln!("{line}"),
+            Err(e) => eprintln!(
+                r#"{{"type":"event","event":"{EVENT_DAEMON_ERROR}","data":{{"severity":"{ERROR_SEVERITY_FATAL}","code":"{ERROR_CODE_FATAL_PANIC}","message":"panic hook serialize failed: {e}"}}}}"#
+            ),
+        }
+        std::process::exit(1);
+    }));
 }
 
 async fn run() -> Result<(), i32> {

--- a/rust/crates/orbit-audio-daemon/src/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/src/protocol.rs
@@ -70,6 +70,20 @@ impl ProtocolError {
     }
 }
 
+// Event / error code constants. Shared across session and panic-hook paths so the
+// wire schema is produced from a single source.
+pub const EVENT_DAEMON_ERROR: &str = "DaemonError";
+pub const EVENT_STREAM_STATS: &str = "StreamStats";
+pub const EVENT_PLAY_STARTED: &str = "PlayStarted";
+pub const EVENT_PLAY_ENDED: &str = "PlayEnded";
+
+pub const ERROR_SEVERITY_WARNING: &str = "warning";
+pub const ERROR_SEVERITY_FATAL: &str = "fatal";
+
+pub const ERROR_CODE_STREAM_XRUN: &str = "STREAM_XRUN";
+pub const ERROR_CODE_DEVICE_LOST: &str = "DEVICE_LOST";
+pub const ERROR_CODE_FATAL_PANIC: &str = "FATAL_PANIC";
+
 /// Daemon → Client の event（通知、id なし）。
 #[derive(Debug, Serialize)]
 pub struct Event {

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -17,18 +17,14 @@ use tokio_tungstenite::{tungstenite::Message, WebSocketStream};
 use tracing::warn;
 
 use crate::engine_wrap::{EngineWrap, WrapError};
-use crate::protocol::{Command, ErrorResponse, Event, Handshake, OkResponse, ProtocolError};
+use crate::protocol::{
+    Command, ErrorResponse, Event, Handshake, OkResponse, ProtocolError, ERROR_CODE_DEVICE_LOST,
+    ERROR_CODE_STREAM_XRUN, ERROR_SEVERITY_FATAL, ERROR_SEVERITY_WARNING, EVENT_DAEMON_ERROR,
+    EVENT_PLAY_ENDED, EVENT_PLAY_STARTED, EVENT_STREAM_STATS,
+};
 
 /// writer task のキュー容量。過大に積まれると back pressure をかける。
 const EVENT_CHANNEL_CAPACITY: usize = 128;
-
-const EVENT_PLAY_STARTED: &str = "PlayStarted";
-const EVENT_PLAY_ENDED: &str = "PlayEnded";
-const EVENT_STREAM_STATS: &str = "StreamStats";
-const EVENT_DAEMON_ERROR: &str = "DaemonError";
-
-const ERROR_SEVERITY_WARNING: &str = "warning";
-const ERROR_CODE_STREAM_XRUN: &str = "STREAM_XRUN";
 
 /// StreamStats の送出間隔。protocol 仕様で 1 Hz 固定。
 const STREAM_STATS_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
@@ -66,10 +62,27 @@ pub async fn run(
             let mut ticker = tokio::time::interval_at(start, STREAM_STATS_INTERVAL);
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             let mut last_xruns: u64 = 0;
+            let mut device_lost_reported = false;
             loop {
                 ticker.tick().await;
                 let snapshot = engine.stream_stats_snapshot();
                 let now_sec = engine.transport_or_uptime_sec();
+
+                // fatal を warning より先に送り、client が最終イベントとして確実に観測できる順序にする。
+                if snapshot.device_lost && !device_lost_reported {
+                    let fatal_evt = Event::new(
+                        EVENT_DAEMON_ERROR,
+                        json!({
+                            "severity": ERROR_SEVERITY_FATAL,
+                            "code": ERROR_CODE_DEVICE_LOST,
+                            "message": "audio device disappeared",
+                        }),
+                    );
+                    if tx.send(to_json_or_fallback(&fatal_evt)).await.is_err() {
+                        break;
+                    }
+                    device_lost_reported = true;
+                }
 
                 if snapshot.xruns > last_xruns {
                     let warn_evt = Event::new(

--- a/rust/crates/orbit-audio-native/src/output.rs
+++ b/rust/crates/orbit-audio-native/src/output.rs
@@ -1,6 +1,6 @@
 //! cpal を使った既定出力デバイスへのストリーム設定。
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -14,10 +14,16 @@ use orbit_audio_core::Engine;
 /// err_fn は audio スレッドから呼ばれるため atomic で更新する。
 /// `buffer_underruns` は cpal の `StreamError` が underrun を個別に示さないため
 /// 常に 0。将来 backend-specific な判別ができるようになれば増分経路を追加する。
+///
+/// `device_lost` は `cpal::StreamError::DeviceNotAvailable` を受け取った際に
+/// true にセットされ、上位 (daemon session) が 1 Hz ticker で polling して
+/// fatal DaemonError イベントを発火するためのフラグ。一度 true になったら
+/// 現 stream は回復不能なので、set 後の再初期化は scope 外。
 #[derive(Debug, Default)]
 pub struct StreamStats {
     xruns: AtomicU64,
     buffer_underruns: AtomicU64,
+    device_lost: AtomicBool,
 }
 
 impl StreamStats {
@@ -25,11 +31,27 @@ impl StreamStats {
         StreamStatsSnapshot {
             xruns: self.xruns.load(Ordering::Relaxed),
             buffer_underruns: self.buffer_underruns.load(Ordering::Relaxed),
+            device_lost: self.device_lost.load(Ordering::Relaxed),
         }
     }
 
     fn record_xrun(&self) {
         self.xruns.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_device_lost(&self) {
+        self.device_lost.store(true, Ordering::Relaxed);
+    }
+
+    /// cpal::StreamError を variant で振り分けて atomic を更新する。
+    /// audio thread から呼ばれるので blocking I/O を避け atomic 操作のみ。
+    /// make_err_fn と test helper の両方がこれを参照するため、
+    /// dispatch ロジックの drift 防止に single-source として機能する。
+    fn record_error(&self, err: &cpal::StreamError) {
+        match err {
+            cpal::StreamError::DeviceNotAvailable => self.record_device_lost(),
+            cpal::StreamError::BackendSpecific { .. } => self.record_xrun(),
+        }
     }
 }
 
@@ -37,6 +59,7 @@ impl StreamStats {
 pub struct StreamStatsSnapshot {
     pub xruns: u64,
     pub buffer_underruns: u64,
+    pub device_lost: bool,
 }
 
 #[derive(Error, Debug)]
@@ -98,12 +121,9 @@ fn build_stream(
     stats: Arc<StreamStats>,
 ) -> Result<Stream, OutputError> {
     let make_err_fn = || {
-        // audio thread から呼ばれるため blocking I/O を避け、atomic increment のみ行う。
         // 上位 (daemon session) が StreamStats / DaemonError 経由で可視化する責務を持つ。
         let stats = stats.clone();
-        move |_err| {
-            stats.record_xrun();
-        }
+        move |err: cpal::StreamError| stats.record_error(&err)
     };
 
     /// scratch バッファを事前に 1 秒分確保してクロージャにムーブするヘルパー。
@@ -197,6 +217,7 @@ fn build_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cpal::BackendSpecificError;
 
     #[test]
     fn stream_stats_starts_at_zero() {
@@ -204,6 +225,7 @@ mod tests {
         let snap = stats.snapshot();
         assert_eq!(snap.xruns, 0);
         assert_eq!(snap.buffer_underruns, 0);
+        assert!(!snap.device_lost);
     }
 
     #[test]
@@ -215,6 +237,7 @@ mod tests {
         let snap = stats.snapshot();
         assert_eq!(snap.xruns, 3);
         assert_eq!(snap.buffer_underruns, 0);
+        assert!(!snap.device_lost);
     }
 
     #[test]
@@ -224,5 +247,49 @@ mod tests {
         stats.record_xrun();
         let s2 = stats.snapshot();
         assert!(s2.xruns > s1.xruns);
+    }
+
+    #[test]
+    fn record_device_lost_sets_flag() {
+        let stats = StreamStats::default();
+        assert!(!stats.snapshot().device_lost);
+        stats.record_device_lost();
+        assert!(stats.snapshot().device_lost);
+    }
+
+    #[test]
+    fn device_lost_and_xrun_are_independent() {
+        let stats = StreamStats::default();
+        stats.record_xrun();
+        let after_xrun = stats.snapshot();
+        assert_eq!(after_xrun.xruns, 1);
+        assert!(!after_xrun.device_lost);
+
+        stats.record_device_lost();
+        let after_lost = stats.snapshot();
+        assert_eq!(after_lost.xruns, 1, "record_device_lost must not touch xruns");
+        assert!(after_lost.device_lost);
+    }
+
+    #[test]
+    fn record_error_dispatches_device_not_available_as_device_lost() {
+        let stats = StreamStats::default();
+        stats.record_error(&cpal::StreamError::DeviceNotAvailable);
+        let snap = stats.snapshot();
+        assert!(snap.device_lost);
+        assert_eq!(snap.xruns, 0);
+    }
+
+    #[test]
+    fn record_error_dispatches_backend_specific_as_xrun() {
+        let stats = StreamStats::default();
+        stats.record_error(&cpal::StreamError::BackendSpecific {
+            err: BackendSpecificError {
+                description: "transient underrun".to_string(),
+            },
+        });
+        let snap = stats.snapshot();
+        assert_eq!(snap.xruns, 1);
+        assert!(!snap.device_lost);
     }
 }


### PR DESCRIPTION
## Summary
- `DaemonError severity=fatal` の 2 経路 (`DEVICE_LOST` / `FATAL_PANIC`) を実装し、daemon 側の Phase 1b protocol を完了
- 既存 1 Hz stats_task を再利用した device-lost 検知、panic hook 経由の stderr fallback、protocol constants を集約

## 変更内容

### DEVICE_LOST (per-session 1 Hz ticker)
- `StreamStats` に `device_lost: AtomicBool` を追加、`record_device_lost` / snapshot を拡張
- `StreamStats::record_error(cpal::StreamError)` で variant 判別を一元化し、production closure と test helper が同一ロジックを共有
- `session.rs` stats_task で device_lost を観測し、1 回だけ fatal DaemonError を warning より先に送出

### FATAL_PANIC (stderr fallback)
- `main.rs` の `install_fatal_panic_hook` が panic 時に DaemonError wire format (WS と同一 schema) を stderr に 1 行出力、`process::exit(1)` で確実終了
- `StartupError { ready:false }` は pre-ready 失敗専用のため意図的に不使用

### protocol constants 集約
- `EVENT_DAEMON_ERROR` / `ERROR_SEVERITY_FATAL` / `ERROR_CODE_*` を `protocol.rs` に集約し、main.rs と session.rs で共有

## Test plan
- [x] cargo test --workspace (core 14 / native 16 / daemon 1 smoke = 31 pass)
- [x] cargo clippy --workspace --all-targets -- -D warnings clean
- [x] unit test 4 件追加 (device_lost atomic 2 件 + record_error dispatch 2 件)

## スコープ外（次フェーズ）
- 複数 client 同時接続時の DEVICE_LOST broadcast 一元化
- FATAL_PANIC の E2E test (Issue #117 の統合テスト基盤で対応)

Refs #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)