### PR TITLE
fix(hooks): use JSON deny schema so block reason reaches user

### DIFF
--- a/.claude/hooks/pre-edit-check.sh
+++ b/.claude/hooks/pre-edit-check.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 # PreEdit Hook - Check branch before editing files
+#
+# Claude Code PreToolUse hook protocol:
+# - Block: exit 0 with stdout JSON
+#   {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+#    "permissionDecision":"deny","permissionDecisionReason":"..."}}
+# - Legacy shell style: exit 2 + reason on stderr (not stdout)
+# Ref: https://code.claude.com/docs/en/hooks-guide
 
 # Get project root and current branch
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
@@ -10,24 +17,40 @@ else
   CURRENT_BRANCH=""
 fi
 
-# Check if on main branch
+# Block edits on main branch (JSON-style deny so the reason reaches the user)
 if [[ "$CURRENT_BRANCH" == "main" ]]; then
-  cat << 'EOF'
-{
-  "error": "🚫 **実装ブロック: mainブランチでの編集禁止**\n\n現在のブランチ: `main`\n\n**ワークフロー違反**: mainブランチで直接実装を開始しようとしています。\n\n**正しい手順**:\n1. Issue作成: `gh issue create --title \"...\"`\n2. ブランチ作成: `git checkout -b <issue-number>-description`\n3. 実装開始\n\n**理由**:\n- ブランチ管理の崩壊を防ぐ\n- Issue追跡を確実にする\n- PRとIssueの紐付けを保証する\n\n詳細: CLAUDE.md「実装前の必須ワークフロー」"
-}
-EOF
-  exit 2  # Block edit
+  REASON=$(cat <<'MSG'
+🚫 実装ブロック: mainブランチでの編集禁止
+
+ワークフロー違反: mainブランチで直接実装を開始しようとしています。
+
+正しい手順:
+1. Issue作成: gh issue create --title "..."
+2. ブランチ作成: git checkout -b <issue-number>-description
+3. 実装開始
+
+理由: ブランチ管理の崩壊防止 / Issue 追跡の確実化 / PR-Issue 紐付け保証
+詳細: CLAUDE.md「実装前の必須ワークフロー」
+MSG
+)
+  # jq で安全に JSON エスケープ (fallback: python3)
+  if command -v jq >/dev/null 2>&1; then
+    REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
+  else
+    REASON_JSON=$(printf '%s' "$REASON" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+  fi
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+  exit 0
 fi
 
-# Check if branch name contains issue number (format: <number>-<description>)
+# Warn (don't block) when branch name lacks an issue number prefix
 if [[ "$CURRENT_BRANCH" != "" ]] && ! [[ "$CURRENT_BRANCH" =~ ^[0-9]+-.*$ ]]; then
-  cat << 'EOF'
+  # 非 quoted heredoc で ${CURRENT_BRANCH} を展開する
+  cat <<EOF
 {
-  "notification": "⚠️ **ブランチ命名規則の警告**\n\n現在のブランチ: `${CURRENT_BRANCH}`\n\nブランチ名にIssue番号が含まれていません。\n\n**推奨形式**: `<issue-number>-<descriptive-name>`\n\n例: `55-improve-type-safety-process-statement`\n\n作業を続ける前に、正しいブランチ名で作り直すことを推奨します。"
+  "notification": "⚠️ ブランチ命名規則の警告\n\n現在のブランチ: \`${CURRENT_BRANCH}\`\n\nブランチ名にIssue番号が含まれていません。\n\n推奨形式: <issue-number>-<descriptive-name>\n例: 55-improve-type-safety-process-statement\n\n作業を続ける前に、正しいブランチ名で作り直すことを推奨します。"
 }
 EOF
-  # Warning only, don't block
   exit 0
 fi
 

--- a/.claude/hooks/pre-edit-check.sh
+++ b/.claude/hooks/pre-edit-check.sh
@@ -45,12 +45,15 @@ fi
 
 # Warn (don't block) when branch name lacks an issue number prefix
 if [[ "$CURRENT_BRANCH" != "" ]] && ! [[ "$CURRENT_BRANCH" =~ ^[0-9]+-.*$ ]]; then
-  # 非 quoted heredoc で ${CURRENT_BRANCH} を展開する
-  cat <<EOF
-{
-  "notification": "⚠️ ブランチ命名規則の警告\n\n現在のブランチ: \`${CURRENT_BRANCH}\`\n\nブランチ名にIssue番号が含まれていません。\n\n推奨形式: <issue-number>-<descriptive-name>\n例: 55-improve-type-safety-process-statement\n\n作業を続ける前に、正しいブランチ名で作り直すことを推奨します。"
-}
-EOF
+  # ブランチ名に " や \ 等が含まれた場合でも malformed JSON を出さないよう
+  # deny 分岐と同じ escape パスを通す
+  MSG=$(printf '⚠️ ブランチ命名規則の警告\n\n現在のブランチ: `%s`\n\nブランチ名にIssue番号が含まれていません。\n\n推奨形式: <issue-number>-<descriptive-name>\n例: 55-improve-type-safety-process-statement\n\n作業を続ける前に、正しいブランチ名で作り直すことを推奨します。' "$CURRENT_BRANCH")
+  if command -v jq >/dev/null 2>&1; then
+    MSG_JSON=$(printf '%s' "$MSG" | jq -Rs .)
+  else
+    MSG_JSON=$(printf '%s' "$MSG" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+  fi
+  printf '{"notification":%s}\n' "$MSG_JSON"
   exit 0
 fi
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -3396,6 +3396,24 @@ git mv docs/IMPROVEMENT_RECOMMENDATIONS.md docs/planning/
 
 ---
 
+### 6.46 Fix pre-edit-check.sh hook protocol violation (April 18, 2026)
+
+#### 背景
+`.claude/hooks/pre-edit-check.sh` の main ブランチ block 時に Claude Code が "No stderr output" エラーを表示し、親切なブロック理由が user に到達していなかった (Issue #119)。
+
+#### 原因
+1. Shell スタイル block (`exit 2`) なのに理由を stdout に `{"error":"..."}` 独自 schema で出していた。exit 2 は stderr を期待するため stdout は捨てられ、Claude Code から見ると「exit 2 で block、stderr 空」状態だった
+2. notification 分岐で `<<'EOF'` (quoted heredoc) を使っていたため `${CURRENT_BRANCH}` が展開されずリテラル文字列のまま埋め込まれていた
+
+#### 修正
+- main block は Claude Code 公式 JSON schema (`hookSpecificOutput.permissionDecision=deny` + `permissionDecisionReason`) + `exit 0` に変更。jq (fallback: python3) で JSON escape
+- notification heredoc は `<<EOF` に変更して変数展開を有効化
+- 3 シナリオ (main / 非 issue ブランチ / issue ブランチ) で動作検証済み
+
+**Branch**: `119-fix-pre-edit-check-hook-protocol`
+
+---
+
 ## Archived Work
 
 Older work logs have been moved to the archive:


### PR DESCRIPTION
## 概要

`.claude/hooks/pre-edit-check.sh` が main ブランチ編集を block する際、Claude Code が `No stderr output` と表示して親切な理由メッセージが user に届かない問題を修正。

## 原因

1. **Shell スタイル protocol 違反**: `exit 2` で block する場合、理由は **stderr** に出す必要があるが、本 hook は stdout に `{"error":"..."}` という Claude Code 未知の独自 schema を出力していた
2. **quoted heredoc のバグ**: notification 分岐の `<<'EOF'` では `${CURRENT_BRANCH}` が展開されず、リテラル文字列のまま user に表示されていた

## 修正

- main block を Claude Code 公式 JSON schema (`hookSpecificOutput.permissionDecision=deny` + `permissionDecisionReason`) + `exit 0` に変更
- JSON escape は `jq -Rs .` (fallback: `python3 -c 'import json; ...'`) で安全に実施
- notification 分岐も同じ escape パスを通し、ブランチ名に `"` や `\` が含まれても malformed JSON を出さないようにする（レビュアー指摘対応）
- notification heredoc の `<<'EOF'` 引用符を除去し `${CURRENT_BRANCH}` を展開
- hook protocol を doc comment で明記

## 検証

- ✅ main ブランチ: JSON deny で理由が user に到達
- ✅ 非 issue ブランチ (`foo-bar`): notification で `foo-bar` が正しく展開
- ✅ issue ブランチ (`42-foo`): 静かに exit 0
- ✅ `bash -n` syntax check pass

## 関連

- Issue #119 で `claude-tools#218` と同根のトラップとして報告
- Ref: https://code.claude.com/docs/en/hooks-guide

Closes #119