### PR TITLE
Add translation prompts for Claude on the Web

### DIFF
--- a/docs/development/translation-prompts/README.md
+++ b/docs/development/translation-prompts/README.md
@@ -1,0 +1,44 @@
+# Translation Prompts
+
+OrbitScore learning サイト 2 つを Claude Desktop / Claude on the Web に丸投げするための self-contained プロンプト集。
+
+## 使い方
+
+1. このディレクトリの該当ファイル (`translate-user-site.md` または `translate-dev-site.md`) を開く
+2. 「プロンプト本文」 のコードブロック内 (`` ``` `` で囲まれた部分) を **そのまま全選択コピー**
+3. Claude Desktop 等で on-the-web に渡す
+4. on-the-web が PR を作成するのを待つ
+5. PR が来たら local build / glossary 整合性 / トーン規律 を review
+6. 問題なければ merge、`docs/development/TRANSLATION_STATUS.md` の進捗が `done` に更新されていることを確認
+
+## ファイル一覧
+
+| ファイル | 対象 | 章数 | 特記事項 |
+|---|---|---|---|
+| `translate-user-site.md` | `sites/user/` | 8 章（残り） | spike 章 2 つ既に完訳済 |
+| `translate-dev-site.md` | `sites/dev/` | 18 章（残り） | **verbatim 規律 CRITICAL**、spike 章 1 つ既に完訳済 |
+
+## ルーチン化への展望
+
+両プロンプトとも将来 CronCreate routine で自動化する想定:
+
+```
+ja の章更新検出 → TRANSLATION_STATUS.md で outdated にマーク
+                ↓
+              該当章のプロンプトを on-the-web に dispatch
+                ↓
+              再翻訳 PR 作成 → review → merge
+```
+
+そのため、プロンプトは:
+- Self-contained（外部 context 不要）
+- 出力フォーマット明示
+- Verification ステップ含む
+- ジ章単位で再 dispatch 可能（将来の細粒度化に備える）
+
+## 関連ドキュメント
+
+- [`TRANSLATION_WORKFLOW.md`](../TRANSLATION_WORKFLOW.md) — 翻訳 workflow 全体
+- [`TRANSLATION_STATUS.md`](../TRANSLATION_STATUS.md) — 章ごとの進捗
+- `sites/user/.translation-glossary.md` — user サイト用語規律
+- `sites/dev/.translation-glossary.md` — dev サイト用語規律 + verbatim 規律

--- a/docs/development/translation-prompts/translate-dev-site.md
+++ b/docs/development/translation-prompts/translate-dev-site.md
@@ -1,0 +1,244 @@
+# Translation Prompt: Dev Site (ja → en)
+
+このプロンプトは Claude Desktop / Claude on the Web に **そのまま貼り付けて** 使う想定です。
+
+将来の routine 化を見据えて self-contained に書かれています。
+
+User サイトとは異なり **verbatim 規律** が CRITICAL なので、code block / line range / KaTeX / Sources の取り扱いに特に注意してください。
+
+---
+
+## プロンプト本文 (ここから↓を copy)
+
+```
+You are translating the OrbitScore developer learning site (implementation reading notes) from Japanese to English.
+
+## Repository
+
+https://github.com/signalcompose/orbitscore
+
+You have GitHub access. Clone the repo, work on a new branch, and open a single PR when done.
+
+## Required Reading (read these first, in order)
+
+1. `sites/dev/.translation-glossary.md` — terminology pairs, tone rules, **CRITICAL §4 verbatim discipline**
+2. `sites/dev/STYLE_GUIDE.md` — writing rules including §5-bis verbatim citation rules
+3. `sites/dev/en/orientation/architecture-overview.md` — translated chapter (use as reference for tone/style/verbatim discipline)
+4. `docs/development/TRANSLATION_WORKFLOW.md` — high-level workflow doc
+5. `docs/development/DEV_LEARNING_SITE.md` — project brief explaining the site's purpose and SoT relationship
+
+## Chapters to Translate (18 total)
+
+For each chapter, translate the Japanese source and overwrite the English stub at the same relative path under `sites/dev/en/`:
+
+| # | Source (ja) | Target (en, overwrite) | Title |
+|---|---|---|---|
+| - | `sites/dev/index.md` | `sites/dev/en/index.md` | OrbitScore Dev (landing) |
+| 0-1 | `sites/dev/orientation/what-is-orbitscore.md` | `sites/dev/en/orientation/what-is-orbitscore.md` | What is OrbitScore |
+| I-1 | `sites/dev/pipeline/text-to-ast.md` | `sites/dev/en/pipeline/text-to-ast.md` | Text to AST |
+| I-2 | `sites/dev/pipeline/evaluation.md` | `sites/dev/en/pipeline/evaluation.md` | AST Evaluation Model |
+| I-3 | `sites/dev/pipeline/selective-execution.md` | `sites/dev/en/pipeline/selective-execution.md` | Selective Execution |
+| II-1 | `sites/dev/scheduling/time-representation.md` | `sites/dev/en/scheduling/time-representation.md` | Time Representation |
+| II-2 | `sites/dev/scheduling/polymeter.md` | `sites/dev/en/scheduling/polymeter.md` | Polymeter / Polyrhythm |
+| II-3 | `sites/dev/scheduling/event-queue.md` | `sites/dev/en/scheduling/event-queue.md` | Event Queue and Look-Ahead |
+| II-4 | `sites/dev/scheduling/transport.md` | `sites/dev/en/scheduling/transport.md` | Transport |
+| III-1 | `sites/dev/audio/supercollider.md` | `sites/dev/en/audio/supercollider.md` | Communication with SuperCollider |
+| III-2 | `sites/dev/audio/audio-file-playback.md` | `sites/dev/en/audio/audio-file-playback.md` | Audio File Playback |
+| III-3 | `sites/dev/audio/scsynth-bundle.md` | `sites/dev/en/audio/scsynth-bundle.md` | scsynth Bundle and Path Resolution |
+| IV-1 | `sites/dev/editor/vscode-architecture.md` | `sites/dev/en/editor/vscode-architecture.md` | VS Code Extension Architecture |
+| IV-2 | `sites/dev/editor/execution-feedback.md` | `sites/dev/en/editor/execution-feedback.md` | Inline Execution and Feedback |
+| ADR | `sites/dev/decisions/adr-001-supercollider.md` | `sites/dev/en/decisions/adr-001-supercollider.md` | ADR-001 Choosing SC-based Implementation |
+| ADR | `sites/dev/decisions/adr-002-dsl-v3-pivot.md` | `sites/dev/en/decisions/adr-002-dsl-v3-pivot.md` | ADR-002 DSL v1 to v3 Pivot |
+| ADR | `sites/dev/decisions/adr-003-scsynth-bundle.md` | `sites/dev/en/decisions/adr-003-scsynth-bundle.md` | ADR-003 scsynth Bundle Strict Mode |
+| - | `sites/dev/glossary.md` | `sites/dev/en/glossary.md` | Glossary |
+
+The stub files currently contain only a "Translation in progress" warning. Overwrite them entirely with full translations.
+
+Chapter `orientation/architecture-overview.md` is ALREADY translated as a spike example — use it as your tone/style/verbatim reference, do NOT modify it.
+
+## CRITICAL: Verbatim Rules
+
+The dev site has a strict citation discipline. The following must remain **byte-identical** between ja and en versions:
+
+### Code blocks
+
+The contents of TS/JS/Shell code blocks MUST NOT be translated or reformatted:
+
+```typescript
+// packages/engine/src/audio/supercollider/scsynth-resolver.ts:76-99
+export function resolveScsynthPath(opts: ResolveOptions = {}): ScsynthResolution {
+  // ...
+}
+```
+
+- The `// <file>:<start>-<end>` line range comment is byte-identical
+- Indentation, whitespace, and line breaks are byte-identical
+- `// ...` omission markers are byte-identical
+- English inline comments stay in English; Japanese inline comments are translated to English while preserving formatting
+
+### Sources sections
+
+File paths and line ranges must be byte-identical. Only the trailing description (after `—`) is translated:
+
+ja: `- packages/engine/src/audio/supercollider/scsynth-resolver.ts:76-99 — resolveScsynthPath() の優先順位ロジック`
+
+en: `- packages/engine/src/audio/supercollider/scsynth-resolver.ts:76-99 — Priority logic of resolveScsynthPath()`
+
+### KaTeX
+
+Math expressions inside `$...$` and `$$...$$` are byte-identical.
+
+### Mermaid diagrams
+
+The graph syntax (`flowchart TD`, `sequenceDiagram`, edge arrows) is byte-identical. Only Japanese node labels are translated to English.
+
+### Frontmatter
+
+```yaml
+---
+title: <translate>
+description: <translate if present>
+verified-against: <commit-sha-IDENTICAL>
+verified-at: <YYYY-MM-DD-IDENTICAL>
+status: <draft|reviewed|stable - keyword IDENTICAL>
+---
+```
+
+Only `title` and `description` are translated. Other fields preserve their values exactly.
+
+### Disclaimer line
+
+If a chapter has a disclaimer line at the top, translate it as follows:
+
+ja: `> **Note**: 本ページは {YYYY-MM-DD} 時点での著者の reading の足跡です。code が真実、本ページはその時点の理解の snapshot に過ぎません。`
+
+en: `> **Note**: This page is a trace of the author's reading as of {YYYY-MM-DD}. The code is the truth; this page is merely a snapshot of understanding at that point in time.`
+
+(Preserve the original date.)
+
+## Tone
+
+Technical, objective, explanatory — like a colleague walking through the code with you, not academic paper formality. The ja "sempai-like warmth" should not be transliterated; English equivalent is just clear, helpful explanation.
+
+| ja | en |
+|---|---|
+| この理由は〜です | The reason is that ... |
+| 〜になります | This results in ... / This becomes ... |
+| 詳細は〜を参照 | For details, see ... / Refer to ... |
+| ここで気をつけたいのは | A point worth noting is ... / What is worth noting is ... |
+
+Avoid: "Let's...", "You should always...", excessive emojis.
+
+## Cross-chapter links
+
+Keep relative paths the same in both ja and en (both versions live at the same depth):
+
+- ja: `[アーキテクチャ全景](/orientation/architecture-overview)` → en: `[Architecture Overview](/en/orientation/architecture-overview)`
+
+NOTE: Absolute paths to dev site internal pages need `/en/` prefix in the en version. Use the spike `architecture-overview.md` as reference for how it handles these.
+
+For relative paths like `./other.md` or `../section/other.md`, keep them as-is.
+
+## Glossary terminology
+
+Follow `sites/dev/.translation-glossary.md` §1 strictly. Key examples:
+
+- 実装レイヤー → implementation layer
+- 単一信頼情報源 / SoT → Single Source of Truth (SoT)
+- 構文木 / AST → AST (abstract syntax tree)
+- スケジューラ → scheduler
+- 注入 → injection / inject
+- 解決 → resolve / resolution
+- 同梱 → bundled
+- 拡張機能 → extension
+- 拡張機能ホスト → Extension Host (preserve VS Code official capitalization)
+
+If a term is not in the glossary, infer from context and note it in the PR description.
+
+## Workflow
+
+1. Create a branch: `en-translation-dev-site`
+2. Translate all 18 chapters by overwriting the stub files at `sites/dev/en/<path>.md`
+3. Run locally to verify:
+   ```bash
+   npm install
+   npm run -w @orbitscore/dev-site docs:build
+   ```
+   Build must pass with no dead links and no KaTeX rendering errors.
+4. Update `docs/development/TRANSLATION_STATUS.md`:
+   - For each of the 18 dev chapters in the table, change `Status` from `pending` to `done`
+   - Set `Last translated against (ja commit)` to the current `main` HEAD commit hash
+   - Update the `残り: 18 章` summary line (`残り: 0 章` if all done)
+5. Commit with title: `docs(en): translate dev site chapters (18)`
+6. Open a PR against `main` with title: `Translate dev site to English (18 chapters)`
+
+## PR Description Template
+
+```
+## Summary
+
+18 章の英訳を完了。spike 章 (architecture-overview.md) と同じトーン・glossary・verbatim 規律に従って翻訳。
+
+## Translated chapters
+
+(List each chapter as a checkbox, ticking those done)
+
+## Verbatim discipline self-check
+
+- [ ] All TS code blocks byte-identical (range comments, indentation, omission markers)
+- [ ] All Sources file paths and line ranges byte-identical
+- [ ] All KaTeX math expressions byte-identical
+- [ ] Mermaid syntax preserved (only Japanese node labels translated)
+- [ ] Frontmatter `verified-against` / `verified-at` / `status` values preserved
+
+## Source ja commit
+
+Translated against `main` at <commit-sha-here>.
+
+## Verification
+
+- [ ] `npm run -w @orbitscore/dev-site docs:build` passes locally
+- [ ] No dead links
+- [ ] No KaTeX rendering errors
+- [ ] Glossary §1 terms used consistently
+
+## Glossary terms not found in glossary
+
+(List any terms you had to infer, or write "None")
+
+## Notes
+
+(Anything reviewer should know — e.g., places where ja source seemed unclear and en interpretation was a judgment call)
+```
+
+## Verification Checklist (before opening PR)
+
+- [ ] All 18 stub files overwritten with full translations
+- [ ] `docs:build` passes with no dead links
+- [ ] KaTeX math expressions render correctly
+- [ ] Code blocks: byte-identical content, range comments preserved, omission markers preserved
+- [ ] Sources sections: file paths and line ranges byte-identical, only descriptions translated
+- [ ] Frontmatter: `title`/`description` translated, other fields preserved exactly
+- [ ] Mermaid: graph syntax preserved, only ja node labels translated
+- [ ] Cross-chapter links: absolute paths use `/en/` prefix, relative paths unchanged
+- [ ] Glossary §1 terminology applied consistently
+- [ ] `TRANSLATION_STATUS.md` updated
+
+## Notes
+
+- This is a single-PR-for-all-chapters approach (not one PR per chapter), per project preference.
+- The dev site is a "personal learning notes" reference, so the en version should also feel like reading detailed implementation notes, not marketing/tutorial copy.
+- The verbatim discipline is non-negotiable: the SoT is the code, and citations must remain trustworthy.
+```
+
+---
+
+## Routine 化への展望
+
+User サイトと同様、CronCreate routine で自動化想定:
+
+1. ja の章が更新された commit を検出
+2. `TRANSLATION_STATUS.md` の該当章を `done` → `outdated` に変更
+3. このプロンプトを on-the-web に投げて再翻訳 PR 作成
+
+特に dev サイトは verbatim 規律のため、ja 側の code block range が変わったときは en 側も同じ commit ベースで再翻訳が必要。

--- a/docs/development/translation-prompts/translate-user-site.md
+++ b/docs/development/translation-prompts/translate-user-site.md
@@ -1,0 +1,183 @@
+# Translation Prompt: User Site (ja → en)
+
+このプロンプトは Claude Desktop / Claude on the Web に **そのまま貼り付けて** 使う想定です。
+
+将来の routine 化を見据えて self-contained に書かれています。
+
+---
+
+## プロンプト本文 (ここから↓を copy)
+
+```
+You are translating the OrbitScore user-facing learning site from Japanese to English.
+
+## Repository
+
+https://github.com/signalcompose/orbitscore
+
+You have GitHub access. Clone the repo, work on a new branch, and open a single PR when done.
+
+## Required Reading (read these first, in order)
+
+1. `sites/user/.translation-glossary.md` — terminology pairs, tone rules, do-not-translate list
+2. `sites/user/STYLE_GUIDE.md` — writing rules (tone, structure, link conventions)
+3. `sites/user/en/index.md` — translated landing page (use as reference for tone/style)
+4. `sites/user/en/getting-started/first-sound.md` — translated chapter 3 (use as reference for tone/style)
+5. `docs/development/TRANSLATION_WORKFLOW.md` — high-level workflow doc
+
+## Chapters to Translate (8 total)
+
+For each chapter, translate the Japanese source and overwrite the English stub at the same relative path under `sites/user/en/`:
+
+| # | Source (ja) | Target (en, overwrite) | Title |
+|---|---|---|---|
+| 2 | `sites/user/getting-started/installation.md` | `sites/user/en/getting-started/installation.md` | Installation |
+| 4 | `sites/user/basics/patterns.md` | `sites/user/en/basics/patterns.md` | Building Patterns |
+| 5 | `sites/user/basics/multiple-sequences.md` | `sites/user/en/basics/multiple-sequences.md` | Multiple Sequences |
+| 6 | `sites/user/basics/polyrhythm.md` | `sites/user/en/basics/polyrhythm.md` | Polymeter and Polyrhythm |
+| 7 | `sites/user/basics/audio-manipulation.md` | `sites/user/en/basics/audio-manipulation.md` | Audio Manipulation |
+| 8 | `sites/user/basics/live-coding.md` | `sites/user/en/basics/live-coding.md` | Live Coding |
+| 9 | `sites/user/reference/methods.md` | `sites/user/en/reference/methods.md` | Reference |
+| 10 | `sites/user/troubleshooting.md` | `sites/user/en/troubleshooting.md` | Troubleshooting |
+
+The stub files currently contain only a "Translation in progress" warning. Overwrite them entirely with full translations.
+
+Chapters 1 and 3 (`index.md` and `getting-started/first-sound.md`) are ALREADY translated as spike examples — use them as your tone/style reference, do NOT modify them.
+
+## Critical Rules
+
+### Do NOT translate (keep byte-identical)
+
+- DSL/code block contents (e.g., `var global = init GLOBAL`)
+- File paths (`kick.wav`, `./audio`, `examples/01_getting_started.orbs`)
+- Method/function names (`audio()`, `play()`, `chop()`, etc.)
+- Keyboard shortcuts (`Cmd+Enter`, `Cmd+Shift+P`)
+- VS Code UI quotations (`🎵 OrbitScore: Ready`, `Extensions: Install from VSIX...`)
+- Numbers and version strings
+
+### DO translate
+
+- Body prose
+- Headings (`#`, `##`, `###`)
+- Frontmatter `title` and `description` (preserve other fields if any)
+- Inline link text (e.g., `[インストール](./installation.md)` → `[Installation](./installation.md)`)
+- Comments inside code blocks if they are in Japanese (translate the comment, keep the code)
+
+### Tone
+
+Polite, friendly, kind — but **NOT condescending or childish**.
+
+| NG | OK |
+|---|---|
+| "Let's give it a try!" | "Try the following." or "You can try it." |
+| "You did it! Awesome!" | "This is the result." or "You have completed this step." |
+| "Watch out!" | "Please note that..." |
+| Excessive `🎉🚀✨` emojis | Use UI/code emojis (`🎵`, `✅`) only when they are in the source as UI quotations |
+
+Use polite English equivalent of the ja ですます tone. Read the spike chapters (`en/index.md`, `en/getting-started/first-sound.md`) and match their register.
+
+### Cross-chapter links
+
+Keep relative paths. Both ja and en versions live at the same depth so paths translate 1:1:
+
+- ja: `[インストール](./installation.md)` → en: `[Installation](./installation.md)`
+- ja: `[パターンを作る](../basics/patterns.md)` → en: `[Building Patterns](../basics/patterns.md)`
+
+### Glossary terminology
+
+Follow `sites/user/.translation-glossary.md` §1 strictly. Examples:
+
+- ライブコーディング → live coding
+- シーケンス → sequence
+- パターン → pattern
+- ポリメーター → polymeter
+- ポリリズム → polyrhythm
+- 拍子 → time signature
+- 拍 → beat
+- 拡張機能 → extension
+- 同梱 → bundled
+- バスドラム / キック → kick (not "kick drum")
+
+If a term is not in the glossary, infer from context and note it in the PR description.
+
+## Workflow
+
+1. Create a branch: `en-translation-user-site`
+2. Translate all 8 chapters by overwriting the stub files at `sites/user/en/<path>.md`
+3. Run locally to verify:
+   ```bash
+   npm install
+   npm run -w @orbitscore/user-site docs:build
+   ```
+   Build must pass with no dead links.
+4. Update `docs/development/TRANSLATION_STATUS.md`:
+   - For each of the 8 user chapters in the table, change `Status` from `pending` to `done`
+   - Set `Last translated against (ja commit)` to the current `main` HEAD commit hash
+   - Update the `残り: 8 章` summary line to reflect the new count (`残り: 0 章` if all done)
+5. Commit with title: `docs(en): translate user site chapters (8)`
+6. Open a PR against `main` with title: `Translate user site to English (8 chapters)`
+
+## PR Description Template
+
+```
+## Summary
+
+8 章の英訳を完了。spike 章 (index.md, first-sound.md) と同じトーン・glossary に従って翻訳。
+
+## Translated chapters
+
+- [ ] getting-started/installation.md (Installation)
+- [ ] basics/patterns.md (Building Patterns)
+- [ ] basics/multiple-sequences.md (Multiple Sequences)
+- [ ] basics/polyrhythm.md (Polymeter and Polyrhythm)
+- [ ] basics/audio-manipulation.md (Audio Manipulation)
+- [ ] basics/live-coding.md (Live Coding)
+- [ ] reference/methods.md (Reference)
+- [ ] troubleshooting.md (Troubleshooting)
+
+(Replace [ ] with [x] for completed chapters)
+
+## Source ja commit
+
+Translated against `main` at <commit-sha-here>.
+
+## Verification
+
+- [ ] `npm run -w @orbitscore/user-site docs:build` passes locally
+- [ ] No dead links
+- [ ] Glossary §1 terms used consistently
+- [ ] Tone matches spike chapters (no condescending/childish phrasing)
+
+## Glossary terms not found in glossary
+
+(List any terms you had to infer, or write "None")
+```
+
+## Verification Checklist (before opening PR)
+
+- [ ] All 8 stub files overwritten with full translations
+- [ ] `docs:build` passes with no dead links
+- [ ] Frontmatter `title` and `description` translated for all 8 files
+- [ ] Cross-chapter links use relative paths (`./other.md`, `../section/other.md`)
+- [ ] Code blocks unchanged (DSL, file paths, method names preserved)
+- [ ] Glossary §1 terminology applied consistently
+- [ ] No "Let's...", "You did it!", or other condescending phrasing
+- [ ] `TRANSLATION_STATUS.md` updated with `done` and commit hash
+
+## Notes
+
+- This is a single-PR-for-all-chapters approach (not one PR per chapter), per project preference.
+- The output should read like a polite English tutorial written for absolute beginners — clear, kind, and respectful, but not childish.
+- If you encounter a term that should be added to the glossary, mention it in the PR description so the glossary can be updated separately.
+```
+
+---
+
+## Routine 化への展望
+
+このプロンプトは将来 CronCreate routine で自動化する想定:
+
+1. ja の章が更新された commit を検出
+2. `TRANSLATION_STATUS.md` の該当章を `done` → `outdated` に変更
+3. このプロンプトを on-the-web に投げて再翻訳 PR を作成
+4. PR review → merge


### PR DESCRIPTION
## Summary

dev / user 両学習サイトを Claude Desktop / Claude on the Web に丸投げするための self-contained プロンプト 2 つを追加。将来の CronCreate routine 化を見据えた設計。

## 追加ファイル

| ファイル | 対象 | 章数 |
|---|---|---|
| `translate-user-site.md` | sites/user/ | 8 章 |
| `translate-dev-site.md` | sites/dev/ | 18 章 (verbatim 規律 CRITICAL) |
| `README.md` | 使い方 | - |

## 使い方

1. `docs/development/translation-prompts/translate-{user,dev}-site.md` を開く
2. 「プロンプト本文」 内のコードブロックを全選択コピー
3. Claude Desktop で on-the-web に渡す
4. PR が来たら review → merge

## ルーチン化展望

CronCreate routine で:

\`\`\`
ja 章更新検出 → TRANSLATION_STATUS.md で outdated マーク
              ↓
            該当章のプロンプトを on-the-web に dispatch
              ↓
            再翻訳 PR → review → merge
\`\`\`

self-contained プロンプトなので routine 化が容易。

## Test plan

- [x] プロンプトに必要な情報が揃っている (glossary path, spike example path, workflow doc, verification steps)
- [x] verbatim 規律の CRITICAL ポイントが dev プロンプトに明記されている
- [ ] 実際に on-the-web に投げて 1 章翻訳できるか試す

🤖 Generated with [Claude Code](https://claude.com/claude-code)