### PR TITLE
Backport PUBLISH_MARKETPLACE gate to 1.1.x line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,13 @@ name: Release
 # Required GitHub secrets (set via gh secret set <name> --repo signalcompose/orbitscore):
 #   - VSCE_PAT  : VS Code Marketplace publisher token (Azure DevOps)
 #   - OVSX_PAT  : Open VSX namespace token (Eclipse Foundation account)
-# The publish steps abort with an error if these are unset, so a stable tag push on a repo
-# without secrets fails loud rather than silently skipping.
+# Required GitHub repo variable (set via gh variable set <name> --body 'true' --repo signalcompose/orbitscore):
+#   - PUBLISH_MARKETPLACE : enable Marketplace + Open VSX publish on stable tags ('true' to enable)
+# Publish gating model:
+#   - PUBLISH_MARKETPLACE != 'true' : Marketplace + Open VSX steps are skipped (GitHub Release still runs).
+#     Used while publisher accounts / PATs are not yet provisioned. Tracked in issue #197.
+#   - PUBLISH_MARKETPLACE == 'true' : Marketplace + Open VSX steps run; abort with an error if the
+#     corresponding secret is unset (fail loud rather than silently skipping).
 # Apple Developer ID secrets are NOT required — the bundled scsynth retains the SuperCollider
 # project's existing notarized signature (see docs/research/CODESIGN_PIPELINE.md).
 
@@ -137,7 +142,10 @@ jobs:
 
       - name: Publish to VS Code Marketplace (stable only)
         id: vsce_publish
-        if: startsWith(github.ref, 'refs/tags/v') && steps.release_type.outputs.is_prerelease == 'false'
+        # Gated on PUBLISH_MARKETPLACE repo variable so stable tag pushes don't fail
+        # while publisher accounts / PATs are still being provisioned (tracked in #197).
+        # Set the variable to 'true' once VSCE_PAT is registered to re-enable.
+        if: startsWith(github.ref, 'refs/tags/v') && steps.release_type.outputs.is_prerelease == 'false' && vars.PUBLISH_MARKETPLACE == 'true'
         working-directory: packages/vscode-extension
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
@@ -146,21 +154,22 @@ jobs:
           # Fail loud rather than letting vsce attempt auth with empty token
           # (which produces a confusing error vs an actionable "secret missing" message).
           if [ -z "${VSCE_PAT:-}" ]; then
-            echo "::error::VSCE_PAT secret is not set. Register it via 'gh secret set VSCE_PAT --repo signalcompose/orbitscore' before tagging stable releases." >&2
+            echo "::error::VSCE_PAT secret is not set even though PUBLISH_MARKETPLACE=true. Register it via 'gh secret set VSCE_PAT --repo signalcompose/orbitscore', or unset the variable to skip publish." >&2
             exit 1
           fi
           npx vsce publish --target "$VSIX_TARGET" --packagePath orbitscore-"$VSIX_TARGET"-*.vsix
 
       - name: Publish to Open VSX (stable only)
         id: ovsx_publish
-        if: startsWith(github.ref, 'refs/tags/v') && steps.release_type.outputs.is_prerelease == 'false'
+        # Same PUBLISH_MARKETPLACE gate as the Marketplace step. See #197.
+        if: startsWith(github.ref, 'refs/tags/v') && steps.release_type.outputs.is_prerelease == 'false' && vars.PUBLISH_MARKETPLACE == 'true'
         working-directory: packages/vscode-extension
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: |
           set -euo pipefail
           if [ -z "${OVSX_PAT:-}" ]; then
-            echo "::error::OVSX_PAT secret is not set. Register it via 'gh secret set OVSX_PAT --repo signalcompose/orbitscore' before tagging stable releases." >&2
+            echo "::error::OVSX_PAT secret is not set even though PUBLISH_MARKETPLACE=true. Register it via 'gh secret set OVSX_PAT --repo signalcompose/orbitscore', or unset the variable to skip publish." >&2
             exit 1
           fi
           npx ovsx publish orbitscore-"$VSIX_TARGET"-*.vsix -p "$OVSX_PAT"
@@ -172,6 +181,7 @@ jobs:
         env:
           TAG: ${{ github.ref_name }}
           IS_PRERELEASE: ${{ steps.release_type.outputs.is_prerelease }}
+          PUBLISH_MARKETPLACE: ${{ vars.PUBLISH_MARKETPLACE }}
           GH_RELEASE_OUTCOME: ${{ steps.gh_release.outcome }}
           VSCE_OUTCOME: ${{ steps.vsce_publish.outcome }}
           OVSX_OUTCOME: ${{ steps.ovsx_publish.outcome }}
@@ -184,6 +194,8 @@ jobs:
             PRERELEASE_LABEL="❓ **Unknown release type**"
           elif [ "$IS_PRERELEASE" = "true" ]; then
             PRERELEASE_LABEL="🧪 **Prerelease** — GitHub Release only, Marketplace/Open VSX skipped"
