### PR TITLE
feat(dsl): per-note expression @v velocity + @g articulation (E5, #262)

### DIFF
--- a/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
+++ b/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
@@ -787,6 +787,8 @@ piano.vel(96)          // default velocity 1-127. default 96
 piano.gate(0.8)        // default gate: sounding fraction of a slot. default 0.8
 
 global.key("C")        // numeric-root reference key (note-name token)
+global.key("D3")       // #253 key-center register: note + octave → tonic D, degree 1 at octave 3
+                       //   (the whole piece's register in one place; seq.octave() still overrides)
 global.midiLatency(20) // fixed send offset in ms (for ear-matching the SC path). default 0
 ```
 

--- a/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
+++ b/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
@@ -941,7 +941,9 @@ MIDI and audio sequences.
 (0, m7, 0, m7)*4.root(3)       // postfix is left-to-right; the .root() covers all 4 copies
 var riff = (1, 0, (3, 5), 7)   // pattern variable — a bare-tuple value, no constructor
 var AA   = (1,0,5,0)(0,5,1,0)  // a juxtaposition binding → splices as multiple siblings
+var A    = (1,0,5,0), (0,5,1,0)  // #254 SECTION: comma-separated multi-cell binding
 seq.play(riff*3, fill, AA)
+seq.play(A, A, B, A)           // song form (AABA) — sections spliced and reused
 ```
 
 - `n` is an integer ≥ 1: `*0` is an error, `*1` is identity.
@@ -952,6 +954,10 @@ seq.play(riff*3, fill, AA)
   Redefining it does not retro-affect a running pattern (re-run the `play()` line). No
   reactive binding. A chord value is a *vertical* value; a pattern variable is a *horizontal*
   (tree) value.
+- **Section variables** (#254, §6.5 Q2 revised): a top-level **comma** in a pattern binding
+  separates *section cells* (`var A = (bar1), (bar2), …`), spliced as siblings at the use
+  site — `play(A, A, B, A)` writes a song form. (A comma-less juxtaposition `(..)(..)` shares
+  one root-scope run; a comma ends the run, exactly as in `play()`.)
 
 ### P.10 MIDI realization rules (§7)
 

--- a/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
+++ b/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
@@ -975,11 +975,25 @@ seq.play(A, A, B, A)           // song form (AABA) — sections spliced and reus
   different detunes sounding on one channel at once collide (last bend wins) — the canonical
   spec specifies a warning for this case, but it is not yet implemented. MPE is out of scope.
 
-> **Expression model (velocity / articulation) — not yet specified here.** The per-note
-> `@v` velocity and articulation axes are a confirmed *principle* but their token grammar is
-> a dedicated post-Phase-4 phase; spec reflection is **deferred per decision #42**. See
-> [`DESIGN_DISCUSSION_RECORD.md`](../specs-v2/DESIGN_DISCUSSION_RECORD.md) §10. `@u` absolute
-> duration (v1.0 `@U`) is **rejected** — duration is carried by the tree + ties.
+### P.12 Per-note expression — `@v` velocity / `@g` articulation (§10.3, E5)
+
+The two expression axes (decision #41): velocity and articulation. Per-note `@` postfix
+modifiers; `@u` absolute duration (v1.0 `@U`) is **rejected** — duration is carried by the
+tree + ties.
+
+```js
+5@v110          // absolute velocity 110 (1..127) — overrides seq.vel()
+5@v+20  5@v-30  // velocity relative to seq.vel() (an accent / de-emphasis)
+5@g30           // articulation = gate PERCENT: 30 = 0.30 (staccato) — overrides seq.gate()
+5@g120          // 120 = 1.20 gate (legato-leaning); the axis `{ }` legato also lives on
+5@v100@g30      // compose; also orthogonal to `^N` / `~` / `r`
+```
+
+- **`@v`** = velocity. Absolute `@v<n>` (1..127) or relative `@v+<n>`/`@v-<n>` (accent,
+  added to `seq.vel()` and clamped). An accent is just a velocity boost — no separate token.
+- **`@g`** = articulation as a gate **percent** (`@g30` = 0.30). It is the per-note point on
+  the same axis as `{ }` legato (`@g` > 100 rings past the slot). Overrides `seq.gate()` for
+  that note. Integer/percent args avoid a decimal point splitting the token.
 
 ### P.11 Voicing operators & randomness (§12)
 
@@ -1045,8 +1059,9 @@ Epic #224 phases 1/2/3/R/4:
 - **Ties / legato / hold** (Phase 4): `_` event tie, `_n` voice tie, `{ }` legato, `.hold()`
 - **Voicing + randomness** (E2 / §12): `.drop(n...)`/`.invert(n)`/`.open()`/`.close()`/`.shell()`/
   `.rootless()`; `Xr`/`.r`/`^r` random (see P.11)
-- **Not yet specified**: per-note expression (`@v` velocity / articulation) — deferred per
-  decision #42 (see breadcrumb above)
+- **Key-center register** (E3 / #253): `global.key("D4")` base octave (see P.1)
+- **Section variables** (E4 / #254): comma-separated multi-bar bindings (see P.9)
+- **Per-note expression** (E5 / §10.3): `@v` velocity (absolute / relative) + `@g` articulation (see P.12)
 
 #### Parser
 - **Tokenizer**: Complete lexical analysis

--- a/docs/specs-v2/DESIGN_DISCUSSION_RECORD.md
+++ b/docs/specs-v2/DESIGN_DISCUSSION_RECORD.md
@@ -533,3 +533,15 @@ var no5  = [m7, -5]            // 除去 -N もそのまま
 |---|---|---|---|
 | 54 | `global.key("D4")` で key-center octave を宣言（seq.octave > key octave > 4）。additive | 専用 `seq.register()` / 非 sticky 絶対オクターブ記法 | 実曲の `^` 連発緩和を最小・後方互換で。レジスタを1箇所に |
 | 55 | §6.5 Q2 改訂: パターン束縛の top-level comma = セクションセル区切り（多小節束縛） | Q2 維持（comma 拒否、juxtaposition のみ） | #254 曲構成（AABA）の直接記述。WCTM リードシート skill に直結 |
+
+### 13.4 表現 @v/@g（#42 の先送りを解消、E5/§10.3）
+
+決定 #42（@系トークン文法は Phase 4 後の専用フェーズ）を実装で確定。velocity 軸 + articulation 軸の2軸（#41）を per-note 後置 `@` で:
+- **`@v100`**: 絶対 velocity（1-127）。**`@v+20`/`@v-30`**: seq.vel() 相対（アクセント）。
+- **`@g30`**: articulation = gate **パーセント**（30=0.30 staccato / 120=1.20 legato 寄り）。`{ }` レガートと同一軸を per-note 連続値で。seq.gate() を上書き。
+- 実装注: lexer が `v100`/`g30` を1識別子に併合するため、letter+digits を分離。整数引数（gate は%）にして小数点でのトークン分断を回避。`@v+n` は符号が識別子を割る。
+
+| # | 決定 | 棄却した代替案 | 主な根拠 |
+|---|---|---|---|
+| 56 | per-note 表現 = `@v`（velocity, 絶対/相対）+ `@g`（articulation=gate比）。#42 の先送りを実装で解消 | 表現を更に先送り / 独立記号（accent `>` 等）を増やす | #41 の2軸モデルを最小トークンで。アクセント=velocity 相対に還元 |
+| 57 | `@v`/`@g` は整数引数（`@g` は gate パーセント `@g30`=0.30）。`@v(100)` paren 形は不採用 | `@g0.3` 小数形（lexer がトークン分断）/ paren 必須 | 速記性。lexer の letter+digit 併合と整合、小数点問題を回避 |

--- a/docs/specs-v2/DESIGN_DISCUSSION_RECORD.md
+++ b/docs/specs-v2/DESIGN_DISCUSSION_RECORD.md
@@ -512,3 +512,24 @@ var no5  = [m7, -5]            // 除去 -N もそのまま
 3. **確定済 open sub-question**（decisions #51-53）: open/close=エビデンス定義 / 既定確率 50%・最低音保証なし / `^r` ランダムオクターブ。残る純実装詳細（`r`/`^r` の lexer 位置）は実装時に組む。
 4. **`.comp`（自動ジャズコンピング）= 別フィーチャー（本 PR 対象外）**: voicing + 間引き + `^r` + リズムパターンを束ねる**生成マクロ**。E2 の primitives の上に乗る。リズム生成・密度・スイング等を含むため専用設計＋別 issue（#259）。E2 完了後に検討。
 5. ②表現フェーズ（@v/articulation）とは独立した別軸。jazz リードシート狙いなら本フェーズ先行も可。
+
+---
+
+## 13. 実曲フィードバック由来の小機能 (2026-06-14、E3/E4 実装時)
+
+実曲写経（パヴァーヌ/ジムノペティ）で surfaced した friction の解消。いずれも additive で、設計対話というより実装時の確定事項。
+
+### 13.1 key-center register（#253, E3）
+
+`global.key("D4")` = 音名 + オクターブで**曲全体のレジスタを1箇所宣言**。優先順位 `seq.octave(N)` > key octave > 既定4。`global.key("D")`（octave 無し）は従来通り。純 additive。1オクターブ超をまたぐ旋律は本質的に `^N` が要る点は不変（レジスタ宣言の手間だけ削減）。
+
+### 13.2 section variables（#254, E4 — §6.5 Q2 改訂）
+
+§6.5 Q2「パターン束縛のトップレベル comma は拒否」を**改訂**: comma は**セクションセル区切り**（`var A = (bar1), (bar2), …`）として複数小節を1変数に束縛、使用箇所で兄弟スプライス（`play(A, A, B, A)` = AABA）。comma-less 並置 `(..)(..)` は1 root-scope run を共有、comma は run を閉じる（play() の comma と同一）。
+
+### 13.3 決定ログ(続き)
+
+| # | 決定 | 棄却した代替案 | 主な根拠 |
+|---|---|---|---|
+| 54 | `global.key("D4")` で key-center octave を宣言（seq.octave > key octave > 4）。additive | 専用 `seq.register()` / 非 sticky 絶対オクターブ記法 | 実曲の `^` 連発緩和を最小・後方互換で。レジスタを1箇所に |
+| 55 | §6.5 Q2 改訂: パターン束縛の top-level comma = セクションセル区切り（多小節束縛） | Q2 維持（comma 拒否、juxtaposition のみ） | #254 曲構成（AABA）の直接記述。WCTM リードシート skill に直結 |

--- a/packages/engine/src/core/global/midi-manager.ts
+++ b/packages/engine/src/core/global/midi-manager.ts
@@ -23,6 +23,8 @@ export class MidiManager {
 
   /** Global key pitch class (0..11), undefined until `global.key()` is called. */
   private keyPitchClass?: number
+  /** Global key-center octave (#253), set by `global.key("D4")`; undefined = none. */
+  private keyOctave?: number
   /** Global send latency in ms applied to every MIDI send (§1). */
   private midiLatencyMs = 0
   /** Per-port lead (negative offset) in ms — sends this much earlier (§9). */
@@ -53,14 +55,32 @@ export class MidiManager {
     return this.scheduler !== undefined
   }
 
-  /** Set the global key from a note name (e.g. "C", "F#", "Bb"). */
+  /**
+   * Set the global key from a note name, with an optional **key-center octave**
+   * (#253): `"C"` / `"F#"` / `"Bb"` set only the pitch class; `"D4"` / `"Bb3"` /
+   * `"F#5"` also set the base octave for degree 1 — the whole piece's register in
+   * one place (a per-sequence `seq.octave()` still overrides it). A name without an
+   * octave clears any previous key octave.
+   */
   key(name: string): void {
-    this.keyPitchClass = noteNameToPitchClass(name)
+    const m = name.match(/^([A-Ga-g][#b]*)(-?\d+)$/)
+    if (m) {
+      this.keyPitchClass = noteNameToPitchClass(m[1]!)
+      this.keyOctave = parseInt(m[2]!, 10)
+    } else {
+      this.keyPitchClass = noteNameToPitchClass(name)
+      this.keyOctave = undefined
+    }
   }
 
   /** The global key pitch class, or undefined if `global.key()` was never called. */
   getKeyPitchClass(): number | undefined {
     return this.keyPitchClass
+  }
+
+  /** The global key-center octave (#253), or undefined if `global.key()` had no octave. */
+  getKeyOctave(): number | undefined {
+    return this.keyOctave
   }
 
   /** Set the global MIDI send latency (ms). */

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -78,7 +78,7 @@ export class Sequence {
   private _gate = 0.8 // default gate length (fraction of slot). spec §1
   private _vel = 96 // default velocity 1..127. spec §1
   private _hold = false // §5.3: auto common-tone tie between consecutive stacks
-  private _octave = 4 // base octave; degree 1 MIDI note. default 4 (C4=60)
+  private _octave?: number // base octave (degree 1) IF seq.octave() was set; else falls back
   private _rootDegree?: number // seq.root(n): numeric root = degree of global.key()
 
   constructor(global: Global, audioEngine: AudioEngine) {
@@ -499,6 +499,17 @@ export class Sequence {
    * n-th degree of `global.key()`; with no `seq.root()`, the key tonic is the
    * root. A degree with neither a key nor a root is a hard error.
    */
+  /**
+   * The base octave for degree 1 (§2.1 / #253 key-center register): an explicit
+   * `seq.octave(N)` wins; otherwise the global key octave from `global.key("D4")`
+   * (the whole piece's register, declared once); otherwise 4 (C4 = 60). This is the
+   * key-center register — it lets a low/high piece be placed in one place instead of
+   * setting `seq.octave()` (or a `^N` range) on every sequence.
+   */
+  private baseOctave(): number {
+    return this._octave ?? this.global.getMidiManager().getKeyOctave() ?? 4
+  }
+
   private resolveRootContext(): RootContext {
     const name = this.stateManager.getName() || 'sequence'
     const keyPC = this.global.getMidiManager().getKeyPitchClass()
@@ -515,7 +526,7 @@ export class Sequence {
         ? this.degreeRootToPitchClass(this._rootDegree, 0, keyPC)
         : keyPC
 
-    return { rootPitchClass, octave: this._octave }
+    return { rootPitchClass, octave: this.baseOctave() }
   }
 
   /**
@@ -564,7 +575,7 @@ export class Sequence {
     }
     const root = scope.root!
     if (root.kind === 'note') {
-      return { rootPitchClass: root.pitchClass, octave: this._octave }
+      return { rootPitchClass: root.pitchClass, octave: this.baseOctave() }
     }
     // Degree root: resolve against the key (key-undeclared = error).
     const keyPC = this.global.getMidiManager().getKeyPitchClass()
@@ -575,7 +586,7 @@ export class Sequence {
     }
     return {
       rootPitchClass: this.degreeRootToPitchClass(root.degree, root.alteration, keyPC),
-      octave: this._octave,
+      octave: this.baseOctave(),
     }
   }
 
@@ -1178,7 +1189,7 @@ export class Sequence {
       midiChannel: this._midiChannel,
       gate: this._gate,
       vel: this._vel,
-      octave: this._octave,
+      octave: this.baseOctave(),
       rootDegree: this._rootDegree,
     }
   }

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -51,6 +51,8 @@ interface PlannedNote {
   tieSlots: number // extra slot duration absorbed from following `_` ties
   offTime: number
   emit: boolean
+  velocity: number // §10.3 resolved per-note velocity (`@v`/seq.vel())
+  articulation?: number // §10.3 per-note gate ratio (`@g`); undefined = use seq.gate()
 }
 
 export class Sequence {
@@ -724,6 +726,12 @@ export class Sequence {
       // (a rest) — no minimum-voice guarantee, silence is allowed (decision #52).
       const present = ev.random === undefined || Math.random() < ev.random
       const note = resolved && present ? resolved.midiNote : null
+      // §10.3 per-note velocity: absolute `@v` wins; else `@v±` relative to seq.vel(); else seq.vel().
+      const velocity =
+        ev.velocity ??
+        (ev.velocityDelta !== undefined
+          ? Math.max(1, Math.min(127, this._vel + ev.velocityDelta))
+          : this._vel)
       return {
         onTime,
         slotDur: ev.duration,
@@ -736,6 +744,8 @@ export class Sequence {
         tieSlots: 0,
         offTime: 0,
         emit: note !== null,
+        velocity,
+        ...(ev.articulation !== undefined && { articulation: ev.articulation }), // §10.3 `@g`
       }
     })
 
@@ -761,7 +771,7 @@ export class Sequence {
         port,
         channel,
         note: p.note,
-        velocity: this._vel,
+        velocity: p.velocity, // §10.3 per-note `@v` (or seq.vel())
         detune: p.detune,
         onTime: p.onTime,
         offTime: p.offTime,
@@ -785,6 +795,7 @@ export class Sequence {
       tieSlots: 0,
       offTime: 0,
       emit: false,
+      velocity: this._vel, // a tie plan never emits; value is irrelevant
     }
   }
 
@@ -821,7 +832,9 @@ export class Sequence {
   private applyGateAndLegato(plans: PlannedNote[], onsetTimes: number[]): void {
     for (const p of plans) {
       if (p.note === null) continue
-      p.offTime = p.onTime + (p.slotDur + p.tieSlots) * this._gate
+      // §10.3 per-note articulation (`@g`) overrides seq.gate() for the span.
+      const gate = p.articulation ?? this._gate
+      p.offTime = p.onTime + (p.slotDur + p.tieSlots) * gate
       if (p.legato) {
         const next = onsetTimes.find((t) => t > p.onTime)
         if (next !== undefined) p.offTime = next + LEGATO_OVERLAP_MS
@@ -850,7 +863,10 @@ export class Sequence {
         if (wantTie && held) {
           // suppress this retrigger; extend the held note to cover this slot
           // (plus any `_` event tie absorbed onto the suppressed note, §5.1).
-          held.offTime = Math.max(held.offTime, n.onTime + (n.slotDur + n.tieSlots) * this._gate)
+          held.offTime = Math.max(
+            held.offTime,
+            n.onTime + (n.slotDur + n.tieSlots) * (n.articulation ?? this._gate),
+          )
           n.emit = false
           curSounding.set(n.note!, held) // chain: the same note may hold across 3+ stacks
         } else {

--- a/packages/engine/src/parser/parse-expression.ts
+++ b/packages/engine/src/parser/parse-expression.ts
@@ -196,12 +196,13 @@ export class ExpressionParser {
    * another `^M`/`^0` overrides it. The parser only records the per-note
    * annotation; the running range is applied during scheduling, not here.
    */
-  /** True if the current token starts a pitch modifier: `^N` / `^r`, `~`, or a trailing `r`. */
+  /** True if the current token starts a pitch modifier: `^N`/`^r`, `~`, `@v`/`@g`, or `r`. */
   private nextIsPitchModifier(): boolean {
     const cur = ParserUtils.current(this.tokens, this.pos)
     return (
       cur.type === 'CARET' ||
       cur.type === 'TILDE' ||
+      cur.type === 'AT' ||
       (cur.type === 'IDENTIFIER' && cur.value === 'r')
     )
   }
@@ -215,11 +216,45 @@ export class ExpressionParser {
     let detune = 0
     let random: number | undefined
     let randomOctave = false
+    let velocity: number | undefined
+    let velocityDelta: number | undefined
+    let articulation: number | undefined
     let parsed = true
     while (parsed) {
       parsed = false
       const t = ParserUtils.current(this.tokens, this.pos).type
-      if (t === 'CARET') {
+      if (t === 'AT') {
+        // §10.3 expression (E5): `@v100` absolute velocity / `@v+20`/`@v-30` relative
+        // (accent) / `@g30` articulation as a gate PERCENT (30 = 0.30, 120 = 1.20).
+        // The lexer merges `v100`/`g30` into one identifier, so split letter + digits;
+        // integer args avoid a decimal point splitting the token.
+        this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
+        const sub = ParserUtils.current(this.tokens, this.pos)
+        const raw = sub.type === 'IDENTIFIER' ? String(sub.value) : ''
+        const kind = raw[0]
+        const rest = raw.slice(1)
+        if (kind !== 'v' && kind !== 'g') {
+          throw new Error(`expected @v (velocity) or @g (articulation), got @${raw || '?'}`)
+        }
+        if (rest !== '' && !/^\d+$/.test(rest)) {
+          throw new Error(`@${kind} expects an integer, e.g. @v100 or @g30 (got @${raw})`)
+        }
+        this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
+        if (kind === 'v') {
+          if (rest === '') {
+            // `@v` alone → a relative accent `@v+n` / `@v-n` (the sign split the identifier).
+            const next = ParserUtils.current(this.tokens, this.pos).type
+            if (next === 'PLUS' || next === 'MINUS') velocityDelta = this.parseSignedNumber()
+            else throw new Error('@v needs a value, e.g. @v100 or @v+20')
+          } else {
+            velocity = Math.max(1, Math.min(127, parseInt(rest, 10)))
+          }
+        } else {
+          if (rest === '') throw new Error('@g needs a gate percent, e.g. @g30 (= 0.30)')
+          articulation = parseInt(rest, 10) / 100 // percent → ratio (@g120 = 1.20 legato)
+        }
+        parsed = true
+      } else if (t === 'CARET') {
         this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
         // `^r` = a random octave (§12, #53); otherwise `^N` sets the sticky range (§2.4),
         // rangeSet marking this note as a running-range set point for the walk.
@@ -253,6 +288,9 @@ export class ExpressionParser {
         detune,
         ...(random !== undefined && { random }),
         ...(randomOctave && { randomOctave: true }),
+        ...(velocity !== undefined && { velocity }),
+        ...(velocityDelta !== undefined && { velocityDelta }),
+        ...(articulation !== undefined && { articulation }),
       },
       newPos: this.pos,
     }

--- a/packages/engine/src/parser/parse-statement.ts
+++ b/packages/engine/src/parser/parse-statement.ts
@@ -160,8 +160,10 @@ export class StatementParser {
    * top-level play siblings (a group, a juxtaposition `(...)(...)`, or a chained /
    * `*n` form), parsed exactly like inline play-args (collapseScopedRun + the
    * `*n`/chain postfix) minus the wrapping parens. Terminates at the statement end.
-   * A top-level comma is rejected (§6.5 Q2): a binding is a single root-scope cell
-   * or a juxtaposition run, not a comma list.
+   * A top-level comma separates SECTION cells (§6.5 Q2, revised by #254): a binding may
+   * be a multi-bar section (`var A = (bar1), (bar2), ...`) for song forms, spliced as
+   * siblings at the use site — `play(A, A, B, A)` writes an AABA structure. A comma ends
+   * the current root-scope juxtaposition run (like a play() comma).
    */
   private parsePatternBinding(variableName: string): { statement: PatternBinding; newPos: number } {
     const elements: PlayElement[] = []
@@ -182,15 +184,17 @@ export class StatementParser {
         runStart = lastIdx
       }
 
+      this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
       const t = ParserUtils.current(this.tokens, this.pos).type
       if (t === 'COMMA') {
-        throw new Error(
-          'a pattern binding is a single cell or a juxtaposition run; ' +
-            'use juxtaposition `(...)(...)`, not commas (§6.5).',
-        )
+        // #254 section cell separator: advance, open a fresh juxtaposition run.
+        this.pos = ParserUtils.advance(this.tokens, this.pos).newPos
+        this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
+        runStart = elements.length
+        continue
       }
       if (t === 'LPAREN') {
-        continue // juxtaposition: another group with no comma
+        continue // juxtaposition: another group with no comma (shares the run)
       }
       break // NEWLINE / EOF / end of statement
     }

--- a/packages/engine/src/parser/tokenizer.ts
+++ b/packages/engine/src/parser/tokenizer.ts
@@ -240,6 +240,11 @@ export class AudioTokenizer {
           tokens.push({ type: 'TILDE', value: '~', line, column })
           this.advance()
           break
+        case '@':
+          // §10.3 expression (E5): `@v` velocity / `@g` articulation per-note modifiers.
+          tokens.push({ type: 'AT', value: '@', line, column })
+          this.advance()
+          break
         case '[':
           tokens.push({ type: 'LBRACKET', value: '[', line, column })
           this.advance()

--- a/packages/engine/src/parser/types.ts
+++ b/packages/engine/src/parser/types.ts
@@ -28,6 +28,7 @@ export type AudioTokenType =
   | 'ACCIDENTAL' // pitch alteration prefix: b, bb, #, ## (degree b/# notation)
   | 'CARET' // ^ (octave shift modifier, e.g. 3^+1)
   | 'TILDE' // ~ (detune modifier, e.g. b7~-0.25)
+  | 'AT' // @ (expression modifier: @v velocity / @g articulation, §10.3 E5)
   | 'LBRACKET' // [ (stack — reserved, not yet supported in v1.1)
   | 'RBRACKET' // ] (stack — reserved, not yet supported in v1.1)
   | 'LBRACE' // { (legato group, §4/§5.4)
@@ -330,6 +331,9 @@ export type PlayPitch = {
   tie?: boolean // §5.2 voice-level tie: a `_` prefix inside a stack ([1, _5]) — resolved-pitch-match suppress
   random?: number // §12 `Xr`: presence probability (0..1) — rolled per cycle at dispatch. Absent = always
   randomOctave?: boolean // §12 `^r`: a random octave (±1) picked per cycle at dispatch
+  velocity?: number // §10.3 `@v<n>`: absolute per-note velocity (1..127). Overrides seq.vel()
+  velocityDelta?: number // §10.3 `@v+n`/`@v-n`: velocity relative to seq.vel() (accent)
+  articulation?: number // §10.3 `@g<ratio>`: per-note gate ratio (sounding fraction). Overrides seq.gate()
 }
 
 export type PlayWithModifier = {

--- a/packages/engine/src/timing/calculation/calculate-event-timing.ts
+++ b/packages/engine/src/timing/calculation/calculate-event-timing.ts
@@ -215,6 +215,9 @@ export function calculateEventTiming(
           ...(scope && { scope }),
           ...(element.random !== undefined && { random: element.random }), // §12 `Xr`
           ...(element.randomOctave && { randomOctave: true }), // §12 `^r`
+          ...(element.velocity !== undefined && { velocity: element.velocity }), // §10.3 `@v`
+          ...(element.velocityDelta !== undefined && { velocityDelta: element.velocityDelta }),
+          ...(element.articulation !== undefined && { articulation: element.articulation }), // `@g`
         })
       } else if (element.type === 'modified') {
         // Modified element (e.g., with .chop())

--- a/packages/engine/src/timing/calculation/types.ts
+++ b/packages/engine/src/timing/calculation/types.ts
@@ -66,4 +66,13 @@ export interface TimedEvent {
    */
   random?: number
   randomOctave?: boolean
+  /**
+   * §10.3 per-note expression (E5), applied at the output stage:
+   * - `velocity`: absolute per-note velocity (1..127), overriding `seq.vel()`.
+   * - `velocityDelta`: velocity relative to `seq.vel()` (an accent), clamped at dispatch.
+   * - `articulation`: per-note gate ratio (sounding fraction), overriding `seq.gate()`.
+   */
+  velocity?: number
+  velocityDelta?: number
+  articulation?: number
 }

--- a/tests/audio-parser/pattern-binding-parsing.spec.ts
+++ b/tests/audio-parser/pattern-binding-parsing.spec.ts
@@ -32,8 +32,19 @@ describe('Phase R — pattern binding parsing (§6.5)', () => {
     expect(stmt.elements[1]).toMatchObject({ type: 'nested', elements: [0, 5, 1, 0] })
   })
 
-  it('a top-level comma in a binding is rejected (§6.5 — use juxtaposition)', () => {
-    expect(() => parseAudioDSL('var x = (1, 0), (5, 0)')).toThrow(/juxtaposition|single cell/)
+  it('a top-level comma binds a multi-cell SECTION (#254, §6.5 Q2 revised)', () => {
+    const stmt = parseAudioDSL('var A = (1, 0), (5, 0)').statements[0] as any
+    expect(stmt.type).toBe('pattern_binding')
+    expect(stmt.elements).toHaveLength(2) // two section cells, spliced at the use site
+    expect(stmt.elements[0]).toMatchObject({ type: 'nested', elements: [1, 0] })
+    expect(stmt.elements[1]).toMatchObject({ type: 'nested', elements: [5, 0] })
+  })
+
+  it('a section may mix bars and per-cell `.root()` chains (`var A = (..).root(3), (..)`)', () => {
+    const stmt = parseAudioDSL('var A = (1, 0).root(3), (5, 0)').statements[0] as any
+    expect(stmt.elements).toHaveLength(2)
+    expect(stmt.elements[0]).toMatchObject({ type: 'scoped', root: { kind: 'degree', degree: 3 } })
+    expect(stmt.elements[1]).toMatchObject({ type: 'nested', elements: [5, 0] })
   })
 
   it('init declarations are unaffected (regression)', () => {

--- a/tests/core/sequence-pattern-dispatch.spec.ts
+++ b/tests/core/sequence-pattern-dispatch.spec.ts
@@ -88,6 +88,12 @@ describe('Phase R — pattern variables dispatch (§6.5)', () => {
     expect(notesOf(out)).toEqual([60, 67])
   })
 
+  it('a multi-cell section splices and is reusable: A = (1),(5); play(A, A) → AA (#254)', async () => {
+    const out = await playWith((g) => g.definePattern('a', patternElements('(1), (5)')), 'a, a')
+    // A = two section cells [1][5]; play(A, A) writes the section twice (song-form reuse)
+    expect(notesOf(out)).toEqual([60, 67, 60, 67])
+  })
+
   it('`*n` on a pattern ref repeats the splice: riff*3, riff = (1, 5)', async () => {
     const out = await playWith((g) => g.definePattern('riff', patternElements('(1, 5)')), 'riff*3')
     expect(notesOf(out)).toEqual([60, 67, 60, 67, 60, 67])

--- a/tests/midi/expression.spec.ts
+++ b/tests/midi/expression.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+import { Global } from '../../packages/engine/src/core/global'
+import { Sequence } from '../../packages/engine/src/core/sequence'
+import { MidiManager } from '../../packages/engine/src/core/global/midi-manager'
+import { MidiOutput } from '../../packages/engine/src/midi/midi-output'
+
+/**
+ * E5 (#262) — per-note expression (§10.3): `@v100` absolute velocity / `@v±n` relative
+ * (accent) / `@g30` articulation as a gate PERCENT (30 = 0.30, 120 = 1.20). `@v` overrides
+ * seq.vel(), `@g` overrides seq.gate() for that note. `@u` absolute duration is rejected (#41).
+ */
+
+describe('E5 — expression parse shape (§10.3)', () => {
+  const arg = (src: string) => (parseAudioDSL(`p.play(${src})`).statements[0] as any).args[0]
+
+  it('`5@v100` → absolute velocity 100', () => {
+    expect(arg('5@v100')).toMatchObject({ type: 'pitch', degree: 5, velocity: 100 })
+  })
+
+  it('`5@v+20` / `5@v-30` → relative velocity (accent)', () => {
+    expect(arg('5@v+20')).toMatchObject({ degree: 5, velocityDelta: 20 })
+    expect(arg('5@v-30')).toMatchObject({ degree: 5, velocityDelta: -30 })
+  })
+
+  it('`5@g30` → articulation (gate ratio) 0.3', () => {
+    expect(arg('5@g30')).toMatchObject({ degree: 5, articulation: 0.3 })
+  })
+
+  it('`5@v100@g30` → velocity and articulation compose', () => {
+    expect(arg('5@v100@g30')).toMatchObject({ degree: 5, velocity: 100, articulation: 0.3 })
+  })
+
+  it('`@x` is rejected (only @v / @g)', () => {
+    expect(() => parseAudioDSL('p.play(5@x9)')).toThrow(/@v.*@g|velocity.*articulation/)
+  })
+})
+
+// ── dispatch harness: capture note-on velocity + note-off time ──
+const T0 = 1_000_000
+type On = { note: number; vel: number }
+function recordingOutput(on: On[], offT: Record<number, number>): MidiOutput {
+  return {
+    ensurePort: vi.fn((q: string) => (/iac/i.test(q) ? 'IACドライバ バス1' : q)),
+    noteOn: vi.fn((_p: string, _c: number, note: number, vel: number) => on.push({ note, vel })),
+    noteOff: vi.fn((_p: string, _c: number, note: number) => (offT[note] = Date.now() - T0)),
+    pitchBend: vi.fn(),
+    releaseOwner: vi.fn(),
+    panic: vi.fn(),
+    getActiveNotes: vi.fn(() => []),
+    listPorts: vi.fn(() => ['IACドライバ バス1']),
+    closeAll: vi.fn(),
+  }
+}
+function mockScheduler() {
+  return {
+    isRunning: true,
+    startTime: T0,
+    getCurrentTime: () => 0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(),
+    clearSequenceEvents: vi.fn(),
+    reinitializeSequenceTracking: vi.fn(),
+    getMasterGainDb: () => 0,
+  } as never
+}
+async function play(src: string): Promise<{ on: On[]; offT: Record<number, number> }> {
+  vi.setSystemTime(T0)
+  const sched = mockScheduler()
+  const on: On[] = []
+  const offT: Record<number, number> = {}
+  const global = new Global(sched, new MidiManager(() => recordingOutput(on, offT)))
+  global.key('C')
+  global.start()
+  const seq = new Sequence(global, sched)
+  seq.setName('piano')
+  seq.midi('iac', 1).octave(4) // default vel 96, gate 0.8
+  seq.play(...(parseAudioDSL(`p.play(${src})`).statements[0].args as never[]))
+  await seq.run()
+  await vi.advanceTimersByTimeAsync(3000)
+  return { on, offT }
+}
+
+describe('E5 — expression dispatch (§10.3)', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('`@v` sets the MIDI velocity (absolute and relative to seq.vel()=96)', async () => {
+    expect((await play('5@v100')).on[0]!.vel).toBe(100)
+    expect((await play('5@v+20')).on[0]!.vel).toBe(116) // 96 + 20
+    expect((await play('5@v-50')).on[0]!.vel).toBe(46) // 96 - 50
+    expect((await play('5')).on[0]!.vel).toBe(96) // default
+  })
+
+  it('`@g` shortens (staccato) / lengthens the sounding duration vs the default gate', async () => {
+    const stacc = (await play('5@g20')).offT[67]! // G4 = 67, gate 0.20
+    const sustained = (await play('5@g90')).offT[67]! // gate 0.90
+    expect(stacc).toBeLessThan(sustained) // staccato rings far shorter
+  })
+})

--- a/tests/midi/key-center.spec.ts
+++ b/tests/midi/key-center.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+import { Global } from '../../packages/engine/src/core/global'
+import { Sequence } from '../../packages/engine/src/core/sequence'
+import { MidiManager } from '../../packages/engine/src/core/global/midi-manager'
+import { MidiOutput } from '../../packages/engine/src/midi/midi-output'
+
+/**
+ * E3 (#253) — key-center register: `global.key("D4")` sets the tonic pitch class AND a
+ * base octave for degree 1, declaring the whole piece's register in one place. A plain
+ * `global.key("D")` keeps the default octave (4); an explicit `seq.octave()` overrides.
+ */
+
+const T0 = 1_000_000
+function recordingOutput(log: number[]): MidiOutput {
+  return {
+    ensurePort: vi.fn((q: string) => (/iac/i.test(q) ? 'IACドライバ バス1' : q)),
+    noteOn: vi.fn((_p: string, _c: number, note: number) => log.push(note)),
+    noteOff: vi.fn(),
+    pitchBend: vi.fn(),
+    releaseOwner: vi.fn(),
+    panic: vi.fn(),
+    getActiveNotes: vi.fn(() => []),
+    listPorts: vi.fn(() => ['IACドライバ バス1']),
+    closeAll: vi.fn(),
+  }
+}
+function mockScheduler() {
+  return {
+    isRunning: true,
+    startTime: T0,
+    getCurrentTime: () => 0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(),
+    clearSequenceEvents: vi.fn(),
+    reinitializeSequenceTracking: vi.fn(),
+    getMasterGainDb: () => 0,
+  } as never
+}
+
+/** Play degree `1` under `key`, optionally setting seq.octave; return degree-1's MIDI note. */
+async function rootNote(key: string, seqOctave?: number): Promise<number> {
+  vi.setSystemTime(T0)
+  const sched = mockScheduler()
+  const ons: number[] = []
+  const global = new Global(sched, new MidiManager(() => recordingOutput(ons)))
+  global.key(key)
+  global.start()
+  const seq = new Sequence(global, sched)
+  seq.setName('piano')
+  seq.midi('iac', 1)
+  if (seqOctave !== undefined) seq.octave(seqOctave)
+  seq.play(...(parseAudioDSL('p.play(1)').statements[0].args as never[]))
+  await seq.run()
+  await vi.advanceTimersByTimeAsync(2100)
+  return ons[0]!
+}
+
+describe('E3 — key-center register (#253)', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('`global.key("D3")` places degree 1 at D3 (50) without seq.octave()', async () => {
+    expect(await rootNote('D3')).toBe(50)
+  })
+
+  it('`global.key("D")` (no octave) keeps the default octave 4 → D4 (62)', async () => {
+    expect(await rootNote('D')).toBe(62)
+  })
+
+  it('`global.key("Bb5")` places degree 1 at Bb5 (82)', async () => {
+    expect(await rootNote('Bb5')).toBe(82)
+  })
+
+  it('an explicit `seq.octave()` overrides the key-center octave', async () => {
+    // global.key("D4") would give D4=62, but seq.octave(5) wins → D5=74
+    expect(await rootNote('D4', 5)).toBe(74)
+  })
+
+  it('the key octave parses but does not change the pitch class (C4=60, C3=48)', async () => {
+    expect(await rootNote('C')).toBe(60)
+    expect(await rootNote('C3')).toBe(48)
+  })
+})


### PR DESCRIPTION
## 概要

Pitch DSL 完成ロードマップ **PR-C**。表現の2軸（§10.3 / 決定 #41）を per-note `@` で実装。決定 **#42 の先送りを実装で解消**。**PR-B (#261) の上にスタック**（base = `253-key-center-register`）。

`Closes #262`.

## 文法

- `@v100`（絶対 velocity）/ `@v+20`・`@v-30`（seq.vel 相対 = アクセント）
- `@g30`（articulation = gate パーセント。30=0.30 staccato / 120=1.20 legato 寄り。`{ }` と同一軸）
- 合成 `5@v100@g30`、`^N`/`~`/`r` と直交

## 設計判断（要レビュー）

- **gate を整数パーセント**（`@g30`）にした: lexer が `v100`/`g30` を1識別子に併合するため。小数 `@g0.3` は DOT でトークン分断され扱いづらい。`@v(100)` paren 形より速記性を優先。← ここは大和さんの好みが効く所。記法変更の希望あれば veto を。

## テスト
`tests/midi/expression.spec.ts` 7件。**全体 1011 passed / 23 skipped**。DESIGN §13.4（#56/#57）+ core spec P.12。

Closes #262