### PR TITLE
feat(dsl): Phase 2 — .root()/.mode()/.oct() group scope chains (§2.3, §3)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -51,7 +51,11 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **Phase 2 完了**: パーサー + timing + dispatch + エディタ支援。テスト 863 passed / 23 skipped。core spec はポインタ規約で反映。
 
-**次**: Phase 2 PR 作成 → レビュー。follow-up: span レベルハイライト（PlayScoped offset 要）、Phase 3 (#231 `[ ]` スタック + chord 値)。
+**Phase 2 PR**: #247 作成済み。
+
+**/simplify パス (2026-06-13)**: 4観点で Phase 2 production code (787行) をレビュー。適用4件: (A) 共有 `collapseScopedRun` で parser の run-collapse 重複を統合（pre/post-push の drift 解消、3 agent が指摘）、(B) 共有 `degreeRootToPitchClass` で度数解決カーネル統合、(D) `resolveScope` 空スタック早期 return、(E) `.mode()` エラーが `ScopeMode.raw` を使用（dead field 解消）。スキップ: 条件スプレッド・timing/dispatch 分離（正しい層）、microopt、diff 外の paren ループ。863 passed 維持。
+
+**次**: `/code:pr-review-team` で #247 をレビュー（critical/important=0 まで）→ マージ判断。follow-up: span レベルハイライト（PlayScoped offset 要）、Phase 3 (#231 `[ ]` スタック + chord 値)。
 
 ---
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -33,7 +33,13 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **テスト**: `tests/audio-parser/scope-chain-parsing.spec.ts` 20件（音名/度数 root、oct、mode 予約、重複/衝突/chain-closes エラー、並置 run 集約、§3 入れ子 override 例、no-chain 並置の回帰ガード）。全体 848 passed / 23 skipped。
 
-**次**: B5 timing 透過 + scope descriptor 付与 → B6 dispatch スコープ解決（inner→outer→seq→error）→ B7 `.oct()`×`^N` 合成（要・大和確認: additive 推奨）→ VS Code セマンティックハイライト（Sonnet 委譲）→ core spec 反映。
+**追加コミット (B5-B6: dispatch スコープ解決)**:
+- `timing/calculation/types.ts`: `TimedEvent.scope`（TimedEventScope: root/mode/groupOct）追加
+- `timing/calculation/calculate-event-timing.ts`: scope スタックをツリー walk でスレッド、PlayScoped は timing 透過（並置と同じスロット）+ frame push、各リーフに inner→outer 解決した scope を付与
+- `core/sequence.ts`: `resolveScopeToContext(scope, getSeqDefault)` を追加し scheduleMidiEvents / validateMidiDispatch で per-event 解決。音名 root は key 不要・度数 root は key 必須（未宣言はエラー）・mode は throw。seq 既定は遅延算出（音名 root のみのシーケンスが key を要求されないように）
+- テスト: `scope-timing.spec.ts` 4件（timing 透過 + inner→outer + groupOct）、`sequence-scope-dispatch.spec.ts` 8件（音名/度数 root、並置共有、入れ子 override、key 有無、mode 拒否）。全体 860 passed。
+
+**次**: B7 `.oct()`×`^N` 合成（**要・大和確認**: additive 推奨）→ VS Code セマンティックハイライト（Sonnet 委譲）→ core spec 反映。
 
 ---
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -39,7 +39,9 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 - `core/sequence.ts`: `resolveScopeToContext(scope, getSeqDefault)` を追加し scheduleMidiEvents / validateMidiDispatch で per-event 解決。音名 root は key 不要・度数 root は key 必須（未宣言はエラー）・mode は throw。seq 既定は遅延算出（音名 root のみのシーケンスが key を要求されないように）
 - テスト: `scope-timing.spec.ts` 4件（timing 透過 + inner→outer + groupOct）、`sequence-scope-dispatch.spec.ts` 8件（音名/度数 root、並置共有、入れ子 override、key 有無、mode 拒否）。全体 860 passed。
 
-**次**: B7 `.oct()`×`^N` 合成（**要・大和確認**: additive 推奨）→ VS Code セマンティックハイライト（Sonnet 委譲）→ core spec 反映。
+**追加コミット (B7: `.oct()`×`^N` 合成)**: 大和確認で **additive** に決定。`effectiveOctave = runningRange + groupOct`（§9.3 直交＝足し合わせ）。`^N` は `.oct()` グループを抜けても持続（§9.4 linear）、groupOct は running range にフィードバックしない。テスト3件追加（加算合成 / oct 単独 / `^N` 持続）。全体 863 passed。
+
+**次**: VS Code セマンティックハイライト（Sonnet 委譲）→ core spec 反映（B8）→ Phase 2 PR。
 
 ---
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,26 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.106 Issue #230 — Phase 2: `.root()`/`.mode()`/`.oct()` グループスコープ — パーサー層 (Jun 13, 2026)
+
+**Date**: 2026-06-13
+**Status**: 🚧 IN PROGRESS (パーサー層完了。dispatch のスコープ解決は後続コミット)
+**Issue**: signalcompose/orbitscore#230
+**Branch**: `230-phase-2-root-group-chains`
+
+**設計**: code-architect で blueprint を策定（PlayScoped 新ノード、スコープは calculateEventTiming のツリー walk で捕捉しフラット dispatch では per-event descriptor で消費、共有 run ヘルパで no-chain 並置の splice を保全、build sequence B0-B8）。spec §2.3/§3 正本。
+
+**本コミット（パーサー層 B1-B4 のパーサー部分）**:
+- `parser/types.ts`: `PlayScoped`/`ScopeRoot`/`ScopeMode` を追加、PlayElement union に。スコープチェーンが有る時だけ生成（no-chain 並置は従来通り別 sibling）
+- `parser/parse-expression.ts`: `parseScopeChain`（root/mode/oct、重複・root+mode 衝突を diagnostic エラー、last-wins 不採用）、`parseRootArg`（音名 F#/Bb/C をトークンから再構成 + 度数 3/b6、`noteNameToPitchClass` 再利用）、`parseModeArg`（mode 予約＝raw 捕捉、dispatch で throw 予定）、`assertChainClosesRun`（チェーン直後カンマなし `(` = エラー §3）、`collapseScopedRun`（並置 run を1スコープに集約）
+- `parser/parse-statement.ts`: `parseArguments` に run 集約（`(A)(B).root(X)` を1ノードに、カンマが run 境界）
+
+**テスト**: `tests/audio-parser/scope-chain-parsing.spec.ts` 20件（音名/度数 root、oct、mode 予約、重複/衝突/chain-closes エラー、並置 run 集約、§3 入れ子 override 例、no-chain 並置の回帰ガード）。全体 848 passed / 23 skipped。
+
+**次**: B5 timing 透過 + scope descriptor 付与 → B6 dispatch スコープ解決（inner→outer→seq→error）→ B7 `.oct()`×`^N` 合成（要・大和確認: additive 推奨）→ VS Code セマンティックハイライト（Sonnet 委譲）→ core spec 反映。
+
+---
+
 ### 6.105 Issue #228 — Phase 1: 度数記法の再設計 (pitch range / スティッキー `^N`) (Jun 13, 2026)
 
 **Date**: 2026-06-13

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -55,7 +55,13 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **/simplify パス (2026-06-13)**: 4観点で Phase 2 production code (787行) をレビュー。適用4件: (A) 共有 `collapseScopedRun` で parser の run-collapse 重複を統合（pre/post-push の drift 解消、3 agent が指摘）、(B) 共有 `degreeRootToPitchClass` で度数解決カーネル統合、(D) `resolveScope` 空スタック早期 return、(E) `.mode()` エラーが `ScopeMode.raw` を使用（dead field 解消）。スキップ: 条件スプレッド・timing/dispatch 分離（正しい層）、microopt、diff 外の paren ループ。863 passed 維持。
 
-**次**: `/code:pr-review-team` で #247 をレビュー（critical/important=0 まで）→ マージ判断。follow-up: span レベルハイライト（PlayScoped offset 要）、Phase 3 (#231 `[ ]` スタック + chord 値)。
+**/code:pr-review-team イテレーション1 (#247)**: 4 専門レビュアー。Critical 0、Important 修正:
+- **(silent-failure) `.root(0)` のサイレント tonic fallback**: 群 `.root()` は seq.root() の guard が無く degree 0 が黙って key tonic に落ちていた → `parseRootArg` に degree<1 の parse エラー（`expectRootDegree`）+ `degreeRootToPitchClass` の silent fallback を throw に。
+- **(comment) 度数範囲 `1-12` 誤記**（受理は {1-9,11,13}）→ tmLanguage + 補完 + hover の3箇所を `1-9, 11, 13` に修正。
+- **(test) カバレッジ +9**: nested レベルの run-collapse（`((1)(2).root(3), 5)`、/simplify の共有関数を両経路で検証）、不正 root 引数（`.root(0)`/`.root(b0)`/`.root(H)`/空）、note-root + bare degree 混在で no-key reject、inner `.oct()` × outer `.root()` 別フレーム、`.oct(-N)`。
+- code-reviewer は Critical/Important ゼロ。872 passed。
+
+**次**: イテレーション2（再レビュー）→ マージ判断。follow-up: span レベルハイライト（PlayScoped offset 要）、Phase 3 (#231)。
 
 ---
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -43,9 +43,15 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **B8 core spec 反映**: Phase 1 の前例に倣い、core spec (`INSTRUCTION_ORBITSCORE_DSL.md`) は line 12 の「v1.1 は specs-v2 が正本」ポインタで反映済みとする（§2.3/§3 を core spec に複製すると specs-v2 と二重保守＝乖離リスク。operating rule #7 の眼目「乖離を作らない」はポインタで満たす）。v1.1 安定後にまとめて fold-in する方針。
 
-**VS Code セマンティックハイライト**: Sonnet subagent に委譲（packages/vscode-extension、§5「拡張側に閉じる」）。完了時に別コミットで同梱。
+**VS Code エディタ支援**（Sonnet subagent、§5「拡張側に閉じる」、main がレビュー）:
+- `syntaxes/orbitscore-audio.tmLanguage.json`: `.root()`/`.mode()`/`.oct()` チェーンの TextMate ハイライト（begin/end で引数内の `F#` を保護）+ 音名/度数/整数の引数ハイライト
+- `src/extension.ts`: root/mode/oct の hover + play() 引数内 `).` 文脈での補完（paren balance ガードで `play(...).` の誤発火を回避）
+- **main レビューで修正**: (1) grammar の legacy `#.*$` コメント規則を**削除**（OrbitScore のコメントは `//`、`#` は ACCIDENTAL。この規則が `#5`/`F#`/`##1` を全域でコメント誤認していた＝Phase 1 シャープ表示のバグ。agent の begin/end 回避の根本原因を除去）。(2) hover 例の `(1 2 3)` → `(1, 2, 3)`（OrbitScore はカンマ区切り）
+- **span レベルのセマンティックハイライト（並置 run の可視化）は見送り**: `PlayScoped` ノードにソース位置(offset)が無く、実装には engine パーサー拡張（PlayScoped に startOffset/endOffset）+ `DocumentSemanticTokensProvider` + package.json の semanticTokenTypes が必要。「`.root()`+カンマ両忘れ→静かな併合」緩和の本命だが engine 変更を伴うため follow-up（chain-closes/重複のパースエラーで多くは既に検出される）。
 
-**次**: VS Code ハイライト fold-in → Phase 2 PR → レビュー。
+**Phase 2 完了**: パーサー + timing + dispatch + エディタ支援。テスト 863 passed / 23 skipped。core spec はポインタ規約で反映。
+
+**次**: Phase 2 PR 作成 → レビュー。follow-up: span レベルハイライト（PlayScoped offset 要）、Phase 3 (#231 `[ ]` スタック + chord 値)。
 
 ---
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -61,7 +61,9 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 - **(test) カバレッジ +9**: nested レベルの run-collapse（`((1)(2).root(3), 5)`、/simplify の共有関数を両経路で検証）、不正 root 引数（`.root(0)`/`.root(b0)`/`.root(H)`/空）、note-root + bare degree 混在で no-key reject、inner `.oct()` × outer `.root()` 別フレーム、`.oct(-N)`。
 - code-reviewer は Critical/Important ゼロ。872 passed。
 
-**次**: イテレーション2（再レビュー）→ マージ判断。follow-up: span レベルハイライト（PlayScoped offset 要）、Phase 3 (#231)。
+**/code:pr-review-team イテレーション2 (#247)**: 再レビュー（code-reviewer + silent-failure-hunter）でイテレーション1修正が正しく新規問題なしを確認（Critical 0 / Important 0）。surfaced Minor 1件を fold-in: `expectRootDegree` に `Number.isInteger` チェック追加（seq.root() setter と対称、`.root(1.5)` を parse エラーに）+ テスト。**完了条件達成: Critical 0 / Important 0 / security pass**。873 passed / 23 skipped。
+
+**次**: #247 マージ判断（ユーザー指示待ち）。follow-up: span レベルハイライト（PlayScoped offset 要）、Phase 3 (#231 `[ ]` スタック + chord 値)。
 
 ---
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -41,7 +41,11 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **追加コミット (B7: `.oct()`×`^N` 合成)**: 大和確認で **additive** に決定。`effectiveOctave = runningRange + groupOct`（§9.3 直交＝足し合わせ）。`^N` は `.oct()` グループを抜けても持続（§9.4 linear）、groupOct は running range にフィードバックしない。テスト3件追加（加算合成 / oct 単独 / `^N` 持続）。全体 863 passed。
 
-**次**: VS Code セマンティックハイライト（Sonnet 委譲）→ core spec 反映（B8）→ Phase 2 PR。
+**B8 core spec 反映**: Phase 1 の前例に倣い、core spec (`INSTRUCTION_ORBITSCORE_DSL.md`) は line 12 の「v1.1 は specs-v2 が正本」ポインタで反映済みとする（§2.3/§3 を core spec に複製すると specs-v2 と二重保守＝乖離リスク。operating rule #7 の眼目「乖離を作らない」はポインタで満たす）。v1.1 安定後にまとめて fold-in する方針。
+
+**VS Code セマンティックハイライト**: Sonnet subagent に委譲（packages/vscode-extension、§5「拡張側に閉じる」）。完了時に別コミットで同梱。
+
+**次**: VS Code ハイライト fold-in → Phase 2 PR → レビュー。
 
 ---
 

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -10,6 +10,7 @@ import { AudioEngine } from '../audio/types'
 import { PlayElement, RandomValue } from '../parser/audio-parser'
 import { resolveDegree } from '../midi/degree-resolution'
 import { RootContext } from '../midi/types'
+import { TimedEventScope } from '../timing/calculation/types'
 
 import { Global } from './global'
 import { Scheduler } from './global/types'
@@ -474,6 +475,49 @@ export class Sequence {
   }
 
   /**
+   * Resolve a per-event lexical group scope (§3) to a RootContext. A group
+   * `.root()` (already collapsed inner→outer in the timing walk) overrides the
+   * sequence default; `.mode()` is reserved (throws — Phase 2.2); no scope (or
+   * an oct-only scope) falls back to the sequence default. A degree root
+   * resolves against `global.key()` exactly like a sequence root (§2.3) — a
+   * numeric/degree root with no key declared is an error here.
+   */
+  private resolveScopeToContext(
+    scope: TimedEventScope | undefined,
+    getSeqDefault: () => RootContext,
+  ): RootContext {
+    // The seq default is taken lazily: a note-name-rooted event needs no key
+    // (§2.3), so a sequence that only uses note roots must not be forced to
+    // declare global.key() just to compute a default it never uses.
+    if (!scope || (scope.root === undefined && scope.mode === undefined)) {
+      return getSeqDefault()
+    }
+    const name = this.stateManager.getName() || 'sequence'
+    if (scope.mode !== undefined) {
+      throw new Error(
+        `Sequence '${name}': .mode() is not implemented in v1.1 (the mode lattice is Phase 2.2).`,
+      )
+    }
+    const root = scope.root!
+    if (root.kind === 'note') {
+      return { rootPitchClass: root.pitchClass, octave: this._octave }
+    }
+    // Degree root: resolve against the key (key-undeclared = error).
+    const keyPC = this.global.getMidiManager().getKeyPitchClass()
+    if (keyPC === undefined) {
+      throw new Error(
+        `Sequence '${name}': a degree root (.root(${root.degree})) needs global.key("C").`,
+      )
+    }
+    const resolved = resolveDegree(
+      { degree: root.degree, alteration: root.alteration, octaveShift: 0, detune: 0 },
+      { rootPitchClass: keyPC, octave: 0 },
+    )
+    const rootPitchClass = resolved ? ((resolved.midiNote % 12) + 12) % 12 : keyPC
+    return { rootPitchClass, octave: this._octave }
+  }
+
+  /**
    * Eagerly validate a MIDI sequence's dispatch before scheduling: resolve the
    * root context (key/root errors) AND resolve every degree once (so a rejected
    * degree — 10/12/14/15+, §2.1 — throws here). This runs synchronously in the
@@ -484,10 +528,15 @@ export class Sequence {
    */
   private validateMidiDispatch(): void {
     if (!this.isMidi()) return
-    const context = this.resolveRootContext()
     const timedEvents = this.stateManager.getTimedEvents()
     if (!timedEvents) return
+    let seqDefault: RootContext | undefined
+    const getSeqDefault = (): RootContext => (seqDefault ??= this.resolveRootContext())
     for (const ev of timedEvents) {
+      // Resolve the per-event group scope (§3) so a bad scope (.mode, a degree
+      // root with no key) or a rejected degree throws here, in the awaited
+      // chain, rather than later in the fire-and-forget scheduling callback.
+      const context = this.resolveScopeToContext(ev.scope, getSeqDefault)
       const symbolic = ev.pitch ?? {
         degree: ev.sliceNumber,
         alteration: 0,
@@ -518,7 +567,10 @@ export class Sequence {
     const owner = this.stateManager.getName()
     const port = this._midiPort!
     const channel = this._midiChannel!
-    const context = this.resolveRootContext()
+    // Sequence-default context, computed lazily (only if some event falls back
+    // to it — a note-name-rooted-only sequence needs no key, §2.3).
+    let seqDefault: RootContext | undefined
+    const getSeqDefault = (): RootContext => (seqDefault ??= this.resolveRootContext())
     const sendDelay = midi.sendDelayFor(port)
 
     // §2.4 sticky pitch range: a note/rest with an explicit `^N` (rangeSet) sets
@@ -538,7 +590,11 @@ export class Sequence {
       if (written.rangeSet) {
         runningRange = written.octaveShift
       }
+      // Per-event group scope (§3): a group `.root()` overrides the sequence
+      // default for this note (inner→outer already collapsed in the timing walk).
+      const context = this.resolveScopeToContext(ev.scope, getSeqDefault)
       // Resolve at the effective running range, not the per-note `^N` literal.
+      // (`.oct()` group register composition with `^N` arrives in B7.)
       const symbolic = { ...written, octaveShift: runningRange }
       const resolved = resolveDegree(symbolic, context)
       if (!resolved) {

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -478,7 +478,13 @@ export class Sequence {
       { degree, alteration, octaveShift: 0, detune: 0 },
       { rootPitchClass: keyPC, octave: 0 },
     )
-    return resolved ? ((resolved.midiNote % 12) + 12) % 12 : keyPC
+    if (!resolved) {
+      // resolveDegree returns null only for degree 0 (a rest). A rest is not a
+      // valid pitch center — never silently fall back to the key tonic. (Both
+      // callers also guard upstream: seq.root() setter + parseRootArg.)
+      throw new Error('root degree 0 is a rest, not a valid root.')
+    }
+    return ((resolved.midiNote % 12) + 12) % 12
   }
 
   /**

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -593,9 +593,12 @@ export class Sequence {
       // Per-event group scope (§3): a group `.root()` overrides the sequence
       // default for this note (inner→outer already collapsed in the timing walk).
       const context = this.resolveScopeToContext(ev.scope, getSeqDefault)
-      // Resolve at the effective running range, not the per-note `^N` literal.
-      // (`.oct()` group register composition with `^N` arrives in B7.)
-      const symbolic = { ...written, octaveShift: runningRange }
+      // Effective octave = sticky running range (`^N`, linear) + group register
+      // (`.oct()`, lexical). The two are orthogonal axes and compose additively
+      // (§9.3); `.oct()` is local to its group, while `^N` persists across group
+      // boundaries (§9.4), so groupOct never feeds back into runningRange.
+      const effectiveOctave = runningRange + (ev.scope?.groupOct ?? 0)
+      const symbolic = { ...written, octaveShift: effectiveOctave }
       const resolved = resolveDegree(symbolic, context)
       if (!resolved) {
         continue // rest (degree 0)

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -459,19 +459,26 @@ export class Sequence {
       )
     }
 
-    let rootPitchClass = keyPC
-    if (this._rootDegree !== undefined) {
-      // The numeric root resolves against the key exactly like any degree (§2.3).
-      const resolved = resolveDegree(
-        { degree: this._rootDegree, alteration: 0, octaveShift: 0, detune: 0 },
-        { rootPitchClass: keyPC, octave: 0 },
-      )
-      if (resolved) {
-        rootPitchClass = ((resolved.midiNote % 12) + 12) % 12
-      }
-    }
+    // The numeric root resolves against the key exactly like any degree (§2.3).
+    const rootPitchClass =
+      this._rootDegree !== undefined
+        ? this.degreeRootToPitchClass(this._rootDegree, 0, keyPC)
+        : keyPC
 
     return { rootPitchClass, octave: this._octave }
+  }
+
+  /**
+   * Resolve a degree against the key to a pitch class — shared by the sequence
+   * root (§2.3) and a group `.root(degree)` scope. The degree numbers from the
+   * key tonic at octave 0; only the resulting pitch class is kept.
+   */
+  private degreeRootToPitchClass(degree: number, alteration: number, keyPC: number): number {
+    const resolved = resolveDegree(
+      { degree, alteration, octaveShift: 0, detune: 0 },
+      { rootPitchClass: keyPC, octave: 0 },
+    )
+    return resolved ? ((resolved.midiNote % 12) + 12) % 12 : keyPC
   }
 
   /**
@@ -495,7 +502,8 @@ export class Sequence {
     const name = this.stateManager.getName() || 'sequence'
     if (scope.mode !== undefined) {
       throw new Error(
-        `Sequence '${name}': .mode() is not implemented in v1.1 (the mode lattice is Phase 2.2).`,
+        `Sequence '${name}': .mode(${scope.mode.raw}) is not implemented in v1.1 ` +
+          `(the mode lattice is Phase 2.2).`,
       )
     }
     const root = scope.root!
@@ -509,12 +517,10 @@ export class Sequence {
         `Sequence '${name}': a degree root (.root(${root.degree})) needs global.key("C").`,
       )
     }
-    const resolved = resolveDegree(
-      { degree: root.degree, alteration: root.alteration, octaveShift: 0, detune: 0 },
-      { rootPitchClass: keyPC, octave: 0 },
-    )
-    const rootPitchClass = resolved ? ((resolved.midiNote % 12) + 12) % 12 : keyPC
-    return { rootPitchClass, octave: this._octave }
+    return {
+      rootPitchClass: this.degreeRootToPitchClass(root.degree, root.alteration, keyPC),
+      octave: this._octave,
+    }
   }
 
   /**

--- a/packages/engine/src/parser/parse-expression.ts
+++ b/packages/engine/src/parser/parse-expression.ts
@@ -523,17 +523,32 @@ export class ExpressionParser {
       this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
       const num = ParserUtils.expect(this.tokens, this.pos, 'NUMBER')
       this.pos = num.newPos
-      return { kind: 'degree', degree: ParserUtils.parseNumber(num.token), alteration }
+      return { kind: 'degree', degree: this.expectRootDegree(num.token), alteration }
     }
 
     if (cur.type === 'NUMBER') {
       this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
-      return { kind: 'degree', degree: ParserUtils.parseNumber(cur), alteration: 0 }
+      return { kind: 'degree', degree: this.expectRootDegree(cur), alteration: 0 }
     }
 
     throw new Error(
       `.root() expects a note name (e.g. F#) or a degree (e.g. 3, b6), got ${cur.type}`,
     )
+  }
+
+  /**
+   * Parse a degree-root number, rejecting 0 (a rest is not a valid pitch center).
+   * Parallels the `seq.root()` setter guard — `.root(0)` must error, not silently
+   * fall back to the key tonic (§2.3).
+   */
+  private expectRootDegree(token: AudioToken): number {
+    const degree = ParserUtils.parseNumber(token)
+    if (degree < 1) {
+      throw new Error(
+        `.root() degree must be a positive degree (1+); 0 is a rest, not a valid root.`,
+      )
+    }
+    return degree
   }
 
   /**

--- a/packages/engine/src/parser/parse-expression.ts
+++ b/packages/engine/src/parser/parse-expression.ts
@@ -543,9 +543,11 @@ export class ExpressionParser {
    */
   private expectRootDegree(token: AudioToken): number {
     const degree = ParserUtils.parseNumber(token)
-    if (degree < 1) {
+    // Match the seq.root() setter guard: a positive integer. 0 is a rest, and a
+    // fractional degree is meaningless (would otherwise throw later at resolve).
+    if (!Number.isInteger(degree) || degree < 1) {
       throw new Error(
-        `.root() degree must be a positive degree (1+); 0 is a rest, not a valid root.`,
+        `.root() degree must be a positive integer (1+); 0 is a rest, not a valid root.`,
       )
     }
     return degree

--- a/packages/engine/src/parser/parse-expression.ts
+++ b/packages/engine/src/parser/parse-expression.ts
@@ -3,6 +3,8 @@
  * Based on specification: docs/INSTRUCTION_ORBITSCORE_DSL.md
  */
 
+import { noteNameToPitchClass } from '../midi/note-name'
+
 import {
   AudioToken,
   RandomValue,
@@ -11,6 +13,9 @@ import {
   PlayWithModifier,
   PlayModifier,
   PlayPitch,
+  PlayScoped,
+  ScopeRoot,
+  ScopeMode,
   Meter,
 } from './types'
 import { ParserUtils } from './parser-utils'
@@ -421,10 +426,141 @@ export class ExpressionParser {
   }
 
   /**
+   * Parse a `.root()` / `.mode()` / `.oct()` pitch-scope chain after a group
+   * (§2.3, §3). Returns the accumulated scope. Duplicate or conflicting chains
+   * (`.root().root()`, `.root()`+`.mode()`) are diagnostic errors — last-wins is
+   * not allowed; only nesting overrides (§3, decision #10). The scope stays
+   * symbolic here; it is resolved lexically at dispatch (§7-0).
+   */
+  private parseScopeChain(): { root?: ScopeRoot; mode?: ScopeMode; oct?: number } {
+    const scope: { root?: ScopeRoot; mode?: ScopeMode; oct?: number } = {}
+
+    while (ParserUtils.current(this.tokens, this.pos).type === 'DOT') {
+      const method = ParserUtils.peek(this.tokens, this.pos).value
+      if (method !== 'root' && method !== 'mode' && method !== 'oct') break
+
+      this.pos = ParserUtils.advance(this.tokens, this.pos).newPos // DOT
+      this.pos = ParserUtils.advance(this.tokens, this.pos).newPos // method IDENTIFIER
+      const lparen = ParserUtils.expect(this.tokens, this.pos, 'LPAREN')
+      this.pos = lparen.newPos
+
+      if (method === 'root') {
+        if (scope.root !== undefined) {
+          throw new Error(
+            'duplicate .root() on the same group — last-wins is not allowed; ' +
+              'override only by nesting (§3)',
+          )
+        }
+        if (scope.mode !== undefined) {
+          throw new Error('.root() and .mode() cannot both be set on the same group (§3)')
+        }
+        scope.root = this.parseRootArg()
+      } else if (method === 'mode') {
+        if (scope.mode !== undefined) {
+          throw new Error('duplicate .mode() on the same group (§3)')
+        }
+        if (scope.root !== undefined) {
+          throw new Error('.root() and .mode() cannot both be set on the same group (§3)')
+        }
+        scope.mode = this.parseModeArg()
+      } else {
+        if (scope.oct !== undefined) {
+          throw new Error('duplicate .oct() on the same group (§3)')
+        }
+        scope.oct = this.parseSignedNumber()
+      }
+
+      const rparen = ParserUtils.expect(this.tokens, this.pos, 'RPAREN')
+      this.pos = rparen.newPos
+    }
+
+    return scope
+  }
+
+  /**
+   * Parse a `.root()` argument: a note name (`F#`, `Bb`, `C`) or a degree of
+   * `global.key()` (`3`, `b6`). Note names are reassembled from tokens here (no
+   * tokenizer mode): `Bb`/`C` arrive as one IDENTIFIER; `F#` as IDENTIFIER + a
+   * `#` ACCIDENTAL. The pitch class is resolved now; the spelling is kept for
+   * §7-0 reversibility. Degree roots resolve against the key at dispatch.
+   */
+  private parseRootArg(): ScopeRoot {
+    const cur = ParserUtils.current(this.tokens, this.pos)
+
+    if (cur.type === 'IDENTIFIER') {
+      this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
+      let spelling = cur.value
+      // `Bb`/`Db` already carry their flats in the identifier; only a sharp run
+      // lexes separately as an ACCIDENTAL, so append that if present.
+      const next = ParserUtils.current(this.tokens, this.pos)
+      if (next.type === 'ACCIDENTAL' && next.value[0] === '#') {
+        this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
+        spelling += next.value
+      }
+      return { kind: 'note', pitchClass: noteNameToPitchClass(spelling), spelling }
+    }
+
+    if (cur.type === 'ACCIDENTAL') {
+      const alteration = this.accidentalToAlteration(cur.value)
+      this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
+      const num = ParserUtils.expect(this.tokens, this.pos, 'NUMBER')
+      this.pos = num.newPos
+      return { kind: 'degree', degree: ParserUtils.parseNumber(num.token), alteration }
+    }
+
+    if (cur.type === 'NUMBER') {
+      this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
+      return { kind: 'degree', degree: ParserUtils.parseNumber(cur), alteration: 0 }
+    }
+
+    throw new Error(
+      `.root() expects a note name (e.g. F#) or a degree (e.g. 3, b6), got ${cur.type}`,
+    )
+  }
+
+  /**
+   * Parse a `.mode()` argument. v1.1 reserves the syntax (mode lattice = Phase
+   * 2.2): capture the raw arg for duplicate/conflict diagnostics; dispatch
+   * throws not-implemented (parallel to time()/fixpitch()).
+   */
+  private parseModeArg(): ScopeMode {
+    const parts: string[] = []
+    while (
+      ParserUtils.current(this.tokens, this.pos).type !== 'RPAREN' &&
+      !ParserUtils.isEOF(this.tokens, this.pos)
+    ) {
+      parts.push(String(ParserUtils.current(this.tokens, this.pos).value ?? ''))
+      this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
+    }
+    return { kind: 'unimplemented', raw: parts.join(' ') }
+  }
+
+  /**
+   * §3 "a chain closes the juxtaposition run": after a `.root()/.mode()/.oct()`
+   * chain, a `(` with no comma is a parse error — the comma (or `)` / arg end)
+   * bounds the run. Newlines are lexically insignificant, so skip them first.
+   * Peeks only; does not advance.
+   */
+  private assertChainClosesRun(): void {
+    const after = ParserUtils.skipNewlines(this.tokens, this.pos)
+    if (ParserUtils.current(this.tokens, after).type === 'LPAREN') {
+      throw new Error(
+        'expected comma after chained group: a .root()/.mode()/.oct() chain ' +
+          'closes the juxtaposition run (§3)',
+      )
+    }
+  }
+
+  /**
    * Parse nested play structure
    */
-  private parseNestedPlay(): { value: PlayNested | PlayWithModifier; newPos: number } {
+  private parseNestedPlay(): {
+    value: PlayNested | PlayWithModifier | PlayScoped
+    newPos: number
+  } {
     const elements: PlayElement[] = []
+    // Start of the current juxtaposition run within this group (reset on comma).
+    let runStart = 0
 
     // Parse nested structure like ((1)(2)) or (1, 2, 3)
     const lparenResult = ParserUtils.expect(this.tokens, this.pos, 'LPAREN')
@@ -439,11 +575,16 @@ export class ExpressionParser {
         break
       }
       this.parseNestedPlayElement(elements)
+      this.collapseScopedRun(elements, runStart)
 
       this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
-      // Handle comma or continue
+      // Handle comma or continue. A comma ends the juxtaposition run.
+      const sepType = ParserUtils.current(this.tokens, this.pos).type
       if (!this.handleNestedPlaySeparator()) {
         break
+      }
+      if (sepType === 'COMMA') {
+        runStart = elements.length
       }
       this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
     }
@@ -451,13 +592,40 @@ export class ExpressionParser {
     const rparenResult = ParserUtils.expect(this.tokens, this.pos, 'RPAREN')
     this.pos = rparenResult.newPos
 
-    // Check for modifiers on the nested structure itself
+    // Check for a chain on the group itself. `.root()/.mode()/.oct()` are pitch-
+    // scope chains → a PlayScoped node (§3); `.chop()` is the audio modifier.
     if (ParserUtils.current(this.tokens, this.pos).type === 'DOT') {
+      const method = ParserUtils.peek(this.tokens, this.pos).value
+      if (method === 'root' || method === 'mode' || method === 'oct') {
+        const scope = this.parseScopeChain()
+        this.assertChainClosesRun()
+        // B2: single group. Juxtaposition runs (multiple groups sharing the
+        // scope) are assembled by the caller (B3).
+        return {
+          value: { type: 'scoped', groups: [{ type: 'nested', elements }], ...scope },
+          newPos: this.pos,
+        }
+      }
       const modifierResult = this.parsePlayWithModifier({ type: 'nested', elements })
       return { value: modifierResult.value, newPos: modifierResult.newPos }
     }
 
     return { value: { type: 'nested', elements }, newPos: this.pos }
+  }
+
+  /**
+   * If the element just pushed is a scope chain (PlayScoped), collapse the
+   * preceding juxtaposition run (the sibling groups since `runStart`) into its
+   * `groups`, so `(A)(B).root(X)` shares one scope (§3). No-op otherwise — a
+   * no-chain run stays as separate siblings.
+   */
+  private collapseScopedRun(elements: PlayElement[], runStart: number): void {
+    const lastIdx = elements.length - 1
+    const last = elements[lastIdx]
+    if (last && typeof last === 'object' && last.type === 'scoped' && runStart < lastIdx) {
+      const preceding = elements.splice(runStart, lastIdx - runStart)
+      last.groups = [...preceding, ...last.groups]
+    }
   }
 
   /**

--- a/packages/engine/src/parser/parse-expression.ts
+++ b/packages/engine/src/parser/parse-expression.ts
@@ -21,6 +21,24 @@ import {
 import { ParserUtils } from './parser-utils'
 
 /**
+ * If the last element of `list` is a scope chain (PlayScoped) and there are
+ * preceding sibling groups since `runStart`, collapse the juxtaposition run
+ * into its `groups`, so `(A)(B).root(X)` shares one scope (§3). No-op otherwise
+ * — a no-chain run stays as separate siblings. Shared by the nested-level
+ * (ExpressionParser) and statement-level (StatementParser) parse loops; both
+ * call it AFTER pushing the just-parsed element, so the run rule lives in one
+ * place (the pre-/post-push arithmetic is otherwise an easy source of drift).
+ */
+export function collapseScopedRun(list: PlayElement[], runStart: number): void {
+  const lastIdx = list.length - 1
+  const last = list[lastIdx]
+  if (last && typeof last === 'object' && last.type === 'scoped' && runStart < lastIdx) {
+    const preceding = list.splice(runStart, lastIdx - runStart)
+    last.groups = [...preceding, ...last.groups]
+  }
+}
+
+/**
  * Expression parser for audio DSL
  */
 export class ExpressionParser {
@@ -575,7 +593,7 @@ export class ExpressionParser {
         break
       }
       this.parseNestedPlayElement(elements)
-      this.collapseScopedRun(elements, runStart)
+      collapseScopedRun(elements, runStart)
 
       this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
       // Handle comma or continue. A comma ends the juxtaposition run.
@@ -611,21 +629,6 @@ export class ExpressionParser {
     }
 
     return { value: { type: 'nested', elements }, newPos: this.pos }
-  }
-
-  /**
-   * If the element just pushed is a scope chain (PlayScoped), collapse the
-   * preceding juxtaposition run (the sibling groups since `runStart`) into its
-   * `groups`, so `(A)(B).root(X)` shares one scope (§3). No-op otherwise — a
-   * no-chain run stays as separate siblings.
-   */
-  private collapseScopedRun(elements: PlayElement[], runStart: number): void {
-    const lastIdx = elements.length - 1
-    const last = elements[lastIdx]
-    if (last && typeof last === 'object' && last.type === 'scoped' && runStart < lastIdx) {
-      const preceding = elements.splice(runStart, lastIdx - runStart)
-      last.groups = [...preceding, ...last.groups]
-    }
   }
 
   /**

--- a/packages/engine/src/parser/parse-statement.ts
+++ b/packages/engine/src/parser/parse-statement.ts
@@ -360,6 +360,9 @@ export class StatementParser {
     const lparenResult = ParserUtils.expect(this.tokens, this.pos, 'LPAREN')
     this.pos = lparenResult.newPos
     const args: any[] = []
+    // Index where the current juxtaposition run began (reset after each comma).
+    // A `.root()/.mode()/.oct()` chain collapses the run since this index (§3).
+    let runStart = 0
 
     while (
       ParserUtils.current(this.tokens, this.pos).type !== 'RPAREN' &&
@@ -372,13 +375,21 @@ export class StatementParser {
       const expressionParser = new ExpressionParser(this.tokens, this.pos)
       const argResult = expressionParser.parseArgument()
       this.pos = argResult.newPos
-      args.push(argResult.value)
+      const arg = argResult.value
+      // A scope chain (PlayScoped) applies to the whole juxtaposition run: pull
+      // the preceding sibling groups (since the last comma) into its groups so
+      // `(A)(B).root(X)` shares one scope. No-chain `(A)(B)` stays separate.
+      if (arg && typeof arg === 'object' && arg.type === 'scoped' && runStart < args.length) {
+        arg.groups = [...args.splice(runStart), ...arg.groups]
+      }
+      args.push(arg)
 
       this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
       if (ParserUtils.current(this.tokens, this.pos).type === 'COMMA') {
         const commaResult = ParserUtils.advance(this.tokens, this.pos)
         this.pos = commaResult.newPos
         this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
+        runStart = args.length // comma ends the run
       } else if (ParserUtils.current(this.tokens, this.pos).type === 'RPAREN') {
         // End of arguments
         break

--- a/packages/engine/src/parser/parse-statement.ts
+++ b/packages/engine/src/parser/parse-statement.ts
@@ -5,7 +5,7 @@
 
 import { AudioToken, GlobalInit, SequenceInit, Statement, MethodChain } from './types'
 import { ParserUtils } from './parser-utils'
-import { ExpressionParser } from './parse-expression'
+import { ExpressionParser, collapseScopedRun } from './parse-expression'
 
 /**
  * Statement parser for audio DSL
@@ -375,14 +375,11 @@ export class StatementParser {
       const expressionParser = new ExpressionParser(this.tokens, this.pos)
       const argResult = expressionParser.parseArgument()
       this.pos = argResult.newPos
-      const arg = argResult.value
       // A scope chain (PlayScoped) applies to the whole juxtaposition run: pull
       // the preceding sibling groups (since the last comma) into its groups so
       // `(A)(B).root(X)` shares one scope. No-chain `(A)(B)` stays separate.
-      if (arg && typeof arg === 'object' && arg.type === 'scoped' && runStart < args.length) {
-        arg.groups = [...args.splice(runStart), ...arg.groups]
-      }
-      args.push(arg)
+      args.push(argResult.value)
+      collapseScopedRun(args, runStart)
 
       this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
       if (ParserUtils.current(this.tokens, this.pos).type === 'COMMA') {

--- a/packages/engine/src/parser/types.ts
+++ b/packages/engine/src/parser/types.ts
@@ -85,11 +85,48 @@ export type PlayElement =
   | PlayNested // nested structure (e.g., (1)(2))
   | PlayWithModifier // with .chop(), .time(), etc.
   | PlayPitch // degree with alteration / octave-shift / detune (e.g. b3, #5, 3^+1)
+  | PlayScoped // group(s) with a .root()/.mode()/.oct() pitch-scope chain (§2.3, §3)
 
 export type PlayNested = {
   type: 'nested'
   elements: PlayElement[]
 }
+
+/**
+ * One or more juxtaposed groups sharing a lexical pitch scope, produced by a
+ * `.root()` / `.mode()` / `.oct()` chain on a (run of) group(s) (§2.3, §3).
+ *
+ * Spec: docs/specs-v2/PITCH_DSL_SPEC_v1.1.html §3 / DESIGN_DISCUSSION_RECORD §9.3
+ *
+ * Created ONLY when a scope chain is present. A bare `(A)(B)` juxtaposition with
+ * no chain stays separate sibling args (unchanged splice behavior). `groups` is
+ * the juxtaposition run (length 1 for a single `(A).root(X)`); they remain
+ * temporal siblings (each keeps its own slot) and only share the pitch context.
+ * The scope is resolved lexically (inner → outer → seq default → error) during
+ * the timing walk, where the nesting is still visible — never at parse time
+ * (§7-0: symbolic pitch is preserved until dispatch).
+ */
+export type PlayScoped = {
+  type: 'scoped'
+  groups: PlayElement[]
+  root?: ScopeRoot // present iff `.root()` was chained
+  mode?: ScopeMode // present iff `.mode()` was chained (v1.1: parsed + reserved; dispatch throws)
+  oct?: number // present iff `.oct(N)` was chained (group-lexical octave register)
+}
+
+/**
+ * A `.root()` argument, kept symbolic until dispatch.
+ * - `note`: a note-name token (`F#`, `Bb`) — pitch class resolved at parse via
+ *   note-name.ts; `spelling` is retained for §7-0 reversibility (D# vs Eb).
+ * - `degree`: a numeric/altered degree of `global.key()` (`3`, `b6`) — resolved
+ *   against the key at dispatch (key-undeclared numeric root is an error then).
+ */
+export type ScopeRoot =
+  | { kind: 'note'; pitchClass: number; spelling: string }
+  | { kind: 'degree'; degree: number; alteration: number }
+
+/** A `.mode()` argument. v1.1 reserves the syntax; dispatch throws (mode = Phase 2.2). */
+export type ScopeMode = { kind: 'unimplemented'; raw: string }
 
 /**
  * A MIDI degree carrying pitch alteration and event modifiers.

--- a/packages/engine/src/timing/calculation/calculate-event-timing.ts
+++ b/packages/engine/src/timing/calculation/calculate-event-timing.ts
@@ -21,6 +21,7 @@ interface ScopeFrame {
  * group declared a scope (= sequence default).
  */
 function resolveScope(stack: ScopeFrame[]): TimedEventScope | undefined {
+  if (stack.length === 0) return undefined // common case: no enclosing scope group
   let root: ScopeRoot | undefined
   let mode: ScopeMode | undefined
   let groupOct: number | undefined

--- a/packages/engine/src/timing/calculation/calculate-event-timing.ts
+++ b/packages/engine/src/timing/calculation/calculate-event-timing.ts
@@ -3,8 +3,44 @@
  */
 
 import { PlayElement } from '../../parser/audio-parser'
+import { ScopeRoot, ScopeMode } from '../../parser/types'
 
-import { TimedEvent } from './types'
+import { TimedEvent, TimedEventScope } from './types'
+
+/** One enclosing `.root()`/`.mode()`/`.oct()` group on the path to a leaf. */
+interface ScopeFrame {
+  root?: ScopeRoot
+  mode?: ScopeMode
+  oct?: number
+}
+
+/**
+ * Resolve a scope stack to a leaf descriptor (§3 inner→outer). The nearest
+ * frame that sets a root/mode wins for the pitch context; the nearest frame
+ * that sets an oct wins independently. Returns undefined when no enclosing
+ * group declared a scope (= sequence default).
+ */
+function resolveScope(stack: ScopeFrame[]): TimedEventScope | undefined {
+  let root: ScopeRoot | undefined
+  let mode: ScopeMode | undefined
+  let groupOct: number | undefined
+  let haveContext = false
+  for (let i = stack.length - 1; i >= 0; i--) {
+    const f = stack[i]
+    if (!haveContext && (f.root !== undefined || f.mode !== undefined)) {
+      root = f.root
+      mode = f.mode
+      haveContext = true
+    }
+    if (groupOct === undefined && f.oct !== undefined) {
+      groupOct = f.oct
+    }
+  }
+  if (!haveContext && groupOct === undefined) {
+    return undefined
+  }
+  return { root, mode, groupOct }
+}
 
 /**
  * Calculate timing for play() arguments
@@ -16,6 +52,7 @@ import { TimedEvent } from './types'
  * @param barDuration - Total bar duration in milliseconds
  * @param startTime - Start time offset (default 0)
  * @param depth - Current nesting depth (for debugging)
+ * @param scopeStack - Enclosing `.root()`/`.mode()`/`.oct()` frames (§3), innermost last
  * @returns Array of timed events
  */
 export function calculateEventTiming(
@@ -23,6 +60,7 @@ export function calculateEventTiming(
   barDuration: number,
   startTime: number = 0,
   depth: number = 0,
+  scopeStack: ScopeFrame[] = [],
 ): TimedEvent[] {
   const events: TimedEvent[] = []
 
@@ -33,6 +71,8 @@ export function calculateEventTiming(
 
   // Calculate duration for each element at this level
   const elementDuration = barDuration / elements.length
+  // The lexical scope for leaf events at this level (undefined = seq default).
+  const scope = resolveScope(scopeStack)
 
   // Process each element
   for (let i = 0; i < elements.length; i++) {
@@ -40,12 +80,13 @@ export function calculateEventTiming(
     const elementStartTime = startTime + i * elementDuration
 
     if (typeof element === 'number') {
-      // Simple slice number
+      // Simple slice number (audio) or bare degree (MIDI) — carries the scope.
       events.push({
         sliceNumber: element,
         startTime: elementStartTime,
         duration: elementDuration,
         depth,
+        ...(scope && { scope }),
       })
     } else if (Array.isArray(element)) {
       // Array of elements (nested structure)
@@ -54,6 +95,7 @@ export function calculateEventTiming(
         elementDuration, // Nested elements split their parent's duration
         elementStartTime, // Start at parent's position
         depth + 1,
+        scopeStack,
       )
       events.push(...nestedEvents)
     } else if (element && typeof element === 'object') {
@@ -64,6 +106,21 @@ export function calculateEventTiming(
           elementDuration, // Nested elements split their parent's duration
           elementStartTime, // Start at parent's position
           depth + 1,
+          scopeStack,
+        )
+        events.push(...nestedEvents)
+      } else if (element.type === 'scoped') {
+        // §3: a scope-bearing group run. Timing-transparent — it splits its slot
+        // among its groups exactly as a nested of equal length would (so
+        // `(A)(B).root(X)` has the same slots as `(A)(B)`). Push the group's
+        // scope frame so descendant leaves resolve inner→outer.
+        const frame: ScopeFrame = { root: element.root, mode: element.mode, oct: element.oct }
+        const nestedEvents = calculateEventTiming(
+          element.groups,
+          elementDuration,
+          elementStartTime,
+          depth + 1,
+          [...scopeStack, frame],
         )
         events.push(...nestedEvents)
       } else if (element.type === 'pitch') {
@@ -82,6 +139,7 @@ export function calculateEventTiming(
             rangeSet: element.rangeSet, // §2.4: carry the `^N` set-point flag for the sticky-range walk
             detune: element.detune,
           },
+          ...(scope && { scope }),
         })
       } else if (element.type === 'modified') {
         // Modified element (e.g., with .chop())
@@ -101,6 +159,7 @@ export function calculateEventTiming(
             elementDuration,
             elementStartTime,
             depth + 1,
+            scopeStack,
           )
           events.push(...nestedEvents)
         }

--- a/packages/engine/src/timing/calculation/types.ts
+++ b/packages/engine/src/timing/calculation/types.ts
@@ -3,6 +3,19 @@
  */
 
 import { SymbolicPitch } from '../../midi/types'
+import { ScopeRoot, ScopeMode } from '../../parser/types'
+
+/**
+ * The lexical pitch scope (§2.3, §3) resolved for a MIDI event during the
+ * timing walk — the nearest enclosing `.root()`/`.mode()` (one axis) and the
+ * nearest enclosing `.oct()` (independent axis). Resolved to a RootContext /
+ * octave offset at the output stage. Absent = sequence default.
+ */
+export interface TimedEventScope {
+  root?: ScopeRoot
+  mode?: ScopeMode
+  groupOct?: number
+}
 
 /**
  * Represents a scheduled playback event.
@@ -25,4 +38,11 @@ export interface TimedEvent {
    * using the sequence's root context.
    */
   pitch?: SymbolicPitch
+  /**
+   * Phase 2 (§3): the lexical group scope (`.root()`/`.mode()`/`.oct()`) in
+   * effect for this event, resolved inner→outer during the timing walk. Absent
+   * = sequence default. Consumed at the output stage to build the RootContext
+   * and the group-octave offset (independent of the sticky `^N` running range).
+   */
+  scope?: TimedEventScope
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1151,6 +1151,28 @@ function registerCompletionProviders(context: vscode.ExtensionContext) {
           return undefined
         }
 
+        // Detect pitch-scope chain context: cursor is after `).` and we are INSIDE
+        // the argument list of a .play() call (paren balance > 0 after the last .play(
+        // token). This distinguishes the inner-group position `play((A)(B).` (balance 1)
+        // from the post-play position `play(1,2,3).` (balance 0). The check also avoids
+        // firing when .play( is on an earlier line (linePrefix won't contain it at all).
+        if (/\)\.$/.test(linePrefix)) {
+          const playIdx = linePrefix.lastIndexOf('.play(')
+          if (playIdx !== -1) {
+            const afterPlay = linePrefix.slice(playIdx + 1) // starts with "play("
+            let balance = 0
+            for (const ch of afterPlay) {
+              if (ch === '(') balance++
+              else if (ch === ')') balance--
+            }
+            // balance > 0: the play( is still open → cursor is inside play args
+            if (balance > 0) {
+              return getPitchScopeCompletions()
+            }
+            // balance === 0: play() has closed → fall through to existing completions
+          }
+        }
+
         // Analyze the method chain context
         const chainContext = analyzeMethodChain(lineText, position.character)
 
@@ -1167,6 +1189,38 @@ function registerCompletionProviders(context: vscode.ExtensionContext) {
   context.subscriptions.push(completionProvider)
 }
 
+/**
+ * Completion items for pitch-scope group chains: .root() / .mode() / .oct() (§2.3, §3).
+ * Offered when the cursor follows a `)` inside a play() argument list.
+ */
+function getPitchScopeCompletions(): vscode.CompletionItem[] {
+  const root = new vscode.CompletionItem('root', vscode.CompletionItemKind.Method)
+  root.documentation = new vscode.MarkdownString(
+    '**root(note | degree)** — Set pitch-class root for the preceding group or juxtaposition run (§2.3, §3).\n\n' +
+      'Note names: `C`, `Db`, `D`, `Eb`, `E`, `F`, `F#`, `Gb`, `G`, `Ab`, `A`, `Bb`, `B`\n\n' +
+      'Degrees (of `global.key()`): `1`–`12`, `b3`, `#5`, etc.\n\n' +
+      'Examples: `(1, 2, 3).root(F#)` · `(A)(B).root(Bb)` · `(A).root(b6)`',
+  )
+  root.insertText = new vscode.SnippetString('root(${1:F})')
+  root.sortText = '1'
+
+  const mode = new vscode.CompletionItem('mode', vscode.CompletionItemKind.Method)
+  mode.documentation = new vscode.MarkdownString(
+    '**mode(name)** — Set modal context for the group (§2.3). _v1.1: syntax reserved; dispatch throws. Arrives in Phase 2.2._',
+  )
+  mode.insertText = new vscode.SnippetString('mode(${1:dorian})')
+  mode.sortText = '2'
+
+  const oct = new vscode.CompletionItem('oct', vscode.CompletionItemKind.Method)
+  oct.documentation = new vscode.MarkdownString(
+    '**oct(N)** — Set group-lexical octave register (§2.3, §3). Integer.\n\nExample: `(1, 2, 3).oct(4)` · `(A)(B).root(C).oct(5)`',
+  )
+  oct.insertText = new vscode.SnippetString('oct(${1:4})')
+  oct.sortText = '3'
+
+  return [root, mode, oct]
+}
+
 function registerHoverProvider(context: vscode.ExtensionContext) {
   const provider = vscode.languages.registerHoverProvider('orbitscore', {
     provideHover(document, position) {
@@ -1180,6 +1234,9 @@ function registerHoverProvider(context: vscode.ExtensionContext) {
         quantize:
           '**quantize(value)**\n\nLaunch quantize for `LOOP()` and LOOP-time `play()` updates.\n\nValues: `"off"` | `"beat"` | `"bar"` | `"2bar"` | `"4bar"` | `"8bar"`. Default: `"bar"`. `RUN()` is always immediate.',
         play: '**play(...slices)**\n\nPlay audio slices. Supports numbers, nested structures, and modifiers',
+        root: '**root(note | degree)**\n\nSet the pitch-class root for a group or juxtaposition run (§2.3, §3).\n\nExamples: `(1, 2, 3).root(F#)` · `(A)(B).root(Bb)` · `(1, 2).root(3)` · `(A).root(b6)`\n\nNote names: `C`, `Db`, `D`, `Eb`, `E`, `F`, `F#`, `Gb`, `G`, `Ab`, `A`, `Bb`, `B`\nDegrees (of `global.key()`): `1`–`12`, `b3`, `#5`, etc.',
+        mode: '**mode(name)**\n\nSet the modal context for a group (§2.3). _v1.1: syntax reserved; dispatch throws. Arrives in Phase 2.2._',
+        oct: '**oct(N)**\n\nSet the group-lexical octave register for a group or run (§2.3, §3). Integer.\n\nExample: `(1, 2, 3).oct(4)` · `(A)(B).root(C).oct(5)`',
         chop: '**chop(n)**\n\nDivide audio into n equal slices',
         fixpitch:
           '**fixpitch(semitones)** _(planned, not yet implemented — see issue #213)_\n\nPitch shift in semitones, preserving slice duration.',

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1198,7 +1198,7 @@ function getPitchScopeCompletions(): vscode.CompletionItem[] {
   root.documentation = new vscode.MarkdownString(
     '**root(note | degree)** — Set pitch-class root for the preceding group or juxtaposition run (§2.3, §3).\n\n' +
       'Note names: `C`, `Db`, `D`, `Eb`, `E`, `F`, `F#`, `Gb`, `G`, `Ab`, `A`, `Bb`, `B`\n\n' +
-      'Degrees (of `global.key()`): `1`–`12`, `b3`, `#5`, etc.\n\n' +
+      'Degrees (of `global.key()`): `1`–`9`, `11`, `13`, `b3`, `#5`, etc.\n\n' +
       'Examples: `(1, 2, 3).root(F#)` · `(A)(B).root(Bb)` · `(A).root(b6)`',
   )
   root.insertText = new vscode.SnippetString('root(${1:F})')
@@ -1234,7 +1234,7 @@ function registerHoverProvider(context: vscode.ExtensionContext) {
         quantize:
           '**quantize(value)**\n\nLaunch quantize for `LOOP()` and LOOP-time `play()` updates.\n\nValues: `"off"` | `"beat"` | `"bar"` | `"2bar"` | `"4bar"` | `"8bar"`. Default: `"bar"`. `RUN()` is always immediate.',
         play: '**play(...slices)**\n\nPlay audio slices. Supports numbers, nested structures, and modifiers',
-        root: '**root(note | degree)**\n\nSet the pitch-class root for a group or juxtaposition run (§2.3, §3).\n\nExamples: `(1, 2, 3).root(F#)` · `(A)(B).root(Bb)` · `(1, 2).root(3)` · `(A).root(b6)`\n\nNote names: `C`, `Db`, `D`, `Eb`, `E`, `F`, `F#`, `Gb`, `G`, `Ab`, `A`, `Bb`, `B`\nDegrees (of `global.key()`): `1`–`12`, `b3`, `#5`, etc.',
+        root: '**root(note | degree)**\n\nSet the pitch-class root for a group or juxtaposition run (§2.3, §3).\n\nExamples: `(1, 2, 3).root(F#)` · `(A)(B).root(Bb)` · `(1, 2).root(3)` · `(A).root(b6)`\n\nNote names: `C`, `Db`, `D`, `Eb`, `E`, `F`, `F#`, `Gb`, `G`, `Ab`, `A`, `Bb`, `B`\nDegrees (of `global.key()`): `1`–`9`, `11`, `13`, `b3`, `#5`, etc.',
         mode: '**mode(name)**\n\nSet the modal context for a group (§2.3). _v1.1: syntax reserved; dispatch throws. Arrives in Phase 2.2._',
         oct: '**oct(N)**\n\nSet the group-lexical octave register for a group or run (§2.3, §3). Integer.\n\nExample: `(1, 2, 3).oct(4)` · `(A)(B).root(C).oct(5)`',
         chop: '**chop(n)**\n\nDivide audio into n equal slices',

--- a/packages/vscode-extension/syntaxes/orbitscore-audio.tmLanguage.json
+++ b/packages/vscode-extension/syntaxes/orbitscore-audio.tmLanguage.json
@@ -60,7 +60,7 @@
               "match": "(?:b{1,2}|#{1,2})[1-9][0-9]?"
             },
             {
-              "comment": "Bare degree root: 1-12",
+              "comment": "Bare degree root: bare integer; semantically valid degrees are 1-9, 11, 13",
               "name": "constant.numeric.degree.orbitscore",
               "match": "\\b[1-9][0-9]?\\b"
             }

--- a/packages/vscode-extension/syntaxes/orbitscore-audio.tmLanguage.json
+++ b/packages/vscode-extension/syntaxes/orbitscore-audio.tmLanguage.json
@@ -6,6 +6,9 @@
       "include": "#comments"
     },
     {
+      "include": "#pitch-scope-chains"
+    },
+    {
       "include": "#variables"
     },
     {
@@ -31,15 +34,85 @@
     }
   ],
   "repository": {
+    "pitch-scope-chains": {
+      "comment": "Pitch-scope group chains: (group).root(F#) / .mode(dorian) / .oct(2) — §2.3, §3. Uses begin/end so that '#' inside the argument (e.g. F#) is not captured as a line comment by the top-level '#comments' rule.",
+      "patterns": [
+        {
+          "comment": ".root(<note-name|degree>) — e.g. .root(F#), .root(Bb), .root(3), .root(b6)",
+          "name": "meta.pitch-scope.root.orbitscore",
+          "begin": "\\.(root)\\(",
+          "beginCaptures": {
+            "1": { "name": "entity.name.function.scope.orbitscore" }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.parameters.end.orbitscore" }
+          },
+          "patterns": [
+            {
+              "comment": "Note-name root: C, Db, D, Eb, E, F, F#, Gb, G, Ab, A, Bb, B, C#, D#, G#, A#",
+              "name": "variable.other.pitch-class.orbitscore",
+              "match": "\\b[A-G][b#]?(?:#)?"
+            },
+            {
+              "comment": "Altered degree root: b3, #5, bb7, ##2, etc.",
+              "name": "variable.other.degree.orbitscore",
+              "match": "(?:b{1,2}|#{1,2})[1-9][0-9]?"
+            },
+            {
+              "comment": "Bare degree root: 1-12",
+              "name": "constant.numeric.degree.orbitscore",
+              "match": "\\b[1-9][0-9]?\\b"
+            }
+          ]
+        },
+        {
+          "comment": ".mode(<name>) — e.g. .mode(dorian). v1.1: syntax reserved, parsed but dispatch throws.",
+          "name": "meta.pitch-scope.mode.orbitscore",
+          "begin": "\\.(mode)\\(",
+          "beginCaptures": {
+            "1": { "name": "entity.name.function.scope.orbitscore" }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.parameters.end.orbitscore" }
+          },
+          "patterns": [
+            {
+              "comment": "Mode name argument (identifier or string)",
+              "name": "variable.other.mode-name.orbitscore",
+              "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
+            },
+            {
+              "include": "#strings"
+            }
+          ]
+        },
+        {
+          "comment": ".oct(N) — group-lexical octave register, integer (possibly signed)",
+          "name": "meta.pitch-scope.oct.orbitscore",
+          "begin": "\\.(oct)\\(",
+          "beginCaptures": {
+            "1": { "name": "entity.name.function.scope.orbitscore" }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.parameters.end.orbitscore" }
+          },
+          "patterns": [
+            {
+              "name": "constant.numeric.integer.orbitscore",
+              "match": "-?\\d+"
+            }
+          ]
+        }
+      ]
+    },
     "comments": {
       "patterns": [
         {
           "name": "comment.line.double-slash.orbitscore",
           "match": "//.*$"
-        },
-        {
-          "name": "comment.line.number-sign.orbitscore",
-          "match": "#.*$"
         }
       ]
     },

--- a/tests/audio-parser/scope-chain-parsing.spec.ts
+++ b/tests/audio-parser/scope-chain-parsing.spec.ts
@@ -171,6 +171,9 @@ describe('Phase 2 — invalid .root() arguments error at parse', () => {
   it('.root(b0) — altered degree 0 — throws', () => {
     expect(() => parseAudioDSL('seq1.play((1).root(b0))')).toThrow(/positive degree|rest/)
   })
+  it('.root(1.5) — fractional degree — throws (positive integer required)', () => {
+    expect(() => parseAudioDSL('seq1.play((1).root(1.5))')).toThrow(/positive integer/)
+  })
   it('.root(H) — invalid note letter — throws', () => {
     expect(() => parseAudioDSL('seq1.play((1).root(H))')).toThrow(/note letter/)
   })

--- a/tests/audio-parser/scope-chain-parsing.spec.ts
+++ b/tests/audio-parser/scope-chain-parsing.spec.ts
@@ -143,6 +143,42 @@ describe('Phase 2 — juxtaposition run shares one scope (§3)', () => {
   })
 })
 
+describe('Phase 2 — run-collapse at the NESTED level (§3)', () => {
+  it('(A)(B).root(X) inside an outer group collapses to one PlayScoped (nested path)', () => {
+    // ((1)(2).root(3), 5): inside the outer group, the (1)(2) run shares root 3,
+    // then a comma, then bare 5. Exercises collapseScopedRun in parseNestedPlay.
+    const outer = firstArg('seq1.play(((1)(2).root(3), 5))')
+    expect(outer).toMatchObject({ type: 'nested' })
+    const els = (outer as any).elements
+    expect(els[0]).toMatchObject({ type: 'scoped', root: { kind: 'degree', degree: 3 } })
+    expect((els[0] as any).groups).toHaveLength(2)
+    expect(els[1]).toBe(5)
+  })
+
+  it('comma bounds the nested run: (0, (1)(2).root(5)) keeps 0 separate', () => {
+    const outer = firstArg('seq1.play((0, (1)(2).root(5)))')
+    const els = (outer as any).elements
+    expect(els[0]).toBe(0)
+    expect(els[1]).toMatchObject({ type: 'scoped' })
+    expect((els[1] as any).groups).toHaveLength(2)
+  })
+})
+
+describe('Phase 2 — invalid .root() arguments error at parse', () => {
+  it('.root(0) — degree 0 is a rest, not a root — throws', () => {
+    expect(() => parseAudioDSL('seq1.play((1).root(0))')).toThrow(/positive degree|rest/)
+  })
+  it('.root(b0) — altered degree 0 — throws', () => {
+    expect(() => parseAudioDSL('seq1.play((1).root(b0))')).toThrow(/positive degree|rest/)
+  })
+  it('.root(H) — invalid note letter — throws', () => {
+    expect(() => parseAudioDSL('seq1.play((1).root(H))')).toThrow(/note letter/)
+  })
+  it('.root() — empty argument — throws', () => {
+    expect(() => parseAudioDSL('seq1.play((1).root())')).toThrow(/\.root\(\) expects/)
+  })
+})
+
 describe('Phase 2 — no-chain juxtaposition is unaffected (regression guard)', () => {
   it('a bare group stays a plain nested node (not scoped)', () => {
     expect(firstArg('seq1.play((1, 3, 5))')).toMatchObject({ type: 'nested' })

--- a/tests/audio-parser/scope-chain-parsing.spec.ts
+++ b/tests/audio-parser/scope-chain-parsing.spec.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+
+/**
+ * Phase 2 (#230) — `.root()` / `.mode()` / `.oct()` group-scope chain parsing.
+ * Spec: docs/specs-v2/PITCH_DSL_SPEC_v1.1.html §2.3, §3
+ *
+ * Parser-level (this file): the PlayScoped AST shape, note-name reassembly,
+ * degree roots, .oct, duplicate/conflict diagnostics, "chain closes the run",
+ * and that no-chain juxtaposition is unaffected. Scope RESOLUTION (dispatch)
+ * and juxtaposition-run grouping are covered separately.
+ */
+function firstArg(src: string): any {
+  return parseAudioDSL(src).statements[0].args[0]
+}
+
+describe('Phase 2 — .root() scope chain parsing (single group)', () => {
+  it('note-name root `.root(F#)` → PlayScoped with pitchClass + spelling', () => {
+    expect(firstArg('seq1.play((1, 3, 5).root(F#))')).toMatchObject({
+      type: 'scoped',
+      root: { kind: 'note', pitchClass: 6, spelling: 'F#' },
+      groups: [{ type: 'nested' }],
+    })
+  })
+
+  it('flat note-name `.root(Bb)` (b stays in the identifier) → pitchClass 10', () => {
+    expect(firstArg('seq1.play((1).root(Bb))')).toMatchObject({
+      type: 'scoped',
+      root: { kind: 'note', pitchClass: 10, spelling: 'Bb' },
+    })
+  })
+
+  it('natural note-name `.root(C)` → pitchClass 0', () => {
+    expect(firstArg('seq1.play((1).root(C))')).toMatchObject({
+      type: 'scoped',
+      root: { kind: 'note', pitchClass: 0, spelling: 'C' },
+    })
+  })
+
+  it('numeric degree root `.root(3)` → degree 3 (resolved against key at dispatch)', () => {
+    expect(firstArg('seq1.play((1).root(3))')).toMatchObject({
+      type: 'scoped',
+      root: { kind: 'degree', degree: 3, alteration: 0 },
+    })
+  })
+
+  it('non-diatonic degree root `.root(b6)` → degree 6, alteration -1', () => {
+    expect(firstArg('seq1.play((1).root(b6))')).toMatchObject({
+      type: 'scoped',
+      root: { kind: 'degree', degree: 6, alteration: -1 },
+    })
+  })
+
+  it('the group is preserved in groups[] (single-element run)', () => {
+    const scoped = firstArg('seq1.play((1, 0, 5).root(2))')
+    expect(scoped.groups).toHaveLength(1)
+    expect(scoped.groups[0]).toMatchObject({
+      type: 'nested',
+      elements: [1, 0, 5],
+    })
+  })
+})
+
+describe('Phase 2 — .oct() scope chain parsing', () => {
+  it('`.oct(1)` → oct +1', () => {
+    expect(firstArg('seq1.play((1).oct(1))')).toMatchObject({ type: 'scoped', oct: 1 })
+  })
+  it('`.oct(-2)` → oct -2 (downward)', () => {
+    expect(firstArg('seq1.play((1).oct(-2))')).toMatchObject({ type: 'scoped', oct: -2 })
+  })
+  it('`.root(3).oct(1)` → root and oct coexist on one group', () => {
+    expect(firstArg('seq1.play((1).root(3).oct(1))')).toMatchObject({
+      type: 'scoped',
+      root: { kind: 'degree', degree: 3 },
+      oct: 1,
+    })
+  })
+})
+
+describe('Phase 2 — .mode() reserved (parsed, dispatch throws later)', () => {
+  it('`.mode(dorian)` parses to an unimplemented scope marker', () => {
+    expect(firstArg('seq1.play((1).mode(dorian))')).toMatchObject({
+      type: 'scoped',
+      mode: { kind: 'unimplemented' },
+    })
+  })
+})
+
+describe('Phase 2 — scope-chain diagnostics (§3, no last-wins)', () => {
+  it('duplicate .root() is an error', () => {
+    expect(() => parseAudioDSL('seq1.play((1).root(2).root(5))')).toThrow(/duplicate .root/)
+  })
+  it('.root() + .mode() on the same group is an error', () => {
+    expect(() => parseAudioDSL('seq1.play((1).root(2).mode(dorian))')).toThrow(
+      /root.*mode.*cannot both/,
+    )
+  })
+  it('a chain followed by `(` with no comma is an error ("chain closes the run")', () => {
+    expect(() => parseAudioDSL('seq1.play((1).root(3)(2))')).toThrow(/expected comma after chained/)
+  })
+})
+
+describe('Phase 2 — juxtaposition run shares one scope (§3)', () => {
+  it('(A)(B).root(X) collapses to one PlayScoped covering both groups', () => {
+    const scoped = firstArg('seq1.play((1, 0)(0, 1).root(3))')
+    expect(scoped).toMatchObject({ type: 'scoped', root: { kind: 'degree', degree: 3 } })
+    expect(scoped.groups).toHaveLength(2)
+    expect(scoped.groups[0]).toMatchObject({ type: 'nested', elements: [1, 0] })
+    expect(scoped.groups[1]).toMatchObject({ type: 'nested', elements: [0, 1] })
+  })
+
+  it('three-group run (A)(B)(C).root(X) covers all three', () => {
+    const scoped = firstArg('seq1.play((1)(2)(3).root(5))')
+    expect(scoped.type).toBe('scoped')
+    expect(scoped.groups).toHaveLength(3)
+  })
+
+  it('the run is bounded by a preceding comma (the 0 is not pulled in)', () => {
+    const args = parseAudioDSL('seq1.play(0, (1)(2).root(3))').statements[0].args
+    expect(args).toHaveLength(2)
+    expect(args[0]).toBe(0)
+    expect(args[1]).toMatchObject({ type: 'scoped' })
+    expect((args[1] as any).groups).toHaveLength(2)
+  })
+
+  it('nested inner .root() sits inside an outer .root() group (§3 example)', () => {
+    const scoped = firstArg('seq1.play(((1, b3).root(b6), 5, 1).root(2))')
+    expect(scoped).toMatchObject({ type: 'scoped', root: { kind: 'degree', degree: 2 } })
+    const outer = (scoped.groups[0] as any).elements
+    expect(outer[0]).toMatchObject({
+      type: 'scoped',
+      root: { kind: 'degree', degree: 6, alteration: -1 },
+    })
+    expect(outer[1]).toBe(5)
+    expect(outer[2]).toBe(1)
+  })
+
+  it('chain closes the run: (A)(B).root(3)(C) is an error', () => {
+    expect(() => parseAudioDSL('seq1.play((1)(2).root(3)(3))')).toThrow(
+      /expected comma after chained/,
+    )
+  })
+})
+
+describe('Phase 2 — no-chain juxtaposition is unaffected (regression guard)', () => {
+  it('a bare group stays a plain nested node (not scoped)', () => {
+    expect(firstArg('seq1.play((1, 3, 5))')).toMatchObject({ type: 'nested' })
+  })
+  it('no-chain juxtaposition (1)(2) stays separate sibling args', () => {
+    const args = parseAudioDSL('seq1.play((1)(2))').statements[0].args
+    expect(args).toHaveLength(2)
+    expect(args[0]).toMatchObject({ type: 'nested' })
+    expect(args[1]).toMatchObject({ type: 'nested' })
+  })
+})

--- a/tests/core/sequence-scope-dispatch.spec.ts
+++ b/tests/core/sequence-scope-dispatch.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { Global } from '../../packages/engine/src/core/global'
+import { Sequence } from '../../packages/engine/src/core/sequence'
+import { MidiManager } from '../../packages/engine/src/core/global/midi-manager'
+import { MidiOutput } from '../../packages/engine/src/midi/midi-output'
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+
+/**
+ * Phase 2 (#230) — group-scope dispatch (§3): a `.root()` group resolves to a
+ * RootContext per event (inner→outer→seq→error), degrees number against it.
+ */
+
+const T0 = 1_000_000
+
+function mockMidiOutput(): MidiOutput {
+  return {
+    ensurePort: vi.fn((q: string) => (/iac/i.test(q) ? 'IACドライバ バス1' : q)),
+    noteOn: vi.fn(),
+    noteOff: vi.fn(),
+    pitchBend: vi.fn(),
+    releaseOwner: vi.fn(),
+    panic: vi.fn(),
+    getActiveNotes: vi.fn(() => []),
+    listPorts: vi.fn(() => ['IACドライバ バス1']),
+    closeAll: vi.fn(),
+  }
+}
+
+function mockScheduler() {
+  return {
+    isRunning: true,
+    startTime: T0,
+    getCurrentTime: () => 0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(),
+    clearSequenceEvents: vi.fn(),
+    reinitializeSequenceTracking: vi.fn(),
+    getMasterGainDb: () => 0,
+  } as never
+}
+
+function notesOf(out: MidiOutput): number[] {
+  return (out.noteOn as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[2])
+}
+
+/** Build a started, keyed MIDI sequence (octave 4) and play a parsed pattern. */
+async function playKeyed(src: string, key = 'C'): Promise<MidiOutput> {
+  vi.setSystemTime(T0)
+  const sched = mockScheduler()
+  const out = mockMidiOutput()
+  const global = new Global(sched, new MidiManager(() => out))
+  global.key(key)
+  global.start()
+  const seq = new Sequence(global, sched)
+  seq.setName('piano')
+  seq.midi('iac', 1).octave(4)
+  const args = parseAudioDSL(`p.play(${src})`).statements[0].args
+  seq.play(...(args as never[]))
+  await seq.run()
+  await vi.advanceTimersByTimeAsync(2100)
+  return out
+}
+
+describe('Sequence group-scope dispatch (§3)', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('note-name root: (1, 3, 5).root(F#) → F#4, A#4, C#5', async () => {
+    const out = await playKeyed('(1, 3, 5).root(F#)')
+    // F#4 = 66; degree 3 = +4 = 70; degree 5 = +7 = 73
+    expect(notesOf(out)).toEqual(expect.arrayContaining([66, 70, 73]))
+    expect(notesOf(out)).toHaveLength(3)
+  })
+
+  it('degree root: (1).root(3) in C → E4 (root = III of C)', async () => {
+    const out = await playKeyed('(1).root(3)')
+    expect(notesOf(out)).toContain(64) // E4
+  })
+
+  it('juxtaposition shares the root: (1)(5).root(2) in C → both at root D', async () => {
+    const out = await playKeyed('(1)(5).root(2)')
+    // root D (pc 2), octave 4 → rootPitch 62; degree 1 = 62, degree 5 = 69
+    expect(notesOf(out)).toEqual(expect.arrayContaining([62, 69]))
+    expect(notesOf(out)).toHaveLength(2)
+  })
+
+  it('inner .root() overrides outer: ((1).root(b6), 5).root(2) in C', async () => {
+    const out = await playKeyed('((1).root(b6), 5).root(2)')
+    // inner: 1 at b6 = Ab(pc8) → 68; outer: 5 at root 2 = D(pc2) → 62 + 7 = 69
+    expect(notesOf(out)).toEqual(expect.arrayContaining([68, 69]))
+    expect(notesOf(out)).toHaveLength(2)
+  })
+
+  it('unscoped event still uses the sequence default (key tonic)', async () => {
+    const out = await playKeyed('1, (5).root(2)')
+    // bare 1 → C4(60) via key tonic; (5).root(2) → 5 at D → 69
+    expect(notesOf(out)).toEqual(expect.arrayContaining([60, 69]))
+  })
+
+  it('note-name root needs NO global.key() (only numeric roots require a key)', async () => {
+    vi.setSystemTime(T0)
+    const sched = mockScheduler()
+    const out = mockMidiOutput()
+    const g = new Global(sched, new MidiManager(() => out)) // no global.key()
+    g.start()
+    const seq = new Sequence(g, sched)
+    seq.setName('lead')
+    seq.midi('iac', 1).octave(4)
+    const args = parseAudioDSL('p.play((1, 5).root(C))').statements[0].args
+    seq.play(...(args as never[]))
+    await expect(seq.run()).resolves.toBeDefined()
+    await vi.advanceTimersByTimeAsync(2100)
+    // root C (pc 0), octave 4 → 60; degree 5 = 67
+    expect(notesOf(out)).toEqual(expect.arrayContaining([60, 67]))
+  })
+
+  it('a degree root with no global.key() rejects run()', async () => {
+    vi.setSystemTime(T0)
+    const sched = mockScheduler()
+    const out = mockMidiOutput()
+    const g = new Global(sched, new MidiManager(() => out)) // no key
+    g.start()
+    const seq = new Sequence(g, sched)
+    seq.setName('lead')
+    seq.midi('iac', 1).octave(4)
+    const args = parseAudioDSL('p.play((1).root(3))').statements[0].args
+    seq.play(...(args as never[]))
+    await expect(seq.run()).rejects.toThrow(/key|root/i)
+  })
+
+  it('.mode() rejects run() (reserved in v1.1)', async () => {
+    vi.setSystemTime(T0)
+    const sched = mockScheduler()
+    const out = mockMidiOutput()
+    const g = new Global(sched, new MidiManager(() => out))
+    g.key('C')
+    g.start()
+    const seq = new Sequence(g, sched)
+    seq.setName('lead')
+    seq.midi('iac', 1).octave(4)
+    const args = parseAudioDSL('p.play((1).mode(dorian))').statements[0].args
+    seq.play(...(args as never[]))
+    await expect(seq.run()).rejects.toThrow(/mode.*not implemented/i)
+  })
+})

--- a/tests/core/sequence-scope-dispatch.spec.ts
+++ b/tests/core/sequence-scope-dispatch.spec.ts
@@ -144,4 +144,27 @@ describe('Sequence group-scope dispatch (§3)', () => {
     seq.play(...(args as never[]))
     await expect(seq.run()).rejects.toThrow(/mode.*not implemented/i)
   })
+
+  it('.oct(N) composes additively with the sticky ^N range (§9.3)', async () => {
+    const out = await playKeyed('3^1, (1).oct(1)')
+    // 3^1 → E5 (range +1: 64 + 12 = 76); (1).oct(1) → range(+1)+oct(+1)=+2 → C6 (84)
+    expect(notesOf(out)).toEqual(expect.arrayContaining([76, 84]))
+    expect(notesOf(out)).toHaveLength(2)
+  })
+
+  it('.oct(N) alone lifts the group register', async () => {
+    const out = await playKeyed('(1, 5).oct(1)')
+    // range 0 + oct +1 → degree 1 = C5 (72), degree 5 = G5 (79)
+    expect(notesOf(out)).toEqual(expect.arrayContaining([72, 79]))
+    expect(notesOf(out)).toHaveLength(2)
+  })
+
+  it('^N persists past a .oct() group; the group oct does not leak out (§9.4)', async () => {
+    const out = await playKeyed('3^1, (1).oct(2), 1')
+    // 3^1 → E5 (76, range +1); (1).oct(2) → +1+2 = +3 → C7 (96);
+    // trailing 1 → range +1 persists, oct gone → C5 (72)
+    expect(notesOf(out)).toEqual(expect.arrayContaining([76, 96, 72]))
+    expect(notesOf(out)).toHaveLength(3)
+    expect(notesOf(out)).not.toContain(60) // would be C4 if ^N had been reset by the group
+  })
 })

--- a/tests/core/sequence-scope-dispatch.spec.ts
+++ b/tests/core/sequence-scope-dispatch.spec.ts
@@ -167,4 +167,31 @@ describe('Sequence group-scope dispatch (§3)', () => {
     expect(notesOf(out)).toHaveLength(3)
     expect(notesOf(out)).not.toContain(60) // would be C4 if ^N had been reset by the group
   })
+
+  it('inner .oct() + outer .root() resolve from different frames (independent axes)', async () => {
+    // ((1, 5).oct(2)).root(3): outer root = III of C = E (64); inner oct = +2.
+    const out = await playKeyed('((1, 5).oct(2)).root(3)')
+    expect(notesOf(out)).toEqual(expect.arrayContaining([88, 95])) // E6(64+24), B6(64+7+24)
+    expect(notesOf(out)).toHaveLength(2)
+  })
+
+  it('.oct(-N) offsets downward', async () => {
+    const out = await playKeyed('(1).oct(-2)')
+    expect(notesOf(out)).toContain(36) // C2 = C4(60) - 24
+  })
+
+  it('a bare degree alongside a note-rooted group still needs global.key()', async () => {
+    vi.setSystemTime(T0)
+    const sched = mockScheduler()
+    const out = mockMidiOutput()
+    const g = new Global(sched, new MidiManager(() => out)) // no key
+    g.start()
+    const seq = new Sequence(g, sched)
+    seq.setName('lead')
+    seq.midi('iac', 1).octave(4)
+    // (1).root(C) needs no key, but the bare 5 falls back to the seq default → needs key
+    const args = parseAudioDSL('p.play((1).root(C), 5)').statements[0].args
+    seq.play(...(args as never[]))
+    await expect(seq.run()).rejects.toThrow(/key|root/i)
+  })
 })

--- a/tests/timing/scope-timing.spec.ts
+++ b/tests/timing/scope-timing.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+import { calculateEventTiming } from '../../packages/engine/src/timing/calculation'
+import { PlayElement } from '../../packages/engine/src/parser/types'
+
+/**
+ * Phase 2 (#230) — scope capture in the timing walk (§3).
+ *
+ * The lexical scope (`.root()`/`.mode()`/`.oct()`) is resolved inner→outer here,
+ * where the nesting is still visible, and attached to each leaf TimedEvent as a
+ * symbolic descriptor (§7-0 — not yet a MIDI number). A scoped run is
+ * timing-transparent: it produces the same slots as the equivalent no-chain
+ * juxtaposition.
+ */
+function playElements(src: string): PlayElement[] {
+  return parseAudioDSL(src).statements[0].args as PlayElement[]
+}
+
+const slots = (events: ReturnType<typeof calculateEventTiming>) =>
+  events.map((e) => [e.sliceNumber, e.startTime, e.duration])
+
+describe('Phase 2 — calculateEventTiming scope descriptor + timing transparency', () => {
+  it('a .root(note) group attaches the scope to each leaf; timing matches no-chain', () => {
+    const scoped = calculateEventTiming(playElements('seq.play((1, 3, 5).root(F#))'), 2000)
+    const plain = calculateEventTiming(playElements('seq.play((1, 3, 5))'), 2000)
+
+    expect(slots(scoped)).toEqual(slots(plain)) // timing-transparent
+    for (const e of scoped) {
+      expect(e.scope).toMatchObject({ root: { kind: 'note', pitchClass: 6 } })
+    }
+    expect(plain[0].scope).toBeUndefined() // no-chain carries no scope
+  })
+
+  it('juxtaposition (A)(B).root(3) has the same slots as (A)(B); scope on all leaves', () => {
+    const scoped = calculateEventTiming(playElements('seq.play((1, 0)(0, 1).root(3))'), 2000)
+    const plain = calculateEventTiming(playElements('seq.play((1, 0)(0, 1))'), 2000)
+
+    expect(slots(scoped)).toEqual(slots(plain))
+    expect(scoped).toHaveLength(4)
+    for (const e of scoped) {
+      expect(e.scope?.root).toMatchObject({ kind: 'degree', degree: 3 })
+    }
+  })
+
+  it('inner .root() overrides outer (inner→outer resolution)', () => {
+    // ((1).root(b6), 5).root(2): the 1 resolves to b6 (inner), the 5 to 2 (outer)
+    const events = calculateEventTiming(playElements('seq.play(((1).root(b6), 5).root(2))'), 2000)
+    expect(events).toHaveLength(2)
+    expect(events[0].scope?.root).toMatchObject({ kind: 'degree', degree: 6, alteration: -1 })
+    expect(events[1].scope?.root).toMatchObject({ kind: 'degree', degree: 2 })
+  })
+
+  it('.oct(N) attaches groupOct independently of root', () => {
+    const events = calculateEventTiming(playElements('seq.play((1, 5).root(3).oct(1))'), 2000)
+    for (const e of events) {
+      expect(e.scope?.root).toMatchObject({ kind: 'degree', degree: 3 })
+      expect(e.scope?.groupOct).toBe(1)
+    }
+  })
+})


### PR DESCRIPTION
Epic #224 / 正本: `docs/specs-v2/PITCH_DSL_SPEC_v1.1.html` §2.3, §3 / DESIGN_DISCUSSION_RECORD §9.3

Closes #230

## 概要

グループ閉じ後のメソッドチェーン `.root()` / `.mode()` / `.oct()` を実装し、ピッチコンテキストのレキシカルスコープ解決を追加。Phase 1 の pitch range (sticky `^N`) と直交合成する。code-architect で blueprint を策定し、build sequence B0-B8 を test-gated に進めた。

## 実装（main=Opus 直列のパーサー/dispatch + Sonnet 委譲のエディタ）

| 層 | 内容 |
|---|---|
| **パーサー** | `PlayScoped` AST。`.root()`（音名 `F#`/`Bb` をトークン再構成・度数 `3`/`b6`）、`.mode()`（予約、dispatch で throw）、`.oct(N)`。並置 run `(A)(B).root(X)` を1スコープに集約。重複 `.root().root()` / root+mode 衝突 / 「チェーンは並置を閉じる」（直後カンマなし `(` = エラー）を診断。no-chain 並置の splice は不変 |
| **timing** | scope をツリー walk で inner→outer 解決し各リーフに descriptor 付与。PlayScoped は timing 透過（並置と同じスロット） |
| **dispatch** | per-event スコープ解決（音名 root=key 不要 / 度数 root=key 必須・未宣言はエラー / mode=throw）。seq 既定は遅延算出。`.oct()`×`^N` = **加算**（§9.3 直交、大和確認）、`^N` は群を越えて持続（§9.4 linear） |
| **VS Code** | `.root/.mode/.oct` の TextMate ハイライト + hover + 補完。legacy `#.*$` コメント規則を削除（`#`=ACCIDENTAL のシャープ誤認バグ修正） |

## レキシカルスコープ（§3）

内側グループ → 外側グループ → シーケンス既定 → エラー（stateless）。タプル並置 `(A)(B).root(X)` は並置全体に適用（「複数小節で1コード」）。

## テスト（863 passed / 23 skipped、+35 新規）

- `scope-chain-parsing.spec.ts` 20件（音名/度数 root、oct、mode 予約、重複/衝突/chain-closes、並置 run 集約、§3 入れ子 override、no-chain 回帰）
- `scope-timing.spec.ts` 4件（timing 透過 + inner→outer + groupOct 独立）
- `sequence-scope-dispatch.spec.ts` 11件（音名/度数 root → MIDI 音番号、並置共有、入れ子 override、key 有無、mode 拒否、`.oct()`×`^N` 加算合成、`^N` 持続）
- 既存 audio `play()` 意味論・juxtaposition splice は不変

## スコープ外 / follow-up

- **span レベルのセマンティックハイライト**（並置 run の可視化、§3 の「`.root()`+カンマ両忘れ→静かな併合」緩和）は `PlayScoped` にソース offset が無く engine 拡張が必要なため別 Issue 推奨。chain-closes/重複のパースエラーで多くは既に検出。
- **Phase 3 (#231)**: `[ ]` スタック + chord 値。
- core spec への反映は specs-v2 ポインタ規約（Phase 1 前例、乖離防止）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)