### PR TITLE
feat(dsl): key-center register + section variables (E3+E4, #253 #254)

### DIFF
--- a/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
+++ b/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
@@ -787,6 +787,8 @@ piano.vel(96)          // default velocity 1-127. default 96
 piano.gate(0.8)        // default gate: sounding fraction of a slot. default 0.8
 
 global.key("C")        // numeric-root reference key (note-name token)
+global.key("D3")       // #253 key-center register: note + octave → tonic D, degree 1 at octave 3
+                       //   (the whole piece's register in one place; seq.octave() still overrides)
 global.midiLatency(20) // fixed send offset in ms (for ear-matching the SC path). default 0
 ```
 

--- a/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
+++ b/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
@@ -941,7 +941,9 @@ MIDI and audio sequences.
 (0, m7, 0, m7)*4.root(3)       // postfix is left-to-right; the .root() covers all 4 copies
 var riff = (1, 0, (3, 5), 7)   // pattern variable — a bare-tuple value, no constructor
 var AA   = (1,0,5,0)(0,5,1,0)  // a juxtaposition binding → splices as multiple siblings
+var A    = (1,0,5,0), (0,5,1,0)  // #254 SECTION: comma-separated multi-cell binding
 seq.play(riff*3, fill, AA)
+seq.play(A, A, B, A)           // song form (AABA) — sections spliced and reused
 ```
 
 - `n` is an integer ≥ 1: `*0` is an error, `*1` is identity.
@@ -952,6 +954,10 @@ seq.play(riff*3, fill, AA)
   Redefining it does not retro-affect a running pattern (re-run the `play()` line). No
   reactive binding. A chord value is a *vertical* value; a pattern variable is a *horizontal*
   (tree) value.
+- **Section variables** (#254, §6.5 Q2 revised): a top-level **comma** in a pattern binding
+  separates *section cells* (`var A = (bar1), (bar2), …`), spliced as siblings at the use
+  site — `play(A, A, B, A)` writes a song form. (A comma-less juxtaposition `(..)(..)` shares
+  one root-scope run; a comma ends the run, exactly as in `play()`.)
 
 ### P.10 MIDI realization rules (§7)
 

--- a/docs/specs-v2/DESIGN_DISCUSSION_RECORD.md
+++ b/docs/specs-v2/DESIGN_DISCUSSION_RECORD.md
@@ -512,3 +512,24 @@ var no5  = [m7, -5]            // 除去 -N もそのまま
 3. **確定済 open sub-question**（decisions #51-53）: open/close=エビデンス定義 / 既定確率 50%・最低音保証なし / `^r` ランダムオクターブ。残る純実装詳細（`r`/`^r` の lexer 位置）は実装時に組む。
 4. **`.comp`（自動ジャズコンピング）= 別フィーチャー（本 PR 対象外）**: voicing + 間引き + `^r` + リズムパターンを束ねる**生成マクロ**。E2 の primitives の上に乗る。リズム生成・密度・スイング等を含むため専用設計＋別 issue（#259）。E2 完了後に検討。
 5. ②表現フェーズ（@v/articulation）とは独立した別軸。jazz リードシート狙いなら本フェーズ先行も可。
+
+---
+
+## 13. 実曲フィードバック由来の小機能 (2026-06-14、E3/E4 実装時)
+
+実曲写経（パヴァーヌ/ジムノペティ）で surfaced した friction の解消。いずれも additive で、設計対話というより実装時の確定事項。
+
+### 13.1 key-center register（#253, E3）
+
+`global.key("D4")` = 音名 + オクターブで**曲全体のレジスタを1箇所宣言**。優先順位 `seq.octave(N)` > key octave > 既定4。`global.key("D")`（octave 無し）は従来通り。純 additive。1オクターブ超をまたぐ旋律は本質的に `^N` が要る点は不変（レジスタ宣言の手間だけ削減）。
+
+### 13.2 section variables（#254, E4 — §6.5 Q2 改訂）
+
+§6.5 Q2「パターン束縛のトップレベル comma は拒否」を**改訂**: comma は**セクションセル区切り**（`var A = (bar1), (bar2), …`）として複数小節を1変数に束縛、使用箇所で兄弟スプライス（`play(A, A, B, A)` = AABA）。comma-less 並置 `(..)(..)` は1 root-scope run を共有、comma は run を閉じる（play() の comma と同一）。
+
+### 13.3 決定ログ(続き)
+
+| # | 決定 | 棄却した代替案 | 主な根拠 |
+|---|---|---|---|
+| 54 | `global.key("D4")` で key-center octave を宣言（seq.octave > key octave > 4）。additive | 専用 `seq.register()` / 非 sticky 絶対オクターブ記法 | 実曲の `^` 連発緩和を最小・後方互換で。レジスタを1箇所に |
+| 55 | §6.5 Q2 改訂: パターン束縛の top-level comma = セクションセル区切り（多小節束縛） | Q2 維持（comma 拒否、juxtaposition のみ） | #254 曲構成（AABA）の直接記述。WCTM リードシート skill に直結 |

--- a/packages/engine/src/core/global/midi-manager.ts
+++ b/packages/engine/src/core/global/midi-manager.ts
@@ -23,6 +23,8 @@ export class MidiManager {
 
   /** Global key pitch class (0..11), undefined until `global.key()` is called. */
   private keyPitchClass?: number
+  /** Global key-center octave (#253), set by `global.key("D4")`; undefined = none. */
+  private keyOctave?: number
   /** Global send latency in ms applied to every MIDI send (§1). */
   private midiLatencyMs = 0
   /** Per-port lead (negative offset) in ms — sends this much earlier (§9). */
@@ -53,14 +55,32 @@ export class MidiManager {
     return this.scheduler !== undefined
   }
 
-  /** Set the global key from a note name (e.g. "C", "F#", "Bb"). */
+  /**
+   * Set the global key from a note name, with an optional **key-center octave**
+   * (#253): `"C"` / `"F#"` / `"Bb"` set only the pitch class; `"D4"` / `"Bb3"` /
+   * `"F#5"` also set the base octave for degree 1 — the whole piece's register in
+   * one place (a per-sequence `seq.octave()` still overrides it). A name without an
+   * octave clears any previous key octave.
+   */
   key(name: string): void {
-    this.keyPitchClass = noteNameToPitchClass(name)
+    const m = name.match(/^([A-Ga-g][#b]*)(-?\d+)$/)
+    if (m) {
+      this.keyPitchClass = noteNameToPitchClass(m[1]!)
+      this.keyOctave = parseInt(m[2]!, 10)
+    } else {
+      this.keyPitchClass = noteNameToPitchClass(name)
+      this.keyOctave = undefined
+    }
   }
 
   /** The global key pitch class, or undefined if `global.key()` was never called. */
   getKeyPitchClass(): number | undefined {
     return this.keyPitchClass
+  }
+
+  /** The global key-center octave (#253), or undefined if `global.key()` had no octave. */
+  getKeyOctave(): number | undefined {
+    return this.keyOctave
   }
 
   /** Set the global MIDI send latency (ms). */

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -78,7 +78,7 @@ export class Sequence {
   private _gate = 0.8 // default gate length (fraction of slot). spec §1
   private _vel = 96 // default velocity 1..127. spec §1
   private _hold = false // §5.3: auto common-tone tie between consecutive stacks
-  private _octave = 4 // base octave; degree 1 MIDI note. default 4 (C4=60)
+  private _octave?: number // base octave (degree 1) IF seq.octave() was set; else falls back
   private _rootDegree?: number // seq.root(n): numeric root = degree of global.key()
 
   constructor(global: Global, audioEngine: AudioEngine) {
@@ -499,6 +499,17 @@ export class Sequence {
    * n-th degree of `global.key()`; with no `seq.root()`, the key tonic is the
    * root. A degree with neither a key nor a root is a hard error.
    */
+  /**
+   * The base octave for degree 1 (§2.1 / #253 key-center register): an explicit
+   * `seq.octave(N)` wins; otherwise the global key octave from `global.key("D4")`
+   * (the whole piece's register, declared once); otherwise 4 (C4 = 60). This is the
+   * key-center register — it lets a low/high piece be placed in one place instead of
+   * setting `seq.octave()` (or a `^N` range) on every sequence.
+   */
+  private baseOctave(): number {
+    return this._octave ?? this.global.getMidiManager().getKeyOctave() ?? 4
+  }
+
   private resolveRootContext(): RootContext {
     const name = this.stateManager.getName() || 'sequence'
     const keyPC = this.global.getMidiManager().getKeyPitchClass()
@@ -515,7 +526,7 @@ export class Sequence {
         ? this.degreeRootToPitchClass(this._rootDegree, 0, keyPC)
         : keyPC
 
-    return { rootPitchClass, octave: this._octave }
+    return { rootPitchClass, octave: this.baseOctave() }
   }
 
   /**
@@ -564,7 +575,7 @@ export class Sequence {
     }
     const root = scope.root!
     if (root.kind === 'note') {
-      return { rootPitchClass: root.pitchClass, octave: this._octave }
+      return { rootPitchClass: root.pitchClass, octave: this.baseOctave() }
     }
     // Degree root: resolve against the key (key-undeclared = error).
     const keyPC = this.global.getMidiManager().getKeyPitchClass()
@@ -575,7 +586,7 @@ export class Sequence {
     }
     return {
       rootPitchClass: this.degreeRootToPitchClass(root.degree, root.alteration, keyPC),
-      octave: this._octave,
+      octave: this.baseOctave(),
     }
   }
 
@@ -1178,7 +1189,7 @@ export class Sequence {
       midiChannel: this._midiChannel,
       gate: this._gate,
       vel: this._vel,
-      octave: this._octave,
+      octave: this.baseOctave(),
       rootDegree: this._rootDegree,
     }
   }

--- a/packages/engine/src/parser/parse-statement.ts
+++ b/packages/engine/src/parser/parse-statement.ts
@@ -160,8 +160,10 @@ export class StatementParser {
    * top-level play siblings (a group, a juxtaposition `(...)(...)`, or a chained /
    * `*n` form), parsed exactly like inline play-args (collapseScopedRun + the
    * `*n`/chain postfix) minus the wrapping parens. Terminates at the statement end.
-   * A top-level comma is rejected (§6.5 Q2): a binding is a single root-scope cell
-   * or a juxtaposition run, not a comma list.
+   * A top-level comma separates SECTION cells (§6.5 Q2, revised by #254): a binding may
+   * be a multi-bar section (`var A = (bar1), (bar2), ...`) for song forms, spliced as
+   * siblings at the use site — `play(A, A, B, A)` writes an AABA structure. A comma ends
+   * the current root-scope juxtaposition run (like a play() comma).
    */
   private parsePatternBinding(variableName: string): { statement: PatternBinding; newPos: number } {
     const elements: PlayElement[] = []
@@ -182,15 +184,17 @@ export class StatementParser {
         runStart = lastIdx
       }
 
+      this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
       const t = ParserUtils.current(this.tokens, this.pos).type
       if (t === 'COMMA') {
-        throw new Error(
-          'a pattern binding is a single cell or a juxtaposition run; ' +
-            'use juxtaposition `(...)(...)`, not commas (§6.5).',
-        )
+        // #254 section cell separator: advance, open a fresh juxtaposition run.
+        this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
+        this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
+        runStart = elements.length
+        continue
       }
       if (t === 'LPAREN') {
-        continue // juxtaposition: another group with no comma
+        continue // juxtaposition: another group with no comma (shares the run)
       }
       break // NEWLINE / EOF / end of statement
     }

--- a/tests/audio-parser/pattern-binding-parsing.spec.ts
+++ b/tests/audio-parser/pattern-binding-parsing.spec.ts
@@ -32,8 +32,19 @@ describe('Phase R — pattern binding parsing (§6.5)', () => {
     expect(stmt.elements[1]).toMatchObject({ type: 'nested', elements: [0, 5, 1, 0] })
   })
 
-  it('a top-level comma in a binding is rejected (§6.5 — use juxtaposition)', () => {
-    expect(() => parseAudioDSL('var x = (1, 0), (5, 0)')).toThrow(/juxtaposition|single cell/)
+  it('a top-level comma binds a multi-cell SECTION (#254, §6.5 Q2 revised)', () => {
+    const stmt = parseAudioDSL('var A = (1, 0), (5, 0)').statements[0] as any
+    expect(stmt.type).toBe('pattern_binding')
+    expect(stmt.elements).toHaveLength(2) // two section cells, spliced at the use site
+    expect(stmt.elements[0]).toMatchObject({ type: 'nested', elements: [1, 0] })
+    expect(stmt.elements[1]).toMatchObject({ type: 'nested', elements: [5, 0] })
+  })
+
+  it('a section may mix bars and per-cell `.root()` chains (`var A = (..).root(3), (..)`)', () => {
+    const stmt = parseAudioDSL('var A = (1, 0).root(3), (5, 0)').statements[0] as any
+    expect(stmt.elements).toHaveLength(2)
+    expect(stmt.elements[0]).toMatchObject({ type: 'scoped', root: { kind: 'degree', degree: 3 } })
+    expect(stmt.elements[1]).toMatchObject({ type: 'nested', elements: [5, 0] })
   })
 
   it('init declarations are unaffected (regression)', () => {

--- a/tests/core/sequence-pattern-dispatch.spec.ts
+++ b/tests/core/sequence-pattern-dispatch.spec.ts
@@ -88,6 +88,12 @@ describe('Phase R — pattern variables dispatch (§6.5)', () => {
     expect(notesOf(out)).toEqual([60, 67])
   })
 
+  it('a multi-cell section splices and is reusable: A = (1),(5); play(A, A) → AA (#254)', async () => {
+    const out = await playWith((g) => g.definePattern('a', patternElements('(1), (5)')), 'a, a')
+    // A = two section cells [1][5]; play(A, A) writes the section twice (song-form reuse)
+    expect(notesOf(out)).toEqual([60, 67, 60, 67])
+  })
+
   it('`*n` on a pattern ref repeats the splice: riff*3, riff = (1, 5)', async () => {
     const out = await playWith((g) => g.definePattern('riff', patternElements('(1, 5)')), 'riff*3')
     expect(notesOf(out)).toEqual([60, 67, 60, 67, 60, 67])

--- a/tests/midi/key-center.spec.ts
+++ b/tests/midi/key-center.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+import { Global } from '../../packages/engine/src/core/global'
+import { Sequence } from '../../packages/engine/src/core/sequence'
+import { MidiManager } from '../../packages/engine/src/core/global/midi-manager'
+import { MidiOutput } from '../../packages/engine/src/midi/midi-output'
+
+/**
+ * E3 (#253) — key-center register: `global.key("D4")` sets the tonic pitch class AND a
+ * base octave for degree 1, declaring the whole piece's register in one place. A plain
+ * `global.key("D")` keeps the default octave (4); an explicit `seq.octave()` overrides.
+ */
+
+const T0 = 1_000_000
+function recordingOutput(log: number[]): MidiOutput {
+  return {
+    ensurePort: vi.fn((q: string) => (/iac/i.test(q) ? 'IACドライバ バス1' : q)),
+    noteOn: vi.fn((_p: string, _c: number, note: number) => log.push(note)),
+    noteOff: vi.fn(),
+    pitchBend: vi.fn(),
+    releaseOwner: vi.fn(),
+    panic: vi.fn(),
+    getActiveNotes: vi.fn(() => []),
+    listPorts: vi.fn(() => ['IACドライバ バス1']),
+    closeAll: vi.fn(),
+  }
+}
+function mockScheduler() {
+  return {
+    isRunning: true,
+    startTime: T0,
+    getCurrentTime: () => 0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(),
+    clearSequenceEvents: vi.fn(),
+    reinitializeSequenceTracking: vi.fn(),
+    getMasterGainDb: () => 0,
+  } as never
+}
+
+/** Play degree `1` under `key`, optionally setting seq.octave; return degree-1's MIDI note. */
+async function rootNote(key: string, seqOctave?: number): Promise<number> {
+  vi.setSystemTime(T0)
+  const sched = mockScheduler()
+  const ons: number[] = []
+  const global = new Global(sched, new MidiManager(() => recordingOutput(ons)))
+  global.key(key)
+  global.start()
+  const seq = new Sequence(global, sched)
+  seq.setName('piano')
+  seq.midi('iac', 1)
+  if (seqOctave !== undefined) seq.octave(seqOctave)
+  seq.play(...(parseAudioDSL('p.play(1)').statements[0].args as never[]))
+  await seq.run()
+  await vi.advanceTimersByTimeAsync(2100)
+  return ons[0]!
+}
+
+describe('E3 — key-center register (#253)', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('`global.key("D3")` places degree 1 at D3 (50) without seq.octave()', async () => {
+    expect(await rootNote('D3')).toBe(50)
+  })
+
+  it('`global.key("D")` (no octave) keeps the default octave 4 → D4 (62)', async () => {
+    expect(await rootNote('D')).toBe(62)
+  })
+
+  it('`global.key("Bb5")` places degree 1 at Bb5 (82)', async () => {
+    expect(await rootNote('Bb5')).toBe(82)
+  })
+
+  it('an explicit `seq.octave()` overrides the key-center octave', async () => {
+    // global.key("D4") would give D4=62, but seq.octave(5) wins → D5=74
+    expect(await rootNote('D4', 5)).toBe(74)
+  })
+
+  it('the key octave parses but does not change the pitch class (C4=60, C3=48)', async () => {
+    expect(await rootNote('C')).toBe(60)
+    expect(await rootNote('C3')).toBe(48)
+  })
+})


### PR DESCRIPTION
## 概要

Pitch DSL 完成ロードマップ **PR-B**（Epic #224）。実曲写経で surfaced した作曲エルゴノミクス2件。**PR-A (#260) の上にスタック**（base = `257-harmony-voicing`）。PR-A マージ後に base は main に向く。

`Closes #253, #254`.

## 内容

- **E3 key-center register（#253）**: `global.key("D4")` で音名+オクターブ → 曲全体のレジスタを1箇所で宣言。`seq.octave()` > key octave > 既定4。additive・後方互換。
- **E4 section variables（#254）**: §6.5 Q2 改訂 — パターン束縛の top-level comma = セクションセル区切り（`var A = (bar1),(bar2)` → `play(A,A,B,A)` で AABA）。

## 設計記録

DESIGN_DISCUSSION_RECORD §13（decisions #54/#55）。core spec P.1/P.9 反映。

## テスト

`tests/midi/key-center.spec.ts`（5）+ pattern-binding section テスト + dispatch splice。**全体 1004 passed / 23 skipped**。

## レビュー観点

E3: 既定オクターブ（4）の後方互換維持 / seq.octave override の優先順位。E4: §6.5 Q2 改訂の妥当性（comma=section）、既存 juxtaposition 意味論の不変。

Closes #253, #254