### PR TITLE
feat(vscode-extension): bundle scsynth + strict path resolver (no SC.app fallback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The previous MIDI-based implementation (Phases 1-10) is now deprecated but prese
 
 **Current Status**: ICMC v1.0 Phase 1 — scsynth bundle integration (Issue #136, PR pending) 🎁
 
+**Supported Platforms (v1.0)**: macOS (Apple Silicon) only. Bundled `scsynth` ships only macOS Mach-O binaries; Windows / Linux are out of scope for the initial ICMC release.
+
 **ICMC v1.0 Phase 1 (Epic #131)** — `.vsix` install だけで音が鳴る状態を実現:
 
 | Issue | Status | Description |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,16 @@ The previous MIDI-based implementation (Phases 1-10) is now deprecated but prese
 | **Phase 8** | 📝 Next | 0% | Polymeter Testing & Advanced Features |
 | **Phase 9** | 📝 Planned | 0% | DAW Plugin Development |
 
-**Current Status**: Documentation reorganization (Issue #67) 📚
+**Current Status**: ICMC v1.0 Phase 1 — scsynth bundle integration (Issue #136, PR pending) 🎁
+
+**ICMC v1.0 Phase 1 (Epic #131)** — `.vsix` install だけで音が鳴る状態を実現:
+
+| Issue | Status | Description |
+|-------|--------|-------------|
+| #136 | ✅ Implementation complete | scsynth + 26 plugins + libsndfile bundle (~11.5MB), path resolver unification, first-run UX |
+| #139 | 🚧 Placeholder bundled in #136 | LICENSE/NOTICE 文言洗練・SC source URL 確定 |
+| #138 | 📝 Pending | Cold-install acceptance test (SC-less macOS) |
+| #137 | 📝 Pending | Marketplace 自動 publish workflow |
 
 **Phase 7 Achievements**:
 - ✅ SuperCollider audio engine (replaced sox)

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -28,7 +28,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **Version**: 1.0.1 → **1.1.0** (Phase 13 で minor bump、scsynth bundle 同梱は major feature)
 
-**実装** (17 commits、各単独で `npm test` 通過):
+**実装** (18 commits、各単独で `npm test` 通過):
 
 | # | Commit | 内容 |
 |---|--------|------|
@@ -48,7 +48,8 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 | 14 | `df3e8f7` | refactor(vscode-extension): rename killSuperCollider command to forceKillScsynth |
 | 15 | `fbd033a` | fix(vscode-extension): exec→execFile in selectAudioDevice + status bar settings target |
 | 16 | `e82e0ef` | fix(vscode-extension): skip engine spawn when scsynth unresolvable (avoid double error notice) |
-| 17 | this | refactor(vscode-extension): reuse pre-check resolution + execFile for all killall (review minors) |
+| 17 | `2f8f4d8` | refactor(vscode-extension): reuse pre-check resolution + execFile for all killall (review minors) |
+| 18 | this | docs(legal): embed GPL-3.0 verbatim + NOTICE aggregation clause (closes #139) |
 
 **新規ファイル**:
 - `packages/engine/src/audio/supercollider/scsynth-resolver.ts` (resolver 本体、strict mode)
@@ -89,9 +90,12 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 **スコープ外** (本 PR で実装しない):
 - #137 Marketplace 自動 publish workflow (リリース戦略変更で ICMC ブロッカーから降格、別 issue で再整理予定)
 - #138 cold-install acceptance test (実機 SC-less Mac で別途検証)
-- #139 LICENSE/NOTICE 文言洗練 (本 PR は placeholder のみ)
 - #151 OrbitScore: Check Audio Setup (post-icmc)
 - #152 OrbitScore: Open Examples (post-icmc)
+- #156 環境変数名統一 (post-icmc、Phase 15 review feedback)
+
+**スコープに吸収** (本 PR で完了):
+- #139 LICENSE/NOTICE 文言洗練 → Phase 18 で GPL-3.0 verbatim 同梱 + NOTICE に separate works (OSC IPC) aggregation 明記 + libsndfile LGPL-2.1 区別 (Phase 12)。本 PR マージで #139 close。
 
 **後続**:
 - 本 PR マージ → #138 で SC-less Mac の cold-install 検証

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -28,7 +28,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **Version**: 1.0.1 → **1.1.0** (Phase 13 で minor bump、scsynth bundle 同梱は major feature)
 
-**実装** (13 commits、各単独で `npm test` 通過):
+**実装** (15 commits、各単独で `npm test` 通過):
 
 | # | Commit | 内容 |
 |---|--------|------|
@@ -44,7 +44,9 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 | 10 | `5f93169` | docs(worklog,readme,build-guide): document strict resolver and dev workaround |
 | 11 | `98277db` | docs(platform): scope v1.0 to macOS Apple Silicon only |
 | 12 | `bb94fe6` | fix(review): address claude-review feedback (libsndfile LGPL, JSDoc, DRY, dead code) |
-| 13 | this | docs(extension-readme): restructure for marketplace + bump version to 1.1.0 |
+| 13 | `58d9825` | docs(extension-readme): restructure for marketplace + bump version to 1.1.0 |
+| 14 | `df3e8f7` | refactor(vscode-extension): rename killSuperCollider command to forceKillScsynth |
+| 15 | this | fix(vscode-extension): exec→execFile in selectAudioDevice + status bar settings target |
 
 **新規ファイル**:
 - `packages/engine/src/audio/supercollider/scsynth-resolver.ts` (resolver 本体、strict mode)

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -28,7 +28,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **Version**: 1.0.1 → **1.1.0** (Phase 13 で minor bump、scsynth bundle 同梱は major feature)
 
-**実装** (16 commits、各単独で `npm test` 通過):
+**実装** (17 commits、各単独で `npm test` 通過):
 
 | # | Commit | 内容 |
 |---|--------|------|
@@ -47,7 +47,8 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 | 13 | `58d9825` | docs(extension-readme): restructure for marketplace + bump version to 1.1.0 |
 | 14 | `df3e8f7` | refactor(vscode-extension): rename killSuperCollider command to forceKillScsynth |
 | 15 | `fbd033a` | fix(vscode-extension): exec→execFile in selectAudioDevice + status bar settings target |
-| 16 | this | fix(vscode-extension): skip engine spawn when scsynth unresolvable (avoid double error notice) |
+| 16 | `e82e0ef` | fix(vscode-extension): skip engine spawn when scsynth unresolvable (avoid double error notice) |
+| 17 | this | refactor(vscode-extension): reuse pre-check resolution + execFile for all killall (review minors) |
 
 **新規ファイル**:
 - `packages/engine/src/audio/supercollider/scsynth-resolver.ts` (resolver 本体、strict mode)

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,70 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.65 Issue #136: scsynth bundle integration in vscode-extension (May 02, 2026)
+
+**Date**: May 02, 2026
+**Status**: ✅ COMPLETE (PR pending review)
+**Branch**: `136-bundle-scsynth-vscode-extension`
+**Issue**: #136 (Epic #131 Phase 1 — ICMC v1.0)
+
+**Work Content**: ICMC 2026 リリースの最大インストール障壁 (SC.app の手動 install 強要) を解消するため、scsynth + 26 plugins + libsndfile.dylib (~11.5MB) を `.vsix` に同梱、path resolver を extension/engine 共通化、bundle 不在時の first-run UX を実装。旧 #146 の (1)(2) (bundle 検出 + Notification) を統合 (CodeX レビュー承認、#146 close 済)。
+
+**実装** (7 commits、各単独で `npm test` 通過):
+
+| # | Commit | 内容 |
+|---|--------|------|
+| 1 | `63e298b` | feat(audio): add scsynth path resolver with multi-source fallback |
+| 2 | `24a2e5c` | refactor(audio): wire SuperColliderPlayer through scsynth resolver |
+| 3 | `a4bad3b` | feat(vscode-extension): add orbitscore.scsynthPath setting and pass to engine |
+| 4 | `7880462` | refactor(vscode-extension): unify selectAudioDevice through scsynth resolver |
+| 5 | `9663a83` | feat(vscode-extension): add bundle status bar and first-run notification |
+| 6 | `aca6450` | feat(build): add scsynth bundle extract/verify scripts and legal placeholders |
+| 7 | this | docs(worklog,readme): record scsynth bundle integration |
+
+**新規ファイル**:
+- `packages/engine/src/audio/supercollider/scsynth-resolver.ts` (resolver 本体)
+- `tests/audio/scsynth-resolver.spec.ts` (11 unit tests、CI 実行可)
+- `scripts/extract-scsynth-bundle.sh` (SC.app 自動 discovery + 26 plugin filter + 検証)
+- `scripts/verify-bundle.sh` (`.vsix` 解凍後の signature/permission 確認)
+- `packages/vscode-extension/legal/scsynth-LICENSE.GPL-3.0` (#139 placeholder)
+- `packages/vscode-extension/legal/scsynth-NOTICE` (GPL-3.0 §6 corresponding source URL 明記)
+
+**Path resolver 仕様** (engine 側に唯一存在、extension は `require` で再利用):
+1. `opts.explicit` (caller 明示)
+2. `process.env.ORBIT_SCSYNTH_PATH` (extension が settings から渡す)
+3. Bundle (`<engine root>/scsynth/Contents/Resources/scsynth`)
+4. SC.app fallback (`/Applications/SuperCollider.app/...`)
+5. Spotlight (`mdfind -name SuperCollider.app`)
+
+各候補で `fs.statSync` + 実行権限ビット (`mode & 0o111`) を検査。全 miss 時は `ScsynthNotFoundError` (`searched` 配列付き) を throw。`daemon-client.ts:417-433` の `resolveDaemonBinary()` パターン流用。
+
+**First-run UX** (CodeX 指摘「初回限定 + status bar degraded」反映):
+- StatusBar item (priority 99) で source 別に icon + 警告色背景 (sc-app/spotlight 時)
+- `startEngine()` 実行時に bundle 不在 (sc-app/spotlight) 時のみ Warning Notification 1 回
+- `globalState.orbitscore.bundleNotice.dismissedVersion` で version 単位 dismiss を記録
+- resolver 失敗時は毎回エラー Notification (修復必須のため)
+
+**実機検証 (SC 3.14.1 環境)**:
+- `npm run build:bundle` → 11MB bundle 生成、26 plugins、universal arm64+x86_64
+- `npm run verify:bundle` → 11/11 checks pass (signature valid、TeamIdentifier=HE5VJFE9E4)
+- engine test 241 pass / 23 skipped (resolver 11 新規 + 既存 230 維持)
+- TypeScript build clean、ESLint clean
+
+**スコープ外** (本 PR で実装しない):
+- #137 Marketplace 自動 publish workflow
+- #138 cold-install acceptance test (実機 SC-less Mac で別途検証)
+- #139 LICENSE/NOTICE 文言洗練 (本 PR は placeholder のみ)
+- #151 OrbitScore: Check Audio Setup (post-icmc)
+- #152 OrbitScore: Open Examples (post-icmc)
+
+**後続**:
+- 本 PR マージ → #138 で SC-less Mac の cold-install 検証
+- #138 通過 → #137 で Marketplace publish workflow
+- ICMC 2026 リリース ready
+
+---
+
 ### 6.64 Issue #153: pre-edit-check.sh allow plan-mode plan files (May 02, 2026)
 
 **Date**: May 02, 2026

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -69,6 +69,8 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 - ICMC v1.0 初回は **GitHub Release に `.vsix` を添付**して配布、ユーザは ダウンロード + ダブルクリック (or `code --install-extension`) で install
 - Marketplace 自動 publish (#137) は ICMC ブロッカーから降格可能 (別 issue で再整理)
 
+**動作環境** (v1.0): **macOS (Apple Silicon)** のみ。bundle scsynth は universal binary だが、Intel Mac は未テスト。Windows / Linux は scsynth bundle に対応 binary が同梱されないため非対応 (cross-platform は将来 issue で扱う)。Marketplace publish 時は `vsce package --target darwin-arm64` で OS gate を明示する想定。
+
 **実機検証 (SC 3.14.1 環境)**:
 - `npm run build:bundle` → 11MB bundle 生成、26 plugins、universal arm64+x86_64
 - `npm run verify:bundle` → 11/11 checks pass (signature valid、TeamIdentifier=HE5VJFE9E4)

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -26,7 +26,9 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **Work Content**: ICMC 2026 リリースの最大インストール障壁 (SC.app の手動 install 強要) を解消するため、scsynth + 26 plugins + libsndfile.dylib (~11.5MB) を `.vsix` に同梱、path resolver を extension/engine 共通化、bundle 不在時の first-run UX を実装。旧 #146 の (1)(2) (bundle 検出 + Notification) を統合 (CodeX レビュー承認、#146 close 済)。
 
-**実装** (10 commits、各単独で `npm test` 通過):
+**Version**: 1.0.1 → **1.1.0** (Phase 13 で minor bump、scsynth bundle 同梱は major feature)
+
+**実装** (13 commits、各単独で `npm test` 通過):
 
 | # | Commit | 内容 |
 |---|--------|------|
@@ -39,7 +41,10 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 | 7 | `e25894d` | docs(worklog,readme): record scsynth bundle integration |
 | 8 | `1569110` | refactor(audio): drop SC.app/spotlight fallback from scsynth resolver |
 | 9 | `08c2855` | refactor(vscode-extension): align UX with strict bundle requirement |
-| 10 | this | docs(worklog,readme,build-guide): document strict resolver and dev workaround |
+| 10 | `5f93169` | docs(worklog,readme,build-guide): document strict resolver and dev workaround |
+| 11 | `98277db` | docs(platform): scope v1.0 to macOS Apple Silicon only |
+| 12 | `bb94fe6` | fix(review): address claude-review feedback (libsndfile LGPL, JSDoc, DRY, dead code) |
+| 13 | this | docs(extension-readme): restructure for marketplace + bump version to 1.1.0 |
 
 **新規ファイル**:
 - `packages/engine/src/audio/supercollider/scsynth-resolver.ts` (resolver 本体、strict mode)

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -28,7 +28,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **Version**: 1.0.1 → **1.1.0** (Phase 13 で minor bump、scsynth bundle 同梱は major feature)
 
-**実装** (15 commits、各単独で `npm test` 通過):
+**実装** (16 commits、各単独で `npm test` 通過):
 
 | # | Commit | 内容 |
 |---|--------|------|
@@ -46,7 +46,8 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 | 12 | `bb94fe6` | fix(review): address claude-review feedback (libsndfile LGPL, JSDoc, DRY, dead code) |
 | 13 | `58d9825` | docs(extension-readme): restructure for marketplace + bump version to 1.1.0 |
 | 14 | `df3e8f7` | refactor(vscode-extension): rename killSuperCollider command to forceKillScsynth |
-| 15 | this | fix(vscode-extension): exec→execFile in selectAudioDevice + status bar settings target |
+| 15 | `fbd033a` | fix(vscode-extension): exec→execFile in selectAudioDevice + status bar settings target |
+| 16 | this | fix(vscode-extension): skip engine spawn when scsynth unresolvable (avoid double error notice) |
 
 **新規ファイル**:
 - `packages/engine/src/audio/supercollider/scsynth-resolver.ts` (resolver 本体、strict mode)

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -26,7 +26,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **Work Content**: ICMC 2026 リリースの最大インストール障壁 (SC.app の手動 install 強要) を解消するため、scsynth + 26 plugins + libsndfile.dylib (~11.5MB) を `.vsix` に同梱、path resolver を extension/engine 共通化、bundle 不在時の first-run UX を実装。旧 #146 の (1)(2) (bundle 検出 + Notification) を統合 (CodeX レビュー承認、#146 close 済)。
 
-**実装** (7 commits、各単独で `npm test` 通過):
+**実装** (10 commits、各単独で `npm test` 通過):
 
 | # | Commit | 内容 |
 |---|--------|------|
@@ -36,11 +36,14 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 | 4 | `7880462` | refactor(vscode-extension): unify selectAudioDevice through scsynth resolver |
 | 5 | `9663a83` | feat(vscode-extension): add bundle status bar and first-run notification |
 | 6 | `aca6450` | feat(build): add scsynth bundle extract/verify scripts and legal placeholders |
-| 7 | this | docs(worklog,readme): record scsynth bundle integration |
+| 7 | `e25894d` | docs(worklog,readme): record scsynth bundle integration |
+| 8 | `1569110` | refactor(audio): drop SC.app/spotlight fallback from scsynth resolver |
+| 9 | `08c2855` | refactor(vscode-extension): align UX with strict bundle requirement |
+| 10 | this | docs(worklog,readme,build-guide): document strict resolver and dev workaround |
 
 **新規ファイル**:
-- `packages/engine/src/audio/supercollider/scsynth-resolver.ts` (resolver 本体)
-- `tests/audio/scsynth-resolver.spec.ts` (11 unit tests、CI 実行可)
+- `packages/engine/src/audio/supercollider/scsynth-resolver.ts` (resolver 本体、strict mode)
+- `tests/audio/scsynth-resolver.spec.ts` (10 unit tests、CI 実行可)
 - `scripts/extract-scsynth-bundle.sh` (SC.app 自動 discovery + 26 plugin filter + 検証)
 - `scripts/verify-bundle.sh` (`.vsix` 解凍後の signature/permission 確認)
 - `packages/vscode-extension/legal/scsynth-LICENSE.GPL-3.0` (#139 placeholder)
@@ -50,25 +53,30 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 1. `opts.explicit` (caller 明示)
 2. `process.env.ORBIT_SCSYNTH_PATH` (extension が settings から渡す)
 3. Bundle (`<engine root>/scsynth/Contents/Resources/scsynth`)
-4. SC.app fallback (`/Applications/SuperCollider.app/...`)
-5. Spotlight (`mdfind -name SuperCollider.app`)
 
-各候補で `fs.statSync` + 実行権限ビット (`mode & 0o111`) を検査。全 miss 時は `ScsynthNotFoundError` (`searched` 配列付き) を throw。`daemon-client.ts:417-433` の `resolveDaemonBinary()` パターン流用。
+**Strict mode の理由** (本 PR レビュー過程で確定): 当初は SC.app fallback と Spotlight も持っていたが、ICMC リリース目標 (「SC が無くても動く」) に対して fallback はテストの意味を曖昧にすると判断。bundle 抽出失敗を SC.app が肩代わりして production の不具合を隠蔽するリスクを排除するため、Phase 8 で fallback を削除。bundle が無ければ即 `ScsynthNotFoundError` で fail loud。各候補で `fs.statSync` + 実行権限ビット (`mode & 0o111`) を検査。`daemon-client.ts:417-433` の `resolveDaemonBinary()` パターン流用。
 
-**First-run UX** (CodeX 指摘「初回限定 + status bar degraded」反映):
-- StatusBar item (priority 99) で source 別に icon + 警告色背景 (sc-app/spotlight 時)
-- `startEngine()` 実行時に bundle 不在 (sc-app/spotlight) 時のみ Warning Notification 1 回
-- `globalState.orbitscore.bundleNotice.dismissedVersion` で version 単位 dismiss を記録
-- resolver 失敗時は毎回エラー Notification (修復必須のため)
+**Dev workflow への影響**:
+- engine 単独 CLI (`npm run dev:engine`) で SC.app に依存していた dev は `ORBIT_SCSYNTH_PATH=/Applications/SuperCollider.app/Contents/Resources/scsynth` を env で渡す
+- vscode-extension 経由 (通常 user) は build pipeline で bundle 同梱、何もしなくて OK
+
+**First-run UX** (CodeX 指摘「status bar degraded」反映 + Phase 9 で strict mode 整合):
+- StatusBar item (priority 99) で source 別に icon: `bundle` (✅) / `env`/`explicit` (⚙️ custom) / 解決失敗 (❌ error 背景)
+- `startEngine()` 実行時に解決失敗 → 毎回 `showErrorMessage` (Open Settings / View Logs)
+- 当初設計の "Don't Show Again" dismiss 機構は廃止 (silent fallback がない以上、Notice を黙らせる選択肢自体が不適切)
+
+**リリース戦略** (本 PR レビュー過程で確定):
+- ICMC v1.0 初回は **GitHub Release に `.vsix` を添付**して配布、ユーザは ダウンロード + ダブルクリック (or `code --install-extension`) で install
+- Marketplace 自動 publish (#137) は ICMC ブロッカーから降格可能 (別 issue で再整理)
 
 **実機検証 (SC 3.14.1 環境)**:
 - `npm run build:bundle` → 11MB bundle 生成、26 plugins、universal arm64+x86_64
 - `npm run verify:bundle` → 11/11 checks pass (signature valid、TeamIdentifier=HE5VJFE9E4)
-- engine test 241 pass / 23 skipped (resolver 11 新規 + 既存 230 維持)
+- engine test 240 pass / 23 skipped (resolver 10 新規 + 既存 230 維持、Phase 8 で sc-app/spotlight test 1 件削減)
 - TypeScript build clean、ESLint clean
 
 **スコープ外** (本 PR で実装しない):
-- #137 Marketplace 自動 publish workflow
+- #137 Marketplace 自動 publish workflow (リリース戦略変更で ICMC ブロッカーから降格、別 issue で再整理予定)
 - #138 cold-install acceptance test (実機 SC-less Mac で別途検証)
 - #139 LICENSE/NOTICE 文言洗練 (本 PR は placeholder のみ)
 - #151 OrbitScore: Check Audio Setup (post-icmc)
@@ -76,7 +84,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **後続**:
 - 本 PR マージ → #138 で SC-less Mac の cold-install 検証
-- #138 通過 → #137 で Marketplace publish workflow
+- #138 通過 → 手動 GitHub Release で `.vsix` 配布開始
 - ICMC 2026 リリース ready
 
 ---

--- a/examples/01_getting_started.osc
+++ b/examples/01_getting_started.osc
@@ -4,7 +4,7 @@
 // === Section 1: Basic Setup ===
 // Initialize and configure global transport
 var global = init GLOBAL
-global.tempo(200)
+global.tempo(120)
 global.beat(4 by 4)
 global.audioPath("../test-assets/audio")  // Set base path for audio files (relative to .osc file)
 global.start()  // Start the scheduler
@@ -12,13 +12,13 @@ global.start()  // Start the scheduler
 // === Section 2: Your First Sequence ===
 var drum = init global.seq
 drum.beat(5 by 4).length(1)
-drum.audio("kick.wav").chop(4)  // audioPath already set
+drum.audio("kick.wav").chop(1)  // audioPath already set
 drum.play(1, 1, 1, 1)  // Simple kick pattern
 
 // === Section 3: Add More Layers ===
 var snare = init global.seq
 snare.beat(4 by 4).length(1)
-snare.audio("snare.wav").chop(4)  // audioPath already set
+snare.audio("snare.wav").chop(1)  // audioPath already set
 snare.play(1, 1, 1, 1)  // Snare on beat 3
 
 // === Section 4: Control Playback ===

--- a/packages/engine/src/audio/supercollider-player.ts
+++ b/packages/engine/src/audio/supercollider-player.ts
@@ -8,6 +8,7 @@ import { OSCClient } from './supercollider/osc-client'
 import { BufferManager } from './supercollider/buffer-manager'
 import { EventScheduler } from './supercollider/event-scheduler'
 import { SynthDefLoader } from './supercollider/synthdef-loader'
+import { resolveScsynthPath } from './supercollider/scsynth-resolver'
 
 /**
  * SuperCollider audio player with low-latency scheduling
@@ -26,10 +27,21 @@ export class SuperColliderPlayer {
   }
 
   /**
-   * Boot SuperCollider server and load SynthDef
+   * Boot SuperCollider server and load SynthDef.
+   *
+   * `BootOptions.scsynth` 未指定時は `resolveScsynthPath()` で
+   * explicit / env / bundle / SC.app / Spotlight の順に解決する。
    */
   async boot(outputDevice?: string, options?: BootOptions): Promise<void> {
-    await this.oscClient.boot(outputDevice, options)
+    const mergedOptions: BootOptions = { ...options }
+    if (!mergedOptions.scsynth) {
+      const resolution = resolveScsynthPath()
+      mergedOptions.scsynth = resolution.path
+      if (process.env.ORBITSCORE_DEBUG) {
+        console.log(`🔍 scsynth resolved via ${resolution.source}: ${resolution.path}`)
+      }
+    }
+    await this.oscClient.boot(outputDevice, mergedOptions)
     await this.synthDefLoader.loadMainSynthDef()
     await this.synthDefLoader.loadMasteringEffectSynthDefs()
   }

--- a/packages/engine/src/audio/supercollider-player.ts
+++ b/packages/engine/src/audio/supercollider-player.ts
@@ -30,7 +30,10 @@ export class SuperColliderPlayer {
    * Boot SuperCollider server and load SynthDef.
    *
    * `BootOptions.scsynth` 未指定時は `resolveScsynthPath()` で
-   * explicit / env / bundle / SC.app / Spotlight の順に解決する。
+   * explicit / env / bundle の順に解決する (strict mode、Issue #136)。
+   * SC.app / Spotlight への暗黙 fallback は持たない — bundle が無ければ
+   * `ScsynthNotFoundError` で fail loud。dev 環境で SC.app を使う場合は
+   * `ORBIT_SCSYNTH_PATH` env を経由すること。
    */
   async boot(outputDevice?: string, options?: BootOptions): Promise<void> {
     const mergedOptions: BootOptions = { ...options }

--- a/packages/engine/src/audio/supercollider/osc-client.ts
+++ b/packages/engine/src/audio/supercollider/osc-client.ts
@@ -12,15 +12,24 @@ export class OSCClient {
   private currentOutputDevice: string | null = null
 
   /**
-   * SuperColliderサーバーを起動
+   * SuperColliderサーバーを起動。
+   *
+   * `BootOptions.scsynth` は caller (`SuperColliderPlayer.boot()` 等) で
+   * `resolveScsynthPath()` を通して必ず埋めること。本メソッドは hardcode を持たず、
+   * 未指定時は明示エラーを投げる。
    */
   async boot(outputDevice?: string, options?: BootOptions): Promise<void> {
     console.log('🎵 Booting SuperCollider server...')
 
     const bootOptions: any = {
-      scsynth: '/Applications/SuperCollider.app/Contents/Resources/scsynth',
       debug: false,
       ...options,
+    }
+
+    if (!bootOptions.scsynth) {
+      throw new Error(
+        'OSCClient.boot: BootOptions.scsynth is required. Caller must resolve scsynth path (see scsynth-resolver.ts).',
+      )
     }
 
     // Set output device if specified (by name)

--- a/packages/engine/src/audio/supercollider/scsynth-resolver.ts
+++ b/packages/engine/src/audio/supercollider/scsynth-resolver.ts
@@ -1,0 +1,117 @@
+/**
+ * scsynth binary path resolver.
+ *
+ * 優先順位:
+ *   1. explicit (caller 明示)
+ *   2. env (ORBIT_SCSYNTH_PATH)
+ *   3. bundle (extension 同梱、`<engine root>/scsynth/Contents/Resources/scsynth`)
+ *   4. SC.app fallback (`/Applications/SuperCollider.app/Contents/Resources/scsynth`)
+ *   5. Spotlight (`mdfind` で SuperCollider.app を検索)
+ *
+ * パターンは `packages/engine/src/audio/rust-engine/daemon-client.ts` の
+ * `resolveDaemonBinary()` を流用。各候補は `fs.existsSync` + 実行権限を検査。
+ */
+
+import { spawnSync } from 'child_process'
+import * as fs from 'fs'
+import * as path from 'path'
+
+export type ScsynthSource = 'explicit' | 'env' | 'bundle' | 'sc-app' | 'spotlight'
+
+export interface ScsynthResolution {
+  path: string
+  source: ScsynthSource
+  searched: string[]
+}
+
+export interface ResolveOptions {
+  explicit?: string
+}
+
+export class ScsynthNotFoundError extends Error {
+  public readonly searched: string[]
+
+  constructor(searched: string[]) {
+    super(
+      `scsynth binary not found. Searched paths:\n${searched.map((p) => '  - ' + p).join('\n')}`,
+    )
+    this.name = 'ScsynthNotFoundError'
+    this.searched = searched
+  }
+}
+
+const SC_APP_DEFAULT_PATH = '/Applications/SuperCollider.app/Contents/Resources/scsynth'
+const SPOTLIGHT_TIMEOUT_MS = 500
+const ENV_VAR = 'ORBIT_SCSYNTH_PATH'
+
+/**
+ * `<engine root>/scsynth/Contents/Resources/scsynth` を計算。
+ *
+ * - vscode-extension 同梱: `packages/vscode-extension/engine/dist/audio/supercollider/scsynth-resolver.js`
+ *   から見ると `engine/scsynth/...` は `../../../scsynth/...`
+ * - engine package 単独: `packages/engine/dist/audio/supercollider/scsynth-resolver.js`
+ *   から見ると bundle は存在しない (常に miss → 次候補へ)
+ */
+function bundleCandidatePath(): string {
+  return path.resolve(__dirname, '../../../scsynth/Contents/Resources/scsynth')
+}
+
+function isExecutableFile(p: string): boolean {
+  try {
+    const stat = fs.statSync(p)
+    if (!stat.isFile()) return false
+    return (stat.mode & 0o111) !== 0
+  } catch {
+    return false
+  }
+}
+
+function findViaSpotlight(): string | null {
+  try {
+    const result = spawnSync('mdfind', ['-name', 'SuperCollider.app'], {
+      timeout: SPOTLIGHT_TIMEOUT_MS,
+      encoding: 'utf8',
+    })
+    if (result.status !== 0 || !result.stdout) return null
+    const firstHit = result.stdout
+      .split('\n')
+      .map((s) => s.trim())
+      .find((s) => s.length > 0)
+    if (!firstHit) return null
+    return path.join(firstHit, 'Contents/Resources/scsynth')
+  } catch {
+    return null
+  }
+}
+
+/**
+ * scsynth binary を解決する。
+ *
+ * @throws {ScsynthNotFoundError} 全候補 miss 時
+ */
+export function resolveScsynthPath(opts: ResolveOptions = {}): ScsynthResolution {
+  const searched: string[] = []
+
+  const tryCandidate = (
+    candidate: string | null | undefined,
+    source: ScsynthSource,
+  ): ScsynthResolution | null => {
+    if (!candidate) return null
+    searched.push(candidate)
+    if (isExecutableFile(candidate)) {
+      return { path: candidate, source, searched: [...searched] }
+    }
+    return null
+  }
+
+  return (
+    tryCandidate(opts.explicit, 'explicit') ??
+    tryCandidate(process.env[ENV_VAR], 'env') ??
+    tryCandidate(bundleCandidatePath(), 'bundle') ??
+    tryCandidate(SC_APP_DEFAULT_PATH, 'sc-app') ??
+    tryCandidate(findViaSpotlight(), 'spotlight') ??
+    (() => {
+      throw new ScsynthNotFoundError(searched)
+    })()
+  )
+}

--- a/packages/engine/src/audio/supercollider/scsynth-resolver.ts
+++ b/packages/engine/src/audio/supercollider/scsynth-resolver.ts
@@ -1,22 +1,25 @@
 /**
  * scsynth binary path resolver.
  *
- * 優先順位:
+ * 優先順位 (strict mode — Issue #136 の "SC 不要で動く" を保証するため
+ * SC.app / Spotlight への暗黙 fallback は意図的に持たない):
  *   1. explicit (caller 明示)
  *   2. env (ORBIT_SCSYNTH_PATH)
  *   3. bundle (extension 同梱、`<engine root>/scsynth/Contents/Resources/scsynth`)
- *   4. SC.app fallback (`/Applications/SuperCollider.app/Contents/Resources/scsynth`)
- *   5. Spotlight (`mdfind` で SuperCollider.app を検索)
+ *
+ * 全 miss 時は `ScsynthNotFoundError` を投げ、bundle が無い状況を「サイレントに
+ * SC.app で誤魔化す」のではなく明示的に検知できるようにする。dev 環境で
+ * SC.app を使いたい場合は `ORBIT_SCSYNTH_PATH=/Applications/SuperCollider.app/...`
+ * を env で渡すこと。
  *
  * パターンは `packages/engine/src/audio/rust-engine/daemon-client.ts` の
- * `resolveDaemonBinary()` を流用。各候補は `fs.existsSync` + 実行権限を検査。
+ * `resolveDaemonBinary()` を流用。各候補は `fs.statSync` + 実行権限を検査。
  */
 
-import { spawnSync } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
 
-export type ScsynthSource = 'explicit' | 'env' | 'bundle' | 'sc-app' | 'spotlight'
+export type ScsynthSource = 'explicit' | 'env' | 'bundle'
 
 export interface ScsynthResolution {
   path: string
@@ -33,15 +36,14 @@ export class ScsynthNotFoundError extends Error {
 
   constructor(searched: string[]) {
     super(
-      `scsynth binary not found. Searched paths:\n${searched.map((p) => '  - ' + p).join('\n')}`,
+      `scsynth binary not found. Searched paths:\n${searched.map((p) => '  - ' + p).join('\n')}\n\n` +
+        `For development without a bundled scsynth, set ORBIT_SCSYNTH_PATH to a system scsynth (e.g. /Applications/SuperCollider.app/Contents/Resources/scsynth).`,
     )
     this.name = 'ScsynthNotFoundError'
     this.searched = searched
   }
 }
 
-const SC_APP_DEFAULT_PATH = '/Applications/SuperCollider.app/Contents/Resources/scsynth'
-const SPOTLIGHT_TIMEOUT_MS = 500
 const ENV_VAR = 'ORBIT_SCSYNTH_PATH'
 
 /**
@@ -50,7 +52,7 @@ const ENV_VAR = 'ORBIT_SCSYNTH_PATH'
  * - vscode-extension 同梱: `packages/vscode-extension/engine/dist/audio/supercollider/scsynth-resolver.js`
  *   から見ると `engine/scsynth/...` は `../../../scsynth/...`
  * - engine package 単独: `packages/engine/dist/audio/supercollider/scsynth-resolver.js`
- *   から見ると bundle は存在しない (常に miss → 次候補へ)
+ *   から見ると bundle は存在しない (常に miss → エラー、dev は env 経由で解決)
  */
 function bundleCandidatePath(): string {
   return path.resolve(__dirname, '../../../scsynth/Contents/Resources/scsynth')
@@ -63,24 +65,6 @@ function isExecutableFile(p: string): boolean {
     return (stat.mode & 0o111) !== 0
   } catch {
     return false
-  }
-}
-
-function findViaSpotlight(): string | null {
-  try {
-    const result = spawnSync('mdfind', ['-name', 'SuperCollider.app'], {
-      timeout: SPOTLIGHT_TIMEOUT_MS,
-      encoding: 'utf8',
-    })
-    if (result.status !== 0 || !result.stdout) return null
-    const firstHit = result.stdout
-      .split('\n')
-      .map((s) => s.trim())
-      .find((s) => s.length > 0)
-    if (!firstHit) return null
-    return path.join(firstHit, 'Contents/Resources/scsynth')
-  } catch {
-    return null
   }
 }
 
@@ -108,8 +92,6 @@ export function resolveScsynthPath(opts: ResolveOptions = {}): ScsynthResolution
     tryCandidate(opts.explicit, 'explicit') ??
     tryCandidate(process.env[ENV_VAR], 'env') ??
     tryCandidate(bundleCandidatePath(), 'bundle') ??
-    tryCandidate(SC_APP_DEFAULT_PATH, 'sc-app') ??
-    tryCandidate(findViaSpotlight(), 'spotlight') ??
     (() => {
       throw new ScsynthNotFoundError(searched)
     })()

--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -24,3 +24,7 @@ engine/package.json
 !engine/dist/**
 !engine/supercollider/**
 !engine/node_modules/**
+# Keep bundled scsynth (binary + plugins + libsndfile + LICENSE/NOTICE)
+!engine/scsynth/**
+# Keep legal templates (used by extract-scsynth-bundle.sh)
+!legal/**

--- a/packages/vscode-extension/BUILD_GUIDE.md
+++ b/packages/vscode-extension/BUILD_GUIDE.md
@@ -36,9 +36,45 @@ cd packages/vscode-extension
 npm run build
 ```
 
-### 4. パッケージ化
+### 4. scsynth bundle の抽出 (リリース時のみ)
+
+`.vsix` 配布版には scsynth バイナリ + plugins + libsndfile.dylib (~11.5 MB)
+を同梱します。開発時は SC.app があれば不要 (resolver が SC.app fallback)
+ですが、Marketplace publish や cold-install テストでは必須です。
 
 ```bash
+# SC.app から抽出 (default: SC.app 不在時 fail-fast)
+cd packages/vscode-extension
+npm run build:bundle
+
+# dev で SC.app が無い場合は warning + skip
+bash ../../scripts/extract-scsynth-bundle.sh --allow-skip
+
+# 抽出後の検証 (構造、universal binary、codesign、plugin count 等)
+npm run verify:bundle
+```
+
+抽出される構造:
+```
+packages/vscode-extension/engine/scsynth/
+├── Contents/
+│   ├── Resources/
+│   │   ├── scsynth                (1.5 MB, universal arm64+x86_64)
+│   │   └── plugins/               (26 .scx ファイル、5.1 MB)
+│   └── Frameworks/
+│       └── libsndfile.dylib       (4.9 MB)
+├── LICENSE.GPL-3.0                (legal/scsynth-LICENSE.GPL-3.0 から copy)
+└── NOTICE                          (legal/scsynth-NOTICE から copy)
+```
+
+詳細: [`docs/research/SCSYNTH_BUNDLE_MANIFEST.md`](../../docs/research/SCSYNTH_BUNDLE_MANIFEST.md)
+
+### 5. パッケージ化
+
+```bash
+# build → bundle 抽出 → vsce package の順で実行
+npm run build
+npm run build:bundle
 npx vsce package
 ```
 
@@ -64,8 +100,18 @@ npx vsce package
 
 ### パッケージサイズ
 
-- 約 3.3 MB（2458ファイル）
+- engine のみ: 約 3.3 MB（2458ファイル）
+- scsynth bundle 同梱版: 約 14.8 MB (上記 + scsynth/plugins/libsndfile)
 - `engine/node_modules` を含む（supercolliderjs + wavefile のランタイム依存）
+
+### scsynth bundle ディレクトリの取り扱い
+
+`packages/vscode-extension/engine/` は root `.gitignore:36` で無視されており、
+bundle (`engine/scsynth/`) も git 管理外です。CI / release pipeline で
+`build:bundle` を実行して都度生成します。
+
+LICENSE.GPL-3.0 と NOTICE のテンプレートは git 管理 (`packages/vscode-extension/legal/`)
+で、`extract-scsynth-bundle.sh` が bundle dir に copy します。
 
 ### Engineランタイム依存の管理
 

--- a/packages/vscode-extension/BUILD_GUIDE.md
+++ b/packages/vscode-extension/BUILD_GUIDE.md
@@ -89,8 +89,19 @@ packages/vscode-extension/engine/scsynth/
 # build → bundle 抽出 → vsce package の順で実行
 npm run build
 npm run build:bundle
+
+# Marketplace publish 用 (将来): platform target を Apple Silicon に絞る
+npx vsce package --target darwin-arm64
+
+# GitHub Release 用 (現状): platform target なしの universal vsix
+# (vsix metadata 上は platform agnostic だが、bundle scsynth が macOS Mach-O のみ)
 npx vsce package
 ```
+
+**Platform target の意図**: bundle scsynth + libsndfile.dylib は macOS のみ。
+将来 Marketplace に公開する際は \`--target darwin-arm64\` で Apple Silicon 用と
+明示することで Windows / Linux ユーザーには見えなくなる。Intel Mac は universal
+binary 上は動く可能性があるが未テスト。
 
 ## パッケージサイズの最適化
 

--- a/packages/vscode-extension/BUILD_GUIDE.md
+++ b/packages/vscode-extension/BUILD_GUIDE.md
@@ -39,8 +39,22 @@ npm run build
 ### 4. scsynth bundle の抽出 (リリース時のみ)
 
 `.vsix` 配布版には scsynth バイナリ + plugins + libsndfile.dylib (~11.5 MB)
-を同梱します。開発時は SC.app があれば不要 (resolver が SC.app fallback)
-ですが、Marketplace publish や cold-install テストでは必須です。
+を同梱します。
+
+**Strict mode (Issue #136)**: resolver は SC.app / Spotlight への暗黙
+fallback を持ちません。bundle が無ければ `ScsynthNotFoundError` で fail loud
+します。これは "SC が無い環境で `.vsix` install するだけで動く" を保証する
+ための意図的な設計です (silent fallback があると bundle 抽出失敗を SC.app
+が肩代わりして production の不具合を隠蔽するリスクがあるため)。
+
+**Dev workflow への影響**:
+- vscode-extension 経由 (通常 user): bundle 同梱で何もしなくて OK
+- engine 単独 CLI で SC.app に依存している dev:
+  ```bash
+  ORBIT_SCSYNTH_PATH=/Applications/SuperCollider.app/Contents/Resources/scsynth \
+    npm run dev:engine
+  ```
+  または `build:bundle` で bundle を抽出してから実行
 
 ```bash
 # SC.app から抽出 (default: SC.app 不在時 fail-fast)

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -2,6 +2,18 @@
 
 VS Code extension for the OrbitScore music DSL.
 
+## Supported Platforms
+
+**macOS (Apple Silicon)** only as of v1.0.
+
+| OS / Arch | Status | Notes |
+|---|---|---|
+| macOS Apple Silicon (arm64) | ✅ Supported | Tested target. Bundled scsynth runs natively. |
+| macOS Intel (x86_64) | ⚠️ Untested | The bundled scsynth is a universal binary so it may work, but not actively verified. |
+| Windows / Linux | ❌ Not supported | scsynth bundle ships only macOS binaries (`.dylib`, Mach-O). |
+
+Windows / Linux support is tracked separately as a future cross-platform effort.
+
 ## Features
 
 - **Syntax Highlighting**: Full syntax highlighting for `.osc` files
@@ -17,7 +29,17 @@ VS Code extension for the OrbitScore music DSL.
 - `OrbitScore: Stop Engine` - Stop the engine
 - `OrbitScore: Transport Panel` - Open transport control panel
 
-## Installation
+## Installation (Users)
+
+Download the latest `orbitscore-*.vsix` from the [GitHub Releases](https://github.com/signalcompose/orbitscore/releases) page and either:
+
+- Double-click the `.vsix` file (opens VS Code's install dialog), or
+- In VS Code, run `Extensions: Install from VSIX...` and pick the file, or
+- From the command line: `code --install-extension orbitscore-*.vsix`
+
+**SuperCollider does not need to be installed separately** — the bundled `scsynth` (~11.5 MB) is shipped inside the `.vsix`.
+
+## Installation (From Source — Developers)
 
 1. Build the engine first:
 
@@ -35,7 +57,13 @@ npm install
 npm run build
 ```
 
-3. Install in VS Code:
+3. Optional: bundle scsynth (release builds only — requires `SuperCollider.app` installed on the dev machine):
+
+```bash
+npm run build:bundle
+```
+
+4. Install in VS Code:
 
 - Open VS Code
 - Press `Cmd+Shift+P`

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -1,89 +1,96 @@
-# OrbitScore VS Code Extension
+# OrbitScore
 
-VS Code extension for the OrbitScore music DSL.
+Live coding music DSL for VS Code with a bundled SuperCollider audio engine.
+
+Write `.osc` patches and run them line by line with `Cmd+Enter`. No separate SuperCollider install required.
 
 ## Supported Platforms
 
-**macOS (Apple Silicon)** only as of v1.0.
+**macOS (Apple Silicon)** only as of v1.x.
 
-| OS / Arch | Status | Notes |
-|---|---|---|
-| macOS Apple Silicon (arm64) | ✅ Supported | Tested target. Bundled scsynth runs natively. |
-| macOS Intel (x86_64) | ⚠️ Untested | The bundled scsynth is a universal binary so it may work, but not actively verified. |
-| Windows / Linux | ❌ Not supported | scsynth bundle ships only macOS binaries (`.dylib`, Mach-O). |
+| OS / Arch | Status |
+|---|---|
+| macOS Apple Silicon (arm64) | ✅ Supported |
+| macOS Intel (x86_64) | ⚠️ Untested (bundled binary is universal but not actively verified) |
+| Windows / Linux | ❌ Not supported in v1.x |
 
-Windows / Linux support is tracked separately as a future cross-platform effort.
+Cross-platform support is tracked as a future effort.
+
+## Quick Start
+
+1. Open or create a `.osc` file (a starter template is in [examples/](https://github.com/signalcompose/orbitscore/tree/main/examples))
+2. Run **OrbitScore: Start Engine** (status bar shows `OrbitScore: Ready`)
+3. Select code (or place the cursor on a line) and press `Cmd+Enter`
+
+The status bar item `✅ scsynth (bundled)` confirms the audio engine is using the bundled SuperCollider binary.
+
+Minimal example:
+
+```orbitscore
+var global = init GLOBAL
+global.tempo(120).beat(4 by 4)
+
+var kick = init global.seq
+kick.audio("kick.wav").play(1, 0, 1, 0)
+
+LOOP(kick)
+```
 
 ## Features
 
-- **Syntax Highlighting**: Full syntax highlighting for `.osc` files
-- **Run Selection**: Execute selected code with `Cmd+Enter`
-- **Transport Controls**: Play, pause, stop, jump, and loop controls
-- **Status Bar**: Shows current playback position and BPM
-- **Diagnostics**: Real-time syntax error checking
+- Syntax highlighting for `.osc` files
+- Run selection with `Cmd+Enter` (single line or multi-line block)
+- IntelliSense / hover for DSL keywords
+- Real-time syntax diagnostics
+- Status bar indicators for engine state and audio backend
+- Bundled `scsynth` (~11.5 MB, no manual SuperCollider install)
 
 ## Commands
 
-- `OrbitScore: Start Engine` - Start the OrbitScore engine
-- `OrbitScore: Run Selection` - Execute selected text or entire file (Cmd+Enter)
-- `OrbitScore: Stop Engine` - Stop the engine
-- `OrbitScore: Transport Panel` - Open transport control panel
+| Command | Description |
+|---|---|
+| `OrbitScore: Start Engine` | Boot the audio engine |
+| `OrbitScore: Run Selection` | Execute selected text or current block (`Cmd+Enter`) |
+| `OrbitScore: Stop Engine` | Stop the engine |
+| `OrbitScore: Start Engine (Debug)` | Boot with verbose logging |
+| `OrbitScore: Select Audio Device` | Pick an output device interactively |
+| `OrbitScore: Kill SuperCollider` | Force-kill any stray `scsynth` processes |
+| `OrbitScore: Configure Flash` | Customize line-flash visual feedback |
 
-## Installation (Users)
+## Settings
 
-Download the latest `orbitscore-*.vsix` from the [GitHub Releases](https://github.com/signalcompose/orbitscore/releases) page and either:
+| Setting | Default | Description |
+|---|---|---|
+| `orbitscore.scsynthPath` | `""` | Override path to a custom `scsynth` binary. Leave empty to use the bundled scsynth (recommended). |
+| `orbitscore.flashCount` | `3` | Number of times to flash executed lines (1–5) |
+| `orbitscore.flashDuration` | `150` | Duration of each flash in milliseconds (50–500) |
+| `orbitscore.flashColor` | `selection` | Color theme for flash (`selection` / `error` / `warning` / `info` / `custom`) |
+| `orbitscore.flashCustomColor` | `#ff6b6b` | Custom flash color (hex) when `flashColor` is `custom` |
 
-- Double-click the `.vsix` file (opens VS Code's install dialog), or
-- In VS Code, run `Extensions: Install from VSIX...` and pick the file, or
-- From the command line: `code --install-extension orbitscore-*.vsix`
+## Troubleshooting
 
-**SuperCollider does not need to be installed separately** — the bundled `scsynth` (~11.5 MB) is shipped inside the `.vsix`.
+### Status bar shows `❌ scsynth: not found`
 
-## Installation (From Source — Developers)
+The bundled `scsynth` could not be located. Try:
 
-1. Build the engine first:
+1. Reinstall the extension (the `.vsix` may be corrupted or partially installed)
+2. Or set `orbitscore.scsynthPath` in your VS Code settings to a system `scsynth` binary, e.g. `/Applications/SuperCollider.app/Contents/Resources/scsynth`
+3. Open `View → Output → OrbitScore` to see the resolver's failure reason
 
-```bash
-cd packages/engine
-npm install
-npm run build
-```
+### Engine starts but no sound
 
-2. Build the extension:
+- Run **OrbitScore: Select Audio Device** and pick the correct output device
+- The selected device is saved to `.orbitscore.json` in your workspace root
+- Restart the engine after changing the device
 
-```bash
-cd packages/vscode-extension
-npm install
-npm run build
-```
+### Engine crashes on boot
 
-3. Optional: bundle scsynth (release builds only — requires `SuperCollider.app` installed on the dev machine):
+- Check `View → Output → OrbitScore` for stderr from `scsynth`
+- A common cause is sample-rate mismatch when the input device differs from the output device. Forcing input channels off (`numInputBusChannels: 0`) is already enabled by default.
 
-```bash
-npm run build:bundle
-```
+## Links
 
-4. Install in VS Code:
-
-- Open VS Code
-- Press `Cmd+Shift+P`
-- Run "Developer: Install Extension from Location..."
-- Select the `packages/vscode-extension` folder
-
-## Usage
-
-1. Open a `.osc` file
-2. Start the engine with `OrbitScore: Start Engine`
-3. Select code and press `Cmd+Enter` to run
-4. Use the transport panel for playback control
-
-## Development
-
-To develop the extension:
-
-```bash
-cd packages/vscode-extension
-npm run dev  # Watch mode
-```
-
-Then press `F5` in VS Code to launch a new Extension Development Host window.
+- 📦 [Download the latest `.vsix`](https://github.com/signalcompose/orbitscore/releases) — GitHub Releases
+- 🐛 [Report an issue](https://github.com/signalcompose/orbitscore/issues)
+- 📖 [Source code](https://github.com/signalcompose/orbitscore) — Contributions welcome
+- 📜 License: Signal compose Fair Trade License (extension), GPL-3.0 (bundled SuperCollider), LGPL-2.1 (bundled libsndfile). See `engine/scsynth/NOTICE` for details.

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -54,7 +54,7 @@ LOOP(kick)
 | `OrbitScore: Stop Engine` | Stop the engine |
 | `OrbitScore: Start Engine (Debug)` | Boot with verbose logging |
 | `OrbitScore: Select Audio Device` | Pick an output device interactively |
-| `OrbitScore: Kill SuperCollider` | Force-kill any stray `scsynth` processes |
+| `OrbitScore: Force Kill scsynth` | Escape hatch — force-kill any orphan `scsynth` processes |
 | `OrbitScore: Configure Flash` | Customize line-flash visual feedback |
 
 ## Settings

--- a/packages/vscode-extension/legal/scsynth-LICENSE.GPL-3.0
+++ b/packages/vscode-extension/legal/scsynth-LICENSE.GPL-3.0
@@ -1,19 +1,674 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-------------------------------------------------------------------------
-NOTE: This is a placeholder pointing to the GNU GPL v3.0 text. The full
-text is published at https://www.gnu.org/licenses/gpl-3.0.txt and is
-incorporated by reference. SuperCollider scsynth and its plugins are
-licensed under GPL-3.0-or-later. See NOTICE for the corresponding source
-URL and aggregation disclosure (Issue #139 will replace this with the
-full verbatim license text before public release).
-------------------------------------------------------------------------
+                            Preamble
 
-The complete license text MUST be embedded verbatim before any public
-distribution (e.g. VS Code Marketplace publish). This placeholder is
-sufficient for development builds and internal review only.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/packages/vscode-extension/legal/scsynth-LICENSE.GPL-3.0
+++ b/packages/vscode-extension/legal/scsynth-LICENSE.GPL-3.0
@@ -1,0 +1,19 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+------------------------------------------------------------------------
+NOTE: This is a placeholder pointing to the GNU GPL v3.0 text. The full
+text is published at https://www.gnu.org/licenses/gpl-3.0.txt and is
+incorporated by reference. SuperCollider scsynth and its plugins are
+licensed under GPL-3.0-or-later. See NOTICE for the corresponding source
+URL and aggregation disclosure (Issue #139 will replace this with the
+full verbatim license text before public release).
+------------------------------------------------------------------------
+
+The complete license text MUST be embedded verbatim before any public
+distribution (e.g. VS Code Marketplace publish). This placeholder is
+sufficient for development builds and internal review only.

--- a/packages/vscode-extension/legal/scsynth-NOTICE
+++ b/packages/vscode-extension/legal/scsynth-NOTICE
@@ -14,11 +14,7 @@ SuperCollider 3.14.1 release):
   - scsynth plugins (UGens, *.scx files in plugins/)
 
 License: GNU General Public License version 3 or later (GPL-3.0-or-later)
-See: LICENSE.GPL-3.0 in this directory.
-
-These components are aggregated with OrbitScore (which itself is licensed
-under the Signal compose Fair Trade License — see ../../LICENSE) following
-the GPL aggregation exception (GPL-3.0 §0).
+Full license text: see LICENSE.GPL-3.0 in this directory.
 
 Corresponding source code (GPL-3.0 §6):
   https://github.com/supercollider/supercollider/releases/tag/Version-3.14.1
@@ -29,6 +25,34 @@ code is available under the same GPL-3.0-or-later license at the URL above.
 Copyright notices preserved from the SuperCollider project:
   Copyright (c) 2002-2025 The SuperCollider community
   https://github.com/supercollider/supercollider/blob/main/COPYING
+
+--------------------------------------------------------------------------------
+Aggregation statement (GPL-3.0 §0)
+--------------------------------------------------------------------------------
+
+OrbitScore (the VS Code extension and its TypeScript engine) and the bundled
+SuperCollider components are **separate works** that happen to be distributed
+together inside the same `.vsix` archive. They communicate exclusively via the
+Open Sound Control (OSC) protocol over a UDP socket — there is no source-level
+linking, no shared address space, and no shared headers.
+
+Per GPL-3.0 §0 ("Definitions"):
+
+> A "Modified Version" of the [Program] does not include works merely
+> aggregated with the [Program] on a volume of a storage or distribution
+> medium.
+
+Under the FSF's published interpretation of "aggregation" (see
+https://www.gnu.org/licenses/gpl-faq.html#MereAggregation), software that
+interacts with a GPL'd program "through some kind of pipe, socket, or
+command-line arguments" constitutes aggregation rather than a derivative work.
+Therefore, the OrbitScore extension code itself is **not** a derivative work of
+SuperCollider and remains under the Signal compose Fair Trade License (see
+../../LICENSE).
+
+The bundled GPL-3.0 components retain their GPL-3.0 license. Users who modify
+or redistribute the SuperCollider components must comply with GPL-3.0
+independently of the OrbitScore license.
 
 ================================================================================
 Section B: libsndfile (LGPL-2.1-or-later)
@@ -41,7 +65,8 @@ Bundled component (distributed unmodified, copied from the SuperCollider
 
 License: GNU Lesser General Public License version 2.1 or later
         (LGPL-2.1-or-later)
-See: https://github.com/libsndfile/libsndfile/blob/master/COPYING
+Full license text:
+  https://github.com/libsndfile/libsndfile/blob/master/COPYING
 
 libsndfile is **not** part of the SuperCollider project. It is an
 independent library by Erik de Castro Lopo and contributors, included
@@ -65,18 +90,8 @@ Compliance summary
 ================================================================================
 
 This NOTICE file is provided in compliance with:
-  - GPL-3.0 §5 and §7 (for SuperCollider components)
+  - GPL-3.0 §5 and §7 (for SuperCollider components, aggregation per §0)
   - LGPL-2.1 §1, §2, §6 (for libsndfile)
 
 For the full GPL-3.0 license text, see LICENSE.GPL-3.0 in this directory.
 For the full LGPL-2.1 license text, see the libsndfile COPYING URL above.
-
-------------------------------------------------------------------------
-PLACEHOLDER STATUS:
-This NOTICE will be reviewed and finalized in Issue #139 before any public
-release. Section A (GPL aggregation, SC source URL) is accurate as of the
-bundled SuperCollider 3.14.1 release. Section B (libsndfile LGPL-2.1) was
-added in PR #155 review to correct the prior misclassification. Issue #139
-will additionally embed the verbatim GPL-3.0 license text in
-LICENSE.GPL-3.0 and verify libsndfile version pinning.
-------------------------------------------------------------------------

--- a/packages/vscode-extension/legal/scsynth-NOTICE
+++ b/packages/vscode-extension/legal/scsynth-NOTICE
@@ -1,38 +1,82 @@
-OrbitScore VS Code Extension — Bundled scsynth Notice
+OrbitScore VS Code Extension — Bundled Third-Party Components Notice
 
-This extension bundles the following components from the SuperCollider
-project (https://supercollider.github.io/), distributed under the
-GNU General Public License version 3 or later (GPL-3.0-or-later):
+This extension bundles third-party components from two distinct projects.
+Each is licensed independently and listed separately below.
+
+================================================================================
+Section A: SuperCollider components (GPL-3.0-or-later)
+================================================================================
+
+Bundled components (distributed unmodified, as extracted from the official
+SuperCollider 3.14.1 release):
 
   - scsynth (audio server binary)
   - scsynth plugins (UGens, *.scx files in plugins/)
-  - libsndfile.dylib (audio file I/O library)
 
-These components are distributed unmodified, as extracted from the
-official SuperCollider 3.14.1 release. They are aggregated with
-OrbitScore (which itself is licensed under the Signal compose Fair
-Trade License — see ../../LICENSE) following the GPL aggregation
-exception (GPL-3.0 §0).
+License: GNU General Public License version 3 or later (GPL-3.0-or-later)
+See: LICENSE.GPL-3.0 in this directory.
 
-------------------------------------------------------------------------
+These components are aggregated with OrbitScore (which itself is licensed
+under the Signal compose Fair Trade License — see ../../LICENSE) following
+the GPL aggregation exception (GPL-3.0 §0).
+
 Corresponding source code (GPL-3.0 §6):
   https://github.com/supercollider/supercollider/releases/tag/Version-3.14.1
 
-The bundled binaries were built from the above tagged release. The
-source code is available under the same GPL-3.0-or-later license at the
-URL above.
-------------------------------------------------------------------------
+The bundled binaries were built from the above tagged release. The source
+code is available under the same GPL-3.0-or-later license at the URL above.
 
 Copyright notices preserved from the SuperCollider project:
   Copyright (c) 2002-2025 The SuperCollider community
   https://github.com/supercollider/supercollider/blob/main/COPYING
 
-This NOTICE file is provided in compliance with GPL-3.0 §5 and §7.
-For the full license text, see LICENSE.GPL-3.0 in this directory.
+================================================================================
+Section B: libsndfile (LGPL-2.1-or-later)
+================================================================================
+
+Bundled component (distributed unmodified, copied from the SuperCollider
+3.14.1 macOS distribution which itself ships an unmodified libsndfile):
+
+  - libsndfile.dylib (audio file I/O library)
+
+License: GNU Lesser General Public License version 2.1 or later
+        (LGPL-2.1-or-later)
+See: https://github.com/libsndfile/libsndfile/blob/master/COPYING
+
+libsndfile is **not** part of the SuperCollider project. It is an
+independent library by Erik de Castro Lopo and contributors, included
+because scsynth dynamically links against it for audio file I/O.
+
+Corresponding source code (LGPL-2.1 §6):
+  https://github.com/libsndfile/libsndfile
+
+The bundled libsndfile.dylib was extracted from SuperCollider 3.14.1's
+macOS distribution. Its version corresponds to whatever libsndfile release
+the SuperCollider build embedded; users may replace `libsndfile.dylib` in
+this bundle with a custom build of libsndfile (LGPL §4d) — the resolver
+loads the dylib via `@loader_path/../Frameworks/libsndfile.dylib` so any
+ABI-compatible build will be picked up.
+
+Copyright notices preserved from the libsndfile project:
+  Copyright (c) 1999-2024 Erik de Castro Lopo and contributors
+
+================================================================================
+Compliance summary
+================================================================================
+
+This NOTICE file is provided in compliance with:
+  - GPL-3.0 §5 and §7 (for SuperCollider components)
+  - LGPL-2.1 §1, §2, §6 (for libsndfile)
+
+For the full GPL-3.0 license text, see LICENSE.GPL-3.0 in this directory.
+For the full LGPL-2.1 license text, see the libsndfile COPYING URL above.
 
 ------------------------------------------------------------------------
 PLACEHOLDER STATUS:
-This NOTICE will be reviewed and finalized in Issue #139 before any
-public release. The corresponding source URL and copyright statements
-above are accurate as of the bundled SuperCollider 3.14.1 release.
+This NOTICE will be reviewed and finalized in Issue #139 before any public
+release. Section A (GPL aggregation, SC source URL) is accurate as of the
+bundled SuperCollider 3.14.1 release. Section B (libsndfile LGPL-2.1) was
+added in PR #155 review to correct the prior misclassification. Issue #139
+will additionally embed the verbatim GPL-3.0 license text in
+LICENSE.GPL-3.0 and verify libsndfile version pinning.
 ------------------------------------------------------------------------

--- a/packages/vscode-extension/legal/scsynth-NOTICE
+++ b/packages/vscode-extension/legal/scsynth-NOTICE
@@ -1,0 +1,38 @@
+OrbitScore VS Code Extension — Bundled scsynth Notice
+
+This extension bundles the following components from the SuperCollider
+project (https://supercollider.github.io/), distributed under the
+GNU General Public License version 3 or later (GPL-3.0-or-later):
+
+  - scsynth (audio server binary)
+  - scsynth plugins (UGens, *.scx files in plugins/)
+  - libsndfile.dylib (audio file I/O library)
+
+These components are distributed unmodified, as extracted from the
+official SuperCollider 3.14.1 release. They are aggregated with
+OrbitScore (which itself is licensed under the Signal compose Fair
+Trade License — see ../../LICENSE) following the GPL aggregation
+exception (GPL-3.0 §0).
+
+------------------------------------------------------------------------
+Corresponding source code (GPL-3.0 §6):
+  https://github.com/supercollider/supercollider/releases/tag/Version-3.14.1
+
+The bundled binaries were built from the above tagged release. The
+source code is available under the same GPL-3.0-or-later license at the
+URL above.
+------------------------------------------------------------------------
+
+Copyright notices preserved from the SuperCollider project:
+  Copyright (c) 2002-2025 The SuperCollider community
+  https://github.com/supercollider/supercollider/blob/main/COPYING
+
+This NOTICE file is provided in compliance with GPL-3.0 §5 and §7.
+For the full license text, see LICENSE.GPL-3.0 in this directory.
+
+------------------------------------------------------------------------
+PLACEHOLDER STATUS:
+This NOTICE will be reviewed and finalized in Issue #139 before any
+public release. The corresponding source URL and copyright statements
+above are accurate as of the bundled SuperCollider 3.14.1 release.
+------------------------------------------------------------------------

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -63,8 +63,8 @@
         "icon": "$(stop)"
       },
       {
-        "command": "orbitscore.killSuperCollider",
-        "title": "🔪 Kill SuperCollider",
+        "command": "orbitscore.forceKillScsynth",
+        "title": "🔪 Force Kill scsynth",
         "category": "OrbitScore",
         "icon": "$(close-all)"
       },

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -132,6 +132,12 @@
           "default": "#ff6b6b",
           "description": "Custom flash color (hex format, e.g., #ff6b6b)",
           "format": "color-hex"
+        },
+        "orbitscore.scsynthPath": {
+          "type": "string",
+          "default": "",
+          "description": "Override path to the scsynth binary. Leave empty to use the bundled scsynth (recommended). Advanced users can point this at a custom SuperCollider install.",
+          "scope": "machine-overridable"
         }
       }
     }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,16 +3,30 @@
   "displayName": "OrbitScore",
   "description": "Live coding music DSL with bundled SuperCollider audio engine. macOS (Apple Silicon) only.",
   "publisher": "local",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "Signal compose Inc.",
   "license": "SEE LICENSE IN ../../LICENSE",
   "repository": {
     "type": "git",
     "url": "https://github.com/signalcompose/orbitscore"
   },
+  "bugs": {
+    "url": "https://github.com/signalcompose/orbitscore/issues"
+  },
+  "homepage": "https://github.com/signalcompose/orbitscore#readme",
   "categories": [
     "Programming Languages",
     "Other"
+  ],
+  "keywords": [
+    "live-coding",
+    "music",
+    "dsl",
+    "supercollider",
+    "scsynth",
+    "audio",
+    "polymeter",
+    "orbitscore"
   ],
   "engines": {
     "vscode": "^1.99.0"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,6 +1,7 @@
 {
   "name": "orbitscore",
   "displayName": "OrbitScore",
+  "description": "Live coding music DSL with bundled SuperCollider audio engine. macOS (Apple Silicon) only.",
   "publisher": "local",
   "version": "1.0.1",
   "author": "Signal compose Inc.",
@@ -9,6 +10,10 @@
     "type": "git",
     "url": "https://github.com/signalcompose/orbitscore"
   },
+  "categories": [
+    "Programming Languages",
+    "Other"
+  ],
   "engines": {
     "vscode": "^1.99.0"
   },

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -147,6 +147,8 @@
     "build:clean": "npm run build:engine:clean && tsc -p tsconfig.json",
     "build:engine": "cd ../engine && npm run build && cp -r dist ../vscode-extension/engine/ && cp -r supercollider ../vscode-extension/engine/ && bash ../../scripts/install-engine-deps.sh",
     "build:engine:clean": "cd ../engine && npm run build:clean && cp -r dist ../vscode-extension/engine/ && cp -r supercollider ../vscode-extension/engine/ && bash ../../scripts/install-engine-deps.sh",
+    "build:bundle": "bash ../../scripts/extract-scsynth-bundle.sh",
+    "verify:bundle": "bash ../../scripts/verify-bundle.sh",
     "dev": "tsc -w"
   },
   "devDependencies": {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -711,8 +711,31 @@ async function selectAudioDevice() {
     '🔊 Detecting audio devices... (this may take a few seconds)',
   )
 
-  // Temporarily boot SuperCollider to get device list from its output
-  const scPath = '/Applications/SuperCollider.app/Contents/Resources/scsynth'
+  // Resolve scsynth path via shared resolver (bundle / env / SC.app / spotlight).
+  // 同じ resolver を engine 側 spawn と共有することで path 解決の drift を防ぐ。
+  let scPath: string
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const resolverModule = require('../engine/dist/audio/supercollider/scsynth-resolver') as {
+      resolveScsynthPath: (opts?: { explicit?: string }) => { path: string; source: string }
+    }
+    const userOverride = vscode.workspace
+      .getConfiguration('orbitscore')
+      .get<string>('scsynthPath', '')
+      .trim()
+    const resolution = resolverModule.resolveScsynthPath(
+      userOverride ? { explicit: userOverride } : undefined,
+    )
+    scPath = resolution.path
+    outputChannel?.appendLine(`🔧 Using scsynth (${resolution.source}): ${scPath}`)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    vscode.window.showErrorMessage(
+      `⚠️ scsynth not found. Install SuperCollider or set 'orbitscore.scsynthPath'. (${msg})`,
+    )
+    outputChannel?.appendLine(`❌ scsynth resolve failed: ${msg}`)
+    return
+  }
 
   // Use scsynth directly with -u 0 to get device list without actually starting
   child_process.exec(`${scPath} -u 57199`, { timeout: 3000 }, async (error, stdout) => {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -45,7 +45,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Bundle status indicator (priority 99 → 既存 100 の左隣に並ぶ)
   bundleStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 99)
-  bundleStatusItem.command = 'workbench.action.openSettings'
+  // Click → orbitscore.scsynthPath に絞った設定画面に直接遷移
+  // (tooltip 案内と一致、maybeShowBundleNotice の "Open Settings" ボタンとも統一)
+  bundleStatusItem.command = {
+    command: 'workbench.action.openSettings',
+    title: 'Open scsynth settings',
+    arguments: ['orbitscore.scsynthPath'],
+  }
   updateBundleStatus()
   bundleStatusItem.show()
 
@@ -838,8 +844,11 @@ async function selectAudioDevice() {
   const scPath = resolution.path
   outputChannel?.appendLine(`🔧 Using scsynth (${resolution.source}): ${scPath}`)
 
-  // Use scsynth directly with -u 0 to get device list without actually starting
-  child_process.exec(`${scPath} -u 57199`, { timeout: 3000 }, async (error, stdout) => {
+  // Use scsynth directly with -u 57199 to get device list without actually starting.
+  // execFile (not exec) は scPath をシェル展開せずに直接実行するため、
+  // ユーザー設定値 (orbitscore.scsynthPath) に \`;\` 等が混入しても command injection
+  // にならない (claude-review #155 の必須対応、CWE-78 緩和)。
+  child_process.execFile(scPath, ['-u', '57199'], { timeout: 3000 }, async (error, stdout) => {
     // Parse device list from SuperCollider's boot log
     const deviceRegex = /(\d+)\s*:\s*"([^"]+)"/g
     const devices: Array<{ label: string; id: number; description: string }> = []

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -123,14 +123,20 @@ function resolveScsynthForUI(): { path: string; source: string } | null {
   }
 }
 
-/** Refresh the bundle status bar item to reflect the current resolution. */
+/**
+ * Refresh the bundle status bar item to reflect the current resolution.
+ *
+ * Strict mode (Issue #136): resolver は SC.app / Spotlight 暗黙 fallback を
+ * 持たないため、source は \`bundle\` / \`env\` / \`explicit\` のいずれか。
+ * 解決失敗時は error 状態を強調表示する。
+ */
 function updateBundleStatus(): void {
   if (!bundleStatusItem) return
   const resolution = resolveScsynthForUI()
   if (!resolution) {
     bundleStatusItem.text = '$(error) scsynth: not found'
     bundleStatusItem.tooltip =
-      'No scsynth binary found. Reinstall the extension or set orbitscore.scsynthPath.'
+      'Bundled scsynth not found. Reinstall the extension or set orbitscore.scsynthPath to a system scsynth.'
     bundleStatusItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground')
     return
   }
@@ -145,16 +151,6 @@ function updateBundleStatus(): void {
       bundleStatusItem.text = '$(gear) scsynth (custom)'
       bundleStatusItem.tooltip = `Using user-overridden scsynth\n${resolution.path}`
       break
-    case 'sc-app':
-      bundleStatusItem.text = '$(folder) scsynth (SC.app)'
-      bundleStatusItem.tooltip = `Using system SuperCollider.app (bundle missing)\n${resolution.path}`
-      bundleStatusItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
-      break
-    case 'spotlight':
-      bundleStatusItem.text = '$(search) scsynth (found)'
-      bundleStatusItem.tooltip = `Using SuperCollider found via Spotlight\n${resolution.path}`
-      bundleStatusItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
-      break
     default:
       bundleStatusItem.text = '$(question) scsynth: unknown source'
       bundleStatusItem.tooltip = resolution.path
@@ -162,56 +158,29 @@ function updateBundleStatus(): void {
 }
 
 /**
- * Show first-run / fallback warning when scsynth is missing or running off SC.app.
- * - Bundle / env / explicit → silent (normal operation)
- * - sc-app / spotlight → 1 回だけ Warning (Don't Show Again は globalState に記録)
- * - resolution failed → エラー Notification (毎回出す、修復必須のため)
+ * Show error notification when scsynth resolution fails.
+ *
+ * Strict mode (Issue #136): bundle / env / explicit が解決できれば silent。
+ * いずれも見つからない場合は毎回エラー表示 (修復必須)。
+ * \`globalState\` の dismiss 機構は持たない (silent fallback がないため
+ * 「無視して動かす」選択肢自体がない)。
  */
 async function maybeShowBundleNotice(): Promise<void> {
   if (!extensionContext || !outputChannel) return
   const resolution = resolveScsynthForUI()
-  if (!resolution) {
-    const choice = await vscode.window.showErrorMessage(
-      '⚠️ scsynth not found. OrbitScore cannot start the audio engine.',
-      'Open Settings',
-      'View Logs',
-    )
-    if (choice === 'Open Settings') {
-      vscode.commands.executeCommand('workbench.action.openSettings', 'orbitscore.scsynthPath')
-    } else if (choice === 'View Logs') {
-      outputChannel.show()
-    }
+  if (resolution) {
+    // bundle / env / explicit いずれも resolved → 通知不要
     return
   }
-  if (
-    resolution.source === 'bundle' ||
-    resolution.source === 'env' ||
-    resolution.source === 'explicit'
-  ) {
-    return
-  }
-  // sc-app / spotlight 経由 → 初回限定 Warning (version 単位で dismiss を記録)
-  const packageJsonPath = path.join(__dirname, '../package.json')
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
-  const dismissedVersion = extensionContext.globalState.get<string>(
-    'orbitscore.bundleNotice.dismissedVersion',
-  )
-  if (dismissedVersion === packageJson.version) {
-    return
-  }
-  const fallbackName = resolution.source === 'sc-app' ? 'SuperCollider.app' : 'system SuperCollider'
-  const choice = await vscode.window.showWarningMessage(
-    `⚠️ Bundled scsynth not found. Falling back to ${fallbackName}. Reinstall the extension to restore the bundle.`,
+  const choice = await vscode.window.showErrorMessage(
+    '⚠️ scsynth not found. OrbitScore requires the bundled scsynth to start. Reinstall the extension or set orbitscore.scsynthPath to a system scsynth.',
     'Open Settings',
-    "Don't Show Again",
+    'View Logs',
   )
   if (choice === 'Open Settings') {
     vscode.commands.executeCommand('workbench.action.openSettings', 'orbitscore.scsynthPath')
-  } else if (choice === "Don't Show Again") {
-    await extensionContext.globalState.update(
-      'orbitscore.bundleNotice.dismissedVersion',
-      packageJson.version,
-    )
+  } else if (choice === 'View Logs') {
+    outputChannel.show()
   }
 }
 
@@ -869,7 +838,7 @@ async function selectAudioDevice() {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     vscode.window.showErrorMessage(
-      `⚠️ scsynth not found. Install SuperCollider or set 'orbitscore.scsynthPath'. (${msg})`,
+      `⚠️ scsynth not found. Reinstall the extension to restore the bundle, or set 'orbitscore.scsynthPath' to a system scsynth. (${msg})`,
     )
     outputChannel?.appendLine(`❌ scsynth resolve failed: ${msg}`)
     return

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -684,10 +684,14 @@ function startEngine(debugMode: boolean = false) {
     return
   }
 
-  // Fire-and-forget: scsynth が解決できない場合に毎回エラー Notification を表示
-  // (strict mode のため silent fallback はない)。engine 起動と UI 通知を並行させ、
-  // UI thread をブロックしない。
-  void maybeShowBundleNotice()
+  // Pre-check: scsynth が解決できない場合は engine spawn を行わず、エラー
+  // Notification のみ表示する。spawn してから boot 失敗するとユーザーに
+  // 二重通知 (resolver エラー + engine 終了ログ) が出てしまうのを防ぐ
+  // (claude-review on PR #155 の Significant 指摘 #2)。
+  if (!resolveScsynthForUI()) {
+    void maybeShowBundleNotice()
+    return
+  }
 
   const modeLabel = debugMode ? '(Debug Mode)' : '(Normal Mode)'
   outputChannel?.appendLine(`🚀 Starting engine... ${modeLabel}`)
@@ -724,7 +728,8 @@ function startEngine(debugMode: boolean = false) {
   }
 
   // Pass scsynth path override to engine via env (resolver consumes ORBIT_SCSYNTH_PATH).
-  // Empty / whitespace-only setting → fall through to bundle / SC.app fallback in resolver.
+  // Empty / whitespace-only setting → resolver が bundle 候補を試す
+  // (strict mode、SC.app 暗黙 fallback なし、bundle 不在は ScsynthNotFoundError で fail loud)。
   const scsynthOverride = vscode.workspace
     .getConfiguration('orbitscore')
     .get<string>('scsynthPath', '')

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -65,7 +65,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('orbitscore.runSelection', runSelection),
     vscode.commands.registerCommand('orbitscore.stopEngine', stopEngine),
     vscode.commands.registerCommand('orbitscore.startEngineDebug', startEngineDebug),
-    vscode.commands.registerCommand('orbitscore.killSuperCollider', killSuperCollider),
+    vscode.commands.registerCommand('orbitscore.forceKillScsynth', forceKillScsynth),
     vscode.commands.registerCommand('orbitscore.selectAudioDevice', selectAudioDevice),
     vscode.commands.registerCommand('orbitscore.configureFlash', configureFlash),
     statusBarItem,
@@ -211,9 +211,9 @@ function showCommands() {
       detail: 'Select audio output device for SuperCollider',
     },
     {
-      label: '🔪 Kill SuperCollider',
+      label: '🔪 Force Kill scsynth',
       description: 'killall scsynth',
-      detail: 'Force kill all SuperCollider server processes',
+      detail: 'Escape hatch — force-kill any orphan scsynth processes',
     },
     {
       label: '⚡ Configure Flash',
@@ -246,8 +246,8 @@ function showCommands() {
       case '🔊 Select Audio Device':
         vscode.commands.executeCommand('orbitscore.selectAudioDevice')
         break
-      case '🔪 Kill SuperCollider':
-        vscode.commands.executeCommand('orbitscore.killSuperCollider')
+      case '🔪 Force Kill scsynth':
+        vscode.commands.executeCommand('orbitscore.forceKillScsynth')
         break
       case '⚡ Configure Flash':
         vscode.commands.executeCommand('orbitscore.configureFlash')
@@ -781,23 +781,31 @@ function stopEngine() {
   }
 }
 
-function killSuperCollider() {
-  outputChannel?.appendLine('🔪 Killing SuperCollider processes...')
+/**
+ * Force-kill any stray scsynth processes (escape hatch for zombie cleanup).
+ *
+ * Normal stop is handled via \`stopEngine\` (graceful SIGTERM through the engine
+ * process). This command is for cases where the engine process itself was
+ * SIGKILL'd / force-quit and left an orphan scsynth, or for clearing leftover
+ * processes from external manual boots during development.
+ */
+function forceKillScsynth() {
+  outputChannel?.appendLine('🔪 Force-killing scsynth processes...')
 
-  // Execute killall scsynth, suppress errors if no process found
+  // killall covers both bundled and system scsynth (intentional — escape hatch
+  // should clean up everything). Exit code 1 = "no process found" (not an error).
   child_process.exec('killall scsynth 2>/dev/null', (error) => {
     if (error) {
-      // Exit code 1 means no process found, which is ok
       if (error.code === 1) {
-        outputChannel?.appendLine('✅ No SuperCollider processes found')
-        vscode.window.showInformationMessage('✅ No SuperCollider processes running')
+        outputChannel?.appendLine('✅ No scsynth processes found')
+        vscode.window.showInformationMessage('✅ No scsynth processes running')
       } else {
         outputChannel?.appendLine(`⚠️ Error: ${error.message}`)
-        vscode.window.showWarningMessage(`⚠️ Failed to kill SuperCollider: ${error.message}`)
+        vscode.window.showWarningMessage(`⚠️ Failed to kill scsynth: ${error.message}`)
       }
     } else {
-      outputChannel?.appendLine('✅ SuperCollider processes killed')
-      vscode.window.showInformationMessage('✅ SuperCollider killed')
+      outputChannel?.appendLine('✅ scsynth processes killed')
+      vscode.window.showInformationMessage('✅ scsynth killed')
     }
   })
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -688,7 +688,9 @@ function startEngine(debugMode: boolean = false) {
   // Notification のみ表示する。spawn してから boot 失敗するとユーザーに
   // 二重通知 (resolver エラー + engine 終了ログ) が出てしまうのを防ぐ
   // (claude-review on PR #155 の Significant 指摘 #2)。
-  if (!resolveScsynthForUI()) {
+  // 解決できた場合はその path を engine spawn に再利用 (Minor #1: 二重 fs.statSync 回避)。
+  const scResolution = resolveScsynthForUI()
+  if (!scResolution) {
     void maybeShowBundleNotice()
     return
   }
@@ -727,17 +729,11 @@ function startEngine(debugMode: boolean = false) {
     env.ORBITSCORE_DEBUG = '1'
   }
 
-  // Pass scsynth path override to engine via env (resolver consumes ORBIT_SCSYNTH_PATH).
-  // Empty / whitespace-only setting → resolver が bundle 候補を試す
-  // (strict mode、SC.app 暗黙 fallback なし、bundle 不在は ScsynthNotFoundError で fail loud)。
-  const scsynthOverride = vscode.workspace
-    .getConfiguration('orbitscore')
-    .get<string>('scsynthPath', '')
-    .trim()
-  if (scsynthOverride) {
-    env.ORBIT_SCSYNTH_PATH = scsynthOverride
-    outputChannel?.appendLine(`🔧 scsynth override: ${scsynthOverride}`)
-  }
+  // Pass scsynth path to engine via env. pre-check で解決済 (scResolution.path) を
+  // そのまま engine に渡すことで resolver の二重 fs.statSync を avoid + pre-check と
+  // engine 内部での resolution 結果ズレ (タイミング差) のリスクを排除。
+  env.ORBIT_SCSYNTH_PATH = scResolution.path
+  outputChannel?.appendLine(`🔧 scsynth (${scResolution.source}): ${scResolution.path}`)
 
   // Spawn engine process
   engineProcess = child_process.spawn('node', [enginePath, ...args], {
@@ -805,7 +801,9 @@ function forceKillScsynth() {
 
   // killall covers both bundled and system scsynth (intentional — escape hatch
   // should clean up everything). Exit code 1 = "no process found" (not an error).
-  child_process.exec('killall scsynth 2>/dev/null', (error) => {
+  // execFile (not exec) for consistency with selectAudioDevice (no shell, even
+  // though args are hardcoded here so no injection risk).
+  child_process.execFile('killall', ['scsynth'], (error) => {
     if (error) {
       if (error.code === 1) {
         outputChannel?.appendLine('✅ No scsynth processes found')
@@ -900,7 +898,11 @@ async function selectAudioDevice() {
     )
 
     // Kill the temporary SuperCollider instance
-    child_process.exec('killall scsynth sclang 2>/dev/null')
+    // Cleanup temp scsynth (and sclang if any from system SC). execFile for
+    // shell-free invocation; we ignore the result (best-effort cleanup).
+    child_process.execFile('killall', ['scsynth', 'sclang'], () => {
+      /* best-effort, ignore error */
+    })
   })
 }
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -11,6 +11,8 @@ import { analyzeMethodChain, getContextualCompletions } from './completion-conte
 let engineProcess: child_process.ChildProcess | null = null
 let outputChannel: vscode.OutputChannel | null = null
 let statusBarItem: vscode.StatusBarItem | null = null
+let bundleStatusItem: vscode.StatusBarItem | null = null
+let extensionContext: vscode.ExtensionContext | null = null
 let isLiveCodingMode: boolean = false
 
 // let isDebugMode: boolean = false // Debug mode flag
@@ -42,6 +44,24 @@ export async function activate(context: vscode.ExtensionContext) {
   statusBarItem.command = 'orbitscore.showCommands'
   statusBarItem.show()
 
+  // Bundle status indicator (priority 99 → 既存 100 の左隣に並ぶ)
+  bundleStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 99)
+  bundleStatusItem.command = 'workbench.action.openSettings'
+  updateBundleStatus()
+  bundleStatusItem.show()
+
+  // Save context for first-run notification
+  extensionContext = context
+
+  // Re-evaluate bundle status when user changes the override setting
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration('orbitscore.scsynthPath')) {
+        updateBundleStatus()
+      }
+    }),
+  )
+
   // Register commands
   context.subscriptions.push(
     vscode.commands.registerCommand('orbitscore.toggleEngine', toggleEngine),
@@ -53,6 +73,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('orbitscore.selectAudioDevice', selectAudioDevice),
     vscode.commands.registerCommand('orbitscore.configureFlash', configureFlash),
     statusBarItem,
+    bundleStatusItem,
   )
 
   // Register IntelliSense providers
@@ -79,6 +100,119 @@ export function deactivate() {
   }
   outputChannel?.dispose()
   statusBarItem?.dispose()
+  bundleStatusItem?.dispose()
+}
+
+/**
+ * Resolve scsynth via shared resolver (engine の compiled JS を runtime require).
+ * Returns null on failure (e.g. resolver throws ScsynthNotFoundError).
+ */
+function resolveScsynthForUI(): { path: string; source: string } | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const resolverModule = require('../engine/dist/audio/supercollider/scsynth-resolver') as {
+      resolveScsynthPath: (opts?: { explicit?: string }) => { path: string; source: string }
+    }
+    const userOverride = vscode.workspace
+      .getConfiguration('orbitscore')
+      .get<string>('scsynthPath', '')
+      .trim()
+    return resolverModule.resolveScsynthPath(userOverride ? { explicit: userOverride } : undefined)
+  } catch {
+    return null
+  }
+}
+
+/** Refresh the bundle status bar item to reflect the current resolution. */
+function updateBundleStatus(): void {
+  if (!bundleStatusItem) return
+  const resolution = resolveScsynthForUI()
+  if (!resolution) {
+    bundleStatusItem.text = '$(error) scsynth: not found'
+    bundleStatusItem.tooltip =
+      'No scsynth binary found. Reinstall the extension or set orbitscore.scsynthPath.'
+    bundleStatusItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground')
+    return
+  }
+  bundleStatusItem.backgroundColor = undefined
+  switch (resolution.source) {
+    case 'bundle':
+      bundleStatusItem.text = '$(check) scsynth (bundled)'
+      bundleStatusItem.tooltip = `Using bundled scsynth\n${resolution.path}`
+      break
+    case 'env':
+    case 'explicit':
+      bundleStatusItem.text = '$(gear) scsynth (custom)'
+      bundleStatusItem.tooltip = `Using user-overridden scsynth\n${resolution.path}`
+      break
+    case 'sc-app':
+      bundleStatusItem.text = '$(folder) scsynth (SC.app)'
+      bundleStatusItem.tooltip = `Using system SuperCollider.app (bundle missing)\n${resolution.path}`
+      bundleStatusItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
+      break
+    case 'spotlight':
+      bundleStatusItem.text = '$(search) scsynth (found)'
+      bundleStatusItem.tooltip = `Using SuperCollider found via Spotlight\n${resolution.path}`
+      bundleStatusItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
+      break
+    default:
+      bundleStatusItem.text = '$(question) scsynth: unknown source'
+      bundleStatusItem.tooltip = resolution.path
+  }
+}
+
+/**
+ * Show first-run / fallback warning when scsynth is missing or running off SC.app.
+ * - Bundle / env / explicit → silent (normal operation)
+ * - sc-app / spotlight → 1 回だけ Warning (Don't Show Again は globalState に記録)
+ * - resolution failed → エラー Notification (毎回出す、修復必須のため)
+ */
+async function maybeShowBundleNotice(): Promise<void> {
+  if (!extensionContext || !outputChannel) return
+  const resolution = resolveScsynthForUI()
+  if (!resolution) {
+    const choice = await vscode.window.showErrorMessage(
+      '⚠️ scsynth not found. OrbitScore cannot start the audio engine.',
+      'Open Settings',
+      'View Logs',
+    )
+    if (choice === 'Open Settings') {
+      vscode.commands.executeCommand('workbench.action.openSettings', 'orbitscore.scsynthPath')
+    } else if (choice === 'View Logs') {
+      outputChannel.show()
+    }
+    return
+  }
+  if (
+    resolution.source === 'bundle' ||
+    resolution.source === 'env' ||
+    resolution.source === 'explicit'
+  ) {
+    return
+  }
+  // sc-app / spotlight 経由 → 初回限定 Warning (version 単位で dismiss を記録)
+  const packageJsonPath = path.join(__dirname, '../package.json')
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+  const dismissedVersion = extensionContext.globalState.get<string>(
+    'orbitscore.bundleNotice.dismissedVersion',
+  )
+  if (dismissedVersion === packageJson.version) {
+    return
+  }
+  const fallbackName = resolution.source === 'sc-app' ? 'SuperCollider.app' : 'system SuperCollider'
+  const choice = await vscode.window.showWarningMessage(
+    `⚠️ Bundled scsynth not found. Falling back to ${fallbackName}. Reinstall the extension to restore the bundle.`,
+    'Open Settings',
+    "Don't Show Again",
+  )
+  if (choice === 'Open Settings') {
+    vscode.commands.executeCommand('workbench.action.openSettings', 'orbitscore.scsynthPath')
+  } else if (choice === "Don't Show Again") {
+    await extensionContext.globalState.update(
+      'orbitscore.bundleNotice.dismissedVersion',
+      packageJson.version,
+    )
+  }
 }
 
 function showCommands() {
@@ -575,6 +709,10 @@ function startEngine(debugMode: boolean = false) {
     vscode.window.showWarningMessage('⚠️ Engine is already running')
     return
   }
+
+  // Fire-and-forget: bundle 不在や SC.app fallback の場合に初回限定 Warning。
+  // engine 起動と UI 通知を並行させ、UI thread をブロックしない。
+  void maybeShowBundleNotice()
 
   const modeLabel = debugMode ? '(Debug Mode)' : '(Normal Mode)'
   outputChannel?.appendLine(`🚀 Starting engine... ${modeLabel}`)

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -610,6 +610,17 @@ function startEngine(debugMode: boolean = false) {
     env.ORBITSCORE_DEBUG = '1'
   }
 
+  // Pass scsynth path override to engine via env (resolver consumes ORBIT_SCSYNTH_PATH).
+  // Empty / whitespace-only setting → fall through to bundle / SC.app fallback in resolver.
+  const scsynthOverride = vscode.workspace
+    .getConfiguration('orbitscore')
+    .get<string>('scsynthPath', '')
+    .trim()
+  if (scsynthOverride) {
+    env.ORBIT_SCSYNTH_PATH = scsynthOverride
+    outputChannel?.appendLine(`🔧 scsynth override: ${scsynthOverride}`)
+  }
+
   // Spawn engine process
   engineProcess = child_process.spawn('node', [enginePath, ...args], {
     cwd: workspaceRoot,

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -12,7 +12,6 @@ let engineProcess: child_process.ChildProcess | null = null
 let outputChannel: vscode.OutputChannel | null = null
 let statusBarItem: vscode.StatusBarItem | null = null
 let bundleStatusItem: vscode.StatusBarItem | null = null
-let extensionContext: vscode.ExtensionContext | null = null
 let isLiveCodingMode: boolean = false
 
 // let isDebugMode: boolean = false // Debug mode flag
@@ -49,9 +48,6 @@ export async function activate(context: vscode.ExtensionContext) {
   bundleStatusItem.command = 'workbench.action.openSettings'
   updateBundleStatus()
   bundleStatusItem.show()
-
-  // Save context for first-run notification
-  extensionContext = context
 
   // Re-evaluate bundle status when user changes the override setting
   context.subscriptions.push(
@@ -105,7 +101,8 @@ export function deactivate() {
 
 /**
  * Resolve scsynth via shared resolver (engine の compiled JS を runtime require).
- * Returns null on failure (e.g. resolver throws ScsynthNotFoundError).
+ * Returns null on failure. 失敗時は outputChannel に reason を log するため
+ * View Logs から原因を追える (engine/dist/ 不在 vs. bundle 不在 vs. その他)。
  */
 function resolveScsynthForUI(): { path: string; source: string } | null {
   try {
@@ -118,7 +115,9 @@ function resolveScsynthForUI(): { path: string; source: string } | null {
       .get<string>('scsynthPath', '')
       .trim()
     return resolverModule.resolveScsynthPath(userOverride ? { explicit: userOverride } : undefined)
-  } catch {
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    outputChannel?.appendLine(`❌ scsynth resolver failed: ${reason}`)
     return null
   }
 }
@@ -166,7 +165,7 @@ function updateBundleStatus(): void {
  * 「無視して動かす」選択肢自体がない)。
  */
 async function maybeShowBundleNotice(): Promise<void> {
-  if (!extensionContext || !outputChannel) return
+  if (!outputChannel) return
   const resolution = resolveScsynthForUI()
   if (resolution) {
     // bundle / env / explicit いずれも resolved → 通知不要
@@ -679,8 +678,9 @@ function startEngine(debugMode: boolean = false) {
     return
   }
 
-  // Fire-and-forget: bundle 不在や SC.app fallback の場合に初回限定 Warning。
-  // engine 起動と UI 通知を並行させ、UI thread をブロックしない。
+  // Fire-and-forget: scsynth が解決できない場合に毎回エラー Notification を表示
+  // (strict mode のため silent fallback はない)。engine 起動と UI 通知を並行させ、
+  // UI thread をブロックしない。
   void maybeShowBundleNotice()
 
   const modeLabel = debugMode ? '(Debug Mode)' : '(Normal Mode)'
@@ -818,31 +818,17 @@ async function selectAudioDevice() {
     '🔊 Detecting audio devices... (this may take a few seconds)',
   )
 
-  // Resolve scsynth path via shared resolver (bundle / env / SC.app / spotlight).
-  // 同じ resolver を engine 側 spawn と共有することで path 解決の drift を防ぐ。
-  let scPath: string
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-    const resolverModule = require('../engine/dist/audio/supercollider/scsynth-resolver') as {
-      resolveScsynthPath: (opts?: { explicit?: string }) => { path: string; source: string }
-    }
-    const userOverride = vscode.workspace
-      .getConfiguration('orbitscore')
-      .get<string>('scsynthPath', '')
-      .trim()
-    const resolution = resolverModule.resolveScsynthPath(
-      userOverride ? { explicit: userOverride } : undefined,
-    )
-    scPath = resolution.path
-    outputChannel?.appendLine(`🔧 Using scsynth (${resolution.source}): ${scPath}`)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
+  // Resolve scsynth path via shared resolver (strict mode: bundle / env / explicit のみ)。
+  // status bar / startEngine と同じ resolveScsynthForUI() を再利用。
+  const resolution = resolveScsynthForUI()
+  if (!resolution) {
     vscode.window.showErrorMessage(
-      `⚠️ scsynth not found. Reinstall the extension to restore the bundle, or set 'orbitscore.scsynthPath' to a system scsynth. (${msg})`,
+      "⚠️ scsynth not found. Reinstall the extension to restore the bundle, or set 'orbitscore.scsynthPath' to a system scsynth.",
     )
-    outputChannel?.appendLine(`❌ scsynth resolve failed: ${msg}`)
     return
   }
+  const scPath = resolution.path
+  outputChannel?.appendLine(`🔧 Using scsynth (${resolution.source}): ${scPath}`)
 
   // Use scsynth directly with -u 0 to get device list without actually starting
   child_process.exec(`${scPath} -u 57199`, { timeout: 3000 }, async (error, stdout) => {

--- a/scripts/extract-scsynth-bundle.sh
+++ b/scripts/extract-scsynth-bundle.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# extract-scsynth-bundle.sh
+#
+# SuperCollider.app から scsynth バイナリ + plugins (non-supernova 26 個) +
+# libsndfile.dylib を抽出し、`packages/vscode-extension/engine/scsynth/` の
+# bundle 構造に配置する。
+#
+# 仕様: docs/research/SCSYNTH_BUNDLE_MANIFEST.md
+#
+# Usage:
+#   bash scripts/extract-scsynth-bundle.sh           # default: fail-fast (CI/release 用)
+#   bash scripts/extract-scsynth-bundle.sh --allow-skip   # SC.app 不在で warning + exit 0 (dev 用)
+#
+# Exit codes:
+#   0 - 成功 (または --allow-skip で SC.app 不在)
+#   1 - 一般エラー
+#   2 - SC.app 不在 (--allow-skip なし)
+
+set -euo pipefail
+
+# ============================================================
+# CLI args
+# ============================================================
+ALLOW_SKIP=0
+for arg in "$@"; do
+  case "$arg" in
+    --allow-skip)
+      ALLOW_SKIP=1
+      ;;
+    -h|--help)
+      sed -n '3,20p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ============================================================
+# Paths
+# ============================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEST="$REPO_ROOT/packages/vscode-extension/engine/scsynth/Contents"
+LEGAL_SRC="$REPO_ROOT/packages/vscode-extension/legal"
+
+# ============================================================
+# SC.app discovery
+# ============================================================
+SC_APP=""
+for candidate in \
+  "/Applications/SuperCollider.app" \
+  "/Applications/SuperCollider/SuperCollider.app"; do
+  if [ -d "$candidate" ]; then
+    SC_APP="$candidate"
+    break
+  fi
+done
+
+if [ -z "$SC_APP" ] && command -v mdfind >/dev/null 2>&1; then
+  found=$(mdfind -name SuperCollider.app 2>/dev/null | head -1 || true)
+  if [ -n "$found" ] && [ -d "$found" ]; then
+    SC_APP="$found"
+  fi
+fi
+
+if [ -z "$SC_APP" ]; then
+  msg="SuperCollider.app not found. Install via 'brew install --cask supercollider' or download from https://supercollider.github.io/"
+  if [ "$ALLOW_SKIP" -eq 1 ]; then
+    echo "⚠️  Skipping bundle extract: $msg" >&2
+    exit 0
+  fi
+  echo "ERROR: $msg" >&2
+  exit 2
+fi
+
+SC_ROOT="$SC_APP/Contents"
+SCSYNTH_SRC="$SC_ROOT/Resources/scsynth"
+PLUGINS_SRC="$SC_ROOT/Resources/plugins"
+LIBSNDFILE_SRC="$SC_ROOT/Frameworks/libsndfile.dylib"
+
+# ============================================================
+# Pre-flight checks
+# ============================================================
+if [ ! -f "$SCSYNTH_SRC" ]; then
+  echo "ERROR: scsynth binary not found at: $SCSYNTH_SRC" >&2
+  exit 1
+fi
+if [ ! -d "$PLUGINS_SRC" ]; then
+  echo "ERROR: plugins directory not found at: $PLUGINS_SRC" >&2
+  exit 1
+fi
+if [ ! -f "$LIBSNDFILE_SRC" ]; then
+  echo "ERROR: libsndfile.dylib not found at: $LIBSNDFILE_SRC" >&2
+  exit 1
+fi
+
+echo "📦 Extracting scsynth bundle from: $SC_APP"
+
+# ============================================================
+# Build dest layout
+# ============================================================
+# 既存 bundle を完全に消してから再構築 (stale plugin 残留防止)
+rm -rf "$DEST"
+mkdir -p "$DEST/Resources/plugins" "$DEST/Frameworks"
+
+# scsynth 本体
+cp "$SCSYNTH_SRC" "$DEST/Resources/scsynth"
+chmod +x "$DEST/Resources/scsynth"
+
+# plugins (non-supernova のみ、_supernova suffix を除外)
+plugin_count=0
+for f in "$PLUGINS_SRC"/*.scx; do
+  basename=$(basename "$f")
+  if [[ "$basename" != *_supernova.scx ]]; then
+    cp "$f" "$DEST/Resources/plugins/$basename"
+    plugin_count=$((plugin_count + 1))
+  fi
+done
+
+# libsndfile dylib
+cp "$LIBSNDFILE_SRC" "$DEST/Frameworks/libsndfile.dylib"
+
+# LICENSE / NOTICE (legal/ から copy、bundle 配下に配置)
+if [ -f "$LEGAL_SRC/scsynth-LICENSE.GPL-3.0" ]; then
+  cp "$LEGAL_SRC/scsynth-LICENSE.GPL-3.0" "$DEST/../LICENSE.GPL-3.0"
+fi
+if [ -f "$LEGAL_SRC/scsynth-NOTICE" ]; then
+  cp "$LEGAL_SRC/scsynth-NOTICE" "$DEST/../NOTICE"
+fi
+
+# ============================================================
+# Verification
+# ============================================================
+echo "─────────────────────────────────────────────"
+echo "Bundle size: $(du -sh "$DEST" | cut -f1)"
+echo "Plugin count: $plugin_count (expected: 26 for SC 3.14.x)"
+
+if [ "$plugin_count" -ne 26 ]; then
+  echo "WARN: expected 26 non-supernova plugins, got $plugin_count" >&2
+  echo "  SC version may have added/removed plugins. Verify against SCSYNTH_BUNDLE_MANIFEST.md" >&2
+fi
+
+echo "Architecture check:"
+file_out=$(file "$DEST/Resources/scsynth")
+echo "  $file_out"
+if ! echo "$file_out" | grep -qE "universal|arm64.*x86_64"; then
+  echo "ERROR: scsynth is not a universal binary" >&2
+  exit 1
+fi
+
+echo "Codesign check:"
+if codesign --verify --verbose "$DEST/Resources/scsynth" 2>&1 | tail -3; then
+  echo "  ✅ scsynth signature valid"
+else
+  echo "ERROR: scsynth signature verification failed" >&2
+  exit 1
+fi
+
+team_id=$(codesign -dv "$DEST/Resources/scsynth" 2>&1 | grep TeamIdentifier | awk -F= '{print $2}' | tr -d '[:space:]')
+if [ "$team_id" != "HE5VJFE9E4" ]; then
+  echo "WARN: scsynth TeamIdentifier is '$team_id' (expected 'HE5VJFE9E4' for SC project signature)" >&2
+fi
+
+echo "─────────────────────────────────────────────"
+echo "✅ Bundle prepared at: $DEST"

--- a/scripts/verify-bundle.sh
+++ b/scripts/verify-bundle.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# verify-bundle.sh
+#
+# bundled scsynth (extract-scsynth-bundle.sh の出力 or `.vsix` 解凍済み)
+# が正しい構造・signature・architecture を保っているか検証する。
+#
+# Usage:
+#   bash scripts/verify-bundle.sh                                     # default: packages/vscode-extension/engine/scsynth
+#   bash scripts/verify-bundle.sh /path/to/extracted/extension/engine/scsynth   # arbitrary path (e.g. unzipped .vsix)
+#
+# 受け入れ基準: docs/research/SCSYNTH_BUNDLE_MANIFEST.md § Cold-install verification checklist
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET="${1:-$REPO_ROOT/packages/vscode-extension/engine/scsynth}"
+
+echo "🔍 Verifying scsynth bundle at: $TARGET"
+echo "─────────────────────────────────────────────"
+
+errors=0
+fail() {
+  echo "  ❌ $1" >&2
+  errors=$((errors + 1))
+}
+ok() {
+  echo "  ✅ $1"
+}
+
+# 1. Layout
+if [ ! -d "$TARGET" ]; then
+  fail "bundle directory does not exist: $TARGET"
+  exit 1
+fi
+[ -f "$TARGET/Contents/Resources/scsynth" ] && ok "scsynth binary exists" || fail "scsynth binary missing"
+[ -d "$TARGET/Contents/Resources/plugins" ] && ok "plugins directory exists" || fail "plugins directory missing"
+[ -f "$TARGET/Contents/Frameworks/libsndfile.dylib" ] && ok "libsndfile.dylib exists" || fail "libsndfile.dylib missing"
+
+# 2. Plugin count (non-supernova)
+plugin_count=$(find "$TARGET/Contents/Resources/plugins" -name '*.scx' ! -name '*_supernova.scx' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$plugin_count" -eq 26 ]; then
+  ok "26 non-supernova plugins"
+elif [ "$plugin_count" -gt 0 ]; then
+  fail "expected 26 plugins, got $plugin_count (SC version may differ — verify against SCSYNTH_BUNDLE_MANIFEST.md)"
+else
+  fail "no plugins found"
+fi
+
+supernova_count=$(find "$TARGET/Contents/Resources/plugins" -name '*_supernova.scx' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$supernova_count" -gt 0 ]; then
+  fail "$supernova_count supernova-variant plugins should not be bundled"
+fi
+
+# 3. Executable bit
+if [ -x "$TARGET/Contents/Resources/scsynth" ]; then
+  ok "scsynth has execute permission"
+else
+  fail "scsynth lacks execute permission (mode: $(stat -f '%Mp%Lp' "$TARGET/Contents/Resources/scsynth" 2>/dev/null || echo 'unknown'))"
+fi
+
+# 4. Architecture (universal arm64 + x86_64)
+if [ -f "$TARGET/Contents/Resources/scsynth" ]; then
+  file_out=$(file "$TARGET/Contents/Resources/scsynth")
+  if echo "$file_out" | grep -qE "universal|arm64.*x86_64"; then
+    ok "scsynth is universal binary"
+  else
+    fail "scsynth is not universal binary: $file_out"
+  fi
+fi
+
+# 5. Codesign verification
+if [ -f "$TARGET/Contents/Resources/scsynth" ]; then
+  if codesign --verify --verbose "$TARGET/Contents/Resources/scsynth" >/dev/null 2>&1; then
+    ok "scsynth signature valid (codesign --verify)"
+  else
+    fail "scsynth signature verification failed"
+  fi
+
+  team_id=$(codesign -dv "$TARGET/Contents/Resources/scsynth" 2>&1 | grep TeamIdentifier | awk -F= '{print $2}' | tr -d '[:space:]' || true)
+  if [ "$team_id" = "HE5VJFE9E4" ]; then
+    ok "scsynth TeamIdentifier matches SC project (HE5VJFE9E4)"
+  else
+    fail "TeamIdentifier mismatch: got '$team_id', expected 'HE5VJFE9E4'"
+  fi
+fi
+
+# 6. libsndfile signature
+if [ -f "$TARGET/Contents/Frameworks/libsndfile.dylib" ]; then
+  if codesign --verify --verbose "$TARGET/Contents/Frameworks/libsndfile.dylib" >/dev/null 2>&1; then
+    ok "libsndfile.dylib signature valid"
+  else
+    fail "libsndfile.dylib signature verification failed"
+  fi
+fi
+
+# 7. LICENSE / NOTICE
+[ -f "$TARGET/LICENSE.GPL-3.0" ] && ok "LICENSE.GPL-3.0 present" || fail "LICENSE.GPL-3.0 missing (required for GPL §6)"
+[ -f "$TARGET/NOTICE" ] && ok "NOTICE present" || fail "NOTICE missing (required for GPL aggregation disclosure)"
+
+echo "─────────────────────────────────────────────"
+if [ "$errors" -eq 0 ]; then
+  echo "✅ All bundle verification checks passed"
+  exit 0
+else
+  echo "❌ $errors check(s) failed"
+  exit 1
+fi

--- a/tests/audio/scsynth-resolver.spec.ts
+++ b/tests/audio/scsynth-resolver.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * scsynth-resolver tests.
+ *
+ * `fs` と `child_process` を mock して、resolution 優先順位
+ * (explicit / env / bundle / sc-app / spotlight) と全 miss 時の
+ * `ScsynthNotFoundError` を検証する。
+ *
+ * SC.app の有無に依存しないため CI でも実行可能。
+ */
+
+import { spawnSync } from 'child_process'
+import * as fs from 'fs'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  resolveScsynthPath,
+  ScsynthNotFoundError,
+} from '../../packages/engine/src/audio/supercollider/scsynth-resolver'
+
+vi.mock('fs')
+vi.mock('child_process')
+
+const mockedStatSync = vi.mocked(fs.statSync)
+const mockedSpawnSync = vi.mocked(spawnSync)
+
+const SC_APP_PATH = '/Applications/SuperCollider.app/Contents/Resources/scsynth'
+
+/** isFile=true + execute bit を持つ stat を返す */
+function execFileStat(): fs.Stats {
+  return {
+    isFile: () => true,
+    mode: 0o755,
+  } as unknown as fs.Stats
+}
+
+/** existsSync ではなく statSync を使うので ENOENT を投げる stat を返す */
+function notFoundStat(): never {
+  const err = new Error('ENOENT') as NodeJS.ErrnoException
+  err.code = 'ENOENT'
+  throw err
+}
+
+describe('resolveScsynthPath', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    delete process.env.ORBIT_SCSYNTH_PATH
+  })
+
+  afterEach(() => {
+    delete process.env.ORBIT_SCSYNTH_PATH
+  })
+
+  it('returns explicit path when caller provides one and it is executable', () => {
+    mockedStatSync.mockImplementation((p) => {
+      if (p === '/custom/scsynth') return execFileStat()
+      return notFoundStat()
+    })
+
+    const result = resolveScsynthPath({ explicit: '/custom/scsynth' })
+
+    expect(result.path).toBe('/custom/scsynth')
+    expect(result.source).toBe('explicit')
+    expect(result.searched).toEqual(['/custom/scsynth'])
+  })
+
+  it('falls through explicit when file is missing and tries env next', () => {
+    process.env.ORBIT_SCSYNTH_PATH = '/env/scsynth'
+    mockedStatSync.mockImplementation((p) => {
+      if (p === '/env/scsynth') return execFileStat()
+      return notFoundStat()
+    })
+
+    const result = resolveScsynthPath({ explicit: '/missing/scsynth' })
+
+    expect(result.source).toBe('env')
+    expect(result.path).toBe('/env/scsynth')
+    expect(result.searched).toEqual(['/missing/scsynth', '/env/scsynth'])
+  })
+
+  it('returns env path when ORBIT_SCSYNTH_PATH is set and executable', () => {
+    process.env.ORBIT_SCSYNTH_PATH = '/env/scsynth'
+    mockedStatSync.mockImplementation((p) => {
+      if (p === '/env/scsynth') return execFileStat()
+      return notFoundStat()
+    })
+
+    const result = resolveScsynthPath()
+
+    expect(result.source).toBe('env')
+    expect(result.path).toBe('/env/scsynth')
+  })
+
+  it('returns bundle path when bundled binary exists', () => {
+    mockedStatSync.mockImplementation((p) => {
+      const s = String(p)
+      if (s.endsWith('/scsynth/Contents/Resources/scsynth')) return execFileStat()
+      return notFoundStat()
+    })
+
+    const result = resolveScsynthPath()
+
+    expect(result.source).toBe('bundle')
+    expect(result.path).toMatch(/\/scsynth\/Contents\/Resources\/scsynth$/)
+  })
+
+  it('returns SC.app fallback when bundle missing', () => {
+    mockedStatSync.mockImplementation((p) => {
+      if (p === SC_APP_PATH) return execFileStat()
+      return notFoundStat()
+    })
+
+    const result = resolveScsynthPath()
+
+    expect(result.source).toBe('sc-app')
+    expect(result.path).toBe(SC_APP_PATH)
+  })
+
+  it('returns spotlight result as last resort', () => {
+    const SPOT_PATH = '/Volumes/External/SuperCollider.app/Contents/Resources/scsynth'
+    mockedStatSync.mockImplementation((p) => {
+      if (p === SPOT_PATH) return execFileStat()
+      return notFoundStat()
+    })
+    mockedSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/Volumes/External/SuperCollider.app\n',
+      stderr: '',
+      pid: 0,
+      output: [],
+      signal: null,
+    } as any)
+
+    const result = resolveScsynthPath()
+
+    expect(result.source).toBe('spotlight')
+    expect(result.path).toBe(SPOT_PATH)
+  })
+
+  it('throws ScsynthNotFoundError with searched paths when all candidates miss', () => {
+    mockedStatSync.mockImplementation(() => notFoundStat())
+    mockedSpawnSync.mockReturnValue({
+      status: 1,
+      stdout: '',
+      stderr: '',
+      pid: 0,
+      output: [],
+      signal: null,
+    } as any)
+
+    let caught: ScsynthNotFoundError | null = null
+    try {
+      resolveScsynthPath()
+    } catch (e) {
+      caught = e as ScsynthNotFoundError
+    }
+
+    expect(caught).toBeInstanceOf(ScsynthNotFoundError)
+    expect(caught?.searched.length).toBeGreaterThanOrEqual(2)
+    expect(caught?.searched).toContain(SC_APP_PATH)
+  })
+
+  it('treats existing-but-not-executable file as miss', () => {
+    mockedStatSync.mockImplementation((p) => {
+      if (p === '/explicit/scsynth') {
+        return { isFile: () => true, mode: 0o644 } as unknown as fs.Stats
+      }
+      if (p === SC_APP_PATH) return execFileStat()
+      return notFoundStat()
+    })
+
+    const result = resolveScsynthPath({ explicit: '/explicit/scsynth' })
+
+    expect(result.source).toBe('sc-app')
+    expect(result.searched).toContain('/explicit/scsynth')
+  })
+
+  it('treats directory as miss (not a regular file)', () => {
+    mockedStatSync.mockImplementation((p) => {
+      if (p === '/dir/scsynth') {
+        return { isFile: () => false, mode: 0o755 } as unknown as fs.Stats
+      }
+      if (p === SC_APP_PATH) return execFileStat()
+      return notFoundStat()
+    })
+
+    const result = resolveScsynthPath({ explicit: '/dir/scsynth' })
+
+    expect(result.source).toBe('sc-app')
+  })
+
+  it('handles spotlight failure gracefully (non-zero exit)', () => {
+    mockedStatSync.mockImplementation(() => notFoundStat())
+    mockedSpawnSync.mockReturnValue({
+      status: 1,
+      stdout: '',
+      stderr: 'mdfind: error',
+      pid: 0,
+      output: [],
+      signal: null,
+    } as any)
+
+    expect(() => resolveScsynthPath()).toThrow(ScsynthNotFoundError)
+  })
+
+  it('handles spotlight throwing (e.g. mdfind not found)', () => {
+    mockedStatSync.mockImplementation(() => notFoundStat())
+    mockedSpawnSync.mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+
+    expect(() => resolveScsynthPath()).toThrow(ScsynthNotFoundError)
+  })
+})

--- a/tests/audio/scsynth-resolver.spec.ts
+++ b/tests/audio/scsynth-resolver.spec.ts
@@ -1,14 +1,15 @@
 /**
  * scsynth-resolver tests.
  *
- * `fs` と `child_process` を mock して、resolution 優先順位
- * (explicit / env / bundle / sc-app / spotlight) と全 miss 時の
- * `ScsynthNotFoundError` を検証する。
+ * `fs` を mock して、resolution 優先順位 (explicit / env / bundle) と
+ * 全 miss 時の `ScsynthNotFoundError` を検証する。
+ *
+ * Strict mode (Issue #136): SC.app / Spotlight への暗黙 fallback は持たないため、
+ * bundle が無ければ explicit / env で明示する以外に解決手段はない。
  *
  * SC.app の有無に依存しないため CI でも実行可能。
  */
 
-import { spawnSync } from 'child_process'
 import * as fs from 'fs'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -19,12 +20,8 @@ import {
 } from '../../packages/engine/src/audio/supercollider/scsynth-resolver'
 
 vi.mock('fs')
-vi.mock('child_process')
 
 const mockedStatSync = vi.mocked(fs.statSync)
-const mockedSpawnSync = vi.mocked(spawnSync)
-
-const SC_APP_PATH = '/Applications/SuperCollider.app/Contents/Resources/scsynth'
 
 /** isFile=true + execute bit を持つ stat を返す */
 function execFileStat(): fs.Stats {
@@ -34,7 +31,7 @@ function execFileStat(): fs.Stats {
   } as unknown as fs.Stats
 }
 
-/** existsSync ではなく statSync を使うので ENOENT を投げる stat を返す */
+/** ENOENT を投げる stat を返す */
 function notFoundStat(): never {
   const err = new Error('ENOENT') as NodeJS.ErrnoException
   err.code = 'ENOENT'
@@ -104,49 +101,8 @@ describe('resolveScsynthPath', () => {
     expect(result.path).toMatch(/\/scsynth\/Contents\/Resources\/scsynth$/)
   })
 
-  it('returns SC.app fallback when bundle missing', () => {
-    mockedStatSync.mockImplementation((p) => {
-      if (p === SC_APP_PATH) return execFileStat()
-      return notFoundStat()
-    })
-
-    const result = resolveScsynthPath()
-
-    expect(result.source).toBe('sc-app')
-    expect(result.path).toBe(SC_APP_PATH)
-  })
-
-  it('returns spotlight result as last resort', () => {
-    const SPOT_PATH = '/Volumes/External/SuperCollider.app/Contents/Resources/scsynth'
-    mockedStatSync.mockImplementation((p) => {
-      if (p === SPOT_PATH) return execFileStat()
-      return notFoundStat()
-    })
-    mockedSpawnSync.mockReturnValue({
-      status: 0,
-      stdout: '/Volumes/External/SuperCollider.app\n',
-      stderr: '',
-      pid: 0,
-      output: [],
-      signal: null,
-    } as any)
-
-    const result = resolveScsynthPath()
-
-    expect(result.source).toBe('spotlight')
-    expect(result.path).toBe(SPOT_PATH)
-  })
-
-  it('throws ScsynthNotFoundError with searched paths when all candidates miss', () => {
+  it('throws ScsynthNotFoundError when bundle is missing and no explicit/env given (strict mode)', () => {
     mockedStatSync.mockImplementation(() => notFoundStat())
-    mockedSpawnSync.mockReturnValue({
-      status: 1,
-      stdout: '',
-      stderr: '',
-      pid: 0,
-      output: [],
-      signal: null,
-    } as any)
 
     let caught: ScsynthNotFoundError | null = null
     try {
@@ -156,8 +112,43 @@ describe('resolveScsynthPath', () => {
     }
 
     expect(caught).toBeInstanceOf(ScsynthNotFoundError)
-    expect(caught?.searched.length).toBeGreaterThanOrEqual(2)
-    expect(caught?.searched).toContain(SC_APP_PATH)
+    // bundle 候補のみ searched に入る (explicit/env なしのため)
+    expect(caught?.searched.length).toBe(1)
+    expect(caught?.searched[0]).toMatch(/\/scsynth\/Contents\/Resources\/scsynth$/)
+    // SC.app への暗黙 fallback がないことを確認
+    expect(caught?.searched).not.toContain(
+      '/Applications/SuperCollider.app/Contents/Resources/scsynth',
+    )
+  })
+
+  it('throws ScsynthNotFoundError with all attempted paths when explicit + env + bundle all miss', () => {
+    process.env.ORBIT_SCSYNTH_PATH = '/env/missing'
+    mockedStatSync.mockImplementation(() => notFoundStat())
+
+    let caught: ScsynthNotFoundError | null = null
+    try {
+      resolveScsynthPath({ explicit: '/explicit/missing' })
+    } catch (e) {
+      caught = e as ScsynthNotFoundError
+    }
+
+    expect(caught).toBeInstanceOf(ScsynthNotFoundError)
+    expect(caught?.searched).toContain('/explicit/missing')
+    expect(caught?.searched).toContain('/env/missing')
+    expect(caught?.searched.length).toBe(3) // explicit + env + bundle
+  })
+
+  it('error message guides developers to set ORBIT_SCSYNTH_PATH', () => {
+    mockedStatSync.mockImplementation(() => notFoundStat())
+
+    let caught: ScsynthNotFoundError | null = null
+    try {
+      resolveScsynthPath()
+    } catch (e) {
+      caught = e as ScsynthNotFoundError
+    }
+
+    expect(caught?.message).toContain('ORBIT_SCSYNTH_PATH')
   })
 
   it('treats existing-but-not-executable file as miss', () => {
@@ -165,14 +156,12 @@ describe('resolveScsynthPath', () => {
       if (p === '/explicit/scsynth') {
         return { isFile: () => true, mode: 0o644 } as unknown as fs.Stats
       }
-      if (p === SC_APP_PATH) return execFileStat()
       return notFoundStat()
     })
 
-    const result = resolveScsynthPath({ explicit: '/explicit/scsynth' })
-
-    expect(result.source).toBe('sc-app')
-    expect(result.searched).toContain('/explicit/scsynth')
+    expect(() => resolveScsynthPath({ explicit: '/explicit/scsynth' })).toThrow(
+      ScsynthNotFoundError,
+    )
   })
 
   it('treats directory as miss (not a regular file)', () => {
@@ -180,35 +169,29 @@ describe('resolveScsynthPath', () => {
       if (p === '/dir/scsynth') {
         return { isFile: () => false, mode: 0o755 } as unknown as fs.Stats
       }
-      if (p === SC_APP_PATH) return execFileStat()
       return notFoundStat()
     })
 
-    const result = resolveScsynthPath({ explicit: '/dir/scsynth' })
-
-    expect(result.source).toBe('sc-app')
+    expect(() => resolveScsynthPath({ explicit: '/dir/scsynth' })).toThrow(ScsynthNotFoundError)
   })
 
-  it('handles spotlight failure gracefully (non-zero exit)', () => {
+  it('does not invoke spawnSync (no Spotlight fallback in strict mode)', () => {
+    // child_process は import されていないので呼ばれることがない
+    // この test の意図は「fallback が削除されたことを意図的に確認」
     mockedStatSync.mockImplementation(() => notFoundStat())
-    mockedSpawnSync.mockReturnValue({
-      status: 1,
-      stdout: '',
-      stderr: 'mdfind: error',
-      pid: 0,
-      output: [],
-      signal: null,
-    } as any)
 
-    expect(() => resolveScsynthPath()).toThrow(ScsynthNotFoundError)
-  })
+    let caught: ScsynthNotFoundError | null = null
+    try {
+      resolveScsynthPath()
+    } catch (e) {
+      caught = e as ScsynthNotFoundError
+    }
 
-  it('handles spotlight throwing (e.g. mdfind not found)', () => {
-    mockedStatSync.mockImplementation(() => notFoundStat())
-    mockedSpawnSync.mockImplementation(() => {
-      throw new Error('ENOENT')
-    })
-
-    expect(() => resolveScsynthPath()).toThrow(ScsynthNotFoundError)
+    expect(caught).toBeInstanceOf(ScsynthNotFoundError)
+    // searched に SuperCollider.app の path が出てこない (Spotlight 探索ゼロ)
+    const hasSpotlightPath = caught?.searched.some(
+      (p) => p.includes('SuperCollider.app') && !p.startsWith('/Applications/'),
+    )
+    expect(hasSpotlightPath).toBe(false)
   })
 })

--- a/tests/audio/scsynth-resolver.spec.ts
+++ b/tests/audio/scsynth-resolver.spec.ts
@@ -175,9 +175,9 @@ describe('resolveScsynthPath', () => {
     expect(() => resolveScsynthPath({ explicit: '/dir/scsynth' })).toThrow(ScsynthNotFoundError)
   })
 
-  it('does not invoke spawnSync (no Spotlight fallback in strict mode)', () => {
-    // child_process は import されていないので呼ばれることがない
-    // この test の意図は「fallback が削除されたことを意図的に確認」
+  it('never references SuperCollider.app in any code path (no SC.app/Spotlight fallback)', () => {
+    // strict mode の核心: searched に SuperCollider.app の path が一切現れない
+    // (SC.app fallback も Spotlight 探索もゼロ)。bundle 候補のみ試される。
     mockedStatSync.mockImplementation(() => notFoundStat())
 
     let caught: ScsynthNotFoundError | null = null
@@ -188,10 +188,7 @@ describe('resolveScsynthPath', () => {
     }
 
     expect(caught).toBeInstanceOf(ScsynthNotFoundError)
-    // searched に SuperCollider.app の path が出てこない (Spotlight 探索ゼロ)
-    const hasSpotlightPath = caught?.searched.some(
-      (p) => p.includes('SuperCollider.app') && !p.startsWith('/Applications/'),
-    )
-    expect(hasSpotlightPath).toBe(false)
+    // SuperCollider.app を含む path がいかなる形でも出てこない
+    expect(caught?.searched.some((p) => p.includes('SuperCollider.app'))).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- scsynth + 26 plugins + libsndfile.dylib (~11.5MB) を `.vsix` に同梱、SC.app 手動 install 不要に
- **Strict path resolver** (explicit / env / bundle のみ、SC.app/Spotlight 暗黙 fallback なし) で「SC が無くても動く」を fail loud に保証
- Bundle 不在時の first-run UX: status bar item (priority 99) + 解決失敗時の毎回エラー Notification
- 旧 #146 (1)(2) を統合済 (CodeX レビュー承認、#146 close 済)

## 背景

ICMC 2026 リリースの最大インストール障壁 (`SC.app` の手動 install 強要) を解消し、`.vsix` install だけで音が鳴る状態を実現する。#150 マージ済の研究 (#133/#134/#135) で確定した bundle 構造・signature 戦略を本実装で具現化。

**設計方針 (本 PR レビュー過程で確定)**: 当初 resolver は SC.app fallback と Spotlight も持っていたが、ICMC 目標 (「SC 不要で動く」) に対して fallback はテストの意味を曖昧にすると判断 (bundle 抽出失敗を SC.app が肩代わりして production の不具合を隠蔽するリスク)。Phase 8 で fallback を削除、bundle が無ければ即 `ScsynthNotFoundError` で fail loud に切替。

**リリース戦略 (本 PR レビュー過程で確定)**: ICMC v1.0 初回は **GitHub Release に `.vsix` を添付**して配布、ユーザはダウンロード + ダブルクリック (or `code --install-extension`) で install。Marketplace 自動 publish (#137) は ICMC ブロッカーから降格可能。

## Implementation (10 commits、各単独で `npm test` 通過)

### 初期実装 (Phase 1-7)
| # | Commit | 内容 |
|---|--------|------|
| 1 | `63e298b` | feat(audio): add scsynth path resolver with multi-source fallback |
| 2 | `24a2e5c` | refactor(audio): wire SuperColliderPlayer through scsynth resolver |
| 3 | `a4bad3b` | feat(vscode-extension): add orbitscore.scsynthPath setting and pass to engine |
| 4 | `7880462` | refactor(vscode-extension): unify selectAudioDevice through scsynth resolver |
| 5 | `9663a83` | feat(vscode-extension): add bundle status bar and first-run notification |
| 6 | `aca6450` | feat(build): add scsynth bundle extract/verify scripts and legal placeholders |
| 7 | `e25894d` | docs(worklog,readme): record scsynth bundle integration |

### Strict mode 切替 (Phase 8-10、レビュー過程で追加)
| # | Commit | 内容 |
|---|--------|------|
| 8 | `1569110` | refactor(audio): drop SC.app/spotlight fallback from scsynth resolver |
| 9 | `08c2855` | refactor(vscode-extension): align UX with strict bundle requirement |
| 10 | `5f93169` | docs(worklog,build-guide): document strict resolver and dev workaround |

## Path resolver 仕様 (strict mode)

優先順位:
1. `opts.explicit` (caller 明示)
2. `process.env.ORBIT_SCSYNTH_PATH` (extension が settings から渡す / dev 用 escape hatch)
3. Bundle (`<engine root>/scsynth/Contents/Resources/scsynth`)

各候補で `fs.statSync` + 実行権限ビット (`mode & 0o111`) を検査。全 miss 時は `ScsynthNotFoundError` (`searched` 配列付き、`ORBIT_SCSYNTH_PATH` 案内付き) を throw。

## Dev workflow への影響

- vscode-extension 経由 (通常 user): bundle 同梱で何もしなくて OK
- engine 単独 CLI で SC.app に依存していた dev: `ORBIT_SCSYNTH_PATH=/Applications/SuperCollider.app/Contents/Resources/scsynth npm run dev:engine` を慣行に

## First-run UX (strict mode 整合)

- StatusBar item (priority 99) で source 別 icon: `bundle` (✅) / `env`/`explicit` (⚙️) / 解決失敗 (❌ error 背景)
- `startEngine()` 解決失敗時に毎回 `showErrorMessage` (Open Settings / View Logs)
- "Don't Show Again" dismiss 機構は廃止 (silent fallback がない以上、Notice を黙らせて動かす選択肢自体が不適切)

## Test plan

- [x] Unit tests: `tests/audio/scsynth-resolver.spec.ts` 10 cases pass (CI 実行可、`fs` mock)
- [x] Engine 全 test: 240 pass / 23 skipped (resolver 10 新規 + 既存 230 維持)
- [x] TypeScript build clean (engine + vscode-extension)
- [x] ESLint clean
- [x] Bundle 抽出: `npm run build:bundle` → 11MB、26 plugins、universal arm64+x86_64
- [x] Bundle 検証: `npm run verify:bundle` → 11/11 checks pass (signature valid、TeamIdentifier=HE5VJFE9E4)
- [ ] レビュア確認: `npx vsce package` で `.vsix` 生成、解凍後の signature/permission 維持
- [ ] レビュア確認: VS Code dev host (`F5`) で extension load → `examples/T1_*.osc` を Cmd+Enter で音が出る
- [ ] レビュア確認: status bar に `$(check) scsynth (bundled)` が表示
- [ ] レビュア確認: bundle 一時 rename → engine start で error Notification (Open Settings / View Logs)
- [ ] #138 引き継ぎ: SC-less Mac (別 user account / VM) で `.vsix` install → cold-install acceptance test

## Out of Scope

- #137 Marketplace 自動 publish (ICMC ブロッカーから降格、別 issue で再整理予定)
- #138 cold-install acceptance test (本 PR マージ後に SC-less Mac で別途検証)
- #139 LICENSE/NOTICE 文言洗練・SC source URL 確定 (本 PR は placeholder 同梱のみ)
- #151 OrbitScore: Check Audio Setup (post-icmc)
- #152 OrbitScore: Open Examples (post-icmc)

## 関連
- Closes #136
- Plan: `.claude/plans/parsed-munching-matsumoto.md`
- Research: `docs/research/SCSYNTH_BUNDLE_MANIFEST.md` (#134)、`docs/research/CODESIGN_PIPELINE.md` (#135)、`docs/research/SCSYNTH_STANDALONE.md` (#133)

🤖 Generated with [Claude Code](https://claude.com/claude-code)