+          elif [ "${PUBLISH_MARKETPLACE:-}" != "true" ]; then
+            PRERELEASE_LABEL="🚀 **Stable release** — Marketplace/Open VSX gated off (PUBLISH_MARKETPLACE != 'true', see #197)"
           else
             PRERELEASE_LABEL="🚀 **Stable release** target — per-channel results below"
           fi

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,34 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.77 Issue #216 (1.1.x backport): PUBLISH_MARKETPLACE gate を release.yml に追加 (May 09, 2026)
+
+**Date**: May 09, 2026
+**Status**: ⏳ IN PROGRESS (PR pending)
+**Branch**: `216-backport-publish-marketplace-gate-1.1.x`
+**Issue**: signalcompose/orbitscore#216
+**Origin**: main の entry 6.76 (Issue #197) で導入された gate を 1.1.x にも backport
+
+**動機**: v1.1.1 tag push (release run 25605590449, May 09) で `Publish to VS Code Marketplace` step が `VSCE_PAT` 未登録のまま failure、 `Publish to Open VSX` も skip された partial failure が発生。 main 側では entry 6.76 (May 07) で `vars.PUBLISH_MARKETPLACE == 'true'` gate を入れて、 secret 未登録環境でも GitHub Release だけ成功する clean run になるよう整備していたが、 1.1.x line に backport されておらず ICMC 直前で再露呈した。
+
+**変更内容** (`.github/workflows/release.yml`):
+
+1. **header docstring 更新**: `PUBLISH_MARKETPLACE` repo variable の役割と publish gating model (`!= 'true'` → skip / `== 'true'` → 必須) を明記
+2. **`Publish to VS Code Marketplace` step の `if:` 条件**:
+   - 旧: `startsWith(github.ref, 'refs/tags/v') && steps.release_type.outputs.is_prerelease == 'false'`
+   - 新: 上記に `&& vars.PUBLISH_MARKETPLACE == 'true'` を追加
+3. **`Publish to Open VSX` step の `if:` 条件**: 同 gate を追加
+4. **error message 更新**: 「`VSCE_PAT` 未登録なのに `PUBLISH_MARKETPLACE=true` が立っている」 という actionable な文言に書き換え
+5. **`Summary` step**: `PUBLISH_MARKETPLACE` を env に注入、 stable + gate off 時は `🚀 Stable release — Marketplace/Open VSX gated off (PUBLISH_MARKETPLACE != 'true', see #197)` を表示
+
+**期待効果**:
+- v1.1.1 を tag 打ち直しした際、 secret 未整備のまま Marketplace/Open VSX step が `if:` で skip され、 GitHub Release のみ作成の clean SUCCESS run になる
+- secret 整備後は `gh variable set PUBLISH_MARKETPLACE --body 'true' --repo signalcompose/orbitscore` で gate を開けば再 enable
+
+**スコープ外**:
+- `VSCE_PAT` / `OVSX_PAT` 自体の登録は本 PR では扱わない (Yamato 側の credentials)
+- main の v1.2.0 line への影響なし (main 側は entry 6.76 で導入済)
+
 ### 6.76 Issue #212 (1.1.x backport): LOOP/RUN scheduler を quantize 起動に変更 (May 09, 2026)
 
 **Date**: May 09, 2026


### PR DESCRIPTION
## Summary

main の entry 6.76 (Issue #197) で `release.yml` に導入された `vars.PUBLISH_MARKETPLACE == 'true'` gate を 1.1.x line にも backport。

## 背景

v1.1.1 tag push ([release run 25605590449](https://github.com/signalcompose/orbitscore/actions/runs/25605590449)) で Marketplace publish step が `VSCE_PAT` 未登録のまま failure、 Open VSX も skip された partial failure が発生した。 main では entry 6.76 (May 07) で gate を入れて secret 未整備環境でも GitHub Release のみ作成の clean run になるよう整備済だったが、 1.1.x line には backport 漏れがあり ICMC 直前で再露呈した。

## 変更内容

`.github/workflows/release.yml` を main の最新版と同期 (gate 関連変更のみ):

- header docstring に `PUBLISH_MARKETPLACE` の使い方を追記
- `Publish to VS Code Marketplace` / `Publish to Open VSX` step の `if:` 条件に `&& vars.PUBLISH_MARKETPLACE == 'true'` を追加
- error message を 「gate ON なのに secret 未登録」 という actionable な文言に変更
- `Summary` step で gate off 時に `🚀 Stable release — Marketplace/Open VSX gated off` を表示

## 期待効果

- v1.1.1 tag 再作成 → Marketplace step が `if:` で skip → GitHub Release のみ作成の clean SUCCESS run
- secret 整備後は `gh variable set PUBLISH_MARKETPLACE --body 'true'` で gate を開いて publish 再開

## Test plan

- [ ] PR merge 後、v1.1.1 tag を新 HEAD で再作成
- [ ] release.yml が SUCCESS で完了し Marketplace/Open VSX が正しく skip されること
- [ ] GitHub Release v1.1.1 が `.vsix` asset 付きで作成されること
- [ ] Summary step に gate off 表示が出ること

Closes #216