### PR TITLE
feat(bundle): include OrbitLinkAudio.scx in vsix bundle (Step 4-1)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,64 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.86 Issue #201 (Step 4-1) / Epic #187: .vsix bundle に OrbitLinkAudio.scx 同梱 (May 08, 2026)
+
+**Date**: May 08, 2026
+**Status**: ⏳ IN PROGRESS (PR pending)
+**Branch**: `201-vsix-bundle-orbit-plugin`
+**Issue**: signalcompose/orbitscore#201 (Step 4 sub-task 4-1)
+
+**目的**: Issue #201 (Epic #187 Step 4) の 4 sub-task のうち最初の 1 つ。 release build で stock SuperCollider plugin (26 個) と並んで `OrbitLinkAudio.scx` (LinkAudio dispatch UGen) を同梱し、 エンドユーザーが `.vsix` install するだけで LinkAudio 経路が使える状態を整える。
+
+残り 3 sub-task は別 PR で対応:
+- **4-2**: boot pipeline で plugin available フラグ flip (engine TS layer)
+- **4-3**: release CI workflow に sc-link-audio build step を追加
+- **4-4**: 統合 E2E checklist §A-G の自動化検収
+
+**実装内容**:
+
+- `scripts/extract-scsynth-bundle.sh` を拡張、 stock SC plugin の copy 後に
+  `packages/sc-link-audio/build/OrbitLinkAudio.scx` を bundle
+  (`Resources/plugins/`) に同梱する step を追加。 build 済 `.scx` が存在
+  しない dev workflow では warn + skip して bundle 抽出自体は成功させる
+  (LinkAudio 経路が使えない `.vsix` だが hardware fallback では動く)
+- bundle 検証 line を更新: `Plugin count: 26 stock SC + 1 custom = 27 total`
+  形式で stock 数の regression check (ABS = 26) と total count を区別
+- `packages/vscode-extension/BUILD_GUIDE.md` にビルド手順 (cmake build →
+  extract-scsynth-bundle.sh 順序) を追記、 同梱後の構造図と plugin count
+  を 27 に更新
+
+**実装ファイル**:
+- `scripts/extract-scsynth-bundle.sh` — OrbitLinkAudio.scx 同梱 step + plugin count 検証強化
+- `packages/vscode-extension/BUILD_GUIDE.md` — build 順序 + 構造図 + サイズ更新
+
+**検証結果**:
+- `bash scripts/extract-scsynth-bundle.sh` 実行成功、 OrbitLinkAudio.scx が
+  `engine/scsynth/Contents/Resources/plugins/` に正しく配置
+- `Plugin count: 26 stock SC + 1 custom = 27 total` の出力確認
+- bundle 内の OrbitLinkAudio.scx が ad-hoc 署名済 (build 時の codesign が
+  そのまま残る — Developer ID 再署名は release CI scope で別途対応予定)
+
+**設計上の判断**:
+- **同梱条件: `.scx` 存在チェックのみ**: build 失敗時に bundle 抽出も巻き
+  添えで失敗するのは過剰。 dev workflow の柔軟性を保ち、 LinkAudio 経路は
+  optional として扱う。 production の release CI では sc-link-audio の
+  cmake build step が prerequisite なので、 そちらで失敗 fail-fast に任せる
+- **bundle path**: `Resources/plugins/` 直下に置く。 SC convention (UGen
+  plugin の標準位置) と一致させ、 scsynth が `-U` で plugin path を指定
+  された時に自動で発見する
+- **Developer ID 署名は別 PR**: 本 PR は dev workflow の bundle 同梱が
+  scope。 macOS Gatekeeper 通過のための Developer ID 再署名は release CI
+  workflow (Step 4-3) と一緒に追加するのが自然
+
+**残課題** (本 PR scope 外):
+- Step 4-2: engine TS の `linkAudioPluginAvailable` フラグ flip
+- Step 4-3: release CI に sc-link-audio cmake build step + Developer ID
+  再署名
+- Step 4-4: 統合 E2E checklist 自動化
+
+---
+
 ### 6.85 Issue #205 + #206 / Epic #187: LinkAudio plugin follow-ups (May 08, 2026)
 
 **Date**: May 08, 2026

