### PR TITLE
Eliminate environment-dependent audio file path resolution

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,50 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.69 Issue #168: Eliminate environment-dependent audio file path resolution (May 06, 2026)
+
+**Date**: May 06, 2026
+**Status**: ✅ COMPLETE
+**Branch**: `168-audio-path-environment-independence`
+**Issue**: #168
+
+**動機**: `audioPath()` および `audio()` のパス解決に `process.cwd()` フォールバックが残っており、開発環境依存（VS Code workspace の有無、エンジン spawn 時の cwd 等）でサイレントに誤解決される懸念があった。デモ時に「音が鳴らない」事故になりうる。
+
+**設計方針**:
+- パスは 2 種類のみを許容: 絶対パス、または `.osc` ファイルからの相対パス
+- `process.cwd()` フォールバックを完全排除 → 明示エラー
+- `documentDirectory` を常に保証する仕組みを engine / VS Code 拡張 / CLI 各層に整備
+
+**変更内容**:
+
+Engine:
+- `packages/engine/src/core/global/audio-manager.ts`: 相対パス + documentDirectory 未設定の場合に明示エラー
+- `packages/engine/src/core/sequence.ts`: `audio()` で同様のエラー化
+- `packages/engine/src/interpreter/process-statement.ts`: 冗長な防御的解決を削除（`_audioFilePath` は常に絶対パス前提に簡素化）
+- `packages/engine/src/core/sequence/scheduling/event-scheduler.ts`: `process.cwd()` フォールバックを assertion に変更
+- `packages/engine/src/core/sequence/playback/prepare-playback.ts`: 同上
+- `packages/engine/src/interpreter/interpreter-v2.ts`: `execute()` に `documentDirectory` オプションを追加し、global 初期化後に自動セット
+- `packages/engine/src/cli/play-mode.ts`: `.osc` ファイルパスから documentDirectory を自動導出して execute に渡す
+
+VS Code 拡張:
+- `packages/vscode-extension/src/extension.ts`: `setDocumentDirectory` の自動注入を「global ブロック評価時のみ」から拡張。`globalInitialized` フラグでセッション状態を追跡し、init 後の任意の評価でもコード先頭に prepend するように変更（`.osc` ファイル切り替えにも追従）
+
+テスト:
+- `tests/core/audio-path-resolution.spec.ts` 新規追加（7 テスト）: 絶対パス受理、documentDirectory 経由解決、未設定エラー、各ケースを網羅
+- `tests/core/dsl-v3-underscore-methods.spec.ts`: setUp で `setDocumentDirectory('/tmp/test')` を追加
+- `tests/timing/chop-timing.spec.ts`: 同上
+
+ドキュメント:
+- `sites/dev/glossary.md`: `setDocumentDirectory` エントリを新仕様に更新（注入タイミング 2 種、CLI 自動導出、フォールバック非存在を明記）
+- `sites/dev/pipeline/selective-execution.md`: 注入ロジック節を書き換え
+- `sites/dev/editor/execution-feedback.md`: 同上
+
+**テスト結果**: 247 passed / 23 skipped / 270 total
+
+**破壊的変更**: 暗黙の `cwd` 依存で動いていたコードはエラーになる。ICMC 前のため外部影響は限定的と判断。
+
+---
+
 ### 6.68 Issue #162: Scaffold dev learning site + spike chapter 0-2 (May 05, 2026)
 
 **Date**: May 05, 2026

--- a/packages/engine/src/cli/play-mode.ts
+++ b/packages/engine/src/cli/play-mode.ts
@@ -3,6 +3,7 @@
  */
 
 import * as fs from 'fs'
+import * as path from 'path'
 
 import { InterpreterV2 } from '../interpreter/interpreter-v2'
 import { parseAudioDSL } from '../parser/audio-parser'
