### PR TITLE
feat(dsl): Phase 3 — [ ] stack + chord values (#231)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -20,7 +20,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 ### 6.107 Issue #231 — Phase 3: `[ ]` スタック + chord 値 (Jun 13, 2026)
 
 **Date**: 2026-06-13
-**Status**: 🚧 IN PROGRESS（スタック core 完了 B0-B4。chord 値 spread/除去/import は後続コミット B5-B7）
+**Status**: ✅ 実装完了（B0-B7。スタック core + chord 値 spread/除去/import。/simplify + レビュー前）
 **Issue**: signalcompose/orbitscore#231
 **Branch**: `231-phase-3-stack-chord`
 
@@ -44,6 +44,20 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 - `timing/calculate-event-timing.ts`: 未解決 chord_ref が timing walk に来たら internal error（silent drop 防止）
 
 **テスト**: `chord-resolution.spec.ts` 11件（spread/add/除去/不一致 warning/`^N`/standalone/unknown/whole-stack `^N` 保持/predefined テーブル）。全体 906 passed / 23 skipped。
+
+**追加コミット（B6/B7: chord 値の parse + namespace + 配線）**:
+- `parser/types.ts`: `IMPORT` トークン、`ChordBinding`/`ImportStatement` を Statement union に
+- `parser/tokenizer.ts`: `import` キーワード
+- `parser/parse-statement.ts`: `parseVarDeclaration` を `chord([...])` 束縛に分岐（`init` パスは不変）、`parseImport`（`import chords` のみ受理）
+- `parser/parse-expression.ts`: `parseNestedPlayElement` に IDENTIFIER → chord_ref（§9.1 の `(0, m7, 0)` グループ要素）
+- `core/global.ts`: chord namespace（`importChords`/`defineChord`/`getChordVoices`、衝突 warning §10-4）を Global に（`global.key()` と同様 program-global、interpreter/直接 seq 両経路で共有）
+- `core/sequence.ts`: `play()` で timing 前に `resolveChords`（chord ref を spread/除去/`^N` 解決し純シンボリックに）。warning は console.warn
+- `midi/chord/resolve-chords.ts`: `evaluateChordDefinition`（`var = chord()` の束縛時評価）
+- `interpreter/process-statement.ts`: `import`/`chord_binding` を currentGlobal に配線
+
+**決定（spec 範囲内）**: 除去 `-N` の字面一致は (degree, alteration)（§6 字面一致の具体化）。namespace 衝突は last-write-wins + warning（§10-4）。未定義 chord 名参照は warning + 空展開（§6 は未規定、no-op+warning 哲学に整合）。`{ }` レガート・`_` タイ（§5）と top-level bare chord 名は Phase 3 範囲外（§9.1 のそれらは Phase 4）。
+
+**テスト**: `chord-binding-parsing.spec.ts` 8件 / `sequence-chord-dispatch.spec.ts` 11件（import+`[m7]`、`(0,m7,0,m7).root(3)`、spread+add/除去、whole-chord `^+1`、defineChord、unknown warning、registry、interpreter 配線）。全体 925 passed / 23 skipped。core spec は specs-v2 を正本として参照（§4/§6 は PITCH_DSL_SPEC が正本、乖離なし）。
 
 ### 6.106 Issue #230 — Phase 2: `.root()`/`.mode()`/`.oct()` グループスコープ — パーサー層 (Jun 13, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -36,6 +36,15 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **テスト**: `stack-parsing.spec.ts` 10件 / `stack-timing.spec.ts` 5件 / `sequence-stack-dispatch.spec.ts` 7件（同時 note-on、scope 合成、voice/whole `^N` の加算、running range 非干渉、audio 拒否）。`pitch-parsing.spec.ts` の旧「`[ ]` reserved＝parse throw」3件を新仕様（PlayStack へ parse、拒否は dispatch）に更新。全体 895 passed / 23 skipped。
 
+**追加コミット（B5: chord 評価器 — 純関数モジュール）**:
+- `midi/chord/types.ts`: `ChordVoice`（degree/alteration/構造的 octaveShift/detune）、`BoundValue`（`kind:'chord'` discriminant で Phase R と namespace 共有可能に）
+- `midi/chord/predefined-chords.ts`: `import chords` 標準テーブル（maj/min/dim/aug/sus4/sus2/6/m6/maj7/m7/dom7/m7b5/dim7/mMaj7/maj9/m9/dom9）。度数は長音階基準、quality は accidental に（m7 = 1,b3,5,b7）
+- `midi/chord/resolve-chords.ts`: `resolveChords(elements, getChord)` — spread（ref 展開）/ 除去 `-N`（字面一致 degree+alteration、不一致は warning）/ ref `^N`（spread voice に構造的加算）/ standalone ref → 一スロット stack。namespace は `getChord` 注入で純関数化（§6.5.2 評価時値渡し）
+- `parser/types.ts`: PlayElement union に `PlayChordRef`（§9.1 の `(0, m7, 0)` グループ要素対応、L2 で解決され timing には到達しない transient）、StackElement を `PlayElement | PlayChordRemoval` に整理
+- `timing/calculate-event-timing.ts`: 未解決 chord_ref が timing walk に来たら internal error（silent drop 防止）
+
+**テスト**: `chord-resolution.spec.ts` 11件（spread/add/除去/不一致 warning/`^N`/standalone/unknown/whole-stack `^N` 保持/predefined テーブル）。全体 906 passed / 23 skipped。
+
 ### 6.106 Issue #230 — Phase 2: `.root()`/`.mode()`/`.oct()` グループスコープ — パーサー層 (Jun 13, 2026)
 
 **Date**: 2026-06-13

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,25 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.107 Issue #231 — Phase 3: `[ ]` スタック + chord 値 (Jun 13, 2026)
+
+**Date**: 2026-06-13
+**Status**: 🚧 IN PROGRESS（スタック core 完了 B0-B4。chord 値 spread/除去/import は後続コミット B5-B7）
+**Issue**: signalcompose/orbitscore#231
+**Branch**: `231-phase-3-stack-chord`
+
+**設計**: code-architect で blueprint を策定（4層パイプライン: L1 parse→PlayStack（生）/ L2 evaluate（chord 名解決・spread・除去・^N、namespace を持つ唯一の層）/ L3 timing（並列再帰）/ L4 dispatch（同時 note-on は等 startTime から自動的に従う、audio 拒否は生パターン走査）。spec §4/§6/§10 正本。advisor で「Phase R 未実装＝chord 値用の値束縛基盤を本フェーズで最小構築」を確認）。
+
+**前提の訂正**: 直前要約は Phase R (#227 パターン変数) 完了を前提にしていたが、#227 は OPEN・値束縛/`import`/`*n` 基盤は未実装。chord 値の namespace は本フェーズで chord 専用に最小構築し、`kind` discriminant で Phase R と共有可能にする（`*n`・汎用タプルパターン変数は作らない）。
+
+**本コミット（スタック core B0-B4）**:
+- `parser/types.ts`: `PlayStack`（voices + 任意 octaveShift）/`StackElement`/`PlayChordRef`/`PlayChordRemoval` を追加、PlayElement union に PlayStack
+- `parser/parse-expression.ts`: `parseStack`/`parseStackElement`（`[ ]` を常に PlayStack へ。LBRACKET の旧 `bracketReservedMessage` throw を撤去）、`parseChordRef`（bare 識別子 + `^N`）、`parseChordRemoval`（`-N`/`-bN`、`[ ]` 内 `-` は常に除去）、`asStackVoice`（スタック voice の `^N` は構造的＝rangeSet クリア §2.4）
+- `timing/calculation/calculate-event-timing.ts`: `stack` 分岐（voice ごとに `[voice]` を全長・等 startTime で並列再帰、`[1,(5,3,2,1)]` のサブツリーは同一スパンを再分割）+ `applyStackOctaveShift`（whole-stack `^N` を構造的に加算）。未解決 chord_ref/removal が来たら internal error
+- `core/sequence.ts`: dispatch の octaveShift を加算式に修正（`runningRange + groupOct + (rangeSet?0:octaveShift)`。構造的シフトを上乗せ、従来の旋律音は no-op）。`validateNonMidiDispatch` + `containsStack`（生パターン再帰走査、`( )`/scope/modifier 内のスタックも検出）を追加し run()/loop() で eager 拒否（§10-5 audio スタック予約）
+
+**テスト**: `stack-parsing.spec.ts` 10件 / `stack-timing.spec.ts` 5件 / `sequence-stack-dispatch.spec.ts` 7件（同時 note-on、scope 合成、voice/whole `^N` の加算、running range 非干渉、audio 拒否）。`pitch-parsing.spec.ts` の旧「`[ ]` reserved＝parse throw」3件を新仕様（PlayStack へ parse、拒否は dispatch）に更新。全体 895 passed / 23 skipped。
+
 ### 6.106 Issue #230 — Phase 2: `.root()`/`.mode()`/`.oct()` グループスコープ — パーサー層 (Jun 13, 2026)
 
 **Date**: 2026-06-13

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -57,7 +57,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **決定（spec 範囲内）**: 除去 `-N` の字面一致は (degree, alteration)（§6 字面一致の具体化）。namespace 衝突は last-write-wins + warning（§10-4）。未定義 chord 名参照は warning + 空展開（§6 は未規定、no-op+warning 哲学に整合）。`{ }` レガート・`_` タイ（§5）と top-level bare chord 名は Phase 3 範囲外（§9.1 のそれらは Phase 4）。
 
-**テスト**: `chord-binding-parsing.spec.ts` 8件 / `sequence-chord-dispatch.spec.ts` 11件（import+`[m7]`、`(0,m7,0,m7).root(3)`、spread+add/除去、whole-chord `^+1`、defineChord、unknown warning、registry、interpreter 配線）。全体 925 passed / 23 skipped。core spec は specs-v2 を正本として参照（§4/§6 は PITCH_DSL_SPEC が正本、乖離なし）。
+**テスト**: `chord-binding-parsing.spec.ts` 8件 / `sequence-chord-dispatch.spec.ts` 12件（import+`[m7]`、`(0,m7,0,m7).root(3)`、spread+add/除去、whole-chord `^+1`、defineChord、unknown warning、registry、interpreter 配線、**§9.1 正本 bar 3**）。`sequence-stack-dispatch.spec.ts` に **§9.1 正本 bar 4**（`[1,3,b7,13]`/`b13` の高次テンション 13/b13）を追加。全体 927 passed / 23 skipped。core spec は specs-v2 を正本として参照（§4/§6 は PITCH_DSL_SPEC が正本、乖離なし）。
 
 ### 6.106 Issue #230 — Phase 2: `.root()`/`.mode()`/`.oct()` グループスコープ — パーサー層 (Jun 13, 2026)
 

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -4,6 +4,10 @@
  */
 
 import { AudioEngine } from '../audio/types'
+import { StackElement } from '../parser/types'
+import { BoundValue, ChordVoice } from '../midi/chord/types'
+import { evaluateChordDefinition } from '../midi/chord/resolve-chords'
+import { PREDEFINED_CHORDS } from '../midi/chord/predefined-chords'
 
 import { Sequence } from './sequence'
 import { Scheduler, GlobalState } from './global/types'
@@ -122,6 +126,48 @@ export class Global {
   /** Accessor for the shared MIDI manager (used by Sequence MIDI dispatch). */
   getMidiManager(): MidiManager {
     return this.midiManager
+  }
+
+  // ─── Chord namespace (§6) ──────────────────────────────────────────────────
+  // A program-global table of chord values, read by Sequence.play to spread chord
+  // refs (§6, 評価時値渡し). Lives here — like global.key() — so the interpreter
+  // and direct sequence use share one namespace. Phase R (#227) will add its own
+  // value kind to the same table via the BoundValue `kind` discriminant.
+  private chordRegistry = new Map<string, BoundValue>()
+
+  /** `import chords` (§6): load the stdlib chord qualities into the namespace. */
+  importChords(): this {
+    for (const [name, voices] of Object.entries(PREDEFINED_CHORDS)) {
+      this.setChord(name, { kind: 'chord', voices })
+    }
+    return this
+  }
+
+  /**
+   * `var NAME = chord([ ... ])` (§6): evaluate the raw stack (spread refs to chords
+   * already bound, apply `-N` removals / `^N`) and bind the resulting voice list.
+   */
+  defineChord(name: string, voices: StackElement[]): this {
+    const { voices: resolved, warnings } = evaluateChordDefinition(voices, (n) =>
+      this.getChordVoices(n),
+    )
+    for (const w of warnings) console.warn(`⚠️  chord ${name}: ${w}`)
+    this.setChord(name, { kind: 'chord', voices: resolved })
+    return this
+  }
+
+  /** The voices of a bound chord, or undefined if the name is unbound. */
+  getChordVoices(name: string): ChordVoice[] | undefined {
+    const bound = this.chordRegistry.get(name)
+    return bound?.kind === 'chord' ? bound.voices : undefined
+  }
+
+  /** Bind a chord value, warning on overwrite (§10-4: global binding + conflict warning). */
+  private setChord(name: string, value: BoundValue): void {
+    if (this.chordRegistry.has(name)) {
+      console.warn(`⚠️  chord namespace: "${name}" redefined (last-write-wins, §10-4).`)
+    }
+    this.chordRegistry.set(name, value)
   }
 
   // Audio path and device management

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -9,6 +9,7 @@ import * as path from 'path'
 import { AudioEngine } from '../audio/types'
 import { PlayElement, RandomValue } from '../parser/audio-parser'
 import { resolveDegree } from '../midi/degree-resolution'
+import { resolveChords } from '../midi/chord/resolve-chords'
 import { RootContext } from '../midi/types'
 import { TimedEventScope } from '../timing/calculation/types'
 
@@ -400,19 +401,30 @@ export class Sequence {
   }
 
   play(...elements: PlayElement[]): this {
-    this.stateManager.setPlayPattern(elements)
+    // §6 evaluation (L2): resolve chord-name refs / `-N` removals / `^N` against the
+    // global chord namespace BEFORE timing, so the stored pattern is pure symbolic
+    // (no chord_ref reaches the timing walk). 評価時値渡し — a later chord
+    // redefinition does not retro-affect this already-resolved pattern (§6.5.2).
+    const { elements: resolved, warnings } = resolveChords(elements, (name) =>
+      this.global.getChordVoices(name),
+    )
+    for (const w of warnings) {
+      console.warn(`⚠️  Sequence '${this.stateManager.getName() || 'sequence'}': ${w}`)
+    }
+
+    this.stateManager.setPlayPattern(resolved)
 
     // Calculate timing for the play pattern
     const globalState = this.global.getState()
     const timedEvents = this.tempoManager.calculateEventTiming(
-      elements,
+      resolved,
       globalState.tempo || 120,
       globalState.beat,
     )
 
     this.stateManager.setTimedEvents(timedEvents)
 
-    const patternStr = elements
+    const patternStr = resolved
       .map((e) => (typeof e === 'object' ? JSON.stringify(e) : e))
       .join(' ')
     this.seamlessParameterUpdate('play', patternStr)

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -560,6 +560,49 @@ export class Sequence {
   }
 
   /**
+   * Eager guard: a `[ ]` stack (§4) is reserved as a diagnostic error in AUDIO
+   * sequences (§10-5) — simultaneous note-on is a MIDI feature in v1.1; audio
+   * slice layering is a future addition. By dispatch the timing walk has dissolved
+   * the stack into overlapping events, so this scans the RAW play pattern instead,
+   * in the awaited run()/loop() chain (same rationale as validateMidiDispatch) so
+   * the throw reaches the caller rather than becoming an unhandled rejection.
+   */
+  private validateNonMidiDispatch(): void {
+    if (this.isMidi()) return
+    const pattern = this.stateManager.getPlayPattern()
+    if (pattern && this.containsStack(pattern)) {
+      throw new Error(
+        'Stack "[ ]" is not yet supported in audio sequences (reserved, §10-5). ' +
+          'Simultaneous note-on is a MIDI feature in v1.1; audio slice layering is ' +
+          'a future addition. See PITCH_DSL_SPEC §4 / §10-5.',
+      )
+    }
+  }
+
+  /**
+   * Recursively detect a `[ ]` stack anywhere in a raw play pattern — including
+   * inside `( )` groups, `.root()`/`.oct()` scope groups, and `.chop()` modifiers
+   * (a stack nested in `([...]).root(2)` must still be found).
+   */
+  private containsStack(elements: PlayElement[]): boolean {
+    for (const el of elements) {
+      if (!el || typeof el !== 'object') continue
+      if (el.type === 'stack') return true
+      if (el.type === 'nested' && this.containsStack(el.elements)) return true
+      if (el.type === 'scoped' && this.containsStack(el.groups)) return true
+      if (
+        el.type === 'modified' &&
+        typeof el.value === 'object' &&
+        el.value.type === 'nested' &&
+        this.containsStack(el.value.elements)
+      ) {
+        return true
+      }
+    }
+    return false
+  }
+
+  /**
    * Schedule this sequence's timed events as MIDI notes (§7-0 output stage:
    * symbolic pitch is resolved to a MIDI note number here, at the last moment).
    *
@@ -606,10 +649,16 @@ export class Sequence {
       // default for this note (inner→outer already collapsed in the timing walk).
       const context = this.resolveScopeToContext(ev.scope, getSeqDefault)
       // Effective octave = sticky running range (`^N`, linear) + group register
-      // (`.oct()`, lexical). The two are orthogonal axes and compose additively
-      // (§9.3); `.oct()` is local to its group, while `^N` persists across group
-      // boundaries (§9.4), so groupOct never feeds back into runningRange.
-      const effectiveOctave = runningRange + (ev.scope?.groupOct ?? 0)
+      // (`.oct()`, lexical) + the voice's structural shift. The first two are
+      // orthogonal axes that compose additively (§9.3); `.oct()` is local to its
+      // group, while `^N` persists across group boundaries (§9.4), so groupOct
+      // never feeds back into runningRange. The structural part is a stack voice's
+      // own `^N` (§4/§6 `b7^+1`, rangeSet=false): it layers ON TOP of the running
+      // range without moving it (§2.4). A melodic `^N` (rangeSet=true) has already
+      // folded into runningRange above, so its structural part is 0 — keeping this
+      // additive is a no-op for every pre-stack note.
+      const structural = written.rangeSet ? 0 : written.octaveShift
+      const effectiveOctave = runningRange + (ev.scope?.groupOct ?? 0) + structural
       const symbolic = { ...written, octaveShift: effectiveOctave }
       const resolved = resolveDegree(symbolic, context)
       if (!resolved) {
@@ -754,6 +803,7 @@ export class Sequence {
     // unhandled rejection inside the fire-and-forget scheduleEventsFn callback.
     this.resolveDispatchChannel()
     this.validateMidiDispatch() // eager root + degree validation (same rationale)
+    this.validateNonMidiDispatch() // eager `[ ]`-in-audio rejection (§10-5)
 
     const prepared = await preparePlayback({
       sequenceName: this.stateManager.getName(),
@@ -796,6 +846,7 @@ export class Sequence {
     // unhandled rejection inside the fire-and-forget scheduleEventsFn callback.
     this.resolveDispatchChannel()
     this.validateMidiDispatch() // eager root + degree validation (same rationale)
+    this.validateNonMidiDispatch() // eager `[ ]`-in-audio rejection (§10-5)
 
     const prepared = await preparePlayback({
       sequenceName: this.stateManager.getName(),

--- a/packages/engine/src/interpreter/process-statement.ts
+++ b/packages/engine/src/interpreter/process-statement.ts
@@ -8,6 +8,8 @@ import {
   GlobalStatement,
   SequenceStatement,
   TransportStatement,
+  ChordBinding,
+  ImportStatement,
 } from '../parser/audio-parser'
 
 import { InterpreterState } from './types'
@@ -53,10 +55,44 @@ export async function processStatement(
     case 'transport':
       await processTransportStatement(statement, state)
       break
+    case 'import':
+      processImportStatement(statement, state)
+      break
+    case 'chord_binding':
+      processChordBinding(statement, state)
+      break
     default:
       // TypeScript should prevent this, but handle gracefully at runtime
       console.warn(`Unknown statement type: ${(statement as any).type}`)
   }
+}
+
+/**
+ * Process `import chords` (§6): load the stdlib chord qualities into the active
+ * global's chord namespace. Statements execute in source order, so a later play()
+ * sees the imported chords (評価時値渡し).
+ */
+function processImportStatement(statement: ImportStatement, state: InterpreterState): void {
+  if (statement.module !== 'chords') {
+    console.warn(`Unknown import "${statement.module}" — v1.1 supports only \`import chords\`.`)
+    return
+  }
+  if (!state.currentGlobal) {
+    console.error('`import chords` requires a global (declare `var g = init GLOBAL` first).')
+    return
+  }
+  state.currentGlobal.importChords()
+}
+
+/** Process `var NAME = chord([ ... ])` (§6): bind the evaluated chord value. */
+function processChordBinding(statement: ChordBinding, state: InterpreterState): void {
+  if (!state.currentGlobal) {
+    console.error(
+      `chord "${statement.variableName}" requires a global (declare \`var g = init GLOBAL\` first).`,
+    )
+    return
+  }
+  state.currentGlobal.defineChord(statement.variableName, statement.voices)
 }
 
 /**

--- a/packages/engine/src/midi/chord/predefined-chords.ts
+++ b/packages/engine/src/midi/chord/predefined-chords.ts
@@ -1,0 +1,41 @@
+/**
+ * The `import chords` standard library (§6, §10-4): a table of common chord
+ * qualities as root-unbound degree stacks. Degrees are written against the major
+ * scale, so the quality lives in the accidentals (m7 = 1, b3, 5, b7).
+ *
+ * Brought into the global chord namespace by `import chords`; a later `var` of
+ * the same name shadows it with a conflict warning (§10-4, last-write-wins).
+ */
+import { ChordVoice } from './types'
+
+/** Build a close-position voice (no structural octave / detune). */
+const v = (degree: number, alteration = 0): ChordVoice => ({
+  degree,
+  alteration,
+  octaveShift: 0,
+  detune: 0,
+})
+
+export const PREDEFINED_CHORDS: Record<string, ChordVoice[]> = {
+  // Triads
+  maj: [v(1), v(3), v(5)],
+  min: [v(1), v(3, -1), v(5)],
+  dim: [v(1), v(3, -1), v(5, -1)],
+  aug: [v(1), v(3), v(5, 1)],
+  sus4: [v(1), v(4), v(5)],
+  sus2: [v(1), v(2), v(5)],
+  // Sixths
+  '6': [v(1), v(3), v(5), v(6)],
+  m6: [v(1), v(3, -1), v(5), v(6)],
+  // Sevenths
+  maj7: [v(1), v(3), v(5), v(7)],
+  m7: [v(1), v(3, -1), v(5), v(7, -1)],
+  dom7: [v(1), v(3), v(5), v(7, -1)],
+  m7b5: [v(1), v(3, -1), v(5, -1), v(7, -1)],
+  dim7: [v(1), v(3, -1), v(5, -1), v(7, -2)],
+  mMaj7: [v(1), v(3, -1), v(5), v(7)],
+  // Ninths
+  maj9: [v(1), v(3), v(5), v(7), v(9)],
+  m9: [v(1), v(3, -1), v(5), v(7, -1), v(9)],
+  dom9: [v(1), v(3), v(5), v(7, -1), v(9)],
+}

--- a/packages/engine/src/midi/chord/resolve-chords.ts
+++ b/packages/engine/src/midi/chord/resolve-chords.ts
@@ -148,3 +148,60 @@ export function resolveChords(elements: PlayElement[], getChord: ChordLookup): R
   const resolved = elements.map((e) => resolveElement(e, getChord, warnings))
   return { elements: resolved, warnings }
 }
+
+export interface ChordDefinitionResult {
+  voices: ChordVoice[]
+  warnings: string[]
+}
+
+/**
+ * Evaluate a `chord([ ... ])` definition (§6) to a flat voice list for storage in
+ * the namespace. Like the stack evaluator but in {@link ChordVoice} space: it
+ * spreads refs to other chords (`chord([m7, 9])`), removes literal matches
+ * (`chord([m7, -5])`), and folds a ref's `^N` into the spread voices. Chord
+ * definitions are flat degree stacks (§6) — a non-flat voice (subtree/stack) is a
+ * diagnostic warning and skipped, not silently dropped.
+ */
+export function evaluateChordDefinition(
+  voices: StackElement[],
+  getChord: ChordLookup,
+): ChordDefinitionResult {
+  const result: ChordVoice[] = []
+  const warnings: string[] = []
+  for (const voice of voices) {
+    if (typeof voice === 'number') {
+      result.push({ degree: voice, alteration: 0, octaveShift: 0, detune: 0 })
+    } else if (voice && typeof voice === 'object' && voice.type === 'chord_ref') {
+      const spread = getChord(voice.name)
+      if (!spread) {
+        warnings.push(`unknown chord "${voice.name}" in chord definition — skipped (§6).`)
+        continue
+      }
+      for (const vc of spread) {
+        result.push({ ...vc, octaveShift: vc.octaveShift + voice.octaveShift })
+      }
+    } else if (voice && typeof voice === 'object' && voice.type === 'chord_removal') {
+      const before = result.length
+      for (let i = result.length - 1; i >= 0; i--) {
+        if (result[i]!.degree === voice.degree && result[i]!.alteration === voice.alteration) {
+          result.splice(i, 1)
+        }
+      }
+      if (result.length === before) {
+        const acc =
+          voice.alteration < 0 ? 'b'.repeat(-voice.alteration) : '#'.repeat(voice.alteration)
+        warnings.push(`removal "-${acc}${voice.degree}" matched no voice in chord — no-op (§6).`)
+      }
+    } else if (voice && typeof voice === 'object' && voice.type === 'pitch') {
+      result.push({
+        degree: voice.degree,
+        alteration: voice.alteration,
+        octaveShift: voice.octaveShift,
+        detune: voice.detune,
+      })
+    } else {
+      warnings.push('a chord definition must be a flat degree stack (§6) — voice skipped.')
+    }
+  }
+  return { voices: result, warnings }
+}

--- a/packages/engine/src/midi/chord/resolve-chords.ts
+++ b/packages/engine/src/midi/chord/resolve-chords.ts
@@ -1,0 +1,150 @@
+/**
+ * Chord resolution (§6): the evaluation step (L2) that turns a RAW play pattern
+ * — one that may carry chord-name refs (`m7`), removal markers (`-5`), and stack
+ * octave shifts (`m7^+1`) — into a pure symbolic pattern (numbers / PlayPitch /
+ * PlayStack / PlayNested) that the timing walk and MIDI dispatch can consume.
+ *
+ * Pure: the chord namespace is injected as a `getChord` lookup, so this module
+ * has no I/O and is fully unit-testable. Resolution is "評価時値渡し" (§6.5.2) —
+ * it runs once at play()/define time against the namespace as it exists then, so a
+ * later redefinition does not retro-affect an already-resolved pattern.
+ *
+ * Rules (§6):
+ *  - Spread: a chord ref inside a `[ ]` stack (or as a bare group element) expands
+ *    to its voices; same rule at definition site (`chord([m7, 9])`) and use site.
+ *  - Removal `-N`: removes the LITERAL-matching voice (degree + alteration) from the
+ *    spread stack; no match = no-op + warning (literal match only — §6 rejects
+ *    resolved-pitch matching as context-dependent).
+ *  - `^N` on a ref = a whole-chord structural octave shift on that ref's voices.
+ */
+import { PlayElement, PlayChordRef, PlayChordRemoval, StackElement } from '../../parser/types'
+
+import { ChordVoice } from './types'
+
+/** Namespace lookup: a chord name → its voices, or undefined if unbound. */
+export type ChordLookup = (name: string) => ChordVoice[] | undefined
+
+export interface ResolveResult {
+  elements: PlayElement[]
+  /** Diagnostics (no-match removals, unknown chord names) — surfaced by the caller. */
+  warnings: string[]
+}
+
+/** A close-position chord voice → a play element (a bare degree when plain). */
+function voiceToElement(voice: ChordVoice): PlayElement {
+  if (voice.alteration === 0 && voice.octaveShift === 0 && voice.detune === 0) {
+    return voice.degree
+  }
+  return {
+    type: 'pitch',
+    degree: voice.degree,
+    alteration: voice.alteration,
+    octaveShift: voice.octaveShift,
+    rangeSet: false, // §2.4: a chord voice's octave is structural, never a range set point
+    detune: voice.detune,
+  }
+}
+
+/** True if a resolved voice element literally matches a removal's (degree, alteration). */
+function matchesRemoval(el: PlayElement, removal: PlayChordRemoval): boolean {
+  if (typeof el === 'number') {
+    return el === removal.degree && removal.alteration === 0
+  }
+  return (
+    typeof el === 'object' &&
+    el.type === 'pitch' &&
+    el.degree === removal.degree &&
+    el.alteration === removal.alteration
+  )
+}
+
+/** Spread a chord ref into its voices, folding the ref's `^N` into each voice. */
+function spreadRef(ref: PlayChordRef, getChord: ChordLookup, warnings: string[]): PlayElement[] {
+  const voices = getChord(ref.name)
+  if (!voices) {
+    warnings.push(
+      `unknown chord "${ref.name}" — reference left empty (§6). Did you \`import chords\`?`,
+    )
+    return []
+  }
+  return voices.map((vc) =>
+    voiceToElement({ ...vc, octaveShift: vc.octaveShift + ref.octaveShift }),
+  )
+}
+
+/**
+ * Evaluate a stack's raw voices: spread chord refs, apply `-N` removals to the
+ * accumulated voices (left to right, §6), and recurse into subtree voices.
+ */
+function evaluateStackVoices(
+  voices: StackElement[],
+  getChord: ChordLookup,
+  warnings: string[],
+): PlayElement[] {
+  const result: PlayElement[] = []
+  for (const voice of voices) {
+    if (voice && typeof voice === 'object' && voice.type === 'chord_ref') {
+      result.push(...spreadRef(voice, getChord, warnings))
+    } else if (voice && typeof voice === 'object' && voice.type === 'chord_removal') {
+      const before = result.length
+      for (let i = result.length - 1; i >= 0; i--) {
+        if (matchesRemoval(result[i]!, voice)) result.splice(i, 1)
+      }
+      if (result.length === before) {
+        const acc =
+          voice.alteration < 0 ? 'b'.repeat(-voice.alteration) : '#'.repeat(voice.alteration)
+        warnings.push(`removal "-${acc}${voice.degree}" matched no voice — no-op (§6).`)
+      }
+    } else {
+      // A literal voice (number / PlayPitch) or a subtree voice ((5,3,2,1) etc.):
+      // recurse so any chord ref nested inside a subtree is also resolved.
+      result.push(resolveElement(voice as PlayElement, getChord, warnings))
+    }
+  }
+  return result
+}
+
+/** Resolve a single play element, recursing through groups / stacks / modifiers. */
+function resolveElement(el: PlayElement, getChord: ChordLookup, warnings: string[]): PlayElement {
+  if (!el || typeof el !== 'object') return el // bare degree / slice number
+  switch (el.type) {
+    case 'stack': {
+      const resolved = evaluateStackVoices(el.voices, getChord, warnings)
+      return el.octaveShift !== undefined
+        ? { type: 'stack', voices: resolved, octaveShift: el.octaveShift }
+        : { type: 'stack', voices: resolved }
+    }
+    case 'chord_ref':
+      // A bare chord ref as a standalone element → a one-slot simultaneous stack.
+      return { type: 'stack', voices: spreadRef(el, getChord, warnings) }
+    case 'nested':
+      return {
+        type: 'nested',
+        elements: el.elements.map((e) => resolveElement(e, getChord, warnings)),
+      }
+    case 'scoped':
+      return { ...el, groups: el.groups.map((e) => resolveElement(e, getChord, warnings)) }
+    case 'modified':
+      return el.value && typeof el.value === 'object' && el.value.type === 'nested'
+        ? {
+            ...el,
+            value: {
+              type: 'nested',
+              elements: el.value.elements.map((e) => resolveElement(e, getChord, warnings)),
+            },
+          }
+        : el
+    default:
+      return el // pitch — already symbolic
+  }
+}
+
+/**
+ * Resolve chord refs / removals / shifts across a whole play pattern, producing a
+ * pure symbolic pattern. The single entry point used by Sequence.play (§6 L2).
+ */
+export function resolveChords(elements: PlayElement[], getChord: ChordLookup): ResolveResult {
+  const warnings: string[] = []
+  const resolved = elements.map((e) => resolveElement(e, getChord, warnings))
+  return { elements: resolved, warnings }
+}

--- a/packages/engine/src/midi/chord/types.ts
+++ b/packages/engine/src/midi/chord/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Chord-value types (§6 / DESIGN_DISCUSSION_RECORD §9).
+ *
+ * A chord value is a ROOT-UNBOUND degree stack — a vertical value resolved against
+ * the scope (root/mode) where it is placed, distinct from the placement context
+ * itself (§6: "root はコンテキスト、chord は値"). Chord values live in a runtime
+ * namespace (Global), populated by `import chords` and `var X = chord([...])`.
+ */
+
+/**
+ * One voice of a chord: a symbolic degree against the (later) placement scope.
+ * Mirrors the pitched subset of {@link import('../types').SymbolicPitch} — but
+ * `octaveShift` here is STRUCTURAL voicing (a voice placed an octave up, §6 So What),
+ * layered on the running range at dispatch and never a running-range set point (§2.4).
+ */
+export interface ChordVoice {
+  degree: number
+  alteration: number
+  octaveShift: number // structural voicing octave; 0 for a close-position voice
+  detune: number // semitones (`~`); 0 for an untuned voice
+}
+
+/**
+ * A bound value in the chord namespace. The `kind` discriminant keeps the
+ * namespace shared-ready: Phase R (#227) adds its own value kind (e.g. a tree
+ * pattern variable) to the same table without disturbing chord values.
+ */
+export type BoundValue = { kind: 'chord'; voices: ChordVoice[] }

--- a/packages/engine/src/parser/audio-parser.ts
+++ b/packages/engine/src/parser/audio-parser.ts
@@ -25,6 +25,8 @@ export type {
   GlobalStatement,
   SequenceStatement,
   TransportStatement,
+  ChordBinding,
+  ImportStatement,
   MethodChain,
   RandomValue,
   PlayElement,

--- a/packages/engine/src/parser/parse-expression.ts
+++ b/packages/engine/src/parser/parse-expression.ts
@@ -792,6 +792,10 @@ export class ExpressionParser {
       const pitchResult = this.parsePitch()
       this.pos = pitchResult.newPos
       elements.push(pitchResult.value)
+    } else if (cur === 'IDENTIFIER') {
+      // A bare chord-name element inside a group, e.g. (0, m7, 0).root(3) (§6/§9.1).
+      // Resolved (spread to a one-slot stack) at evaluation against the namespace.
+      elements.push(this.parseChordRef())
     } else if (cur === 'NUMBER') {
       const numResult = ParserUtils.advance(this.tokens, this.pos)
       this.pos = numResult.newPos

--- a/packages/engine/src/parser/parse-expression.ts
+++ b/packages/engine/src/parser/parse-expression.ts
@@ -14,6 +14,10 @@ import {
   PlayModifier,
   PlayPitch,
   PlayScoped,
+  PlayStack,
+  StackElement,
+  PlayChordRef,
+  PlayChordRemoval,
   ScopeRoot,
   ScopeMode,
   Meter,
@@ -81,24 +85,10 @@ export class ExpressionParser {
     }
 
     if (token.type === 'LBRACKET') {
-      throw new Error(this.bracketReservedMessage())
+      return this.parseStack()
     }
 
     throw new Error(`Unexpected token in argument: ${token.type}`)
-  }
-
-  /**
-   * The stack `[ ]` syntax is reserved but not implemented in v1.1 (spec §10-5).
-   * We tokenize `[`/`]` and raise this diagnostic rather than silently dropping
-   * them, so the future opening (MIDI chords in Phase 3, audio layering later)
-   * is a pure addition.
-   */
-  private bracketReservedMessage(): string {
-    return (
-      'Stack "[ ]" is not yet supported in v1.1 (reserved). ' +
-      'Chord stacks for MIDI arrive in a later phase; audio slice layering is reserved. ' +
-      'See PITCH_DSL_SPEC §4 / §10-5.'
-    )
   }
 
   /**
@@ -649,6 +639,136 @@ export class ExpressionParser {
   }
 
   /**
+   * Parse a `[ ]` simultaneous-note-on stack (§4). Voices are parallel — NOT a
+   * juxtaposition run — so, unlike parseNestedPlay, this never calls
+   * collapseScopedRun. A trailing `^N` on the `]` is a whole-stack octave shift
+   * (§6 `m7^+1`). Always produces a PlayStack regardless of sequence domain; the
+   * audio-vs-MIDI rejection (§10-5) is a dispatch-time diagnostic.
+   */
+  private parseStack(): { value: PlayStack; newPos: number } {
+    const voices: StackElement[] = []
+    const lbracket = ParserUtils.expect(this.tokens, this.pos, 'LBRACKET')
+    this.pos = lbracket.newPos
+
+    while (
+      ParserUtils.current(this.tokens, this.pos).type !== 'RBRACKET' &&
+      !ParserUtils.isEOF(this.tokens, this.pos)
+    ) {
+      this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
+      if (ParserUtils.current(this.tokens, this.pos).type === 'RBRACKET') {
+        break
+      }
+      this.parseStackElement(voices)
+      this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
+      if (ParserUtils.current(this.tokens, this.pos).type === 'COMMA') {
+        this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
+      } else {
+        break
+      }
+    }
+
+    const rbracket = ParserUtils.expect(this.tokens, this.pos, 'RBRACKET')
+    this.pos = rbracket.newPos
+
+    // Optional trailing `^N`: a whole-stack octave shift (§6). Structural — never
+    // a running-range set point (§2.4), so it lives on the node, not in a voice.
+    if (ParserUtils.current(this.tokens, this.pos).type === 'CARET') {
+      this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
+      const octaveShift = this.parseSignedNumber()
+      return { value: { type: 'stack', voices, octaveShift }, newPos: this.pos }
+    }
+
+    return { value: { type: 'stack', voices }, newPos: this.pos }
+  }
+
+  /**
+   * Parse a single voice within a `[ ]` stack. Extends the nested-element grammar
+   * with the two chord markers: a bare IDENTIFIER → {@link PlayChordRef} (a bound
+   * chord value, resolved at evaluation), and a leading MINUS → {@link
+   * PlayChordRemoval} (§6 literal removal — inside `[ ]` a `-` is always a removal,
+   * never a negative number, since stack voices are degrees ≥ 1). A `^N` on a
+   * pitched voice is STRUCTURAL (rangeSet cleared, §2.4).
+   */
+  private parseStackElement(voices: StackElement[]): void {
+    this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
+    const cur = ParserUtils.current(this.tokens, this.pos).type
+
+    if (cur === 'LBRACKET') {
+      const stackResult = this.parseStack()
+      this.pos = stackResult.newPos
+      voices.push(stackResult.value)
+    } else if (cur === 'LPAREN') {
+      // Independent subtree voice, e.g. [1, (5, 3, 2, 1)] (one-part polyphony, §4).
+      const nestedResult = this.parseNestedPlay()
+      this.pos = nestedResult.newPos
+      voices.push(nestedResult.value)
+    } else if (cur === 'MINUS') {
+      voices.push(this.parseChordRemoval())
+    } else if (cur === 'IDENTIFIER') {
+      voices.push(this.parseChordRef())
+    } else if (cur === 'ACCIDENTAL') {
+      const pitchResult = this.parsePitch()
+      this.pos = pitchResult.newPos
+      voices.push(this.asStackVoice(pitchResult.value))
+    } else if (cur === 'NUMBER') {
+      const numResult = ParserUtils.advance(this.tokens, this.pos)
+      this.pos = numResult.newPos
+      const value = ParserUtils.parseNumber(numResult.token)
+      const next = ParserUtils.current(this.tokens, this.pos).type
+      if (next === 'CARET' || next === 'TILDE') {
+        const pitchResult = this.parsePitchModifiers(value, 0)
+        this.pos = pitchResult.newPos
+        voices.push(this.asStackVoice(pitchResult.value))
+      } else {
+        voices.push(value)
+      }
+    } else {
+      throw new Error(`Unexpected token in stack [ ]: ${cur}`)
+    }
+  }
+
+  /**
+   * Mark a PlayPitch as a stack voice: clear `rangeSet` so a voice `^N` is
+   * structural (§2.4 — stack-internal `^N` places the voice's octave but does NOT
+   * move the running range, unlike a melodic `^N`).
+   */
+  private asStackVoice(pitch: PlayPitch): PlayPitch {
+    return pitch.rangeSet ? { ...pitch, rangeSet: false } : pitch
+  }
+
+  /**
+   * Parse a bare chord-name reference inside a stack: IDENTIFIER [`^N`] (§6). The
+   * name is resolved at evaluation against the chord namespace. A trailing `^N` is
+   * a whole-chord structural octave shift applied to the spread voices.
+   */
+  private parseChordRef(): PlayChordRef {
+    const id = ParserUtils.advance(this.tokens, this.pos)
+    this.pos = id.newPos
+    if (ParserUtils.current(this.tokens, this.pos).type === 'CARET') {
+      this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
+      return { type: 'chord_ref', name: id.token.value, octaveShift: this.parseSignedNumber() }
+    }
+    return { type: 'chord_ref', name: id.token.value, octaveShift: 0 }
+  }
+
+  /**
+   * Parse a removal marker inside a stack: MINUS [ACCIDENTAL] NUMBER (`-5`, `-b3`).
+   * Inside `[ ]` a leading `-` is always a removal (§6), never a negative number.
+   */
+  private parseChordRemoval(): PlayChordRemoval {
+    this.pos = ParserUtils.advance(this.tokens, this.pos).newPos // MINUS
+    let alteration = 0
+    const cur = ParserUtils.current(this.tokens, this.pos)
+    if (cur.type === 'ACCIDENTAL') {
+      alteration = this.accidentalToAlteration(cur.value)
+      this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
+    }
+    const num = ParserUtils.expect(this.tokens, this.pos, 'NUMBER')
+    this.pos = num.newPos
+    return { type: 'chord_removal', degree: ParserUtils.parseNumber(num.token), alteration }
+  }
+
+  /**
    * Parse a single element within a nested play structure
    */
   private parseNestedPlayElement(elements: PlayElement[]): void {
@@ -657,8 +777,11 @@ export class ExpressionParser {
     const cur = ParserUtils.current(this.tokens, this.pos).type
 
     if (cur === 'LBRACKET') {
-      // Stack [ ] is reserved (spec §10-5) — error rather than silently ignore.
-      throw new Error(this.bracketReservedMessage())
+      // Stack [ ] (§4): a simultaneous-note-on group. Parsed here; the audio-vs-
+      // MIDI rejection (§10-5) is a dispatch-time diagnostic, not a parse error.
+      const stackResult = this.parseStack()
+      this.pos = stackResult.newPos
+      elements.push(stackResult.value)
     } else if (cur === 'LPAREN') {
       // Nested element
       const nestedResult = this.parseNestedPlay()

--- a/packages/engine/src/parser/parse-statement.ts
+++ b/packages/engine/src/parser/parse-statement.ts
@@ -3,7 +3,16 @@
  * Based on specification: docs/INSTRUCTION_ORBITSCORE_DSL.md
  */
 
-import { AudioToken, GlobalInit, SequenceInit, Statement, MethodChain } from './types'
+import {
+  AudioToken,
+  GlobalInit,
+  SequenceInit,
+  Statement,
+  MethodChain,
+  ChordBinding,
+  ImportStatement,
+  PlayStack,
+} from './types'
 import { ParserUtils } from './parser-utils'
 import { ExpressionParser, collapseScopedRun } from './parse-expression'
 
@@ -25,9 +34,14 @@ export class StatementParser {
   parseStatement(): { statement: any; newPos: number } {
     const token = ParserUtils.current(this.tokens, this.pos)
 
-    // Variable declaration: var x = init GLOBAL
+    // Variable declaration: var x = init GLOBAL  /  var m7 = chord([...])
     if (token.type === 'VAR') {
       return this.parseVarDeclaration()
+    }
+
+    // Module import: import chords (§6)
+    if (token.type === 'IMPORT') {
+      return this.parseImport()
     }
 
     // Reserved keywords: RUN(), LOOP(), MUTE()
@@ -49,13 +63,24 @@ export class StatementParser {
   /**
    * Parse variable declaration
    */
-  private parseVarDeclaration(): { statement: GlobalInit | SequenceInit; newPos: number } {
+  private parseVarDeclaration(): {
+    statement: GlobalInit | SequenceInit | ChordBinding
+    newPos: number
+  } {
     const varResult = ParserUtils.expect(this.tokens, this.pos, 'VAR')
     this.pos = varResult.newPos
     const varNameResult = ParserUtils.expect(this.tokens, this.pos, 'IDENTIFIER')
     this.pos = varNameResult.newPos
     const equalsResult = ParserUtils.expect(this.tokens, this.pos, 'EQUALS')
     this.pos = equalsResult.newPos
+
+    // `var m7 = chord([ ... ])` — a chord-value binding (§6). The `init ...`
+    // initializers below are unchanged.
+    const rhs = ParserUtils.current(this.tokens, this.pos)
+    if (rhs.type === 'IDENTIFIER' && rhs.value === 'chord') {
+      return this.parseChordBinding(varNameResult.token.value)
+    }
+
     const initResult = ParserUtils.expect(this.tokens, this.pos, 'INIT')
     this.pos = initResult.newPos
 
@@ -72,7 +97,50 @@ export class StatementParser {
       return this.parseSequenceInit(varNameResult.token.value)
     }
 
-    throw new Error('Expected GLOBAL or variable name after init')
+    throw new Error('Expected GLOBAL, a variable name, or chord([...]) after `=`')
+  }
+
+  /**
+   * Parse `var NAME = chord([ ... ])` (§6). The bracket contents are parsed by the
+   * expression parser (a PlayStack); only its raw voices are kept on the binding,
+   * to be evaluated (spread/removal/`^N`) by the interpreter at execution order.
+   */
+  private parseChordBinding(variableName: string): { statement: ChordBinding; newPos: number } {
+    const chordKw = ParserUtils.expect(this.tokens, this.pos, 'IDENTIFIER') // 'chord'
+    this.pos = chordKw.newPos
+    const lparen = ParserUtils.expect(this.tokens, this.pos, 'LPAREN')
+    this.pos = lparen.newPos
+
+    if (ParserUtils.current(this.tokens, this.pos).type !== 'LBRACKET') {
+      throw new Error('chord(...) expects a `[ ... ]` stack literal, e.g. chord([1, b3, 5, b7])')
+    }
+    const ep = new ExpressionParser(this.tokens, this.pos)
+    const stackResult = ep.parseArgument()
+    this.pos = stackResult.newPos
+    const stack = stackResult.value as PlayStack
+
+    const rparen = ParserUtils.expect(this.tokens, this.pos, 'RPAREN')
+    this.pos = rparen.newPos
+
+    return {
+      statement: { type: 'chord_binding', variableName, voices: stack.voices },
+      newPos: this.pos,
+    }
+  }
+
+  /**
+   * Parse `import chords` (§6). Only the `chords` stdlib is accepted in v1.1.
+   */
+  private parseImport(): { statement: ImportStatement; newPos: number } {
+    const importKw = ParserUtils.expect(this.tokens, this.pos, 'IMPORT')
+    this.pos = importKw.newPos
+    const moduleResult = ParserUtils.expect(this.tokens, this.pos, 'IDENTIFIER')
+    this.pos = moduleResult.newPos
+    const module = moduleResult.token.value
+    if (module !== 'chords') {
+      throw new Error(`Unknown import "${module}". v1.1 supports only \`import chords\` (§6).`)
+    }
+    return { statement: { type: 'import', module }, newPos: this.pos }
   }
 
   /**

--- a/packages/engine/src/parser/tokenizer.ts
+++ b/packages/engine/src/parser/tokenizer.ts
@@ -24,6 +24,7 @@ export class AudioTokenizer {
     'RUN',
     'LOOP',
     'MUTE',
+    'import',
   ])
 
   constructor(src: string) {

--- a/packages/engine/src/parser/types.ts
+++ b/packages/engine/src/parser/types.ts
@@ -12,6 +12,7 @@ export type AudioTokenType =
   | 'RUN' // RUN reserved keyword
   | 'LOOP' // LOOP reserved keyword
   | 'MUTE' // MUTE reserved keyword
+  | 'IMPORT' // import keyword (e.g. `import chords`, §6)
   | 'IDENTIFIER' // variable names, method names
   | 'NUMBER' // numeric values
   | 'STRING' // string literals
@@ -56,7 +57,30 @@ export type SequenceInit = {
   globalVariable?: string // For new syntax: init global.seq
 }
 
-export type Statement = GlobalStatement | SequenceStatement | TransportStatement
+export type Statement =
+  | GlobalStatement
+  | SequenceStatement
+  | TransportStatement
+  | ChordBinding
+  | ImportStatement
+
+/**
+ * `var NAME = chord([ ... ])` — a chord-value binding (§6). Distinct from the
+ * `var x = init ...` initializers (GlobalInit / SequenceInit). Carries the RAW
+ * `[ ]` voices so the interpreter evaluates them (spread/removal/`^N`) at execution
+ * order against the chord namespace as it exists then (§6.5.2 評価時値渡し).
+ */
+export type ChordBinding = {
+  type: 'chord_binding'
+  variableName: string
+  voices: StackElement[]
+}
+
+/** `import chords` — populate the global chord namespace from the stdlib (§6, §10-4). */
+export type ImportStatement = {
+  type: 'import'
+  module: string // 'chords' (the only module accepted in v1.1)
+}
 
 export type GlobalStatement = {
   type: 'global'

--- a/packages/engine/src/parser/types.ts
+++ b/packages/engine/src/parser/types.ts
@@ -87,6 +87,7 @@ export type PlayElement =
   | PlayPitch // degree with alteration / octave-shift / detune (e.g. b3, #5, 3^+1)
   | PlayScoped // group(s) with a .root()/.mode()/.oct() pitch-scope chain (§2.3, §3)
   | PlayStack // `[ ]` simultaneous-note-on stack (§4)
+  | PlayChordRef // a bare chord-name element (§6); transient — resolved away at L2 (resolveChords)
 
 export type PlayNested = {
   type: 'nested'
@@ -123,17 +124,18 @@ export type PlayStack = {
 }
 
 /**
- * A raw `[ ]` stack element before chord evaluation: a {@link PlayElement} plus
- * the two evaluation-only markers ({@link PlayChordRef}, {@link PlayChordRemoval}).
- * The chord evaluator (§6) resolves these to plain PlayElement voices.
+ * A raw `[ ]` stack element before chord evaluation: a {@link PlayElement} (which
+ * already includes {@link PlayChordRef}) plus the stack-only removal marker
+ * {@link PlayChordRemoval}. The chord evaluator (§6) resolves these to plain voices.
  */
-export type StackElement = PlayElement | PlayChordRef | PlayChordRemoval
+export type StackElement = PlayElement | PlayChordRemoval
 
 /**
- * A bare identifier inside a `[ ]` stack (or as a bare play arg): a reference to a
- * bound chord value, resolved at evaluation against the chord namespace (§6).
- * `octaveShift` carries a trailing `^N` (`m7^+1`) — a whole-chord structural shift
- * applied to the spread voices.
+ * A bare chord-name reference (§6): inside a `[ ]` stack it spreads into the stack;
+ * as a standalone group element (`(0, m7, 0)`, §9.1) it becomes a one-slot
+ * simultaneous chord. Resolved at evaluation (L2) against the chord namespace, so
+ * it never reaches the timing walk. `octaveShift` carries a trailing `^N` (`m7^+1`)
+ * — a whole-chord structural shift applied to the spread voices.
  */
 export type PlayChordRef = {
   type: 'chord_ref'

--- a/packages/engine/src/parser/types.ts
+++ b/packages/engine/src/parser/types.ts
@@ -86,10 +86,71 @@ export type PlayElement =
   | PlayWithModifier // with .chop(), .time(), etc.
   | PlayPitch // degree with alteration / octave-shift / detune (e.g. b3, #5, 3^+1)
   | PlayScoped // group(s) with a .root()/.mode()/.oct() pitch-scope chain (§2.3, §3)
+  | PlayStack // `[ ]` simultaneous-note-on stack (§4)
 
 export type PlayNested = {
   type: 'nested'
   elements: PlayElement[]
+}
+
+/**
+ * A `[ ]` simultaneous-note-on stack (§4 / DESIGN_DISCUSSION_RECORD §9).
+ *
+ * Spec: docs/specs-v2/PITCH_DSL_SPEC_v1.1.html §4, §6
+ *
+ * Unlike `( )` (which divides its slot among children in time), a stack occupies
+ * ONE sibling slot and all `voices` share the SAME start time and the FULL slot
+ * duration — they sound at once. A voice may itself be a subtree (`[1, (5,3,2,1)]`
+ * = one-part polyphony): the nested `( )` subdivides the same span the held voice
+ * occupies (timing implements this as parallel recursion, §4).
+ *
+ * The node is produced by the parser ALWAYS — appearing in an AUDIO sequence is a
+ * dispatch-time diagnostic error (§10-5, "[ ] reserved in audio"), mirroring how a
+ * PlayPitch in an audio sequence errors at dispatch rather than at parse.
+ *
+ * `voices` is the RAW element list before chord evaluation: it may carry
+ * {@link PlayChordRef} / {@link PlayChordRemoval} markers that the evaluator (§6)
+ * resolves away. After evaluation it is plain {@link PlayElement}[] (symbolic only).
+ */
+export type PlayStack = {
+  type: 'stack'
+  voices: StackElement[]
+  /**
+   * A whole-stack octave shift from a trailing `^N` on the `]` or a chord name
+   * (§6 `m7^+1`). Structural (does NOT move the §2.4 running range). 0/absent = none.
+   */
+  octaveShift?: number
+}
+
+/**
+ * A raw `[ ]` stack element before chord evaluation: a {@link PlayElement} plus
+ * the two evaluation-only markers ({@link PlayChordRef}, {@link PlayChordRemoval}).
+ * The chord evaluator (§6) resolves these to plain PlayElement voices.
+ */
+export type StackElement = PlayElement | PlayChordRef | PlayChordRemoval
+
+/**
+ * A bare identifier inside a `[ ]` stack (or as a bare play arg): a reference to a
+ * bound chord value, resolved at evaluation against the chord namespace (§6).
+ * `octaveShift` carries a trailing `^N` (`m7^+1`) — a whole-chord structural shift
+ * applied to the spread voices.
+ */
+export type PlayChordRef = {
+  type: 'chord_ref'
+  name: string
+  octaveShift: number // from `^N`; 0 if none
+}
+
+/**
+ * A removal marker `-N` / `-bN` inside a `[ ]` stack (§6): after spread, remove the
+ * voice whose literal `(degree, alteration)` matches. No match = no-op + warning
+ * (literal match only; resolved-pitch matching is rejected — `-3` would become
+ * context-dependent, §6).
+ */
+export type PlayChordRemoval = {
+  type: 'chord_removal'
+  degree: number
+  alteration: number
 }
 
 /**

--- a/packages/engine/src/timing/calculation/calculate-event-timing.ts
+++ b/packages/engine/src/timing/calculation/calculate-event-timing.ts
@@ -44,6 +44,26 @@ function resolveScope(stack: ScopeFrame[]): TimedEventScope | undefined {
 }
 
 /**
+ * Apply a whole-stack octave shift (§6 `m7^+1`) to a stack voice's timed event.
+ * Structural: it adds to the symbolic pitch's `octaveShift` WITHOUT setting
+ * `rangeSet`, so it never perturbs the §2.4 running range. A bare-number voice
+ * (no `pitch` yet) is promoted to a symbolic pitch carrying the shift.
+ */
+function applyStackOctaveShift(ev: TimedEvent, shift: number): void {
+  if (ev.pitch) {
+    ev.pitch = { ...ev.pitch, octaveShift: ev.pitch.octaveShift + shift }
+  } else {
+    ev.pitch = {
+      degree: ev.sliceNumber,
+      alteration: 0,
+      octaveShift: shift,
+      rangeSet: false,
+      detune: 0,
+    }
+  }
+}
+
+/**
  * Calculate timing for play() arguments
  *
  * This function recursively processes nested play() patterns and calculates
@@ -124,6 +144,40 @@ export function calculateEventTiming(
           [...scopeStack, frame],
         )
         events.push(...nestedEvents)
+      } else if (element.type === 'stack') {
+        // §4: a stack occupies ONE sibling slot; every voice shares the SAME
+        // startTime and the FULL slot duration (NOT divided like `( )`). Recurse
+        // each voice as a singleton so it gets the full span (÷1) at the same
+        // start, reusing every leaf handler — `[1, (5,3,2,1)]` falls out (the 1
+        // holds the slot while the subtree subdivides the same span). scopeStack
+        // threads UNCHANGED so chord degrees resolve against the enclosing group
+        // scope (the placement scope, §6).
+        for (const voice of element.voices) {
+          if (
+            voice &&
+            typeof voice === 'object' &&
+            (voice.type === 'chord_ref' || voice.type === 'chord_removal')
+          ) {
+            // §6: chord refs/removals are resolved (spread/removal) by the chord
+            // evaluator BEFORE timing. Reaching here means evaluation was skipped
+            // — a wiring bug, surfaced loudly rather than mis-rendered.
+            throw new Error(
+              `Internal: unresolved ${voice.type} reached the timing walk; ` +
+                `chord stacks must be evaluated before scheduling (§6).`,
+            )
+          }
+          const voiceEvents = calculateEventTiming(
+            [voice],
+            elementDuration,
+            elementStartTime,
+            depth + 1,
+            scopeStack,
+          )
+          if (element.octaveShift) {
+            for (const ev of voiceEvents) applyStackOctaveShift(ev, element.octaveShift)
+          }
+          events.push(...voiceEvents)
+        }
       } else if (element.type === 'pitch') {
         // MIDI degree with alteration / octave-shift / detune (§2.1, §2.4).
         // The rhythm tree gives timing; the symbolic pitch is carried unresolved

--- a/packages/engine/src/timing/calculation/calculate-event-timing.ts
+++ b/packages/engine/src/timing/calculation/calculate-event-timing.ts
@@ -218,6 +218,14 @@ export function calculateEventTiming(
           )
           events.push(...nestedEvents)
         }
+      } else if (element.type === 'chord_ref') {
+        // §6: a bare chord ref is resolved (spread) by the chord evaluator BEFORE
+        // timing. Reaching here means evaluation was skipped — a wiring bug,
+        // surfaced loudly rather than dropped silently.
+        throw new Error(
+          `Internal: unresolved chord ref "${element.name}" reached the timing walk; ` +
+            `chord refs must be evaluated before scheduling (§6).`,
+        )
       }
     }
   }

--- a/tests/audio-parser/chord-binding-parsing.spec.ts
+++ b/tests/audio-parser/chord-binding-parsing.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+
+/**
+ * Phase 3 (#231) — `import chords` / `var X = chord([...])` parsing + bare
+ * chord-name group elements (§6, §9.1). Statement shape only; resolution and MIDI
+ * dispatch are covered in tests/core/sequence-chord-dispatch.spec.ts.
+ */
+
+describe('Phase 3 — import chords parsing', () => {
+  it('`import chords` → an import statement', () => {
+    expect(parseAudioDSL('import chords').statements[0]).toEqual({
+      type: 'import',
+      module: 'chords',
+    })
+  })
+
+  it('an unknown import throws', () => {
+    expect(() => parseAudioDSL('import scales')).toThrow(/only.*import chords/i)
+  })
+})
+
+describe('Phase 3 — var = chord([...]) parsing', () => {
+  it('`var m7 = chord([1, b3, 5, b7])` → a chord_binding with raw voices', () => {
+    const stmt = parseAudioDSL('var m7 = chord([1, b3, 5, b7])').statements[0] as any
+    expect(stmt.type).toBe('chord_binding')
+    expect(stmt.variableName).toBe('m7')
+    expect(stmt.voices[0]).toBe(1)
+    expect(stmt.voices[1]).toMatchObject({
+      type: 'pitch',
+      degree: 3,
+      alteration: -1,
+      rangeSet: false,
+    })
+    expect(stmt.voices[2]).toBe(5)
+    expect(stmt.voices[3]).toMatchObject({ type: 'pitch', degree: 7, alteration: -1 })
+  })
+
+  it('`var m7omit5 = chord([m7, -5])` keeps the ref + removal markers raw', () => {
+    const stmt = parseAudioDSL('var m7omit5 = chord([m7, -5])').statements[0] as any
+    expect(stmt.type).toBe('chord_binding')
+    expect(stmt.voices[0]).toEqual({ type: 'chord_ref', name: 'm7', octaveShift: 0 })
+    expect(stmt.voices[1]).toEqual({ type: 'chord_removal', degree: 5, alteration: 0 })
+  })
+
+  it('chord(...) requires a `[ ]` stack literal', () => {
+    expect(() => parseAudioDSL('var x = chord(1, 3, 5)')).toThrow(/expects a `\[ \.\.\. \]` stack/)
+  })
+})
+
+describe('Phase 3 — init declarations are unaffected (regression)', () => {
+  it('`var g = init GLOBAL` still parses to a global init', () => {
+    expect(parseAudioDSL('var g = init GLOBAL').globalInit).toEqual({
+      type: 'global_init',
+      variableName: 'g',
+    })
+  })
+
+  it('`var s = init g.seq` still parses to a sequence init', () => {
+    const ir = parseAudioDSL('var g = init GLOBAL\nvar s = init g.seq')
+    expect(ir.sequenceInits[0]).toMatchObject({ type: 'seq_init', variableName: 's' })
+  })
+})
+
+describe('Phase 3 — bare chord name as a group element (§9.1)', () => {
+  it('(0, m7, 0, m7).root(3) → chord_ref elements inside the scoped group', () => {
+    const scoped = parseAudioDSL('piano.play((0, m7, 0, m7).root(3))').statements[0].args[0] as any
+    expect(scoped.type).toBe('scoped')
+    const els = scoped.groups[0].elements
+    expect(els[0]).toBe(0)
+    expect(els[1]).toEqual({ type: 'chord_ref', name: 'm7', octaveShift: 0 })
+    expect(els[2]).toBe(0)
+    expect(els[3]).toEqual({ type: 'chord_ref', name: 'm7', octaveShift: 0 })
+  })
+})

--- a/tests/audio-parser/pitch-parsing.spec.ts
+++ b/tests/audio-parser/pitch-parsing.spec.ts
@@ -199,13 +199,24 @@ describe('parser — PlayPitch nodes', () => {
   })
 })
 
-describe('stack [ ] is reserved (§10-5) — diagnostic, not silently ignored', () => {
-  it('top-level [ ] throws a reserved-syntax error', () => {
-    expect(() => parseAudioDSL('seq1.play([1, 3, 5])')).toThrow(/not yet supported|reserved/i)
+describe('stack [ ] parses into a PlayStack (Phase 3, §4)', () => {
+  // Phase 3 (#231) opened `[ ]` for MIDI: it parses into a PlayStack instead of
+  // throwing at parse. The audio-vs-MIDI rejection (§10-5) moved to dispatch — see
+  // tests/core/sequence-stack-dispatch.spec.ts. Stack shape is covered in detail in
+  // tests/audio-parser/stack-parsing.spec.ts; these are the parse-time regression
+  // guards left where the old reserved-syntax tests lived.
+  it('top-level [ ] no longer throws — it is a PlayStack', () => {
+    expect(parseAudioDSL('seq1.play([1, 3, 5])').statements[0].args[0]).toEqual({
+      type: 'stack',
+      voices: [1, 3, 5],
+    })
   })
 
-  it('nested [ ] throws a reserved-syntax error', () => {
-    expect(() => parseAudioDSL('seq1.play(1, [1, 3, 5], 0)')).toThrow(/not yet supported|reserved/i)
+  it('nested [ ] parses as a stack sibling slot', () => {
+    const args = parseAudioDSL('seq1.play(1, [1, 3, 5], 0)').statements[0].args
+    expect(args[0]).toBe(1)
+    expect(args[1]).toEqual({ type: 'stack', voices: [1, 3, 5] })
+    expect(args[2]).toBe(0)
   })
 
   it('tokenizer emits LBRACKET / RBRACKET (not silently dropped)', () => {

--- a/tests/audio-parser/stack-parsing.spec.ts
+++ b/tests/audio-parser/stack-parsing.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+
+/**
+ * Phase 3 (#231) — `[ ]` stack parsing (§4, §6).
+ * Spec: docs/specs-v2/PITCH_DSL_SPEC_v1.1.html §4 (Brackets), §6 (Chord Values)
+ *
+ * Parser-level: the PlayStack AST shape, numeric / altered / subtree voices, the
+ * structural `^N` rule (rangeSet cleared, §2.4), the whole-stack `^N`, chord-name
+ * refs and `-N` removal markers, and that `[ ]` nests inside `( )` / scope groups.
+ * The audio-vs-MIDI rejection is a dispatch-time test (sequence-stack-dispatch).
+ */
+function firstArg(src: string): any {
+  return parseAudioDSL(src).statements[0].args[0]
+}
+
+describe('Phase 3 — [ ] stack parsing', () => {
+  it('[1, 3, 5] → PlayStack with three numeric voices', () => {
+    expect(firstArg('seq.play([1, 3, 5])')).toEqual({ type: 'stack', voices: [1, 3, 5] })
+  })
+
+  it('[b3, 5, b7] → altered voices stay PlayPitch, bare degree stays a number', () => {
+    const stack = firstArg('seq.play([b3, 5, b7])')
+    expect(stack.type).toBe('stack')
+    expect(stack.voices[0]).toMatchObject({ type: 'pitch', degree: 3, alteration: -1 })
+    expect(stack.voices[1]).toBe(5)
+    expect(stack.voices[2]).toMatchObject({ type: 'pitch', degree: 7, alteration: -1 })
+  })
+
+  it('[1, (5, 3, 2, 1)] → a held voice + an independent subtree voice (§4)', () => {
+    const stack = firstArg('seq.play([1, (5, 3, 2, 1)])')
+    expect(stack.voices[0]).toBe(1)
+    expect(stack.voices[1]).toMatchObject({ type: 'nested', elements: [5, 3, 2, 1] })
+  })
+
+  it('a stack voice `^N` is STRUCTURAL — rangeSet cleared (§2.4)', () => {
+    const stack = firstArg('seq.play([1, b7^+1])')
+    expect(stack.voices[1]).toMatchObject({
+      type: 'pitch',
+      degree: 7,
+      alteration: -1,
+      octaveShift: 1,
+      rangeSet: false,
+    })
+  })
+
+  it('trailing `]^+1` → a whole-stack octaveShift on the node', () => {
+    expect(firstArg('seq.play([1, b3, 5]^+1)')).toMatchObject({
+      type: 'stack',
+      octaveShift: 1,
+    })
+  })
+
+  it('a bare chord-name voice → PlayChordRef (resolved at evaluation)', () => {
+    expect(firstArg('seq.play([m7])').voices[0]).toEqual({
+      type: 'chord_ref',
+      name: 'm7',
+      octaveShift: 0,
+    })
+  })
+
+  it('chord-name with `^+1` → chord_ref octaveShift', () => {
+    expect(firstArg('seq.play([m7^+1])').voices[0]).toEqual({
+      type: 'chord_ref',
+      name: 'm7',
+      octaveShift: 1,
+    })
+  })
+
+  it('removal `-5` → PlayChordRemoval (literal key)', () => {
+    expect(firstArg('seq.play([m7, -5])').voices[1]).toEqual({
+      type: 'chord_removal',
+      degree: 5,
+      alteration: 0,
+    })
+  })
+
+  it('altered removal `-b3` → degree 3, alteration -1', () => {
+    expect(firstArg('seq.play([m7, -b3])').voices[1]).toEqual({
+      type: 'chord_removal',
+      degree: 3,
+      alteration: -1,
+    })
+  })
+
+  it('[ ] nests inside a `( )` scope group: ([1,3,5]).root(2)', () => {
+    const scoped = firstArg('seq.play(([1, 3, 5]).root(2))')
+    expect(scoped.type).toBe('scoped')
+    expect(scoped.groups[0]).toMatchObject({ type: 'nested' })
+    expect(scoped.groups[0].elements[0]).toEqual({ type: 'stack', voices: [1, 3, 5] })
+  })
+})

--- a/tests/core/sequence-chord-dispatch.spec.ts
+++ b/tests/core/sequence-chord-dispatch.spec.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { Global } from '../../packages/engine/src/core/global'
+import { Sequence } from '../../packages/engine/src/core/sequence'
+import { MidiManager } from '../../packages/engine/src/core/global/midi-manager'
+import { MidiOutput } from '../../packages/engine/src/midi/midi-output'
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+import { processStatement } from '../../packages/engine/src/interpreter/process-statement'
+import { InterpreterState } from '../../packages/engine/src/interpreter/types'
+
+/**
+ * Phase 3 (#231) — chord values end to end (§6): the global chord namespace,
+ * Sequence.play spread/removal/`^N` resolution, and the interpreter routing for
+ * `import chords` / `var = chord([...])`. Built on the direct Global+Sequence MIDI
+ * harness (the interpreter's full path needs SuperCollider and is skipped).
+ */
+
+const T0 = 1_000_000
+
+function mockMidiOutput(): MidiOutput {
+  return {
+    ensurePort: vi.fn((q: string) => (/iac/i.test(q) ? 'IACドライバ バス1' : q)),
+    noteOn: vi.fn(),
+    noteOff: vi.fn(),
+    pitchBend: vi.fn(),
+    releaseOwner: vi.fn(),
+    panic: vi.fn(),
+    getActiveNotes: vi.fn(() => []),
+    listPorts: vi.fn(() => ['IACドライバ バス1']),
+    closeAll: vi.fn(),
+  }
+}
+
+function mockScheduler() {
+  return {
+    isRunning: true,
+    startTime: T0,
+    getCurrentTime: () => 0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(),
+    clearSequenceEvents: vi.fn(),
+    reinitializeSequenceTracking: vi.fn(),
+    getMasterGainDb: () => 0,
+  } as never
+}
+
+function notesOf(out: MidiOutput): number[] {
+  return (out.noteOn as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[2])
+}
+
+/** Raw `[ ]` voices of a `chord([...])` expression, for direct defineChord() calls. */
+function chordVoices(expr: string): any[] {
+  return (parseAudioDSL(`var _ = ${expr}`).statements[0] as any).voices
+}
+
+/** Build a keyed MIDI sequence, run `setup(global)` (e.g. importChords), play `src`. */
+async function playChords(setup: (g: Global) => void, src: string, key = 'C'): Promise<MidiOutput> {
+  vi.setSystemTime(T0)
+  const sched = mockScheduler()
+  const out = mockMidiOutput()
+  const global = new Global(sched, new MidiManager(() => out))
+  global.key(key)
+  setup(global)
+  global.start()
+  const seq = new Sequence(global, sched)
+  seq.setName('piano')
+  seq.midi('iac', 1).octave(4)
+  const args = parseAudioDSL(`p.play(${src})`).statements[0].args
+  seq.play(...(args as never[]))
+  await seq.run()
+  await vi.advanceTimersByTimeAsync(2100)
+  return out
+}
+
+describe('Phase 3 — chord values dispatch (§6)', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('import chords + [m7] in C oct4 → C, Eb, G, Bb (60, 63, 67, 70)', async () => {
+    const out = await playChords((g) => g.importChords(), '[m7]')
+    expect(notesOf(out)).toEqual(expect.arrayContaining([60, 63, 67, 70]))
+    expect(notesOf(out)).toHaveLength(4)
+  })
+
+  it('bare chord names as group elements: (0, m7, 0, m7).root(3)', async () => {
+    const out = await playChords((g) => g.importChords(), '(0, m7, 0, m7).root(3)')
+    // root degree 3 of C = E (64). m7 on E → 64, 67, 71, 74. Two chords (slots 2, 4).
+    expect(notesOf(out)).toEqual([64, 67, 71, 74, 64, 67, 71, 74])
+  })
+
+  it('spread + add: [m7, 9] in C → m7 plus the 9th (74)', async () => {
+    const out = await playChords((g) => g.importChords(), '[m7, 9]')
+    expect(notesOf(out).sort((a, b) => a - b)).toEqual([60, 63, 67, 70, 74])
+  })
+
+  it('spread + removal: [m7, -5] in C drops the 5 (67)', async () => {
+    const out = await playChords((g) => g.importChords(), '[m7, -5]')
+    expect(notesOf(out).sort((a, b) => a - b)).toEqual([60, 63, 70])
+  })
+
+  it('whole-chord `^+1`: a bare m7^+1 lifts the chord an octave', async () => {
+    const out = await playChords((g) => g.importChords(), '(m7^+1, 0, 0, 0).root(1)')
+    // root degree 1 of C = C (60). m7 +1 octave → 72, 75, 79, 82.
+    expect(notesOf(out).sort((a, b) => a - b)).toEqual([72, 75, 79, 82])
+  })
+
+  it('a user chord built by spread+removal plays back', async () => {
+    const out = await playChords((g) => {
+      g.importChords()
+      g.defineChord('m7omit5', chordVoices('chord([m7, -5])'))
+    }, '[m7omit5]')
+    expect(notesOf(out).sort((a, b) => a - b)).toEqual([60, 63, 70])
+  })
+
+  it('an unknown chord name warns and plays nothing', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const out = await playChords(() => {}, '[mystery]')
+    expect(notesOf(out)).toHaveLength(0)
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/unknown chord "mystery"/))
+    warn.mockRestore()
+  })
+})
+
+describe('Phase 3 — chord namespace registry (§6, §10-4)', () => {
+  function freshGlobal(): Global {
+    return new Global(mockScheduler(), new MidiManager(() => mockMidiOutput()))
+  }
+
+  it('importChords binds the stdlib (m7 = 1, b3, 5, b7)', () => {
+    const g = freshGlobal()
+    g.importChords()
+    expect(g.getChordVoices('m7')).toEqual([
+      { degree: 1, alteration: 0, octaveShift: 0, detune: 0 },
+      { degree: 3, alteration: -1, octaveShift: 0, detune: 0 },
+      { degree: 5, alteration: 0, octaveShift: 0, detune: 0 },
+      { degree: 7, alteration: -1, octaveShift: 0, detune: 0 },
+    ])
+  })
+
+  it('redefining a bound name warns (last-write-wins, §10-4)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const g = freshGlobal()
+    g.importChords()
+    g.defineChord('m7', chordVoices('chord([1, 3, 5, 7])')) // shadow stdlib m7 with maj7 voicing
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/"m7" redefined/))
+    expect(g.getChordVoices('m7')).toEqual([
+      { degree: 1, alteration: 0, octaveShift: 0, detune: 0 },
+      { degree: 3, alteration: 0, octaveShift: 0, detune: 0 },
+      { degree: 5, alteration: 0, octaveShift: 0, detune: 0 },
+      { degree: 7, alteration: 0, octaveShift: 0, detune: 0 },
+    ])
+    warn.mockRestore()
+  })
+})
+
+describe('Phase 3 — interpreter routing for import / chord_binding (§6)', () => {
+  function stateWith(global: Global): InterpreterState {
+    return {
+      globals: new Map([['g', global]]),
+      sequences: new Map(),
+      currentGlobal: global,
+      audioEngine: undefined as never,
+      isBooted: true,
+      runGroup: new Set(),
+      loopGroup: new Set(),
+      muteGroup: new Set(),
+    }
+  }
+
+  it('`import chords` populates the active global namespace', async () => {
+    const g = new Global(mockScheduler(), new MidiManager(() => mockMidiOutput()))
+    const state = stateWith(g)
+    await processStatement({ type: 'import', module: 'chords' } as never, state)
+    expect(g.getChordVoices('maj7')).toBeDefined()
+  })
+
+  it('`var X = chord([...])` binds via the interpreter', async () => {
+    const g = new Global(mockScheduler(), new MidiManager(() => mockMidiOutput()))
+    const state = stateWith(g)
+    const binding = parseAudioDSL('var triad = chord([1, 3, 5])').statements[0]
+    await processStatement(binding as never, state)
+    expect(g.getChordVoices('triad')).toEqual([
+      { degree: 1, alteration: 0, octaveShift: 0, detune: 0 },
+      { degree: 3, alteration: 0, octaveShift: 0, detune: 0 },
+      { degree: 5, alteration: 0, octaveShift: 0, detune: 0 },
+    ])
+  })
+})

--- a/tests/core/sequence-chord-dispatch.spec.ts
+++ b/tests/core/sequence-chord-dispatch.spec.ts
@@ -113,6 +113,13 @@ describe('Phase 3 — chord values dispatch (§6)', () => {
     expect(notesOf(out).sort((a, b) => a - b)).toEqual([60, 63, 70])
   })
 
+  it('§9.1 bar 3 (normative): (0, [m7, 9], 0, [m7, 9]).root(2) in C', async () => {
+    const out = await playChords((g) => g.importChords(), '(0, [m7, 9], 0, [m7, 9]).root(2)')
+    // root degree 2 of C = D (62). m7 on D → 62, 65, 69, 72; + 9 = IONIAN[1]+12 = 14 → 76.
+    // Two chords (slots 2 and 4); slots 1 and 3 are rests.
+    expect(notesOf(out)).toEqual([62, 65, 69, 72, 76, 62, 65, 69, 72, 76])
+  })
+
   it('an unknown chord name warns and plays nothing', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const out = await playChords(() => {}, '[mystery]')

--- a/tests/core/sequence-stack-dispatch.spec.ts
+++ b/tests/core/sequence-stack-dispatch.spec.ts
@@ -106,6 +106,13 @@ describe('Phase 3 — stack MIDI dispatch (§4)', () => {
     expect(notesOf(out)).toHaveLength(4)
     expect(notesOf(out)).not.toContain(60) // would be C4 if the stack had reset the range
   })
+
+  it('§9.1 bar 4 (normative): ([1, 3, b7, 13], 0, 0, [1, 3, b7, b13]).root(5) in C', async () => {
+    const out = await playKeyed('([1, 3, b7, 13], 0, 0, [1, 3, b7, b13]).root(5)')
+    // root degree 5 of C = G (pc 7, oct 4) → rootPitch 67. 1→67, 3→71, b7→77,
+    // 13 = IONIAN[5]+12 = 21 → 88 ; b13 = 20 → 87. Two stacks (slots 1 and 4).
+    expect(notesOf(out)).toEqual([67, 71, 77, 88, 67, 71, 77, 87])
+  })
 })
 
 describe('Phase 3 — `[ ]` rejected in audio sequences (§10-5)', () => {

--- a/tests/core/sequence-stack-dispatch.spec.ts
+++ b/tests/core/sequence-stack-dispatch.spec.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { Global } from '../../packages/engine/src/core/global'
+import { Sequence } from '../../packages/engine/src/core/sequence'
+import { MidiManager } from '../../packages/engine/src/core/global/midi-manager'
+import { MidiOutput } from '../../packages/engine/src/midi/midi-output'
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+
+/**
+ * Phase 3 (#231) — `[ ]` stack dispatch (§4): simultaneous note-on, scope
+ * composition, structural octave shift, and the audio-vs-MIDI rejection (§10-5).
+ *
+ * Stack voices share the same TimedEvent.startTime (proven in stack-timing.spec),
+ * so the deterministic onTime formula yields a simultaneous note-on. These tests
+ * assert the resolved MIDI numbers (degree + scope + structural `^N` all compose).
+ */
+
+const T0 = 1_000_000
+
+function mockMidiOutput(): MidiOutput {
+  return {
+    ensurePort: vi.fn((q: string) => (/iac/i.test(q) ? 'IACドライバ バス1' : q)),
+    noteOn: vi.fn(),
+    noteOff: vi.fn(),
+    pitchBend: vi.fn(),
+    releaseOwner: vi.fn(),
+    panic: vi.fn(),
+    getActiveNotes: vi.fn(() => []),
+    listPorts: vi.fn(() => ['IACドライバ バス1']),
+    closeAll: vi.fn(),
+  }
+}
+
+function mockScheduler() {
+  return {
+    isRunning: true,
+    startTime: T0,
+    getCurrentTime: () => 0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(),
+    clearSequenceEvents: vi.fn(),
+    reinitializeSequenceTracking: vi.fn(),
+    getMasterGainDb: () => 0,
+  } as never
+}
+
+function notesOf(out: MidiOutput): number[] {
+  return (out.noteOn as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[2])
+}
+
+/** Build a started, keyed MIDI sequence (octave 4) and play a parsed pattern. */
+async function playKeyed(src: string, key = 'C'): Promise<MidiOutput> {
+  vi.setSystemTime(T0)
+  const sched = mockScheduler()
+  const out = mockMidiOutput()
+  const global = new Global(sched, new MidiManager(() => out))
+  global.key(key)
+  global.start()
+  const seq = new Sequence(global, sched)
+  seq.setName('piano')
+  seq.midi('iac', 1).octave(4)
+  const args = parseAudioDSL(`p.play(${src})`).statements[0].args
+  seq.play(...(args as never[]))
+  await seq.run()
+  await vi.advanceTimersByTimeAsync(2100)
+  return out
+}
+
+describe('Phase 3 — stack MIDI dispatch (§4)', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('[1, 3, 5] in C oct4 → simultaneous note-on 60, 64, 67', async () => {
+    const out = await playKeyed('[1, 3, 5]')
+    expect(notesOf(out)).toEqual(expect.arrayContaining([60, 64, 67]))
+    expect(notesOf(out)).toHaveLength(3)
+  })
+
+  it('a stack resolves against the enclosing group scope: ([1,3,5]).root(2) in C', async () => {
+    const out = await playKeyed('([1, 3, 5]).root(2)')
+    // root D (pc 2), oct 4 → 62; degree 3 = +4 = 66; degree 5 = +7 = 69
+    expect(notesOf(out)).toEqual(expect.arrayContaining([62, 66, 69]))
+    expect(notesOf(out)).toHaveLength(3)
+  })
+
+  it('a voice `^+1` adds an octave on top of the degree: [1, b7^+1] in C oct4', async () => {
+    const out = await playKeyed('[1, b7^+1]')
+    // degree 1 → 60; b7 = +10 → 70, structural +1 octave → 82
+    expect(notesOf(out)).toEqual(expect.arrayContaining([60, 82]))
+    expect(notesOf(out)).toHaveLength(2)
+  })
+
+  it('whole-stack `^+1` lifts every voice an octave: [1, 3, 5]^+1 in C oct4', async () => {
+    const out = await playKeyed('[1, 3, 5]^+1')
+    expect(notesOf(out)).toEqual(expect.arrayContaining([72, 76, 79]))
+    expect(notesOf(out)).toHaveLength(3)
+  })
+
+  it('a stack does NOT perturb the running range of a following melodic note', async () => {
+    // 3^1 sets range +1 (E5=76); the stack voices carry structural-only shifts and
+    // must not move the running range; the trailing 1 stays at range +1 (C5=72).
+    const out = await playKeyed('3^1, [1, 5], 1')
+    expect(notesOf(out)).toEqual(expect.arrayContaining([76, 72, 79, 72]))
+    // 3^1 → 76; stack [1,5] at range +1 → C5(72), G5(79); trailing 1 → C5(72)
+    expect(notesOf(out)).toHaveLength(4)
+    expect(notesOf(out)).not.toContain(60) // would be C4 if the stack had reset the range
+  })
+})
+
+describe('Phase 3 — `[ ]` rejected in audio sequences (§10-5)', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('a non-MIDI (audio-domain) sequence with a `[ ]` rejects run()', async () => {
+    vi.setSystemTime(T0)
+    const sched = mockScheduler()
+    const out = mockMidiOutput()
+    const global = new Global(sched, new MidiManager(() => out))
+    global.start()
+    const seq = new Sequence(global, sched) // no .midi() → non-MIDI
+    seq.setName('drums')
+    const args = parseAudioDSL('p.play([1, 3, 5])').statements[0].args
+    seq.play(...(args as never[]))
+    await expect(seq.run()).rejects.toThrow(/audio sequences.*reserved|§10-5/i)
+  })
+
+  it('the rejection finds a `[ ]` nested inside a `( )` group', async () => {
+    vi.setSystemTime(T0)
+    const sched = mockScheduler()
+    const out = mockMidiOutput()
+    const global = new Global(sched, new MidiManager(() => out))
+    global.start()
+    const seq = new Sequence(global, sched)
+    seq.setName('drums')
+    const args = parseAudioDSL('p.play((1, [1, 3, 5]))').statements[0].args
+    seq.play(...(args as never[]))
+    await expect(seq.run()).rejects.toThrow(/audio sequences.*reserved|§10-5/i)
+  })
+})

--- a/tests/midi/chord-resolution.spec.ts
+++ b/tests/midi/chord-resolution.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+
+import { resolveChords, ChordLookup } from '../../packages/engine/src/midi/chord/resolve-chords'
+import { PREDEFINED_CHORDS } from '../../packages/engine/src/midi/chord/predefined-chords'
+
+/**
+ * Phase 3 (#231) — chord evaluation (§6): the pure spread / removal / `^N`
+ * resolver. Inputs are raw AST fragments (chord refs, removals) built by hand so
+ * the evaluator is tested in isolation from the parser and the namespace.
+ */
+
+const lookup: ChordLookup = (name) => PREDEFINED_CHORDS[name]
+
+const ref = (name: string, octaveShift = 0) => ({ type: 'chord_ref' as const, name, octaveShift })
+const rm = (degree: number, alteration = 0) => ({
+  type: 'chord_removal' as const,
+  degree,
+  alteration,
+})
+const stack = (voices: any[], octaveShift?: number): any =>
+  octaveShift === undefined ? { type: 'stack', voices } : { type: 'stack', voices, octaveShift }
+
+function resolveStack(voices: any[], octaveShift?: number) {
+  const { elements, warnings } = resolveChords([stack(voices, octaveShift)], lookup)
+  return { stack: elements[0] as any, warnings }
+}
+
+describe('Phase 3 — chord resolution (§6)', () => {
+  it('the predefined m7 is the root-unbound degree stack [1, b3, 5, b7]', () => {
+    expect(PREDEFINED_CHORDS.m7).toEqual([
+      { degree: 1, alteration: 0, octaveShift: 0, detune: 0 },
+      { degree: 3, alteration: -1, octaveShift: 0, detune: 0 },
+      { degree: 5, alteration: 0, octaveShift: 0, detune: 0 },
+      { degree: 7, alteration: -1, octaveShift: 0, detune: 0 },
+    ])
+  })
+
+  it('spread: [m7] expands to its four voices (plain degrees stay numbers)', () => {
+    const { stack } = resolveStack([ref('m7')])
+    expect(stack.voices).toEqual([
+      1,
+      { type: 'pitch', degree: 3, alteration: -1, octaveShift: 0, rangeSet: false, detune: 0 },
+      5,
+      { type: 'pitch', degree: 7, alteration: -1, octaveShift: 0, rangeSet: false, detune: 0 },
+    ])
+  })
+
+  it('spread + add: [m7, 9] appends the extra degree', () => {
+    const { stack } = resolveStack([ref('m7'), 9])
+    expect(stack.voices.map((v: any) => (typeof v === 'number' ? v : v.degree))).toEqual([
+      1, 3, 5, 7, 9,
+    ])
+  })
+
+  it('removal `-5`: literal-matches and removes the natural 5 (§6)', () => {
+    const { stack, warnings } = resolveStack([ref('m7'), rm(5)])
+    expect(stack.voices.map((v: any) => (typeof v === 'number' ? v : v.degree))).toEqual([1, 3, 7])
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('removal `-b3`: matches the altered voice (degree + alteration)', () => {
+    const { stack } = resolveStack([ref('m7'), rm(3, -1)])
+    // b3 removed → 1, 5, b7
+    expect(stack.voices).toEqual([
+      1,
+      5,
+      { type: 'pitch', degree: 7, alteration: -1, octaveShift: 0, rangeSet: false, detune: 0 },
+    ])
+  })
+
+  it('removal `-3` (natural) does NOT match m7’s b3 → no-op + warning', () => {
+    const { stack, warnings } = resolveStack([ref('m7'), rm(3)])
+    expect(stack.voices.map((v: any) => (typeof v === 'number' ? v : v.degree))).toEqual([
+      1, 3, 5, 7,
+    ])
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toMatch(/matched no voice/)
+  })
+
+  it('ref `^+1` shifts every spread voice up an octave (structural)', () => {
+    const { stack } = resolveStack([ref('m7', 1)])
+    for (const v of stack.voices) {
+      expect(v).toMatchObject({ type: 'pitch', octaveShift: 1, rangeSet: false })
+    }
+    expect(stack.voices.map((v: any) => v.degree)).toEqual([1, 3, 5, 7])
+  })
+
+  it('a whole-stack `^N` is preserved on the node (applied at timing)', () => {
+    const { stack } = resolveStack([1, 3, 5], 1)
+    expect(stack).toEqual({ type: 'stack', voices: [1, 3, 5], octaveShift: 1 })
+  })
+
+  it('an unknown chord name resolves to no voices + a warning', () => {
+    const { stack, warnings } = resolveStack([ref('nope')])
+    expect(stack.voices).toEqual([])
+    expect(warnings[0]).toMatch(/unknown chord "nope"/)
+  })
+
+  it('a bare chord ref as a standalone element becomes a one-slot stack', () => {
+    const { elements } = resolveChords([ref('maj') as any], lookup)
+    expect(elements[0]).toEqual({ type: 'stack', voices: [1, 3, 5] })
+  })
+
+  it('a literal stack with no chord refs is unchanged', () => {
+    const { stack, warnings } = resolveStack([1, 3, 5])
+    expect(stack).toEqual({ type: 'stack', voices: [1, 3, 5] })
+    expect(warnings).toHaveLength(0)
+  })
+})

--- a/tests/timing/stack-timing.spec.ts
+++ b/tests/timing/stack-timing.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+import { calculateEventTiming } from '../../packages/engine/src/timing/calculation'
+import { PlayElement } from '../../packages/engine/src/parser/types'
+
+/**
+ * Phase 3 (#231) — `[ ]` stack timing (§4): parallel recursion.
+ *
+ * A stack occupies ONE sibling slot; every voice shares the SAME startTime and the
+ * FULL slot duration (not divided like `( )`). A subtree voice subdivides the same
+ * span the held voices occupy. The whole-stack `^N` adds a structural octaveShift
+ * (rangeSet stays false — §2.4, it never moves the running range).
+ */
+function playElements(src: string): PlayElement[] {
+  return parseAudioDSL(src).statements[0].args as PlayElement[]
+}
+
+describe('Phase 3 — stack timing (parallel recursion)', () => {
+  it('[1, 3, 5] — all three voices share startTime and the full bar', () => {
+    const events = calculateEventTiming(playElements('seq.play([1, 3, 5])'), 2000)
+    expect(events).toHaveLength(3)
+    for (const e of events) {
+      expect(e.startTime).toBe(0)
+      expect(e.duration).toBe(2000)
+    }
+    expect(events.map((e) => e.sliceNumber).sort()).toEqual([1, 3, 5])
+  })
+
+  it('a stack as one of two slots occupies only its slot; voices simultaneous', () => {
+    // play(1, [1,3,5]) — two slots of 1000ms; the stack is the second slot.
+    const events = calculateEventTiming(playElements('seq.play(1, [1, 3, 5])'), 2000)
+    expect(events[0]).toMatchObject({ sliceNumber: 1, startTime: 0, duration: 1000 })
+    const stackEvents = events.slice(1)
+    expect(stackEvents).toHaveLength(3)
+    for (const e of stackEvents) {
+      expect(e.startTime).toBe(1000)
+      expect(e.duration).toBe(1000)
+    }
+  })
+
+  it('[1, (5,3,2,1)] — held voice spans the slot while the subtree subdivides it', () => {
+    const events = calculateEventTiming(playElements('seq.play([1, (5, 3, 2, 1)])'), 2000)
+    // Voice 1: degree 1 spans the full bar.
+    const held = events.find((e) => e.sliceNumber === 1 && e.duration === 2000)
+    expect(held).toBeDefined()
+    expect(held!.startTime).toBe(0)
+    // Subtree: 5,3,2,1 each 500ms, sequential within the same span.
+    const sub = events.filter((e) => e.duration === 500)
+    expect(sub.map((e) => [e.sliceNumber, e.startTime])).toEqual([
+      [5, 0],
+      [3, 500],
+      [2, 1000],
+      [1, 1500],
+    ])
+  })
+
+  it('whole-stack `^+1` adds a structural octaveShift to every voice (rangeSet false)', () => {
+    const events = calculateEventTiming(playElements('seq.play([1, 3, 5]^+1)'), 2000)
+    expect(events).toHaveLength(3)
+    for (const e of events) {
+      expect(e.pitch).toMatchObject({ octaveShift: 1, rangeSet: false })
+    }
+  })
+
+  it('a voice `^+1` is structural on that voice only', () => {
+    const events = calculateEventTiming(playElements('seq.play([1, b7^+1])'), 2000)
+    const shifted = events.find((e) => e.pitch?.degree === 7)
+    expect(shifted!.pitch).toMatchObject({ octaveShift: 1, rangeSet: false })
+    // The plain voice 1 carries no structural shift.
+    const plain = events.find((e) => e.sliceNumber === 1)
+    expect(plain!.pitch).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## 概要

Pitch DSL v1.1 **Phase 3 (#231)** を実装。`[ ]` スタック（同時発音）と chord 値（spread / 除去 / `import chords`）を parse → timing → MIDI dispatch まで通す。WCTM の和声コンピング（リードシート .orbs）の前提。正本: `docs/specs-v2/PITCH_DSL_SPEC_v1.1.html` §4 / §6 / §10。

## アーキテクチャ（4 層）

`[ ]` の名前解決は parser には見えない namespace（interpreter/runtime 状態）が必要なため、4 層に分離:

1. **L1 parse** — `[ ]` を常に `PlayStack` へ（生）。audio 拒否は parse ではなく dispatch（§10-5、`PlayPitch` と同じ流儀）
2. **L2 evaluate** (`resolveChords`) — chord 名 ref を spread、`-N` 除去、`^N` 適用 → 純シンボリック。namespace は `getChord` 注入で純関数化（§6.5.2 評価時値渡し）
3. **L3 timing** — スタックは並列再帰（全 voice 等 startTime・全長、`[1,(5,3,2,1)]` のサブツリーは同一スパンを再分割）
4. **L4 dispatch** — 等 startTime → 同時 note-on は自動的に従う。octaveShift を加算式に修正し構造的 voice シフトを上乗せ（従来の旋律音は no-op）

## コミット

1. `feat(dsl): add [ ] stack simultaneous note-on` — スタック core（B0-B4）
2. `feat(dsl): add chord-value evaluator` — spread/除去/`^N` 純関数（B5）
3. `feat(dsl): wire chord values into play() + namespace` — parse + namespace + 配線（B6/B7）

## 主な決定（spec 範囲内）

- 除去 `-N` の字面一致は (degree, alteration)（§6「字面一致」の具体化、解決後ピッチ照合は不採用）
- namespace 衝突は last-write-wins + warning（§10-4）
- 未定義 chord 名参照は warning + 空展開（§6 未規定、no-op+warning 哲学に整合）
- **Phase 3 範囲外**: `{ }` レガート・`_` タイ（§5 = Phase 4）、top-level の裸 chord 名。`*n`・汎用パターン変数は Phase R (#227)

## 前提の訂正

直前の作業要約は Phase R (#227) 完了を前提にしていたが #227 は OPEN・値束縛/import 基盤は未実装だった。chord 値の namespace を本フェーズで chord 専用に最小構築し、`BoundValue.kind` discriminant で Phase R と共有可能にした（`*n`・汎用タプル変数は作っていない）。

## テスト

新規 56 件（stack-parsing 10 / stack-timing 5 / sequence-stack-dispatch 7 / chord-resolution 11 / chord-binding-parsing 8 / sequence-chord-dispatch 11 + pitch-parsing の旧 reserved 3 件を新仕様へ更新）。**全体 925 passed / 23 skipped**（ベースライン 873 から +52）。core spec は specs-v2 を正本として参照（§4/§6 は PITCH_DSL_SPEC が正本、乖離なし）。

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)