--- a/packages/vscode-extension/BUILD_GUIDE.md
+++ b/packages/vscode-extension/BUILD_GUIDE.md
@@ -61,7 +61,11 @@ fallback を持ちません。bundle が無ければ `ScsynthNotFoundError` で 
 # build 済みの .scx があれば extract-scsynth-bundle.sh が自動で同梱する。
 # 未 build の場合は warn + skip し、 stock SC plugin のみ bundle される
 # (この .vsix は LinkAudio 経路を使えないが、 hardware fallback では動く)。
-cmake -S packages/sc-link-audio -B packages/sc-link-audio/build
+# 初回 configure は SDK + Link の path 指定が必須 (CMakeLists.txt が
+# FATAL_ERROR を返す)。
+cmake -S packages/sc-link-audio -B packages/sc-link-audio/build \
+  -DSC_PATH=packages/sc-link-audio/external_libraries/supercollider-sdk \
+  -DLINK_AUDIO_PATH=packages/sc-link-audio/external_libraries/link
 cmake --build packages/sc-link-audio/build
 
 # 2. SC.app から bundle 抽出 + (上記が build 済なら) OrbitLinkAudio.scx を同梱
@@ -135,7 +139,8 @@ binary 上は動く可能性があるが未テスト。
 
 - engine のみ: 約 3.3 MB（2458ファイル）
 - scsynth bundle 同梱版: 約 14.8 MB (上記 + scsynth/plugins/libsndfile)
-- scsynth bundle + OrbitLinkAudio plugin: 約 15 MB (上記 + ~5.4 MB の OrbitLinkAudio.scx)
+- scsynth bundle + OrbitLinkAudio plugin: 約 15 MB (内訳: scsynth 1.4 MB +
+  libsndfile 4.8 MB + 26 stock plugins ~3.4 MB + OrbitLinkAudio.scx ~5.3 MB)
 - `engine/node_modules` を含む（supercolliderjs + wavefile のランタイム依存）
 
 ### scsynth bundle ディレクトリの取り扱い

--- a/packages/vscode-extension/BUILD_GUIDE.md
+++ b/packages/vscode-extension/BUILD_GUIDE.md
@@ -57,7 +57,15 @@ fallback を持ちません。bundle が無ければ `ScsynthNotFoundError` で 
   または `build:bundle` で bundle を抽出してから実行
 
 ```bash
-# SC.app から抽出 (default: SC.app 不在時 fail-fast)
+# 1. (任意) OrbitLinkAudio plugin (LinkAudio dispatch UGen) を build。
+# build 済みの .scx があれば extract-scsynth-bundle.sh が自動で同梱する。
+# 未 build の場合は warn + skip し、 stock SC plugin のみ bundle される
+# (この .vsix は LinkAudio 経路を使えないが、 hardware fallback では動く)。
+cmake -S packages/sc-link-audio -B packages/sc-link-audio/build
+cmake --build packages/sc-link-audio/build
+
+# 2. SC.app から bundle 抽出 + (上記が build 済なら) OrbitLinkAudio.scx を同梱
+#    default: SC.app 不在時 fail-fast
 cd packages/vscode-extension
 npm run build:bundle
 
@@ -74,14 +82,14 @@ packages/vscode-extension/engine/scsynth/
 ├── Contents/
 │   ├── Resources/
 │   │   ├── scsynth                (1.5 MB, universal arm64+x86_64)
-│   │   └── plugins/               (26 .scx ファイル、5.1 MB)
+│   │   └── plugins/               (26 stock .scx + OrbitLinkAudio.scx if built)
 │   └── Frameworks/
 │       └── libsndfile.dylib       (4.9 MB)
 ├── LICENSE.GPL-3.0                (legal/scsynth-LICENSE.GPL-3.0 から copy)
 └── NOTICE                          (legal/scsynth-NOTICE から copy)
 ```
 
