### PR TITLE
Make translation prompts status-driven and trigger-only

### DIFF
--- a/docs/development/translation-prompts/README.md
+++ b/docs/development/translation-prompts/README.md
@@ -1,44 +1,81 @@
 # Translation Prompts
 
-OrbitScore learning サイト 2 つを Claude Desktop / Claude on the Web に丸投げするための self-contained プロンプト集。
+OrbitScore learning サイトを Claude Desktop / Claude on the Web / CronCreate routine に翻訳作業を投げるためのプロンプトファイル。
 
-## 使い方
+**設計方針**: プロンプト本体はリポジトリ内のこのファイル群が canonical SoT。トリガーは「このファイル読んで実行して」 だけで完結する。これにより:
 
-1. このディレクトリの該当ファイル (`translate-user-site.md` または `translate-dev-site.md`) を開く
-2. 「プロンプト本文」 のコードブロック内 (`` ``` `` で囲まれた部分) を **そのまま全選択コピー**
-3. Claude Desktop 等で on-the-web に渡す
-4. on-the-web が PR を作成するのを待つ
-5. PR が来たら local build / glossary 整合性 / トーン規律 を review
-6. 問題なければ merge、`docs/development/TRANSLATION_STATUS.md` の進捗が `done` に更新されていることを確認
+- プロンプト更新は PR で完結、Claude Desktop に貼り直す必要なし
+- Routine から無修正で再 dispatch できる
+- 章追加・削除は `TRANSLATION_STATUS.md` だけで反映、プロンプトは触らない
+
+---
+
+## トリガーコマンド
+
+### User site
+
+Claude Desktop / on-the-web に以下の 1 文だけ送る:
+
+```
+Read https://github.com/signalcompose/orbitscore/blob/main/docs/development/translation-prompts/translate-user-site.md and execute the task described in that file.
+```
+
+### Dev site
+
+```
+Read https://github.com/signalcompose/orbitscore/blob/main/docs/development/translation-prompts/translate-dev-site.md and execute the task described in that file.
+```
+
+これだけで on-the-web が:
+1. プロンプトファイルを fetch
+2. `TRANSLATION_STATUS.md` を読んで `pending` / `outdated` 章を抽出
+3. 該当章を翻訳
+4. PR を作成
 
 ## ファイル一覧
 
-| ファイル | 対象 | 章数 | 特記事項 |
+| ファイル | 対象 | 章数（残り） | 特記事項 |
 |---|---|---|---|
-| `translate-user-site.md` | `sites/user/` | 8 章（残り） | spike 章 2 つ既に完訳済 |
-| `translate-dev-site.md` | `sites/dev/` | 18 章（残り） | **verbatim 規律 CRITICAL**、spike 章 1 つ既に完訳済 |
+| `translate-user-site.md` | `sites/user/` | 8 章 | spike 章 2 つ完訳済 |
+| `translate-dev-site.md` | `sites/dev/` | 18 章 | **verbatim 規律 CRITICAL**、spike 章 1 つ完訳済 |
 
-## ルーチン化への展望
+## 仕組み
 
-両プロンプトとも将来 CronCreate routine で自動化する想定:
+### Status-driven scope
 
+両プロンプトとも、翻訳対象の章リストを **ハードコードしない**。`docs/development/TRANSLATION_STATUS.md` の `Status` 列が `pending` または `outdated` の章を動的に拾う。
+
+このため:
+- 章を追加 → STATUS.md に行追加（status=pending） → 次回 dispatch で自動翻訳
+- ja 章を更新 → STATUS.md で該当章を outdated にマーク → 次回 dispatch で再翻訳
+- プロンプト本体は触らない
+
+### プロンプト更新
+
+プロンプトの内容（用語規律、verbatim ルール、ワークフロー）を変更したい場合:
+
+1. `translate-{user,dev}-site.md` を直接編集
+2. PR でレビュー → merge
+3. 次回 dispatch から新ルールが効く
+
+Routine 側の設定は変更不要。
+
+### Routine 化想定
+
+```mermaid
+flowchart TD
+    A[ja 章更新 commit] --> B[hook: STATUS.md で outdated マーク]
+    B --> C[CronCreate routine: 一定間隔で起動]
+    C --> D[「Read file X, execute」 を on-the-web に dispatch]
+    D --> E[on-the-web が pending/outdated 章を翻訳]
+    E --> F[翻訳 PR 作成]
+    F --> G[review → merge]
+    G --> H[STATUS.md が done に更新済]
 ```
-ja の章更新検出 → TRANSLATION_STATUS.md で outdated にマーク
-                ↓
-              該当章のプロンプトを on-the-web に dispatch
-                ↓
-              再翻訳 PR 作成 → review → merge
-```
-
-そのため、プロンプトは:
-- Self-contained（外部 context 不要）
-- 出力フォーマット明示
-- Verification ステップ含む
-- ジ章単位で再 dispatch 可能（将来の細粒度化に備える）
 
 ## 関連ドキュメント
 
 - [`TRANSLATION_WORKFLOW.md`](../TRANSLATION_WORKFLOW.md) — 翻訳 workflow 全体
-- [`TRANSLATION_STATUS.md`](../TRANSLATION_STATUS.md) — 章ごとの進捗
+- [`TRANSLATION_STATUS.md`](../TRANSLATION_STATUS.md) — 章ごとの進捗（routine の SoT）
 - `sites/user/.translation-glossary.md` — user サイト用語規律
 - `sites/dev/.translation-glossary.md` — dev サイト用語規律 + verbatim 規律

--- a/docs/development/translation-prompts/translate-dev-site.md
+++ b/docs/development/translation-prompts/translate-dev-site.md
@@ -1,17 +1,12 @@
-# Translation Prompt: Dev Site (ja → en)
+# Translation Task: Dev Site (ja → en)
 
-このプロンプトは Claude Desktop / Claude on the Web に **そのまま貼り付けて** 使う想定です。
+You are translating the OrbitScore developer learning site (implementation reading notes) from Japanese to English.
 
-将来の routine 化を見据えて self-contained に書かれています。
+This file IS the instruction. Read all of it, then execute the workflow.
 
 User サイトとは異なり **verbatim 規律** が CRITICAL なので、code block / line range / KaTeX / Sources の取り扱いに特に注意してください。
 
 ---
-
-## プロンプト本文 (ここから↓を copy)
-
-```
-You are translating the OrbitScore developer learning site (implementation reading notes) from Japanese to English.
 
 ## Repository
 
@@ -21,40 +16,24 @@ You have GitHub access. Clone the repo, work on a new branch, and open a single 
 
 ## Required Reading (read these first, in order)
 
-1. `sites/dev/.translation-glossary.md` — terminology pairs, tone rules, **CRITICAL §4 verbatim discipline**
-2. `sites/dev/STYLE_GUIDE.md` — writing rules including §5-bis verbatim citation rules
-3. `sites/dev/en/orientation/architecture-overview.md` — translated chapter (use as reference for tone/style/verbatim discipline)
+1. `docs/development/TRANSLATION_STATUS.md` — single source of truth for which chapters need translation
+2. `sites/dev/.translation-glossary.md` — terminology pairs, tone rules, **CRITICAL §4 verbatim discipline**
+3. `sites/dev/STYLE_GUIDE.md` — writing rules including §5-bis verbatim citation rules
 4. `docs/development/TRANSLATION_WORKFLOW.md` — high-level workflow doc
 5. `docs/development/DEV_LEARNING_SITE.md` — project brief explaining the site's purpose and SoT relationship
+6. Any chapter under `sites/dev/en/` whose Status is `done` — use as reference for tone/style/verbatim handling. At minimum read `sites/dev/en/orientation/architecture-overview.md` (the original spike chapter).
 
-## Chapters to Translate (18 total)
+## Determining Scope (do NOT hardcode)
 
-For each chapter, translate the Japanese source and overwrite the English stub at the same relative path under `sites/dev/en/`:
+Read `docs/development/TRANSLATION_STATUS.md` and find every row in the **`sites/dev/` (19 章)** section whose `Status` column is `pending` OR `outdated`. Those are your translation targets.
 
-| # | Source (ja) | Target (en, overwrite) | Title |
-|---|---|---|---|
-| - | `sites/dev/index.md` | `sites/dev/en/index.md` | OrbitScore Dev (landing) |
-| 0-1 | `sites/dev/orientation/what-is-orbitscore.md` | `sites/dev/en/orientation/what-is-orbitscore.md` | What is OrbitScore |
-| I-1 | `sites/dev/pipeline/text-to-ast.md` | `sites/dev/en/pipeline/text-to-ast.md` | Text to AST |
-| I-2 | `sites/dev/pipeline/evaluation.md` | `sites/dev/en/pipeline/evaluation.md` | AST Evaluation Model |
-| I-3 | `sites/dev/pipeline/selective-execution.md` | `sites/dev/en/pipeline/selective-execution.md` | Selective Execution |
-| II-1 | `sites/dev/scheduling/time-representation.md` | `sites/dev/en/scheduling/time-representation.md` | Time Representation |
-| II-2 | `sites/dev/scheduling/polymeter.md` | `sites/dev/en/scheduling/polymeter.md` | Polymeter / Polyrhythm |
-| II-3 | `sites/dev/scheduling/event-queue.md` | `sites/dev/en/scheduling/event-queue.md` | Event Queue and Look-Ahead |
-| II-4 | `sites/dev/scheduling/transport.md` | `sites/dev/en/scheduling/transport.md` | Transport |
-| III-1 | `sites/dev/audio/supercollider.md` | `sites/dev/en/audio/supercollider.md` | Communication with SuperCollider |
-| III-2 | `sites/dev/audio/audio-file-playback.md` | `sites/dev/en/audio/audio-file-playback.md` | Audio File Playback |
-| III-3 | `sites/dev/audio/scsynth-bundle.md` | `sites/dev/en/audio/scsynth-bundle.md` | scsynth Bundle and Path Resolution |
-| IV-1 | `sites/dev/editor/vscode-architecture.md` | `sites/dev/en/editor/vscode-architecture.md` | VS Code Extension Architecture |
-| IV-2 | `sites/dev/editor/execution-feedback.md` | `sites/dev/en/editor/execution-feedback.md` | Inline Execution and Feedback |
-| ADR | `sites/dev/decisions/adr-001-supercollider.md` | `sites/dev/en/decisions/adr-001-supercollider.md` | ADR-001 Choosing SC-based Implementation |
-| ADR | `sites/dev/decisions/adr-002-dsl-v3-pivot.md` | `sites/dev/en/decisions/adr-002-dsl-v3-pivot.md` | ADR-002 DSL v1 to v3 Pivot |
-| ADR | `sites/dev/decisions/adr-003-scsynth-bundle.md` | `sites/dev/en/decisions/adr-003-scsynth-bundle.md` | ADR-003 scsynth Bundle Strict Mode |
-| - | `sites/dev/glossary.md` | `sites/dev/en/glossary.md` | Glossary |
+For each target:
+- Source (ja): `sites/dev/<path>` (the path in the table)
+- Target (en, overwrite stub): `sites/dev/en/<path>`
 
-The stub files currently contain only a "Translation in progress" warning. Overwrite them entirely with full translations.
+If `Status` is `done`, skip that chapter (do NOT modify it).
 
-Chapter `orientation/architecture-overview.md` is ALREADY translated as a spike example — use it as your tone/style/verbatim reference, do NOT modify it.
+The number of chapters per run varies by current status. Treat all targets uniformly. Single PR contains all chapters translated in this run.
 
 ## CRITICAL: Verbatim Rules
 
@@ -135,53 +114,48 @@ Keep relative paths the same in both ja and en (both versions live at the same d
 
 - ja: `[アーキテクチャ全景](/orientation/architecture-overview)` → en: `[Architecture Overview](/en/orientation/architecture-overview)`
 
-NOTE: Absolute paths to dev site internal pages need `/en/` prefix in the en version. Use the spike `architecture-overview.md` as reference for how it handles these.
+NOTE: Absolute paths to dev site internal pages need `/en/` prefix in the en version. Use any `done` chapter (e.g., `architecture-overview.md`) as reference for how it handles these.
 
 For relative paths like `./other.md` or `../section/other.md`, keep them as-is.
 
 ## Glossary terminology
 
-Follow `sites/dev/.translation-glossary.md` §1 strictly. Key examples:
-
-- 実装レイヤー → implementation layer
-- 単一信頼情報源 / SoT → Single Source of Truth (SoT)
-- 構文木 / AST → AST (abstract syntax tree)
-- スケジューラ → scheduler
-- 注入 → injection / inject
-- 解決 → resolve / resolution
-- 同梱 → bundled
-- 拡張機能 → extension
-- 拡張機能ホスト → Extension Host (preserve VS Code official capitalization)
-
-If a term is not in the glossary, infer from context and note it in the PR description.
+Follow `sites/dev/.translation-glossary.md` §1 strictly. If a term is not in the glossary, infer from context and note it in the PR description.
 
 ## Workflow
 
-1. Create a branch: `en-translation-dev-site`
-2. Translate all 18 chapters by overwriting the stub files at `sites/dev/en/<path>.md`
-3. Run locally to verify:
+1. Determine scope from `TRANSLATION_STATUS.md` (rows with `pending` or `outdated` for `sites/dev/`).
+2. Create a branch named `en-translation-dev-site-<YYYY-MM-DD>` (today's date) to allow concurrent runs.
+3. Translate every target chapter by overwriting the stub at `sites/dev/en/<path>`.
+4. Run locally to verify:
    ```bash
    npm install
    npm run -w @orbitscore/dev-site docs:build
    ```
    Build must pass with no dead links and no KaTeX rendering errors.
-4. Update `docs/development/TRANSLATION_STATUS.md`:
-   - For each of the 18 dev chapters in the table, change `Status` from `pending` to `done`
+5. Update `docs/development/TRANSLATION_STATUS.md`:
+   - For each translated chapter, change `Status` to `done`
    - Set `Last translated against (ja commit)` to the current `main` HEAD commit hash
-   - Update the `残り: 18 章` summary line (`残り: 0 章` if all done)
-5. Commit with title: `docs(en): translate dev site chapters (18)`
-6. Open a PR against `main` with title: `Translate dev site to English (18 chapters)`
+   - Recompute the `残り: N 章` summary line at the bottom of the dev section
+   - Recompute the global summary at the bottom of the file
+6. Commit with title: `docs(en): translate dev site chapters (N)` where N is the count
+7. Open a PR against `main` with title: `Translate dev site to English (N chapters)`
 
 ## PR Description Template
 
 ```
 ## Summary
 
-18 章の英訳を完了。spike 章 (architecture-overview.md) と同じトーン・glossary・verbatim 規律に従って翻訳。
+N 章の英訳を完了。Status=done の既存章と同じトーン・glossary・verbatim 規律に従って翻訳。
 
-## Translated chapters
+## Translated chapters (this run)
 
-(List each chapter as a checkbox, ticking those done)
+(List each chapter you translated as a bullet. Format: `- <path> (<English title>)`)
+
+## Status changes
+
+- pending → done: <count>
+- outdated → done: <count>
 
 ## Verbatim discipline self-check
 
@@ -193,7 +167,7 @@ If a term is not in the glossary, infer from context and note it in the PR descr
 
 ## Source ja commit
 
-Translated against `main` at <commit-sha-here>.
+Translated against `main` at <commit-sha>.
 
 ## Verification
 
@@ -213,7 +187,8 @@ Translated against `main` at <commit-sha-here>.
 
 ## Verification Checklist (before opening PR)
 
-- [ ] All 18 stub files overwritten with full translations
+- [ ] All target stub files (per current `TRANSLATION_STATUS.md`) overwritten with full translations
+- [ ] No `done` chapters were modified
 - [ ] `docs:build` passes with no dead links
 - [ ] KaTeX math expressions render correctly
 - [ ] Code blocks: byte-identical content, range comments preserved, omission markers preserved
@@ -222,23 +197,14 @@ Translated against `main` at <commit-sha-here>.
 - [ ] Mermaid: graph syntax preserved, only ja node labels translated
 - [ ] Cross-chapter links: absolute paths use `/en/` prefix, relative paths unchanged
 - [ ] Glossary §1 terminology applied consistently
-- [ ] `TRANSLATION_STATUS.md` updated
+- [ ] `TRANSLATION_STATUS.md` updated for every translated chapter
+- [ ] Summary counts recomputed
 
 ## Notes
 
-- This is a single-PR-for-all-chapters approach (not one PR per chapter), per project preference.
-- The dev site is a "personal learning notes" reference, so the en version should also feel like reading detailed implementation notes, not marketing/tutorial copy.
-- The verbatim discipline is non-negotiable: the SoT is the code, and citations must remain trustworthy.
-```
-
----
-
-## Routine 化への展望
-
-User サイトと同様、CronCreate routine で自動化想定:
-
-1. ja の章が更新された commit を検出
-2. `TRANSLATION_STATUS.md` の該当章を `done` → `outdated` に変更
-3. このプロンプトを on-the-web に投げて再翻訳 PR 作成
-
-特に dev サイトは verbatim 規律のため、ja 側の code block range が変わったときは en 側も同じ commit ベースで再翻訳が必要。
+- The number of chapters per run varies. Do not assume any specific count.
+- New ja chapters added since the last run will appear as `pending` rows automatically; pick them up.
+- This is a single-PR-for-all-pending approach.
+- The dev site is "personal learning notes" reference, so en should also feel like detailed implementation notes, not marketing copy.
+- The verbatim discipline is non-negotiable: SoT is the code, citations must remain trustworthy.
+- If you encounter a term not in the glossary, suggest a glossary update in the PR description (do not modify the glossary file in this PR — that is a separate concern).

--- a/docs/development/translation-prompts/translate-user-site.md
+++ b/docs/development/translation-prompts/translate-user-site.md
@@ -1,15 +1,10 @@
-# Translation Prompt: User Site (ja → en)
+# Translation Task: User Site (ja → en)
 
-このプロンプトは Claude Desktop / Claude on the Web に **そのまま貼り付けて** 使う想定です。
+You are translating the OrbitScore user-facing learning site from Japanese to English.
 
-将来の routine 化を見据えて self-contained に書かれています。
+This file IS the instruction. Read all of it, then execute the workflow.
 
 ---
-
-## プロンプト本文 (ここから↓を copy)
-
-```
-You are translating the OrbitScore user-facing learning site from Japanese to English.
 
 ## Repository
 
@@ -19,30 +14,23 @@ You have GitHub access. Clone the repo, work on a new branch, and open a single 
 
 ## Required Reading (read these first, in order)
 
-1. `sites/user/.translation-glossary.md` — terminology pairs, tone rules, do-not-translate list
-2. `sites/user/STYLE_GUIDE.md` — writing rules (tone, structure, link conventions)
-3. `sites/user/en/index.md` — translated landing page (use as reference for tone/style)
-4. `sites/user/en/getting-started/first-sound.md` — translated chapter 3 (use as reference for tone/style)
-5. `docs/development/TRANSLATION_WORKFLOW.md` — high-level workflow doc
+1. `docs/development/TRANSLATION_STATUS.md` — single source of truth for which chapters need translation
+2. `sites/user/.translation-glossary.md` — terminology pairs, tone rules, do-not-translate list
+3. `sites/user/STYLE_GUIDE.md` — writing rules (tone, structure, link conventions)
+4. `docs/development/TRANSLATION_WORKFLOW.md` — high-level workflow doc
+5. Any chapter under `sites/user/en/` whose Status is `done` — use as reference for tone/style. At minimum read `sites/user/en/index.md` and `sites/user/en/getting-started/first-sound.md` (the original spike chapters).
 
-## Chapters to Translate (8 total)
+## Determining Scope (do NOT hardcode)
 
-For each chapter, translate the Japanese source and overwrite the English stub at the same relative path under `sites/user/en/`:
+Read `docs/development/TRANSLATION_STATUS.md` and find every row in the **`sites/user/` (10 章)** section whose `Status` column is `pending` OR `outdated`. Those are your translation targets.
 
-| # | Source (ja) | Target (en, overwrite) | Title |
-|---|---|---|---|
-| 2 | `sites/user/getting-started/installation.md` | `sites/user/en/getting-started/installation.md` | Installation |
-| 4 | `sites/user/basics/patterns.md` | `sites/user/en/basics/patterns.md` | Building Patterns |
-| 5 | `sites/user/basics/multiple-sequences.md` | `sites/user/en/basics/multiple-sequences.md` | Multiple Sequences |
-| 6 | `sites/user/basics/polyrhythm.md` | `sites/user/en/basics/polyrhythm.md` | Polymeter and Polyrhythm |
-| 7 | `sites/user/basics/audio-manipulation.md` | `sites/user/en/basics/audio-manipulation.md` | Audio Manipulation |
-| 8 | `sites/user/basics/live-coding.md` | `sites/user/en/basics/live-coding.md` | Live Coding |
-| 9 | `sites/user/reference/methods.md` | `sites/user/en/reference/methods.md` | Reference |
-| 10 | `sites/user/troubleshooting.md` | `sites/user/en/troubleshooting.md` | Troubleshooting |
+For each target:
+- Source (ja): `sites/user/<path>` (the path in the table)
+- Target (en, overwrite stub): `sites/user/en/<path>`
 
-The stub files currently contain only a "Translation in progress" warning. Overwrite them entirely with full translations.
+If `Status` is `done`, skip that chapter (do NOT modify it).
 
-Chapters 1 and 3 (`index.md` and `getting-started/first-sound.md`) are ALREADY translated as spike examples — use them as your tone/style reference, do NOT modify them.
+The number of chapters per run varies by current status (e.g., 8 in initial bulk, 1 after a single ja update, etc.). Treat all targets uniformly. Single PR contains all chapters translated in this run.
 
 ## Critical Rules
 
@@ -74,7 +62,7 @@ Polite, friendly, kind — but **NOT condescending or childish**.
 | "Watch out!" | "Please note that..." |
 | Excessive `🎉🚀✨` emojis | Use UI/code emojis (`🎵`, `✅`) only when they are in the source as UI quotations |
 
-Use polite English equivalent of the ja ですます tone. Read the spike chapters (`en/index.md`, `en/getting-started/first-sound.md`) and match their register.
+Use polite English equivalent of the ja ですます tone. Match the register of any chapter under `sites/user/en/` whose Status is `done`.
 
 ### Cross-chapter links
 
@@ -85,68 +73,53 @@ Keep relative paths. Both ja and en versions live at the same depth so paths tra
 
 ### Glossary terminology
 
-Follow `sites/user/.translation-glossary.md` §1 strictly. Examples:
-
-- ライブコーディング → live coding
-- シーケンス → sequence
-- パターン → pattern
-- ポリメーター → polymeter
-- ポリリズム → polyrhythm
-- 拍子 → time signature
-- 拍 → beat
-- 拡張機能 → extension
-- 同梱 → bundled
-- バスドラム / キック → kick (not "kick drum")
-
-If a term is not in the glossary, infer from context and note it in the PR description.
+Follow `sites/user/.translation-glossary.md` §1 strictly. If a term is not in the glossary, infer from context and note it in the PR description.
 
 ## Workflow
 
-1. Create a branch: `en-translation-user-site`
-2. Translate all 8 chapters by overwriting the stub files at `sites/user/en/<path>.md`
-3. Run locally to verify:
+1. Determine scope from `TRANSLATION_STATUS.md` (rows with `pending` or `outdated` for `sites/user/`).
+2. Create a branch named `en-translation-user-site-<YYYY-MM-DD>` (today's date) to allow concurrent runs.
+3. Translate every target chapter by overwriting the stub at `sites/user/en/<path>`.
+4. Run locally to verify:
    ```bash
    npm install
    npm run -w @orbitscore/user-site docs:build
    ```
    Build must pass with no dead links.
-4. Update `docs/development/TRANSLATION_STATUS.md`:
-   - For each of the 8 user chapters in the table, change `Status` from `pending` to `done`
-   - Set `Last translated against (ja commit)` to the current `main` HEAD commit hash
-   - Update the `残り: 8 章` summary line to reflect the new count (`残り: 0 章` if all done)
-5. Commit with title: `docs(en): translate user site chapters (8)`
-6. Open a PR against `main` with title: `Translate user site to English (8 chapters)`
+5. Update `docs/development/TRANSLATION_STATUS.md`:
+   - For each translated chapter, change `Status` to `done`
+   - Set `Last translated against (ja commit)` to the current `main` HEAD commit hash (the one your translation is based on)
+   - Recompute the `残り: N 章` summary line at the bottom of the user section
+   - Recompute the global summary at the bottom of the file
+6. Commit with title: `docs(en): translate user site chapters (N)` where N is the count
+7. Open a PR against `main` with title: `Translate user site to English (N chapters)`
 
 ## PR Description Template
 
 ```
 ## Summary
 
-8 章の英訳を完了。spike 章 (index.md, first-sound.md) と同じトーン・glossary に従って翻訳。
+N 章の英訳を完了。Status=done の既存章と同じトーン・glossary に従って翻訳。
 
-## Translated chapters
+## Translated chapters (this run)
 
-- [ ] getting-started/installation.md (Installation)
-- [ ] basics/patterns.md (Building Patterns)
-- [ ] basics/multiple-sequences.md (Multiple Sequences)
-- [ ] basics/polyrhythm.md (Polymeter and Polyrhythm)
-- [ ] basics/audio-manipulation.md (Audio Manipulation)
-- [ ] basics/live-coding.md (Live Coding)
-- [ ] reference/methods.md (Reference)
-- [ ] troubleshooting.md (Troubleshooting)
+(List each chapter you translated as a bullet. Format: `- <path> (<English title>)`)
 
-(Replace [ ] with [x] for completed chapters)
+## Status changes
+
+- pending → done: <count>
+- outdated → done: <count>
 
 ## Source ja commit
 
-Translated against `main` at <commit-sha-here>.
+Translated against `main` at <commit-sha>.
 
 ## Verification
 
 - [ ] `npm run -w @orbitscore/user-site docs:build` passes locally
 - [ ] No dead links
 - [ ] Glossary §1 terms used consistently
-- [ ] Tone matches spike chapters (no condescending/childish phrasing)
+- [ ] Tone matches existing `done` chapters
 
 ## Glossary terms not found in glossary
 
@@ -155,29 +128,21 @@ Translated against `main` at <commit-sha-here>.
 
 ## Verification Checklist (before opening PR)
 
-- [ ] All 8 stub files overwritten with full translations
+- [ ] All target stub files (per current `TRANSLATION_STATUS.md`) overwritten with full translations
+- [ ] No `done` chapters were modified
 - [ ] `docs:build` passes with no dead links
-- [ ] Frontmatter `title` and `description` translated for all 8 files
-- [ ] Cross-chapter links use relative paths (`./other.md`, `../section/other.md`)
+- [ ] Frontmatter `title` and `description` translated
+- [ ] Cross-chapter links use relative paths
 - [ ] Code blocks unchanged (DSL, file paths, method names preserved)
 - [ ] Glossary §1 terminology applied consistently
 - [ ] No "Let's...", "You did it!", or other condescending phrasing
-- [ ] `TRANSLATION_STATUS.md` updated with `done` and commit hash
+- [ ] `TRANSLATION_STATUS.md` updated for every translated chapter
+- [ ] Summary counts (`残り: N 章` and global summary) recomputed
 
 ## Notes
 
-- This is a single-PR-for-all-chapters approach (not one PR per chapter), per project preference.
-- The output should read like a polite English tutorial written for absolute beginners — clear, kind, and respectful, but not childish.
-- If you encounter a term that should be added to the glossary, mention it in the PR description so the glossary can be updated separately.
-```
-
----
-
-## Routine 化への展望
-
-このプロンプトは将来 CronCreate routine で自動化する想定:
-
-1. ja の章が更新された commit を検出
-2. `TRANSLATION_STATUS.md` の該当章を `done` → `outdated` に変更
-3. このプロンプトを on-the-web に投げて再翻訳 PR を作成
-4. PR review → merge
+- The number of chapters per run varies. Do not assume any specific count.
+- This is a single-PR-for-all-pending approach. If `outdated` and `pending` are mixed, include both.
+- New ja chapters added since the last run will appear as `pending` rows automatically; pick them up.
+- The output should read like a polite English tutorial written for absolute beginners — clear, kind, respectful, but not childish.
+- If you encounter a term not in the glossary, suggest a glossary update in the PR description (do not modify the glossary file in this PR — that is a separate concern).


### PR DESCRIPTION
## Summary

プロンプトを「ハードコード章リスト」から「TRANSLATION_STATUS.md ベースの動的 scope」 に書き換え、Claude Desktop / on-the-web / 将来の routine から **1 行のトリガー指示**だけで起動できる形式に再設計。

## なぜ

ユーザー指摘:
> このプロンプトのファイルを指定して、翻訳作業を行え、だけを伝えるようにしたらよくないですか？

→ プロンプト本体をリポジトリに置き、トリガーは「ファイル読んで実行」 だけにすることで、プロンプト更新が PR で完結し、Claude Desktop に貼り直す必要がなくなる。

## 変更内容

- プロンプト 2 つから 8 章 / 18 章のハードコード列挙を削除
- 「TRANSLATION_STATUS.md を読んで pending / outdated の章を翻訳対象とする」 動的 scope に変更
- ブランチ名に YYYY-MM-DD 日付を含める（concurrent run 対応）
- README に 1 行トリガーコマンドを明示

## トリガーコマンド

User site:
\`\`\`
Read https://github.com/signalcompose/orbitscore/blob/main/docs/development/translation-prompts/translate-user-site.md and execute the task described in that file.
\`\`\`

Dev site:
\`\`\`
Read https://github.com/signalcompose/orbitscore/blob/main/docs/development/translation-prompts/translate-dev-site.md and execute the task described in that file.
\`\`\`

## メリット

- 章追加 → STATUS.md に行追加 → 次回自動翻訳（プロンプト触らない）
- ja 章更新 → STATUS.md で outdated マーク → 次回自動再翻訳
- プロンプト更新は PR で完結
- Routine から無修正で再 dispatch 可能

## Test plan

- [x] プロンプト本体に章リストの hardcode が無い
- [x] STATUS.md の参照が必須読み込みリストの先頭に来ている
- [x] verbatim 規律 (dev) が保持されている
- [ ] 実際にトリガー 1 行を on-the-web に投げて翻訳できるか試す

🤖 Generated with [Claude Code](https://claude.com/claude-code)