@@ -42,6 +43,9 @@ export async function playFile(options: PlayOptions): Promise<PlayResult> {
   // Parse the DSL
   const ir = parseAudioDSL(source)
 
+  // Derive documentDirectory from the .osc file location for relative path resolution
+  const documentDirectory = path.dirname(path.resolve(filepath))
+
   // Create interpreter only if not already exists (for REPL persistence)
   let interpreter = globalInterpreter
   if (!interpreter) {
@@ -51,7 +55,7 @@ export async function playFile(options: PlayOptions): Promise<PlayResult> {
     console.log('♻️ Reusing existing interpreter')
   }
 
-  await interpreter.execute(ir)
+  await interpreter.execute(ir, { documentDirectory })
 
   // Get final state
   const state = interpreter.getState()

--- a/packages/engine/src/core/global/audio-manager.ts
+++ b/packages/engine/src/core/global/audio-manager.ts
@@ -32,28 +32,23 @@ export class AudioManager {
     // Resolve to absolute path
     let resolved: string
     if (path.isAbsolute(value)) {
-      // Already absolute
       resolved = value
     } else if (this._documentDirectory) {
-      // Relative to the .osc file's directory
       resolved = path.resolve(this._documentDirectory, value)
     } else {
-      // Fallback to process.cwd() if no document context
-      resolved = path.resolve(process.cwd(), value)
+      throw new Error(
+        `Cannot resolve relative audioPath("${value}"): no document context. ` +
+          `Save the .osc file first, or use an absolute path.`,
+      )
     }
 
     // Singleton behavior: only set if different from current value
     if (this._audioPath === resolved) {
-      // Already set to this value, skip
       return this
     }
 
     console.log(`📂 audioPath: ${value} → ${resolved}`)
-    if (this._documentDirectory) {
-      console.log(`📂 base: ${this._documentDirectory} (.osc file directory)`)
-    } else {
-      console.log(`📂 base: ${process.cwd()} (process.cwd)`)
-    }
+    console.log(`📂 base: ${this._documentDirectory} (.osc file directory)`)
 
     this._audioPath = resolved
     return this

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -204,8 +204,10 @@ export class Sequence {
       // Resolve relative to the .osc file's directory
       fullPath = path.resolve(globalState.documentDirectory, filepath)
     } else {
-      // Fallback to process.cwd()
-      fullPath = path.resolve(process.cwd(), filepath)
+      throw new Error(
+        `Cannot resolve relative audio("${filepath}"): no audioPath() or document context. ` +
+          `Set audioPath() first, save the .osc file, or use an absolute path.`,
+      )
     }
 
     this._audioFilePath = fullPath

--- a/packages/engine/src/core/sequence/playback/prepare-playback.ts
+++ b/packages/engine/src/core/sequence/playback/prepare-playback.ts
@@ -53,11 +53,15 @@ export async function preparePlayback(
   prepareSlicesFn()
 
   // Preload buffer to get correct duration
+  // audioFilePath is always absolute (sequence.audio() resolves at set time)
   if (audioFilePath && scheduler.loadBuffer) {
-    const resolvedPath = path.isAbsolute(audioFilePath)
-      ? audioFilePath
-      : path.resolve(process.cwd(), audioFilePath)
-    await scheduler.loadBuffer(resolvedPath)
+    if (!path.isAbsolute(audioFilePath)) {
+      throw new Error(
+        `Audio file path is not absolute: "${audioFilePath}". ` +
+          `This is an internal error — sequence.audio() should have absolutized the path.`,
+      )
+    }
+    await scheduler.loadBuffer(audioFilePath)
   }
 
   // Clear existing loop timer if any

--- a/packages/engine/src/core/sequence/scheduling/event-scheduler.ts
+++ b/packages/engine/src/core/sequence/scheduling/event-scheduler.ts
@@ -10,10 +10,17 @@ import { ScheduleEventsOptions, ScheduleEventsFromTimeOptions } from '../types'
 import { generateRandomValue } from '../parameters/random-utils'
 
 /**
- * Resolve audio file path to absolute path
+ * Assert that audio file path is absolute.
+ * audioFilePath should always be absolute since sequence.audio() resolves at set time.
  */
 function resolveAudioFilePath(audioFilePath: string): string {
-  return path.isAbsolute(audioFilePath) ? audioFilePath : path.resolve(process.cwd(), audioFilePath)
+  if (!path.isAbsolute(audioFilePath)) {
+    throw new Error(
+      `Audio file path is not absolute: "${audioFilePath}". ` +
+        `This is an internal error — sequence.audio() should have absolutized the path.`,
+    )
+  }
+  return audioFilePath
 }
 
 /**

--- a/packages/engine/src/interpreter/interpreter-v2.ts
+++ b/packages/engine/src/interpreter/interpreter-v2.ts
@@ -59,7 +59,10 @@ export class InterpreterV2 {
    * @param options - Execution options
    * @param options.skipTransportCommands - If true, skip RUN/LOOP/MUTE commands (used on file save)
    */
-  async execute(ir: AudioIR, options?: { skipTransportCommands?: boolean }): Promise<void> {
+  async execute(
+    ir: AudioIR,
+    options?: { skipTransportCommands?: boolean; documentDirectory?: string },
+  ): Promise<void> {
     const skipTransport = options?.skipTransportCommands ?? false
 
     // Ensure SuperCollider is booted
@@ -68,6 +71,11 @@ export class InterpreterV2 {
     // Process global initialization
     if (ir.globalInit) {
       await processGlobalInit(ir.globalInit, this.state)
+    }
+
+    // Set documentDirectory on global so audioPath() / audio() can resolve relative paths
+    if (options?.documentDirectory && this.state.currentGlobal) {
+      this.state.currentGlobal.setDocumentDirectory(options.documentDirectory)
     }
 
     // Process sequence initializations

--- a/packages/engine/src/interpreter/process-statement.ts
+++ b/packages/engine/src/interpreter/process-statement.ts
@@ -292,8 +292,6 @@ async function handleRunCommand(sequenceNames: string[], state: InterpreterState
   // Preload all audio buffers in parallel (to avoid sequential loading delays)
   const scheduler = state.audioEngine as any
   if (scheduler.loadBuffer) {
-    const path = await import('path')
-    const documentDir = state.currentGlobal?.getState().documentDirectory || ''
     console.log(`🔧 [RUN] Preloading ${validSequences.length} buffers in parallel...`)
     await Promise.all(
       validSequences.map(async (seqName) => {
@@ -301,17 +299,9 @@ async function handleRunCommand(sequenceNames: string[], state: InterpreterState
         if (sequence) {
           const audioPath = (sequence as any)._audioFilePath
           if (audioPath) {
-            // Resolve relative paths: prefer documentDirectory, fallback to process.cwd()
-            let resolvedPath: string
-            if (path.isAbsolute(audioPath)) {
-              resolvedPath = audioPath
-            } else if (documentDir) {
-              resolvedPath = path.resolve(documentDir, audioPath)
-            } else {
-              resolvedPath = path.resolve(process.cwd(), audioPath)
-            }
-            console.log(`🔧 [RUN] Preloading ${seqName}: ${resolvedPath}`)
-            await scheduler.loadBuffer(resolvedPath)
+            // _audioFilePath is always absolute (sequence.audio() resolves at set time)
+            console.log(`🔧 [RUN] Preloading ${seqName}: ${audioPath}`)
+            await scheduler.loadBuffer(audioPath)
           }
         }
       }),
@@ -393,24 +383,14 @@ async function startSequencesWithMute(
   // Preload all audio buffers in parallel (to avoid sequential loading delays)
   const scheduler = state.audioEngine as any
   if (scheduler.loadBuffer) {
-    const path = await import('path')
-    const documentDir = state.currentGlobal?.getState().documentDirectory || ''
     await Promise.all(
       sequenceNames.map(async (seqName) => {
         const sequence = state.sequences.get(seqName)
         if (sequence) {
           const audioPath = (sequence as any)._audioFilePath
           if (audioPath) {
-            // Resolve relative paths: prefer documentDirectory, fallback to process.cwd()
-            let resolvedPath: string
-            if (path.isAbsolute(audioPath)) {
-              resolvedPath = audioPath
-            } else if (documentDir) {
-              resolvedPath = path.resolve(documentDir, audioPath)
-            } else {
-              resolvedPath = path.resolve(process.cwd(), audioPath)
-            }
-            await scheduler.loadBuffer(resolvedPath)
+            // _audioFilePath is always absolute (sequence.audio() resolves at set time)
+            await scheduler.loadBuffer(audioPath)
           }
         }
       }),

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -13,6 +13,9 @@ let outputChannel: vscode.OutputChannel | null = null
 let statusBarItem: vscode.StatusBarItem | null = null
 let bundleStatusItem: vscode.StatusBarItem | null = null
 let isLiveCodingMode: boolean = false
+// Tracks whether `var global = init GLOBAL` has been evaluated in the current engine session.
+// Used to decide if `global.setDocumentDirectory(...)` can be prepended safely.
+let globalInitialized: boolean = false
 
 // let isDebugMode: boolean = false // Debug mode flag
 
@@ -22,6 +25,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Reset state on activation (important for reload)
   engineProcess = null
   isLiveCodingMode = false
+  globalInitialized = false
 
   // Create output channel
   outputChannel = vscode.window.createOutputChannel('OrbitScore')
@@ -672,6 +676,7 @@ function setupExitHandler(process: child_process.ChildProcess): void {
     outputChannel?.appendLine(`\n🛑 Engine process exited with code ${code}`)
     engineProcess = null
     isLiveCodingMode = false
+    globalInitialized = false
 
     statusBarItem!.text = '🎵 OrbitScore: Stopped'
     statusBarItem!.tooltip = 'Click to start engine'
@@ -744,6 +749,7 @@ function startEngine(debugMode: boolean = false) {
 
   // Update state
   isLiveCodingMode = true
+  globalInitialized = false
 
   statusBarItem!.text = debugMode ? '🎵 OrbitScore: Ready 🐛' : '🎵 OrbitScore: Ready'
   statusBarItem!.tooltip = 'Click to stop engine'
@@ -769,6 +775,7 @@ function stopEngine() {
     const proc = engineProcess
     engineProcess = null
     isLiveCodingMode = false
+    globalInitialized = false
 
     // Send graceful shutdown signal (SIGTERM)
     // This allows the engine to clean up SuperCollider properly
@@ -1082,21 +1089,27 @@ async function runSelection() {
     createFlash(0)
   }
 
-  // Inject setDocumentDirectory when evaluating global block
+  // Inject setDocumentDirectory so audioPath() / audio() resolve relative paths
+  // against the .osc file's directory, not the engine process's cwd.
+  //
+  // Strategy:
+  // - If this eval contains `var global = init GLOBAL`, insert setDocumentDirectory
+  //   right after it (and remember that global is now initialized).
+  // - Otherwise, if global has already been initialized in this engine session,
+  //   prepend setDocumentDirectory before the user code (refreshes the directory
+  //   in case the user switched .osc files).
+  // - If global has not yet been initialized, do not inject (would fail with
+  //   "global is not defined").
   let codeToSend = trimmedText
-  if (
-    !selection.isEmpty ||
-    getLineSubject(editor.document.lineAt(selection.active.line).text) === 'global'
-  ) {
-    // Check if the code contains global init — inject setDocumentDirectory after it
-    const documentDir = path.dirname(editor.document.uri.fsPath)
-    const setDirCommand = `global.setDocumentDirectory("${documentDir.replace(/\\/g, '\\\\')}")`
-    const globalInitMatch = codeToSend.match(/(var\s+global\s*=\s*init\s+GLOBAL[^\n]*)/)
-    if (globalInitMatch) {
-      const insertPos = globalInitMatch.index! + globalInitMatch[0].length
-      codeToSend =
-        codeToSend.slice(0, insertPos) + '\n' + setDirCommand + codeToSend.slice(insertPos)
-    }
+  const documentDir = path.dirname(editor.document.uri.fsPath)
+  const setDirCommand = `global.setDocumentDirectory("${documentDir.replace(/\\/g, '\\\\')}")`
+  const globalInitMatch = codeToSend.match(/(var\s+global\s*=\s*init\s+GLOBAL[^\n]*)/)
+  if (globalInitMatch) {
+    const insertPos = globalInitMatch.index! + globalInitMatch[0].length
+    codeToSend = codeToSend.slice(0, insertPos) + '\n' + setDirCommand + codeToSend.slice(insertPos)
+    globalInitialized = true
+  } else if (globalInitialized) {
+    codeToSend = setDirCommand + '\n' + codeToSend
   }
 
   // Execute the selected command (both single line and multiline)

--- a/sites/dev/editor/execution-feedback.md
+++ b/sites/dev/editor/execution-feedback.md
@@ -185,31 +185,36 @@ _kick.play(
 
 ## `setDocumentDirectory` の自動注入
 
-収集したテキストを engine に送る直前、**global ブロックの評価時に限り** `setDocumentDirectory` コマンドを自動で挿入します:
+収集したテキストを engine に送る直前、`setDocumentDirectory` コマンドを自動で挿入します。`audioPath()` および `audio()` の相対パス解決を `.osc` ファイルのディレクトリ基準で行うための仕掛けです。
 
 ```typescript
-// extension.ts:1085-1100
-  // Inject setDocumentDirectory when evaluating global block
-  let codeToSend = trimmedText
-  if (
-    !selection.isEmpty ||
-    getLineSubject(editor.document.lineAt(selection.active.line).text) === 'global'
-  ) {
-    // Check if the code contains global init — inject setDocumentDirectory after it
-    const documentDir = path.dirname(editor.document.uri.fsPath)
-    const setDirCommand = `global.setDocumentDirectory("${documentDir.replace(/\\/g, '\\\\')}")`
-    const globalInitMatch = codeToSend.match(/(var\s+global\s*=\s*init\s+GLOBAL[^\n]*)/)
-    if (globalInitMatch) {
-      const insertPos = globalInitMatch.index! + globalInitMatch[0].length
-      codeToSend =
-        codeToSend.slice(0, insertPos) + '\n' + setDirCommand + codeToSend.slice(insertPos)
-    }
-  }
+// extension.ts (Issue #168 で挙動を変更)
+let codeToSend = trimmedText
+const documentDir = path.dirname(editor.document.uri.fsPath)
+const setDirCommand = `global.setDocumentDirectory("${documentDir.replace(/\\/g, '\\\\')}")`
+const globalInitMatch = codeToSend.match(/(var\s+global\s*=\s*init\s+GLOBAL[^\n]*)/)
+if (globalInitMatch) {
+  // global を初期化する評価: init の直後に挿入
+  const insertPos = globalInitMatch.index! + globalInitMatch[0].length
+  codeToSend =
+    codeToSend.slice(0, insertPos) + '\n' + setDirCommand + codeToSend.slice(insertPos)
+  globalInitialized = true
+} else if (globalInitialized) {
+  // 既に global が存在するセッション: コード先頭に prepend
+  codeToSend = setDirCommand + '\n' + codeToSend
+}
 ```
 
-`var global = init GLOBAL ...` にマッチしたら、その行の直後に `global.setDocumentDirectory("...")` を差し込みます。`documentDir` は現在のファイルのディレクトリです。これにより、`audioPath("relative/path")` のような相対パスが正しく解決されます。
+注入は以下の 2 段階で行われます:
+
+1. **global 初期化ブロックの評価時**: `var global = init GLOBAL` の直後に挿入し、`globalInitialized` フラグを立てる
+2. **その後の任意の評価**: コード先頭に prepend する。これにより、ユーザーが別の `.osc` ファイルに切り替えて部分評価しても、現在のファイルのディレクトリが反映される
+
+`globalInitialized` フラグは engine プロセスのライフサイクル（起動・停止・拡張機能の activate）にバインドされ、リセットされます。
 
 Windows のパス区切り文字 (`\`) を `\\` にエスケープする処理も含まれています (`replace(/\\/g, '\\\\')`).
+
+engine 側に `process.cwd()` へのフォールバックは存在しません (Issue #168)。documentDirectory が未設定の状態で相対パスが指定された場合は明示エラーになります。
 
 ---
 

--- a/sites/dev/glossary.md
+++ b/sites/dev/glossary.md
@@ -62,7 +62,14 @@ DSL v1.0 (MIDI フェーズ) のキーワード。`sequence name { ... }` とい
 
 ### setDocumentDirectory
 
-`global.setDocumentDirectory("path/to/dir")` — `.osc` ファイルのディレクトリを engine に伝えます。`audioPath()` での相対パス解決に使われます。VS Code 拡張の `runSelection()` が `global` ブロック評価時に自動注入します。
+`global.setDocumentDirectory("path/to/dir")` — `.osc` ファイルのディレクトリを engine に伝えます。`audioPath()` および `audio()` で相対パスを解決する際の基準として使われます。VS Code 拡張の `runSelection()` が以下のタイミングで自動注入します:
+
+- `var global = init GLOBAL` を含むブロック評価時 (init の直後に挿入)
+- 上記 init 後の任意の評価 (コード先頭に prepend、`.osc` ファイル切り替えにも追従)
+
+CLI (`playFile`) では `.osc` ファイルパスから自動導出されます。
+
+`process.cwd()` へのフォールバックは存在しません。documentDirectory が未設定で、かつ相対パスが指定された場合は明示エラーになります（絶対パスは常に許容）。
 
 ### SoT (Single Source of Truth)
 

--- a/sites/dev/pipeline/selective-execution.md
+++ b/sites/dev/pipeline/selective-execution.md
@@ -128,29 +128,35 @@ subject が `null` の場合 — つまり `RUN(kick, snare)` のようなスタ
 
 ### setDocumentDirectory の注入
 
-送るコードが確定したあと、もう 1 つ処理があります。グローバルブロックを評価するとき、ドキュメントのディレクトリパスを自動注入します。
+送るコードが確定したあと、ドキュメントのディレクトリパスを自動注入します。`audioPath()` および `audio()` の相対パス解決に使われます。
 
 ```typescript
-// extension.ts:1085-1100
-  // Inject setDocumentDirectory when evaluating global block
-  let codeToSend = trimmedText
-  if (
-    !selection.isEmpty ||
-    getLineSubject(editor.document.lineAt(selection.active.line).text) === 'global'
-  ) {
-    // Check if the code contains global init — inject setDocumentDirectory after it
-    const documentDir = path.dirname(editor.document.uri.fsPath)
-    const setDirCommand = `global.setDocumentDirectory("${documentDir.replace(/\\/g, '\\\\')}")`
-    const globalInitMatch = codeToSend.match(/(var\s+global\s*=\s*init\s+GLOBAL[^\n]*)/)
-    if (globalInitMatch) {
-      const insertPos = globalInitMatch.index! + globalInitMatch[0].length
-      codeToSend =
-        codeToSend.slice(0, insertPos) + '\n' + setDirCommand + codeToSend.slice(insertPos)
-    }
-  }
+// extension.ts (実装は条件を簡略化して抜粋)
+let codeToSend = trimmedText
+const documentDir = path.dirname(editor.document.uri.fsPath)
+const setDirCommand = `global.setDocumentDirectory("${documentDir.replace(/\\/g, '\\\\')}")`
+const globalInitMatch = codeToSend.match(/(var\s+global\s*=\s*init\s+GLOBAL[^\n]*)/)
+if (globalInitMatch) {
+  // global を初期化するブロック評価: init の直後に挿入
+  const insertPos = globalInitMatch.index! + globalInitMatch[0].length
+  codeToSend =
+    codeToSend.slice(0, insertPos) + '\n' + setDirCommand + codeToSend.slice(insertPos)
+  globalInitialized = true
+} else if (globalInitialized) {
+  // 既に global が存在するセッション: コード先頭に prepend
+  codeToSend = setDirCommand + '\n' + codeToSend
+}
 ```
 
-`var global = init GLOBAL` という行が見つかったら、その直後に `global.setDocumentDirectory("...")` を挿入します。DSL で相対パスのオーディオファイルを指定した場合に、エンジン側が正しいベースディレクトリを知るための仕掛けです。
+注入条件:
+
+1. `var global = init GLOBAL` を含む評価 → init の直後に挿入し、`globalInitialized` フラグを立てる
+2. 上記後の任意の評価 → コード先頭に prepend (`.osc` ファイル切り替えにも追従)
+3. `globalInitialized` が `false` の状態で `init` 行を含まない評価 → 注入しない (`global` 未定義のためエラー回避)
+
+`globalInitialized` フラグは engine プロセスのライフサイクルにバインドされ、起動・再起動・activate のタイミングでリセットされます。
+
+`process.cwd()` へのフォールバックは engine 側に存在しません (Issue #168)。documentDirectory が未設定で相対パスが指定された場合は明示エラーになります。
 
 ### stdin への書き込み
 

--- a/tests/core/audio-path-resolution.spec.ts
+++ b/tests/core/audio-path-resolution.spec.ts
@@ -1,0 +1,67 @@
+import * as path from 'path'
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+import { Global } from '../../packages/engine/src/core/global'
+import { Sequence } from '../../packages/engine/src/core/sequence'
+import { SuperColliderPlayer } from '../../packages/engine/src/audio/supercollider-player'
+
+describe('Audio path resolution (no process.cwd() fallback)', () => {
+  let global: Global
+  let seq: Sequence
+  let mockPlayer: SuperColliderPlayer
+
+  beforeEach(() => {
+    mockPlayer = {
+      boot: vi.fn().mockResolvedValue(undefined),
+      getCurrentTime: vi.fn().mockReturnValue(0),
+      scheduleEvent: vi.fn(),
+      scheduleSliceEvent: vi.fn(),
+      getMasterGainDb: vi.fn().mockReturnValue(0),
+    } as any
+
+    global = new Global(mockPlayer)
+    seq = new Sequence(global, mockPlayer)
+    seq.setName('test')
+  })
+
+  describe('audioPath()', () => {
+    it('should accept absolute paths without document context', () => {
+      expect(() => global.audioPath('/abs/samples')).not.toThrow()
+      expect(global.audioPath()).toBe('/abs/samples')
+    })
+
+    it('should resolve relative paths against documentDirectory', () => {
+      global.setDocumentDirectory('/Users/foo/songs')
+      global.audioPath('./samples')
+      expect(global.audioPath()).toBe('/Users/foo/songs/samples')
+    })
+
+    it('should throw on relative path without documentDirectory', () => {
+      expect(() => global.audioPath('samples')).toThrowError(/no document context/)
+    })
+  })
+
+  describe('sequence.audio()', () => {
+    it('should accept absolute paths', () => {
+      expect(() => seq.audio('/abs/kick.wav')).not.toThrow()
+    })
+
+    it('should resolve via audioPath when set', () => {
+      global.setDocumentDirectory('/Users/foo/songs')
+      global.audioPath('/abs/samples')
+      seq.audio('kick.wav')
+      expect((seq as any)._audioFilePath).toBe(path.join('/abs/samples', 'kick.wav'))
+    })
+
+    it('should resolve via documentDirectory when audioPath unset', () => {
+      global.setDocumentDirectory('/Users/foo/songs')
+      seq.audio('kick.wav')
+      expect((seq as any)._audioFilePath).toBe(path.resolve('/Users/foo/songs', 'kick.wav'))
+    })
+
+    it('should throw on relative path with no audioPath and no documentDirectory', () => {
+      expect(() => seq.audio('kick.wav')).toThrowError(/no audioPath\(\) or document context/)
+    })
+  })
+})

--- a/tests/core/dsl-v3-underscore-methods.spec.ts
+++ b/tests/core/dsl-v3-underscore-methods.spec.ts
@@ -20,6 +20,8 @@ describe('DSL v3.0: Methods with Seamless Parameter Update', () => {
     } as any
 
     global = new Global(mockPlayer)
+    // Set documentDirectory so relative audio paths resolve in tests
+    global.setDocumentDirectory('/tmp/test')
     seq = new Sequence(global, mockPlayer)
     seq.setName('test')
   })

--- a/tests/timing/chop-timing.spec.ts
+++ b/tests/timing/chop-timing.spec.ts
@@ -19,6 +19,8 @@ describe('Chop Timing', () => {
   beforeEach(() => {
     player = new SuperColliderPlayer()
     global = new Global(player)
+    // Set documentDirectory so relative audio paths resolve in tests
+    global.setDocumentDirectory('/tmp/test')
     sequence = new Sequence(global, player as any)
     sequence.setName('test')
   })


### PR DESCRIPTION
## Summary

オーディオファイルパス解決から `process.cwd()` フォールバックを排除し、環境依存の挙動を取り除く。

`audioPath()` および `audio()` のパス解決に `process.cwd()` フォールバックが残っており、VS Code workspace の有無や engine spawn 時の cwd に依存してサイレントに誤解決される懸念があった。デモ時に「音が鳴らない」事故になりうる。

## 設計方針

- パスは絶対パス、または `.osc` ファイルからの相対パス、の 2 種類のみを許容
- `process.cwd()` フォールバックを完全排除 → 明示エラー
- `documentDirectory` を engine / VS Code 拡張 / CLI 各層で常に保証

## 主な変更

### Engine
- `audio-manager.ts`, `sequence.ts`: 相対パス + documentDirectory 未設定で明示エラー
- `process-statement.ts`, `event-scheduler.ts`, `prepare-playback.ts`: 冗長な防御的解決を削除（`_audioFilePath` は常に絶対パス invariant に簡素化）
- `interpreter-v2.ts`: `execute()` に `documentDirectory` オプションを追加
- `cli/play-mode.ts`: `.osc` ファイルパスから documentDirectory を自動導出

### VS Code 拡張
- `extension.ts`: `setDocumentDirectory` の自動注入を「global ブロック評価時のみ」から拡張
- `globalInitialized` フラグでセッション状態を追跡し、init 後の任意の評価でもコード先頭に prepend
- `.osc` ファイル切り替えにも追従

### テスト
- `tests/core/audio-path-resolution.spec.ts` 新規追加 (7 テスト)
- 既存テスト 2 件で setDocumentDirectory 呼び出しを追加
- 結果: 247 passed / 23 skipped / 270 total

### ドキュメント
- `sites/dev/glossary.md`, `pipeline/selective-execution.md`, `editor/execution-feedback.md` を新仕様に合わせて更新
- WORK_LOG.md にエントリ追加 (6.69)

## 破壊的変更

暗黙の `cwd` 依存で動いていたコードはエラーになる。ICMC 前のため外部影響は限定的と判断。

## Test plan

- [x] 全テストが pass する (247 / 270)
- [x] Lint が pass する
- [x] Build が成功する
- [ ] VS Code 拡張で .vsix を再ビルドし、単体 .osc ファイル（workspace なし）で `audioPath("/abs/path")` 動作確認
- [ ] workspace ありで相対 `audioPath("./samples")` 動作確認
- [ ] `.osc` ファイル切り替え時に documentDirectory が更新されることを確認

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)