-詳細: [`docs/research/SCSYNTH_BUNDLE_MANIFEST.md`](../../docs/research/SCSYNTH_BUNDLE_MANIFEST.md)
+詳細: [`docs/research/SCSYNTH_BUNDLE_MANIFEST.md`](../../docs/research/SCSYNTH_BUNDLE_MANIFEST.md)、 OrbitLinkAudio plugin: [`packages/sc-link-audio/README.md`](../sc-link-audio/README.md)
 
 ### 5. パッケージ化
 
@@ -127,6 +135,7 @@ binary 上は動く可能性があるが未テスト。
 
 - engine のみ: 約 3.3 MB（2458ファイル）
 - scsynth bundle 同梱版: 約 14.8 MB (上記 + scsynth/plugins/libsndfile)
+- scsynth bundle + OrbitLinkAudio plugin: 約 15 MB (上記 + ~5.4 MB の OrbitLinkAudio.scx)
 - `engine/node_modules` を含む（supercolliderjs + wavefile のランタイム依存）
 
 ### scsynth bundle ディレクトリの取り扱い

--- a/scripts/extract-scsynth-bundle.sh
+++ b/scripts/extract-scsynth-bundle.sh
@@ -165,8 +165,10 @@ fi
 echo "─────────────────────────────────────────────"
 echo "Bundle size: $(du -sh "$DEST" | cut -f1)"
 # Re-count includes OrbitLinkAudio.scx if it was bundled — `plugin_count`
-# only tracks the stock SC extraction loop above.
-total_plugin_count=$(find "$DEST/Resources/plugins" -name "*.scx" | wc -l | tr -d '[:space:]')
+# only tracks the stock SC extraction loop above. The supernova exclusion
+# filter is kept here for symmetry with the stock loop, even though the
+# extraction step never copies supernova files into the destination.
+total_plugin_count=$(find "$DEST/Resources/plugins" -name "*.scx" ! -name '*_supernova.scx' | wc -l | tr -d '[:space:]')
 echo "Plugin count: $plugin_count stock SC + $((total_plugin_count - plugin_count)) custom = $total_plugin_count total (expected stock: 26 for SC 3.14.x)"
 
 if [ "$plugin_count" -ne 26 ]; then

--- a/scripts/extract-scsynth-bundle.sh
+++ b/scripts/extract-scsynth-bundle.sh
@@ -147,9 +147,14 @@ if [ -f "$ORBIT_PLUGIN_SRC" ]; then
   cp "$ORBIT_PLUGIN_SRC" "$DEST/Resources/plugins/OrbitLinkAudio.scx"
   echo "  Bundled OrbitLinkAudio.scx (custom LinkAudio UGen)"
 else
+  # First-time configure needs the SDK + Link path overrides; subsequent
+  # `cmake --build` calls reuse the cache. CMakeLists.txt FATAL_ERRORs if
+  # either is missing on a fresh checkout.
   echo "  ⚠️  OrbitLinkAudio.scx not found at $ORBIT_PLUGIN_SRC" >&2
   echo "      Build it first with:" >&2
-  echo "        cmake -S packages/sc-link-audio -B packages/sc-link-audio/build" >&2
+  echo "        cmake -S packages/sc-link-audio -B packages/sc-link-audio/build \\" >&2
+  echo "          -DSC_PATH=packages/sc-link-audio/external_libraries/supercollider-sdk \\" >&2
+  echo "          -DLINK_AUDIO_PATH=packages/sc-link-audio/external_libraries/link" >&2
   echo "        cmake --build packages/sc-link-audio/build" >&2
   echo "      Bundle will be packaged WITHOUT LinkAudio support." >&2
 fi

--- a/scripts/extract-scsynth-bundle.sh
+++ b/scripts/extract-scsynth-bundle.sh
@@ -133,11 +133,36 @@ if [ -f "$LEGAL_SRC/scsynth-NOTICE" ]; then
 fi
 
 # ============================================================
