### PR TITLE
fix(hooks): allow plan-mode plan files on protected branches

### DIFF
--- a/.claude/hooks/pre-edit-check.sh
+++ b/.claude/hooks/pre-edit-check.sh
@@ -17,6 +17,26 @@ else
   CURRENT_BRANCH=""
 fi
 
+# Read tool_input.file_path from stdin (Claude Code PreToolUse hook protocol).
+# Plan-mode の plan file (.claude/plans/) は Phase 4 で書込必須なので protected branch でも許可。
+TARGET_FILE=""
+if ! [ -t 0 ]; then
+  INPUT_JSON=$(cat 2>/dev/null || true)
+  if [ -n "$INPUT_JSON" ]; then
+    if command -v jq >/dev/null 2>&1; then
+      TARGET_FILE=$(printf '%s' "$INPUT_JSON" | jq -r '.tool_input.file_path // ""' 2>/dev/null || true)
+    elif command -v python3 >/dev/null 2>&1; then
+      TARGET_FILE=$(printf '%s' "$INPUT_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("tool_input",{}).get("file_path",""))' 2>/dev/null || true)
+    fi
+  fi
+fi
+
+case "$TARGET_FILE" in
+  */.claude/plans/*)
+    exit 0
+    ;;
+esac
+
 # Block edits on main branch (JSON-style deny so the reason reaches the user)
 if [[ "$CURRENT_BRANCH" == "main" ]]; then
   REASON=$(cat <<'MSG'

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,35 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.64 Issue #153: pre-edit-check.sh allow plan-mode plan files (May 02, 2026)
+
+**Date**: May 02, 2026
+**Status**: ✅ COMPLETE
+**Branch**: `153-hook-allow-plans-dir`
+**Issue**: #153
+
+**Work Content**: Claude Code plan mode の plan file (`.claude/plans/<name>.md`) 書込が main ブランチで `pre-edit-check.sh` にブロックされ workflow が完結しない問題を解決。Issue #136 (scsynth bundle) の plan 作成中に発見した hook 改善作業。
+
+**実装**:
+- `.claude/hooks/pre-edit-check.sh` 修正
+  - stdin から `tool_input.file_path` を読み取る処理を追加 (jq 優先、python3 fallback)
+  - `case` 判定で `*/.claude/plans/*` パスは早期 `exit 0` で通過
+- 既存の main 編集 deny ロジックと branch 命名警告は無改修
+
+**検証**:
+- Sanity test 7 ケースすべて pass
+  - feature branch + 通常 file → exit 0 (既存通り)
+  - feature branch + plan file → exit 0 (新挙動、early allow)
+  - 空 stdin / malformed JSON / `tool_input.file_path` 欠落 → exit 0 (graceful)
+  - simulated main + plan file → exit 0 (新挙動、early allow)
+  - simulated main + 通常 file → deny JSON 出力 + exit 0 (既存通り)
+
+**後続**:
+- 本 fix で plan mode workflow が main ブランチでも完結可能に
+- 将来 `claude-tools` リポジトリに汎用 branch-protection plugin を作る際の参考実装
+
+---
+
 ### 6.63 Issue #107: orbit-audio-daemon fatal DaemonError (April 18, 2026)
 
 **Date**: April 18, 2026


### PR DESCRIPTION
## Summary
- `pre-edit-check.sh` が main ブランチで `.claude/plans/` への Write を block していた問題を解決
- stdin から `tool_input.file_path` を読取り、plan mode の plan file パスは早期 allow
- 既存の main 編集 deny ロジックは無改修で維持

## 背景
Claude Code plan mode は Phase 4 (Final Plan) で `.claude/plans/<name>.md` を Write する必要があるが、本リポの `pre-edit-check.sh` は main の全 Edit/Write を deny していたため、main で plan mode を実行すると workflow が完結しなかった (Issue #136 の plan 作成中に発生)。

## 実装
- `.claude/hooks/pre-edit-check.sh` に stdin パース処理を追加 (jq 優先、python3 fallback、stdin 欠落時もフェイルセーフ)
- `case` 判定で `*/.claude/plans/*` パターンに該当したら早期 `exit 0`
- 既存ロジック (main 編集 deny / branch 命名警告) は無改修

## Test plan
- [x] feature branch + 通常 file → exit 0 (既存通り)
- [x] feature branch + plan file → exit 0 (新挙動、early allow)
- [x] 空 stdin → exit 0 (graceful)
- [x] malformed JSON → exit 0 (graceful)
- [x] `tool_input.file_path` 欠落 → exit 0 (graceful)
- [x] simulated main (`mktemp` で temp git repo) + plan file → exit 0 (新挙動、early allow)
- [x] simulated main + 通常 file → deny JSON 出力 + exit 0 (既存通り)
- [ ] レビュア確認: PR マージ後、main で `/plan` 実行 → plan file 書込が通過すること

## 関連
- Closes #153
- Issue #136 (scsynth bundle) の plan 作成中に発見

🤖 Generated with [Claude Code](https://claude.com/claude-code)