### PR TITLE
feat(dsl): auto voice-leading .voicelead() / .vl() (comp phase C1)

### DIFF
--- a/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
+++ b/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
@@ -1020,9 +1020,27 @@ m7.open() / m7.close() // open / close position; .shell() = R+3+7; .rootless() =
   on replay; no seed (decisions #50/#52/#53).
 - **`.comp`** (auto jazz comping) is a future generative macro over these primitives — see #259.
 
----
+### P.13 Auto voice-leading — `.voicelead()` / `.vl()` (正本 PITCH_DSL_SPEC §6.3, comp C1, #269)
 
-## 12. Implementation Status
+Connects consecutive **chord stacks** with minimal voice motion (octave placement only;
+pitch classes preserved). The deterministic foundation `.comp` builds on.
+
+```js
+([1,3,5], [5,7,2]).voicelead()   // C→G: the B drops an octave to stay near C/E/G
+seq.voicelead()                   // sequence default (alias: seq.vl())
+```
+
+- **Deterministic, context-dependent, computed once** — NOT eval-time (unlike §6.1 voicing) and
+  NOT per-cycle (unlike §6.2 randomness). It needs absolute pitch (the resolved root context), so
+  it runs as a once-run output-stage pass and writes each voice's `octaveShift` back symbolically;
+  `^N` / `.oct()` / `^r` still layer on top (§7-0 preserved). Independent of `.r`/`Xr` thinning.
+- Attaches at **group** `(...).voicelead()` and **sequence default** `seq.voicelead()` (same scope-chain
+  mechanism as `.root()`/`.oct()`). Operates on ≥2-voice chords; single notes pass through. The first
+  chord keeps its authored placement; later chords lead from it. Authored `^N` octaves are subsumed.
+- Algorithm: equal voice-count = sorted + n cyclic rotations (min L1, crossing-free); unequal = lead
+  min(n,m), extras at octave 0 (C1 simplification; full bipartite is C2+). **Limitation**: L1-minimal
+  does NOT guarantee tendency-tone resolution or parallel-5th/8ve avoidance — "smooth by default, user
+  controls specifics."
 
 ### Completed Features ✅
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,29 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.112 Issue #269 — auto voice-leading `.voicelead()` / `.vl()`（comp phase C1） (Jun 14, 2026)
+
+**Date**: 2026-06-14
+**Status**: ✅ 実装完了（C1。/simplify + レビュー前）
+**Issue**: signalcompose/orbitscore#269 / 親 #259 / 設計 #268
+**Branch**: `269-voicelead-c1`
+
+**概要**: `.comp` 段階実装の C1。連続するコード stack を直前に対し最小移動（L1 / Tymoczko）で再ボイシングする決定論的演算子 `.voicelead()`（alias `.vl()`）。`.comp` の土台。
+
+**設計上の重要な確定（実装調査で判明、advisor 検証済）**:
+- voice-leading は **絶対ピッチ（root context）を要する**ため §6.1 voicing のような eval-time ではなく、**出力段で一度だけ走る決定論パス**（`validateMidiDispatch` と同型・同 awaited チェーン、per-cycle ではない）。結果を各声部の `octaveShift` にシンボリックに書き戻し、`^N`/`.oct()`/`^r` が上に加算（§7-0 維持、eval/dispatch 軸の決定論側）。
+- 設計ドラフト #268 の「eval-time symbolic」記述はこの調査で誤りと判明 → #268 側を「deterministic, context-dependent, once-run」に訂正する（doc/impl 乖離防止）。
+
+**実装**:
+- `midi/voice-leading.ts`: 純関数 `voiceLeadOctaves(prev, curBase)`。等数はソート後 n 通り cyclic rotation の L1 最小、不一致は min(n,m) を lead・余剰はオクターブ 0（C1 簡略化、bipartite は C2+）。コモントーンは距離 0 で自然保持。
+- `parser`: `.voicelead()`/`.vl()` をスコープチェーン（`SCOPE_CHAIN_OPS`）に追加。`PlayScoped.voicelead` / `TimedEventScope.voicelead`、timing walk で伝播。
+- `core/sequence.ts`: `seq.voicelead()`/`vl()` setter + `applyVoiceLeading()`（onset でコードをグループ化し、≥2声部・voicelead スコープのコードを最小移動で octave 再配置）。run()/loop() の validateMidiDispatch 直後に実行。
+- `seq` 既定 と グループ `(...).voicelead()` の両対応。単音はスルー、最初のコードは記譜どおり（アンカー）、記譜 `^N` は VL が包摂。
+
+**spec**: PITCH_DSL_SPEC §6.3 に normative セクション追加（phase gate, rule #7）。音楽性限界（傾向音解決・並行回避を保証しない）を明記。
+
+**テスト**: `tests/midi/voice-leading.spec.ts` 11件（純関数の単体 + dispatch 統合 + parse + seq既定/group + 音楽性）。全体 1033 passed / 23 skipped。
+
 ### 6.110 Issue #266 — 正本 HTML の normative 同期（PITCH_DSL_SPEC ← as-built E1-E6） (Jun 14, 2026)
 
 **Date**: 2026-06-14

--- a/docs/specs-v2/PITCH_DSL_SPEC_v1.1.html
+++ b/docs/specs-v2/PITCH_DSL_SPEC_v1.1.html
@@ -714,6 +714,17 @@ m7.drop(2)             // コード変数にも適用可</code></pre>
 <li><strong>最小声部の保証はない</strong>: <code>.r</code> は全声部が落ちて無音になるサイクルも許容する。</li>
 <li>要素自身の <code>Xr</code> はスタックの <code>.r(p)</code> に優先する: <code>[1, 3r, 5].r(1)</code> は<strong>度数 1 と度数 5</strong> が常に鳴り(スタックの <code>.r(1)</code>=確率 1.0)、<strong>度数 3</strong> は自身の <code>3r</code>(0.5)に従う(test: <code>tests/midi/random.spec.ts</code>)。</li>
 </ul>
+<h3 id="auto-voice-leading">6.3 Auto voice-leading: <code>.voicelead()</code> / <code>.vl()</code> (comp C1)</h3>
+<pre><code class="sourceCode javascript">([1,3,5], [5,7,2]).voicelead()   // 連続コードを最小移動で再ボイシング(C→G で B が B3 へ降りる)
+seq.voicelead()                   // シーケンス既定としても可(alias: seq.vl())
+([1,3,5], [5,7,2]).vl()           // .vl() は .voicelead() の別名</code></pre>
+<ul>
+<li><code>.voicelead()</code>(別名 <code>.vl()</code>)は連続する<strong>コード stack</strong>を、直前のコードに対し<strong>総声部移動が最小</strong>(L1 / taxicab、Tymoczko)になるよう各声部のオクターブを置き直す。<strong>構成音(ピッチクラス)は不変</strong>でオクターブ配置のみ変わる。<code>.root()</code>/<code>.oct()</code> と同じスコープチェーン機構で、<strong>グループ単位 <code>(...).voicelead()</code> と シーケンス既定 <code>seq.voicelead()</code> の両方</strong>に付けられる。</li>
+<li><strong>決定論的・一度だけ計算</strong>。ただし §6.1 voicing と違い<strong>絶対ピッチ(root context)を要する</strong>ため、eval 時ではなく<strong>出力段で一度走る</strong>(root context は dispatch で解決される)。結果は各声部の <code>octaveShift</code> としてシンボリックに書き戻され、`^N`(running range)・<code>.oct()</code>・<code>^r</code> はその上に加算される(§7-0 維持)。乱数間引き(<code>.r</code>/<code>Xr</code>)とは独立(VL は常にコード全体を見る)。</li>
+<li>対象は <strong>2声部以上のコード</strong>(同一 onset)。単音はスルー(アンカーにもならない)。<strong>最初のコード</strong>は記譜どおりのオクターブに置かれ(アンカー)、以降のコードが直前から最小移動でリードする。各声部の記譜 <code>^N</code> オクターブは VL が<strong>包摂</strong>する(VL がオクターブ配置を担うため)。</li>
+<li><strong>声部数アルゴリズム</strong>: 等数はソート後 n 通りの cyclic rotation の L1 最小(crossing-free 最適)。声部数不一致は C1 簡略化として min(n,m) 声部を lead し、余剰声部はオクターブ 0 のまま(完全な bipartite/doubling は C2+)。コモントーンは距離 0 で残るため自然に保持される。</li>
+<li><strong>音楽性の限界(明示)</strong>: L1 最小は<strong>傾向音解決(導音・7→3)も並行5度/8度回避も保証しない</strong>。本機能は「デフォルトで滑らか + 細部はユーザー制御」という位置づけで、傾向音や声部独立性が要るときは明示 degree / voicing operator で書く。</li>
+</ul>
 <hr />
 <h2 id="repetition-n-and-pattern-variables-ドメイン共通">6.5 Repetition
 <code>*n</code> and Pattern Variables (ドメイン共通)</h2>

--- a/docs/specs-v2/PITCH_DSL_SPEC_v1.1.html
+++ b/docs/specs-v2/PITCH_DSL_SPEC_v1.1.html
@@ -721,8 +721,8 @@ seq.voicelead()                   // シーケンス既定としても可(alias:
 <ul>
 <li><code>.voicelead()</code>(別名 <code>.vl()</code>)は連続する<strong>コード stack</strong>を、直前のコードに対し<strong>総声部移動が最小</strong>(L1 / taxicab、Tymoczko)になるよう各声部のオクターブを置き直す。<strong>構成音(ピッチクラス)は不変</strong>でオクターブ配置のみ変わる。<code>.root()</code>/<code>.oct()</code> と同じスコープチェーン機構で、<strong>グループ単位 <code>(...).voicelead()</code> と シーケンス既定 <code>seq.voicelead()</code> の両方</strong>に付けられる。</li>
 <li><strong>決定論的・一度だけ計算</strong>。ただし §6.1 voicing と違い<strong>絶対ピッチ(root context)を要する</strong>ため、eval 時ではなく<strong>出力段で一度走る</strong>(root context は dispatch で解決される)。結果は各声部の <code>octaveShift</code> としてシンボリックに書き戻され、`^N`(running range)・<code>.oct()</code>・<code>^r</code> はその上に加算される(§7-0 維持)。乱数間引き(<code>.r</code>/<code>Xr</code>)とは独立(VL は常にコード全体を見る)。</li>
-<li>対象は <strong>2声部以上のコード</strong>(同一 onset)。単音はスルー(アンカーにもならない)。<strong>最初のコード</strong>は記譜どおりのオクターブに置かれ(アンカー)、以降のコードが直前から最小移動でリードする。各声部の記譜 <code>^N</code> オクターブは VL が<strong>包摂</strong>する(VL がオクターブ配置を担うため)。</li>
-<li><strong>声部数アルゴリズム</strong>: 等数はソート後 n 通りの cyclic rotation の L1 最小(crossing-free 最適)。声部数不一致は C1 簡略化として min(n,m) 声部を lead し、余剰声部はオクターブ 0 のまま(完全な bipartite/doubling は C2+)。コモントーンは距離 0 で残るため自然に保持される。</li>
+<li>対象は <strong>同一 onset の 2声部以上</strong>(=コード)。単音はスルー(アンカーにもならない)。<strong>最初のコード</strong>は記譜どおりのオクターブに置かれ(アンカー)、以降のコードが直前から最小移動でリードする。各声部の記譜 <code>^N</code> オクターブは VL が<strong>包摂</strong>する(VL がオクターブ配置を担うため。<code>rangeSet</code> もクリアし running range を汚さない)。<em>注: onset でグループ化するため、<code>[1, (5,3,2,1)]</code> の held 音 + アルペジオ先頭音のような「同 onset の別声部」も1コードとして扱う(稀な併用)。</em></li>
+<li><strong>声部数アルゴリズム</strong>: 等数はソート後 n 通りの cyclic rotation の L1 最小(Tymoczko、MTO 16.1)。声部数不一致は C1 簡略化として min(n,m) 声部を lead し、余剰声部はオクターブ 0 のまま(完全な bipartite/doubling は C2+)。コモントーンは距離 0 で残るため自然に保持される(「crossing-free」はソート時の対応関係の性質で、各声部独立の octave-snap 後は絶対音高の順序が入れ替わりうる。ピッチクラスは常に不変)。</li>
 <li><strong>音楽性の限界(明示)</strong>: L1 最小は<strong>傾向音解決(導音・7→3)も並行5度/8度回避も保証しない</strong>。本機能は「デフォルトで滑らか + 細部はユーザー制御」という位置づけで、傾向音や声部独立性が要るときは明示 degree / voicing operator で書く。</li>
 </ul>
 <hr />

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -670,10 +670,11 @@ export class Sequence {
    * top (§7-0 preserved; deterministic side of the eval/dispatch axis).
    *
    * Operates only on chord stacks (≥2 pitched voices at one onset) under a
-   * `.voicelead()`/`.vl()` scope (seq default or group). Single notes pass through
-   * and do not anchor. The first chord keeps its authored placement; later chords
-   * subsume their authored octave and lead from the previous chord. Stochastic
-   * thinning (`.r`/`Xr`) is independent — VL sees the full chord regardless.
+   * `.voicelead()`/`.vl()` scope (seq default or group). Single notes and `_` event
+   * ties pass through and do not anchor. The first chord keeps its authored placement;
+   * later chords subsume their authored octave (octaveShift replaced, rangeSet cleared)
+   * and lead from the previous chord. Stochastic thinning (`.r`/`Xr`) is independent —
+   * VL sees the full chord regardless.
    */
   private applyVoiceLeading(): void {
     if (!this.isMidi()) return
@@ -698,13 +699,13 @@ export class Sequence {
 
     let prev: number[] | null = null
     for (const onset of onsets) {
-      // Resolve each non-rest voice to an absolute pitch (octave 0 = authored octave subsumed).
+      // Resolve each non-rest voice to an absolute pitch. First chord: authored octave
+      // (anchor); subsequent chords: octave 0, so VL re-places it (authored octave subsumed).
       const voices: { ev: TimedEvent; base: number }[] = []
       for (const ev of byOnset.get(onset)!) {
         const written = writtenPitchOf(ev)
         if (written.degree === 0) continue // rest — not a voice
         const context = this.resolveScopeToContext(ev.scope, getSeqDefault)
-        // First chord: keep authored octave (anchor); later: octave 0 (VL re-places it).
         const r = resolveDegree(
           { ...written, octaveShift: prev ? 0 : written.octaveShift },
           context,
@@ -717,12 +718,24 @@ export class Sequence {
       if (prev) {
         const shifts = voiceLeadOctaves(prev, base)
         voices.forEach((v, i) => {
-          v.ev.pitch = { ...writtenPitchOf(v.ev), octaveShift: shifts[i]! } // subsume authored octave
+          // Subsume the authored octave fully: replace octaveShift AND clear rangeSet, so the
+          // VL placement is the voice's `structural` octave at dispatch and never perturbs the
+          // §2.4 running range (a stack voice's `^N` is overridden by VL, not propagated).
+          v.ev.pitch = { ...writtenPitchOf(v.ev), octaveShift: shifts[i]!, rangeSet: false }
         })
         prev = base.map((b, i) => b + 12 * shifts[i]!) // reuse base[] — single traversal
       } else {
         prev = base // anchor at authored placement; leave events untouched
       }
+    }
+
+    // Discoverability: `.voicelead()` is active but no chord stack (≥2 pitched voices at one
+    // onset) was found, so it had no effect — likely a missing `[ ]` around intended chords.
+    if (prev === null) {
+      console.warn(
+        `⚠️  Sequence '${this.stateManager.getName() || 'sequence'}': .voicelead() found no ` +
+          `chord stacks (≥2 voices at one onset); voice-leading had no effect. Use [a, b, ...] stacks.`,
+      )
     }
   }
 

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -10,8 +10,9 @@ import { AudioEngine } from '../audio/types'
 import { PlayElement, RandomValue } from '../parser/audio-parser'
 import { resolveDegree } from '../midi/degree-resolution'
 import { resolveChords } from '../midi/chord/resolve-chords'
+import { voiceLeadOctaves } from '../midi/voice-leading'
 import { RootContext } from '../midi/types'
-import { TimedEventScope } from '../timing/calculation/types'
+import { TimedEvent, TimedEventScope } from '../timing/calculation/types'
 
 import { Global } from './global'
 import { Scheduler } from './global/types'
@@ -80,6 +81,7 @@ export class Sequence {
   private _gate = 0.8 // default gate length (fraction of slot). spec §1
   private _vel = 96 // default velocity 1..127. spec §1
   private _hold = false // §5.3: auto common-tone tie between consecutive stacks
+  private _voicelead = false // §6.3 (C1): auto voice-leading between consecutive chord stacks
   private _octave?: number // base octave (degree 1) IF seq.octave() was set; else falls back
   private _rootDegree?: number // seq.root(n): numeric root = degree of global.key()
 
@@ -354,6 +356,22 @@ export class Sequence {
     return this
   }
 
+  /**
+   * Enable auto voice-leading between consecutive chord stacks (§6.3, comp phase
+   * C1). Each chord after the first is octave-placed to minimize total voice
+   * motion from the previous chord (pitch classes unchanged). Deterministic,
+   * computed once. `.vl()` is an alias. Also settable per group: `(...).voicelead()`.
+   */
+  voicelead(): this {
+    this._voicelead = true
+    return this
+  }
+
+  /** Alias of {@link voicelead} (§6.3, C1). */
+  vl(): this {
+    return this.voicelead()
+  }
+
   /** Default gate length as a fraction of the slot (0..1). spec §1. */
   gate(value: number): this {
     this._gate = Math.max(0, Math.min(1, value))
@@ -626,6 +644,86 @@ export class Sequence {
         detune: 0,
       }
       resolveDegree(symbolic, context) // throws on a rejected/invalid degree
+    }
+  }
+
+  /**
+   * Auto voice-leading (§6.3, comp phase C1): a deterministic, once-run pass that
+   * annotates each chord stack's symbolic `octaveShift` so consecutive chords move
+   * minimally (Tymoczko L1). It needs ABSOLUTE pitch (the resolved root context),
+   * which only exists at the output stage — so it runs here in the awaited chain
+   * (a sibling of {@link validateMidiDispatch}), NOT per cycle, and writes the
+   * choice back symbolically: scheduleMidiEvents then consumes it as the voice's
+   * `structural` octave, with `^N` / `.oct()` / `^r` still layering additively on
+   * top (§7-0 preserved; deterministic side of the eval/dispatch axis).
+   *
+   * Operates only on chord stacks (≥2 pitched voices at one onset) under a
+   * `.voicelead()`/`.vl()` scope (seq default or group). Single notes pass through
+   * and do not anchor. The first chord keeps its authored placement; later chords
+   * subsume their authored octave and lead from the previous chord. Stochastic
+   * thinning (`.r`/`Xr`) is independent — VL sees the full chord regardless.
+   */
+  private applyVoiceLeading(): void {
+    if (!this.isMidi()) return
+    const timedEvents = this.stateManager.getTimedEvents()
+    if (!timedEvents) return
+    const seqVl = this._voicelead
+    if (!seqVl && !timedEvents.some((e) => e.scope?.voicelead)) return
+
+    let seqDefault: RootContext | undefined
+    const getSeqDefault = (): RootContext => (seqDefault ??= this.resolveRootContext())
+
+    // Group voicelead-scoped pitched events by onset (a chord = voices sharing a startTime).
+    const byOnset = new Map<number, TimedEvent[]>()
+    for (const ev of timedEvents) {
+      if (ev.tie) continue
+      if (!(seqVl || ev.scope?.voicelead)) continue
+      const arr = byOnset.get(ev.startTime)
+      if (arr) arr.push(ev)
+      else byOnset.set(ev.startTime, [ev])
+    }
+    const onsets = [...byOnset.keys()].sort((a, b) => a - b)
+
+    let prev: number[] | null = null
+    for (const onset of onsets) {
+      // Resolve each non-rest voice to an absolute pitch (octave 0 = authored octave subsumed).
+      const voices: { ev: TimedEvent; base: number }[] = []
+      for (const ev of byOnset.get(onset)!) {
+        const written = ev.pitch ?? {
+          degree: ev.sliceNumber,
+          alteration: 0,
+          octaveShift: 0,
+          rangeSet: false,
+          detune: 0,
+        }
+        if (written.degree === 0) continue // rest — not a voice
+        const context = this.resolveScopeToContext(ev.scope, getSeqDefault)
+        // First chord: keep authored octave (anchor); later: octave 0 (VL re-places it).
+        const r = resolveDegree(
+          { ...written, octaveShift: prev ? 0 : written.octaveShift },
+          context,
+        )
+        if (r) voices.push({ ev, base: r.midiNote })
+      }
+      if (voices.length < 2) continue // VL connects chords, not single notes/rests
+
+      const base = voices.map((v) => v.base)
+      if (prev) {
+        const shifts = voiceLeadOctaves(prev, base)
+        voices.forEach((v, i) => {
+          const written = v.ev.pitch ?? {
+            degree: v.ev.sliceNumber,
+            alteration: 0,
+            octaveShift: 0,
+            rangeSet: false,
+            detune: 0,
+          }
+          v.ev.pitch = { ...written, octaveShift: shifts[i]! } // subsume authored octave
+        })
+        prev = voices.map((v, i) => v.base + 12 * shifts[i]!)
+      } else {
+        prev = base // anchor at authored placement; leave events untouched
+      }
     }
   }
 
@@ -1007,6 +1105,7 @@ export class Sequence {
     // unhandled rejection inside the fire-and-forget scheduleEventsFn callback.
     this.resolveDispatchChannel()
     this.validateMidiDispatch() // eager root + degree validation (same rationale)
+    this.applyVoiceLeading() // §6.3 (C1): deterministic auto voice-leading annotation
     this.validateNonMidiDispatch() // eager `[ ]`-in-audio rejection (§10-5)
 
     const prepared = await preparePlayback({
@@ -1050,6 +1149,7 @@ export class Sequence {
     // unhandled rejection inside the fire-and-forget scheduleEventsFn callback.
     this.resolveDispatchChannel()
     this.validateMidiDispatch() // eager root + degree validation (same rationale)
+    this.applyVoiceLeading() // §6.3 (C1): deterministic auto voice-leading annotation
     this.validateNonMidiDispatch() // eager `[ ]`-in-audio rejection (§10-5)
 
     const prepared = await preparePlayback({

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -11,7 +11,7 @@ import { PlayElement, RandomValue } from '../parser/audio-parser'
 import { resolveDegree } from '../midi/degree-resolution'
 import { resolveChords } from '../midi/chord/resolve-chords'
 import { voiceLeadOctaves } from '../midi/voice-leading'
-import { RootContext } from '../midi/types'
+import { RootContext, SymbolicPitch } from '../midi/types'
 import { TimedEvent, TimedEventScope } from '../timing/calculation/types'
 
 import { Global } from './global'
@@ -54,6 +54,24 @@ interface PlannedNote {
   emit: boolean
   velocity: number // §10.3 resolved per-note velocity (`@v`/seq.vel())
   articulation?: number // §10.3 per-note gate ratio (`@g`); undefined = use seq.gate()
+}
+
+/**
+ * The symbolic pitch for a timed event: its explicit `pitch` (§7-0), or a bare-degree
+ * fallback built from `sliceNumber` (a plain MIDI degree carries no PlayPitch). Shared by
+ * every output-stage walk (validate / voice-leading / scheduling) so the fallback shape
+ * stays in one place.
+ */
+function writtenPitchOf(ev: TimedEvent): SymbolicPitch {
+  return (
+    ev.pitch ?? {
+      degree: ev.sliceNumber,
+      alteration: 0,
+      octaveShift: 0,
+      rangeSet: false,
+      detune: 0,
+    }
+  )
 }
 
 export class Sequence {
@@ -637,13 +655,7 @@ export class Sequence {
       // root with no key) or a rejected degree throws here, in the awaited
       // chain, rather than later in the fire-and-forget scheduling callback.
       const context = this.resolveScopeToContext(ev.scope, getSeqDefault)
-      const symbolic = ev.pitch ?? {
-        degree: ev.sliceNumber,
-        alteration: 0,
-        octaveShift: 0,
-        detune: 0,
-      }
-      resolveDegree(symbolic, context) // throws on a rejected/invalid degree
+      resolveDegree(writtenPitchOf(ev), context) // throws on a rejected/invalid degree
     }
   }
 
@@ -689,13 +701,7 @@ export class Sequence {
       // Resolve each non-rest voice to an absolute pitch (octave 0 = authored octave subsumed).
       const voices: { ev: TimedEvent; base: number }[] = []
       for (const ev of byOnset.get(onset)!) {
-        const written = ev.pitch ?? {
-          degree: ev.sliceNumber,
-          alteration: 0,
-          octaveShift: 0,
-          rangeSet: false,
-          detune: 0,
-        }
+        const written = writtenPitchOf(ev)
         if (written.degree === 0) continue // rest — not a voice
         const context = this.resolveScopeToContext(ev.scope, getSeqDefault)
         // First chord: keep authored octave (anchor); later: octave 0 (VL re-places it).
@@ -711,16 +717,9 @@ export class Sequence {
       if (prev) {
         const shifts = voiceLeadOctaves(prev, base)
         voices.forEach((v, i) => {
-          const written = v.ev.pitch ?? {
-            degree: v.ev.sliceNumber,
-            alteration: 0,
-            octaveShift: 0,
-            rangeSet: false,
-            detune: 0,
-          }
-          v.ev.pitch = { ...written, octaveShift: shifts[i]! } // subsume authored octave
+          v.ev.pitch = { ...writtenPitchOf(v.ev), octaveShift: shifts[i]! } // subsume authored octave
         })
-        prev = voices.map((v, i) => v.base + 12 * shifts[i]!)
+        prev = base.map((b, i) => b + 12 * shifts[i]!) // reuse base[] — single traversal
       } else {
         prev = base // anchor at authored placement; leave events untouched
       }
@@ -802,12 +801,7 @@ export class Sequence {
     // It resets to 0 at the top of each play() so re-evaluations stay deterministic.
     let runningRange = 0
     const plans: PlannedNote[] = timedEvents.map((ev) => {
-      const written = ev.pitch ?? {
-        degree: ev.sliceNumber,
-        alteration: 0,
-        octaveShift: 0,
-        detune: 0,
-      }
+      const written = writtenPitchOf(ev)
       const onTime = schedulerStartTime + baseTime + ev.startTime + sendDelay
       if (ev.tie) {
         // §5.1: a `_` event tie carries no pitch and never touches the running

--- a/packages/engine/src/midi/voice-leading.ts
+++ b/packages/engine/src/midi/voice-leading.ts
@@ -43,7 +43,8 @@ export function voiceLeadOctaves(prev: number[], curBase: number[]): number[] {
   const snap = (c: number, t: number): number => Math.round((t - c) / 12)
 
   if (m === n) {
-    let best: number[] | null = null
+    // n >= 1 here, so the loop always replaces `best` on its first iteration.
+    let best = shifts
     let bestCost = Infinity
     for (let r = 0; r < n; r++) {
       const cand = new Array<number>(m).fill(0)
@@ -61,7 +62,7 @@ export function voiceLeadOctaves(prev: number[], curBase: number[]): number[] {
         best = cand
       }
     }
-    return best ?? shifts
+    return best
   }
 
   // Unequal cardinality: lead the min(n,m) lowest-sorted voices; extras stay at 0.

--- a/packages/engine/src/midi/voice-leading.ts
+++ b/packages/engine/src/midi/voice-leading.ts
@@ -20,9 +20,12 @@
  * @param curBase current chord's resolved semitones at octave 0 (authored octave subsumed)
  * @returns one octave shift per `curBase` voice (same length, same order)
  *
- * Equal cardinality: the optimal crossing-free assignment is one of the n cyclic
- * rotations of the sorted pairing (sorted-cur[i] ↔ sorted-prev[(i+r) mod n]);
- * each voice then octave-snaps to its paired previous pitch. Common tones land at
+ * Equal cardinality: the minimum-L1 assignment is one of the n cyclic rotations of
+ * the sorted pairing (sorted-cur[i] ↔ sorted-prev[(i+r) mod n]) — a result from
+ * Tymoczko (MTO 16.1). Each voice then octave-snaps to its paired previous pitch.
+ * Note: "crossing-free" describes the SORTED assignment before snapping; per-voice
+ * independent snapping can reorder the final absolute pitches when voices snap by
+ * different amounts (pitch CLASSES are always preserved). Common tones land at
  * distance 0, so common-tone retention falls out for free.
  *
  * Unequal cardinality (a C1 simplification — full bipartite/doubling is C2+):

--- a/packages/engine/src/midi/voice-leading.ts
+++ b/packages/engine/src/midi/voice-leading.ts
@@ -1,0 +1,74 @@
+/**
+ * Auto voice-leading — the deterministic octave-assignment kernel for
+ * `.voicelead()` / `.vl()` (comp phase C1; PITCH_DSL_SPEC §6.3, design
+ * docs/research/comping-voice-leading-design.md §2.2).
+ *
+ * Pure function: given resolved absolute semitones, it chooses an octave shift
+ * per current voice that minimizes the total voice motion from the previous
+ * chord. It is the §6.1-style symbolic transform extended across chords — only
+ * octave placement changes, pitch classes are preserved — but it is computed at
+ * the output stage because it needs ABSOLUTE pitch (the root context), which is
+ * resolved at dispatch, not at eval time.
+ */
+
+/**
+ * Octave shift (integer; ×12 semitones) for each current voice that minimizes
+ * the total semitone motion (L1 / taxicab distance, after Tymoczko, MTO 16.1)
+ * from the previous chord. Pitch classes are unchanged — only octave placement.
+ *
+ * @param prev    previous chord's resolved absolute semitones (its realized pitches)
+ * @param curBase current chord's resolved semitones at octave 0 (authored octave subsumed)
+ * @returns one octave shift per `curBase` voice (same length, same order)
+ *
+ * Equal cardinality: the optimal crossing-free assignment is one of the n cyclic
+ * rotations of the sorted pairing (sorted-cur[i] ↔ sorted-prev[(i+r) mod n]);
+ * each voice then octave-snaps to its paired previous pitch. Common tones land at
+ * distance 0, so common-tone retention falls out for free.
+ *
+ * Unequal cardinality (a C1 simplification — full bipartite/doubling is C2+):
+ * the min(n,m) lowest-sorted voices are led by sorted pairing; any extra current
+ * voices stay at octave 0 (their authored placement). Deterministic — no rng.
+ * The first chord (empty `prev`) returns all zeros (anchored at its placement).
+ */
+export function voiceLeadOctaves(prev: number[], curBase: number[]): number[] {
+  const m = curBase.length
+  const shifts = new Array<number>(m).fill(0)
+  if (m === 0 || prev.length === 0) return shifts
+
+  // Current voices in ascending-pitch order (indices) and sorted previous pitches.
+  const curOrder = [...curBase.keys()].sort((a, b) => curBase[a]! - curBase[b]!)
+  const prevSorted = [...prev].sort((a, b) => a - b)
+  const n = prevSorted.length
+  // Octave shift bringing pitch `c` nearest to target `t`.
+  const snap = (c: number, t: number): number => Math.round((t - c) / 12)
+
+  if (m === n) {
+    let best: number[] | null = null
+    let bestCost = Infinity
+    for (let r = 0; r < n; r++) {
+      const cand = new Array<number>(m).fill(0)
+      let cost = 0
+      for (let i = 0; i < n; i++) {
+        const ci = curOrder[i]!
+        const c = curBase[ci]!
+        const t = prevSorted[(i + r) % n]!
+        const k = snap(c, t)
+        cand[ci] = k
+        cost += Math.abs(c + 12 * k - t)
+      }
+      if (cost < bestCost) {
+        bestCost = cost
+        best = cand
+      }
+    }
+    return best ?? shifts
+  }
+
+  // Unequal cardinality: lead the min(n,m) lowest-sorted voices; extras stay at 0.
+  const k = Math.min(n, m)
+  for (let i = 0; i < k; i++) {
+    const ci = curOrder[i]!
+    shifts[ci] = snap(curBase[ci]!, prevSorted[i]!)
+  }
+  return shifts
+}

--- a/packages/engine/src/parser/parse-expression.ts
+++ b/packages/engine/src/parser/parse-expression.ts
@@ -29,6 +29,12 @@ import { ParserUtils } from './parser-utils'
 /** Voicing operators parsed as postfix on a chord value / `[ ]` stack (§12, #49/#51). */
 const VOICING_OPS = new Set(['drop', 'invert', 'open', 'close', 'shell', 'rootless'])
 
+/**
+ * Pitch-scope chain methods on a group (§3): `.root()`/`.mode()`/`.oct()`/`.hold()`
+ * and `.voicelead()`/`.vl()` (§6.3 auto voice-leading, C1). All build a PlayScoped node.
+ */
+const SCOPE_CHAIN_OPS = new Set(['root', 'mode', 'oct', 'hold', 'voicelead', 'vl'])
+
 /** Per-op `[min, max]` argument arity (§12.3): drop ≥1, invert exactly 1, the rest 0. */
 const VOICING_ARITY: Record<string, [number, number]> = {
   drop: [1, Infinity],
@@ -536,12 +542,24 @@ export class ExpressionParser {
    * not allowed; only nesting overrides (§3, decision #10). The scope stays
    * symbolic here; it is resolved lexically at dispatch (§7-0).
    */
-  private parseScopeChain(): { root?: ScopeRoot; mode?: ScopeMode; oct?: number; hold?: boolean } {
-    const scope: { root?: ScopeRoot; mode?: ScopeMode; oct?: number; hold?: boolean } = {}
+  private parseScopeChain(): {
+    root?: ScopeRoot
+    mode?: ScopeMode
+    oct?: number
+    hold?: boolean
+    voicelead?: boolean
+  } {
+    const scope: {
+      root?: ScopeRoot
+      mode?: ScopeMode
+      oct?: number
+      hold?: boolean
+      voicelead?: boolean
+    } = {}
 
     while (ParserUtils.current(this.tokens, this.pos).type === 'DOT') {
       const method = ParserUtils.peek(this.tokens, this.pos).value
-      if (method !== 'root' && method !== 'mode' && method !== 'oct' && method !== 'hold') break
+      if (!SCOPE_CHAIN_OPS.has(method)) break
 
       this.pos = ParserUtils.advance(this.tokens, this.pos).newPos // DOT
       this.pos = ParserUtils.advance(this.tokens, this.pos).newPos // method IDENTIFIER
@@ -572,9 +590,12 @@ export class ExpressionParser {
           throw new Error('duplicate .oct() on the same group (§3)')
         }
         scope.oct = this.parseSignedNumber()
-      } else {
+      } else if (method === 'hold') {
         // .hold() — group-level auto common-tone tie (§5.3). Takes no argument.
         scope.hold = true
+      } else {
+        // .voicelead() / .vl() — group-level auto voice-leading (§6.3, C1). No argument.
+        scope.voicelead = true
       }
 
       const rparen = ParserUtils.expect(this.tokens, this.pos, 'RPAREN')
@@ -719,7 +740,7 @@ export class ExpressionParser {
           changed = true
           continue
         }
-        if (method === 'root' || method === 'mode' || method === 'oct' || method === 'hold') {
+        if (SCOPE_CHAIN_OPS.has(method)) {
           if (typeof el === 'string') el = { type: 'chord_ref', name: el, octaveShift: 0 }
           const scope = this.parseScopeChain()
           this.assertChainClosesRun()
@@ -853,11 +874,12 @@ export class ExpressionParser {
     const rparenResult = ParserUtils.expect(this.tokens, this.pos, 'RPAREN')
     this.pos = rparenResult.newPos
 
-    // Check for a chain on the group itself. `.root()/.mode()/.oct()` are pitch-
-    // scope chains → a PlayScoped node (§3); `.chop()` is the audio modifier.
+    // Check for a chain on the group itself. `.root()/.mode()/.oct()/.hold()` and
+    // `.voicelead()/.vl()` are pitch-scope chains → a PlayScoped node (§3); `.chop()`
+    // is the audio modifier.
     if (ParserUtils.current(this.tokens, this.pos).type === 'DOT') {
       const method = ParserUtils.peek(this.tokens, this.pos).value
-      if (method === 'root' || method === 'mode' || method === 'oct' || method === 'hold') {
+      if (SCOPE_CHAIN_OPS.has(method)) {
         const scope = this.parseScopeChain()
         this.assertChainClosesRun()
         // B2: single group. Juxtaposition runs (multiple groups sharing the

--- a/packages/engine/src/parser/parse-expression.ts
+++ b/packages/engine/src/parser/parse-expression.ts
@@ -590,9 +590,13 @@ export class ExpressionParser {
       } else if (method === 'hold') {
         // .hold() — group-level auto common-tone tie (§5.3). Takes no argument.
         scope.hold = true
-      } else {
+      } else if (method === 'voicelead' || method === 'vl') {
         // .voicelead() / .vl() — group-level auto voice-leading (§6.3, C1). No argument.
         scope.voicelead = true
+      } else {
+        // Defensive: any method in SCOPE_CHAIN_OPS must be handled above. A new entry
+        // added to the set without a branch here is a wiring bug, surfaced loudly.
+        throw new Error(`Internal: unhandled scope-chain method '${method}' (§3)`)
       }
 
       const rparen = ParserUtils.expect(this.tokens, this.pos, 'RPAREN')

--- a/packages/engine/src/parser/parse-expression.ts
+++ b/packages/engine/src/parser/parse-expression.ts
@@ -35,6 +35,15 @@ const VOICING_OPS = new Set(['drop', 'invert', 'open', 'close', 'shell', 'rootle
  */
 const SCOPE_CHAIN_OPS = new Set(['root', 'mode', 'oct', 'hold', 'voicelead', 'vl'])
 
+/** The accumulated pitch-scope chain on a group (§3): the result of {@link ExpressionParser.parseScopeChain}. */
+type ScopeChain = {
+  root?: ScopeRoot
+  mode?: ScopeMode
+  oct?: number
+  hold?: boolean
+  voicelead?: boolean
+}
+
 /** Per-op `[min, max]` argument arity (§12.3): drop ≥1, invert exactly 1, the rest 0. */
 const VOICING_ARITY: Record<string, [number, number]> = {
   drop: [1, Infinity],
@@ -542,20 +551,8 @@ export class ExpressionParser {
    * not allowed; only nesting overrides (§3, decision #10). The scope stays
    * symbolic here; it is resolved lexically at dispatch (§7-0).
    */
-  private parseScopeChain(): {
-    root?: ScopeRoot
-    mode?: ScopeMode
-    oct?: number
-    hold?: boolean
-    voicelead?: boolean
-  } {
-    const scope: {
-      root?: ScopeRoot
-      mode?: ScopeMode
-      oct?: number
-      hold?: boolean
-      voicelead?: boolean
-    } = {}
+  private parseScopeChain(): ScopeChain {
+    const scope: ScopeChain = {}
 
     while (ParserUtils.current(this.tokens, this.pos).type === 'DOT') {
       const method = ParserUtils.peek(this.tokens, this.pos).value

--- a/packages/engine/src/parser/types.ts
+++ b/packages/engine/src/parser/types.ts
@@ -308,6 +308,7 @@ export type PlayScoped = {
   mode?: ScopeMode // present iff `.mode(name)` was chained (§2.2, E6: applies a user lattice)
   oct?: number // present iff `.oct(N)` was chained (group-lexical octave register)
   hold?: boolean // present iff `.hold()` was chained (§5.3 auto common-tone tie, group-level)
+  voicelead?: boolean // present iff `.voicelead()`/`.vl()` was chained (§6.3 auto voice-leading, C1)
 }
 
 /**

--- a/packages/engine/src/timing/calculation/calculate-event-timing.ts
+++ b/packages/engine/src/timing/calculation/calculate-event-timing.ts
@@ -13,6 +13,7 @@ interface ScopeFrame {
   mode?: ScopeMode
   oct?: number
   hold?: boolean
+  voicelead?: boolean
 }
 
 /**
@@ -27,6 +28,7 @@ function resolveScope(stack: ScopeFrame[]): TimedEventScope | undefined {
   let mode: ScopeMode | undefined
   let groupOct: number | undefined
   let hold: boolean | undefined
+  let voicelead: boolean | undefined
   let haveContext = false
   for (let i = stack.length - 1; i >= 0; i--) {
     const f = stack[i]
@@ -39,11 +41,12 @@ function resolveScope(stack: ScopeFrame[]): TimedEventScope | undefined {
       groupOct = f.oct
     }
     if (f.hold) hold = true // §5.3: any enclosing .hold() group enables hold for the leaf
+    if (f.voicelead) voicelead = true // §6.3: any enclosing .voicelead()/.vl() group enables it
   }
-  if (!haveContext && groupOct === undefined && !hold) {
+  if (!haveContext && groupOct === undefined && !hold && !voicelead) {
     return undefined
   }
-  return { root, mode, groupOct, ...(hold && { hold }) }
+  return { root, mode, groupOct, ...(hold && { hold }), ...(voicelead && { voicelead }) }
 }
 
 /**
@@ -143,6 +146,7 @@ export function calculateEventTiming(
           mode: element.mode,
           oct: element.oct,
           hold: element.hold,
+          voicelead: element.voicelead,
         }
         const nestedEvents = calculateEventTiming(
           element.groups,

--- a/packages/engine/src/timing/calculation/types.ts
+++ b/packages/engine/src/timing/calculation/types.ts
@@ -16,6 +16,7 @@ export interface TimedEventScope {
   mode?: ScopeMode
   groupOct?: number
   hold?: boolean // §5.3 group-level `.hold()` — auto common-tone tie between stacks
+  voicelead?: boolean // §6.3 group-level `.voicelead()`/`.vl()` — auto voice-leading (C1)
 }
 
 /**

--- a/tests/midi/voice-leading.spec.ts
+++ b/tests/midi/voice-leading.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { voiceLeadOctaves } from '../../packages/engine/src/midi/voice-leading'
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+import { Global } from '../../packages/engine/src/core/global'
+import { Sequence } from '../../packages/engine/src/core/sequence'
+import { MidiManager } from '../../packages/engine/src/core/global/midi-manager'
+import { MidiOutput } from '../../packages/engine/src/midi/midi-output'
+
+/**
+ * C1 (#269) — auto voice-leading `.voicelead()` / `.vl()` (§6.3). Successive chord
+ * stacks are octave-placed to minimize total voice motion (Tymoczko L1). Deterministic,
+ * computed once; pitch classes preserved (only octave changes). The pure kernel is
+ * asserted directly; the wiring is asserted at dispatch over the note-ons.
+ */
+
+describe('C1 — voiceLeadOctaves kernel (§6.3)', () => {
+  it('the first chord (no previous) gets no shift', () => {
+    expect(voiceLeadOctaves([], [60, 64, 67])).toEqual([0, 0, 0])
+  })
+
+  it('an already-aligned chord is left in place', () => {
+    expect(voiceLeadOctaves([60, 64, 67], [60, 64, 67])).toEqual([0, 0, 0])
+  })
+
+  it('retains common tones / pulls an octave-low chord up (distance 0)', () => {
+    expect(voiceLeadOctaves([60, 64, 67], [48, 52, 55])).toEqual([1, 1, 1])
+  })
+
+  it('pulls an octave-high chord down', () => {
+    expect(voiceLeadOctaves([60, 64, 67], [72, 76, 79])).toEqual([-1, -1, -1])
+  })
+
+  it('C→G: the B drops an octave to stay near C/E/G (min motion picks a rotation)', () => {
+    // prev C E G [60,64,67]; cur G B D base [67,71,62] → G stays, B(71)→59, D stays
+    expect(voiceLeadOctaves([60, 64, 67], [67, 71, 62])).toEqual([0, -1, 0])
+  })
+
+  it('unequal cardinality: leads min(n,m) voices, extras stay at octave 0', () => {
+    expect(voiceLeadOctaves([60], [48, 52, 55])).toEqual([1, 0, 0]) // only the lowest is led
+    expect(voiceLeadOctaves([60, 64, 67], [48, 52])).toEqual([1, 1]) // both led, no extras
+  })
+})
+
+// ── dispatch harness: capture note-ons over the bar ──
+const T0 = 1_000_000
+function recordingOutput(log: number[]): MidiOutput {
+  return {
+    ensurePort: vi.fn((q: string) => (/iac/i.test(q) ? 'IACドライバ バス1' : q)),
+    noteOn: vi.fn((_p: string, _c: number, note: number) => log.push(note)),
+    noteOff: vi.fn(),
+    pitchBend: vi.fn(),
+    releaseOwner: vi.fn(),
+    panic: vi.fn(),
+    getActiveNotes: vi.fn(() => []),
+    listPorts: vi.fn(() => ['IACドライバ バス1']),
+    closeAll: vi.fn(),
+  }
+}
+function mockScheduler() {
+  return {
+    isRunning: true,
+    startTime: T0,
+    getCurrentTime: () => 0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(),
+    clearSequenceEvents: vi.fn(),
+    reinitializeSequenceTracking: vi.fn(),
+    getMasterGainDb: () => 0,
+  } as never
+}
+/** key C, octave 4; play `src`; return the note-ons (one bar). */
+async function ons(src: string): Promise<number[]> {
+  vi.setSystemTime(T0)
+  const sched = mockScheduler()
+  const log: number[] = []
+  const global = new Global(sched, new MidiManager(() => recordingOutput(log)))
+  global.key('C')
+  global.start()
+  const seq = new Sequence(global, sched)
+  seq.setName('piano')
+  seq.midi('iac', 1).octave(4)
+  seq.play(...(parseAudioDSL(`p.play(${src})`).statements[0].args as never[]))
+  await seq.run()
+  await vi.advanceTimersByTimeAsync(2100)
+  return log
+}
+
+describe('C1 — voice-leading dispatch (§6.3)', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('parses `.voicelead()` / `.vl()` as a group scope', () => {
+    const a = (parseAudioDSL('p.play(([1,3,5], [5,7,2]).voicelead())').statements[0] as any).args[0]
+    expect(a).toMatchObject({ type: 'scoped', voicelead: true })
+    const b = (parseAudioDSL('p.play(([1,3,5]).vl())').statements[0] as any).args[0]
+    expect(b).toMatchObject({ type: 'scoped', voicelead: true })
+  })
+
+  it('C→G under `.voicelead()`: the B is voice-led down an octave (B3=59, not B4=71)', async () => {
+    const led = await ons('([1,3,5], [5,7,2]).voicelead()')
+    expect(led).toContain(59) // B3 — voice-led down
+    expect(led).not.toContain(71) // not B4
+    expect(led).toContain(67) // G common tone retained
+    // baseline without voice-leading keeps the B at B4 (71)
+    const plain = await ons('([1,3,5], [5,7,2])')
+    expect(plain).toContain(71)
+    expect(plain).not.toContain(59)
+  })
+
+  it('`seq.voicelead()` as a sequence default voice-leads every chord', async () => {
+    vi.setSystemTime(T0)
+    const sched = mockScheduler()
+    const log: number[] = []
+    const global = new Global(sched, new MidiManager(() => recordingOutput(log)))
+    global.key('C')
+    global.start()
+    const seq = new Sequence(global, sched)
+    seq.setName('piano')
+    seq.midi('iac', 1).octave(4).voicelead()
+    seq.play(...(parseAudioDSL('p.play([1,3,5], [5,7,2])').statements[0].args as never[]))
+    await seq.run()
+    await vi.advanceTimersByTimeAsync(2100)
+    expect(log).toContain(59) // B voice-led down even with seq-level .voicelead()
+  })
+
+  it('the first chord keeps its authored octave; only later chords are re-placed', async () => {
+    // chord1 [1,3,5] anchors at C4/E4/G4 (60/64/67); chord2 leads from it.
+    const led = await ons('([1,3,5], [5,7,2]).voicelead()')
+    expect(led).toContain(60) // C4 anchor
+    expect(led).toContain(64) // E4 anchor
+    expect(led).toContain(67) // G4 anchor
+  })
+
+  it('without `.voicelead()` the kernel does not run (chords stay at authored octave)', async () => {
+    const plain = await ons('([1,3,5], [4,6,1])')
+    // F major [4,6,1] at base = F4(65) A4(69) C4(60); unchanged without VL
+    expect(plain).toEqual(expect.arrayContaining([60, 64, 67, 65, 69, 60]))
+  })
+})

--- a/tests/midi/voice-leading.spec.ts
+++ b/tests/midi/voice-leading.spec.ts
@@ -138,4 +138,32 @@ describe('C1 — voice-leading dispatch (§6.3)', () => {
     // F major [4,6,1] at base = F4(65) A4(69) C4(60); unchanged without VL
     expect(plain).toEqual(expect.arrayContaining([60, 64, 67, 65, 69, 60]))
   })
+
+  it('3-chord progression threads the REALIZED (shifted) chord, not the base', async () => {
+    // C→G→([7,2,4]=B/D/F). chord2 voice-leads B down to B3(59); realized chord2 = [67,59,62].
+    // chord3 must lead from the REALIZED chord2 (B at 59), so its B also lands at B3(59).
+    // If `prev` wrongly used the unshifted base (B at 71), chord3's B would stay B4(71).
+    const led = await ons('([1,3,5], [5,7,2], [7,2,4]).voicelead()')
+    expect(led).toContain(59) // B3 — chord2 & chord3 both led down
+    expect(led).not.toContain(71) // B4 never appears: threading uses the realized chord
+  })
+
+  it('cross-root: common tones are kept across a `.root()` change (resolved-semitone level)', async () => {
+    // ([1,3,5]).root(5) in key C = G root → G4/B4/D5 (67/71/74) anchor.
+    // chord2 [5,7,2] in C default = G4/B4/D4 base; G(67) & B(71) are common tones → kept in place.
+    const led = await ons('(([1,3,5]).root(5), [5,7,2]).voicelead()')
+    expect(led).toContain(67) // G common tone retained (distance 0)
+    expect(led).toContain(71) // B common tone retained (distance 0)
+    expect(led).not.toContain(62) // chord2's D is voice-led up to D5(74), not left at D4(62)
+  })
+
+  it('unequal cardinality at dispatch: a 3-voice chord leads from a 4-voice anchor', async () => {
+    // chord1 [1,3,5,7] (4 voices) anchors; chord2 [5,7,2] (3 voices) leads min(4,3)=3 voices.
+    const led = await ons('([1,3,5,7], [5,7,2]).voicelead()')
+    // chord1 anchor present (C/E/G/B = 60/64/67/71)
+    expect(led).toEqual(expect.arrayContaining([60, 64, 67, 71]))
+    // chord2 (G/B/D) is voice-led near chord1; B stays at 71 (common tone), G at 67, D near.
+    expect(led).toContain(67) // G common tone
+    expect(led).toContain(71) // B common tone
+  })
 })

--- a/tests/midi/voice-leading.spec.ts
+++ b/tests/midi/voice-leading.spec.ts
@@ -157,6 +157,18 @@ describe('C1 — voice-leading dispatch (§6.3)', () => {
     expect(led).not.toContain(62) // chord2's D is voice-led up to D5(74), not left at D4(62)
   })
 
+  it('an anchor chord with authored `^N` keeps its octave; the next chord leads from it', async () => {
+    // chord1 [1^1, 3^1, 5^1] anchors UP an octave: C5/E5/G5 (72/76/79). chord2 [5,7,2]
+    // (G/B/D) leads from that raised anchor — voices land in the C5 register, not C4.
+    const led = await ons('([1^1, 3^1, 5^1], [5,7,2]).voicelead()')
+    expect(led).toContain(72) // C5 anchor (authored ^1 kept on the first chord)
+    expect(led).toContain(79) // G5 anchor
+    expect(led).not.toContain(60) // not C4 — the anchor's authored octave was honored
+    // chord2's G is a common tone with the anchor's G5(79) → retained up high, not pulled to G4(67)
+    expect(led).toContain(79)
+    expect(led).not.toContain(67) // G4 absent — chord2 led into the raised register
+  })
+
   it('unequal cardinality at dispatch: a 3-voice chord leads from a 4-voice anchor', async () => {
     // chord1 [1,3,5,7] (4 voices) anchors; chord2 [5,7,2] (3 voices) leads min(4,3)=3 voices.
     const led = await ons('([1,3,5,7], [5,7,2]).voicelead()')


### PR DESCRIPTION
Closes #269 / 親 #259 / 設計 #268 / Epic #224

## 概要

`.comp` 段階実装の **C1**: 連続するコード stack を直前に対し**最小移動（L1 / Tymoczko）**で再ボイシングする決定論的演算子 `.voicelead()`（alias `.vl()`）。`.comp` の土台。

## 設計判断（実装調査で判明・advisor 検証済）

- voice-leading は **絶対ピッチ（root context）を要する**ため §6.1 voicing のような eval-time ではなく、**出力段で一度だけ走る決定論パス**（`validateMidiDispatch` と同型・同 awaited チェーン、per-cycle ではない）。結果を各声部の `octaveShift` にシンボリックに書き戻し、`^N`/`.oct()`/`^r` が上に加算（§7-0 維持、eval/dispatch 軸の決定論側）。`.r`/`Xr` とは独立。
- `seq.voicelead()` 既定 と group `(...).voicelead()` の両対応。単音はスルー、最初のコードは記譜どおり（アンカー）、記譜 `^N` は VL が包摂。

## 実装

- `midi/voice-leading.ts`: 純関数 `voiceLeadOctaves`（等数=ソート後 n 通り cyclic rotation の L1 最小、不一致=min(n,m) を lead・余剰 oct 0、C1 簡略化）
- `parser`: `.voicelead()`/`.vl()` を `SCOPE_CHAIN_OPS` に。`PlayScoped`/`TimedEventScope` に voicelead、timing walk で伝播
- `core/sequence.ts`: `seq.voicelead()`/`vl()` + `applyVoiceLeading()`（onset でコードをグループ化し最小移動で octave 再配置）

## doc / test

- PITCH_DSL_SPEC §6.3 / core INSTRUCTION P.13 に normative 反映（phase gate, rule #7）。音楽性限界（傾向音解決・並行回避を保証しない）を明記
- `tests/midi/voice-leading.spec.ts` 11件（純関数単体 + dispatch 統合 + parse + seq/group + 音楽性）。**1033 passed / 23 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)