+# OrbitLinkAudio plugin (custom UGen for LinkAudio dispatch)
+# ============================================================
+# `packages/sc-link-audio/build/OrbitLinkAudio.scx` に build 済の plugin が
+# あれば bundle に同梱する。 build 自体は CMake で別途実行する想定:
+#   cmake -S packages/sc-link-audio -B packages/sc-link-audio/build
+#   cmake --build packages/sc-link-audio/build
+# CI では plugin build step → bundle extract の順で走らせる。 dev では
+# build 済でない場合 warn して skip する (stock SC plugin だけで .vsix が
+# 動作する path を保つため)。
+ORBIT_PLUGIN_SRC="$REPO_ROOT/packages/sc-link-audio/build/OrbitLinkAudio.scx"
+if [ -f "$ORBIT_PLUGIN_SRC" ]; then
+  cp "$ORBIT_PLUGIN_SRC" "$DEST/Resources/plugins/OrbitLinkAudio.scx"
+  echo "  Bundled OrbitLinkAudio.scx (custom LinkAudio UGen)"
+else
+  echo "  ⚠️  OrbitLinkAudio.scx not found at $ORBIT_PLUGIN_SRC" >&2
+  echo "      Build it first with:" >&2
+  echo "        cmake -S packages/sc-link-audio -B packages/sc-link-audio/build" >&2
+  echo "        cmake --build packages/sc-link-audio/build" >&2
+  echo "      Bundle will be packaged WITHOUT LinkAudio support." >&2
+fi
+
+# ============================================================
 # Verification
 # ============================================================
 echo "─────────────────────────────────────────────"
 echo "Bundle size: $(du -sh "$DEST" | cut -f1)"
-echo "Plugin count: $plugin_count (expected: 26 for SC 3.14.x)"
+# Re-count includes OrbitLinkAudio.scx if it was bundled — `plugin_count`
+# only tracks the stock SC extraction loop above.
+total_plugin_count=$(find "$DEST/Resources/plugins" -name "*.scx" | wc -l | tr -d '[:space:]')
+echo "Plugin count: $plugin_count stock SC + $((total_plugin_count - plugin_count)) custom = $total_plugin_count total (expected stock: 26 for SC 3.14.x)"
 
 if [ "$plugin_count" -ne 26 ]; then
   echo "WARN: expected 26 non-supernova plugins, got $plugin_count" >&2

--- a/scripts/verify-bundle.sh
+++ b/scripts/verify-bundle.sh
@@ -38,12 +38,24 @@ fi
 [ -d "$TARGET/Contents/Resources/plugins" ] && ok "plugins directory exists" || fail "plugins directory missing"
 [ -f "$TARGET/Contents/Frameworks/libsndfile.dylib" ] && ok "libsndfile.dylib exists" || fail "libsndfile.dylib missing"
 
-# 2. Plugin count (non-supernova)
-plugin_count=$(find "$TARGET/Contents/Resources/plugins" -name '*.scx' ! -name '*_supernova.scx' 2>/dev/null | wc -l | tr -d ' ')
-if [ "$plugin_count" -eq 26 ]; then
-  ok "26 non-supernova plugins"
-elif [ "$plugin_count" -gt 0 ]; then
-  fail "expected 26 plugins, got $plugin_count (SC version may differ — verify against SCSYNTH_BUNDLE_MANIFEST.md)"
+# 2. Plugin count (non-supernova). Stock SC contributes 26 plugins; the
+# custom OrbitLinkAudio.scx is optionally bundled by extract-scsynth-bundle.sh
+# when packages/sc-link-audio/build/OrbitLinkAudio.scx exists. Validate the
+# stock count separately so a missing OrbitLinkAudio doesn't false-negative
+# the regression check, and a present OrbitLinkAudio doesn't false-negative
+# the stock count check.
+total_count=$(find "$TARGET/Contents/Resources/plugins" -name '*.scx' ! -name '*_supernova.scx' 2>/dev/null | wc -l | tr -d ' ')
+if [ -f "$TARGET/Contents/Resources/plugins/OrbitLinkAudio.scx" ]; then
+  orbit_present=1
+  ok "OrbitLinkAudio.scx present (custom LinkAudio UGen)"
+else
+  orbit_present=0
+fi
+stock_count=$((total_count - orbit_present))
+if [ "$stock_count" -eq 26 ]; then
+  ok "26 stock non-supernova plugins"
+elif [ "$total_count" -gt 0 ]; then
+  fail "expected 26 stock plugins, got $stock_count (SC version may differ — verify against SCSYNTH_BUNDLE_MANIFEST.md)"
 else
   fail "no plugins found"
 fi


### PR DESCRIPTION
## 概要

Issue #201 (Epic #187 Step 4) の **4 sub-task のうち最初の 1 つ (4-1)**。 release build で stock SC plugin (26 個) と並んで `OrbitLinkAudio.scx` (LinkAudio dispatch UGen) を `.vsix` bundle に同梱し、 エンドユーザーが `.vsix` install するだけで LinkAudio 経路が使える状態を整える。

## Step 4 の sub-task 構成

`/code:pr-review-team` review コスト + diff サイズを抑えるため、 Issue #201 を 4 PR に分割:

| sub-task | 内容 | PR |
|---|---|---|
| **4-1** | `.vsix` bundle に OrbitLinkAudio.scx 同梱 | **本 PR** |
| 4-2 | boot pipeline で `linkAudioPluginAvailable` フラグ flip (engine TS) | 別 PR |
| 4-3 | release CI に sc-link-audio cmake build + Developer ID 再署名 | 別 PR |
| 4-4 | 統合 E2E checklist §A-G 自動化 | 別 PR |

## 設計

### bundle 同梱条件: build 済 `.scx` の存在チェックのみ

`extract-scsynth-bundle.sh` を拡張し、 stock plugin (`SC.app` から copy) の後に:

```
ORBIT_PLUGIN_SRC="$REPO_ROOT/packages/sc-link-audio/build/OrbitLinkAudio.scx"
if [ -f "$ORBIT_PLUGIN_SRC" ]; then
  cp "$ORBIT_PLUGIN_SRC" "$DEST/Resources/plugins/OrbitLinkAudio.scx"
else
  # warn + skip (dev workflow で build 未実施でも bundle 抽出は成功させる)
fi
```

理由:
- build 失敗時に bundle 抽出も巻き添えで失敗するのは過剰
- dev workflow の柔軟性を保ち、 LinkAudio 経路は optional として扱う
- production の release CI (Step 4-3 で追加予定) では cmake build step が prerequisite なので、 そちらで fail-fast に任せる

### Developer ID 署名は別 PR scope

本 PR は dev workflow の bundle 同梱が scope。 macOS Gatekeeper 通過のための Developer ID 再署名は release CI workflow (Step 4-3) と一緒に追加するのが自然 (CI 環境でしか署名 cert に access できないため)。

### plugin count 検証強化

bundle 検証 line を以下に更新:

```
Plugin count: 26 stock SC + 1 custom = 27 total (expected stock: 26 for SC 3.14.x)
```

stock 数の regression check (must = 26) と total を区別。 SC version up で stock 数が変わると warn が出る既存挙動は維持。

## 変更ファイル

| File | 変更 |
|---|---|
| `scripts/extract-scsynth-bundle.sh` | OrbitLinkAudio 同梱 step 追加、 plugin count 検証強化 |
| `packages/vscode-extension/BUILD_GUIDE.md` | cmake build → extract-scsynth-bundle.sh 順序、 構造図更新、 サイズ ~15 MB |
| `docs/development/WORK_LOG.md` | §6.86 追記 |

## 検証

- ✅ `bash scripts/extract-scsynth-bundle.sh` 実行成功 (warn なし)
- ✅ `OrbitLinkAudio.scx` が `engine/scsynth/Contents/Resources/plugins/` に正しく配置 (ad-hoc 署名そのまま)
- ✅ 出力 `Plugin count: 26 stock SC + 1 custom = 27 total` 確認
- ⏳ `.vsix` package + install での実機 boot 検収は Step 4-2 (boot pipeline flag flip) と組み合わせて行う

## 関連

Refs #201
Refs #187
