### PR TITLE
chore(dsl): polish comp C2a per PR #272 bot review

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,22 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.114 Issue #273 — comp C2a polish（PR #272 bot レビュー反映） (Jun 14, 2026)
+
+**Date**: 2026-06-14
+**Status**: ✅ 実装完了（chore）
+**Issue**: signalcompose/orbitscore#273 / 親 #271（#272 マージ後の follow-up）
+**Branch**: `273-comp-c2a-polish`
+
+**概要**: PR #272 マージ後の claude bot レビュー（5件・全件高品質評価・Critical 0）のうち**有効な軽微指摘**を反映。bot の「multi-line コメントが CLAUDE.md 違反」指摘は**誤検知**（両 CLAUDE.md に該当規約なし＋既存コードは multi-line JSDoc 多用、grep で確認）のため対象外。
+
+**対応**:
+- `comp-rhythm.ts`: 未知セル警告の `density ?? 0.5` を `density` に（param 既定 0.5 で常に定義済＝デッドコード除去）。
+- `core/sequence.ts`: `.cell()` と `.density()` 併用時に `comp()` で warn（cell 優先で density 無視を discoverable に。挙動は不変）。`cell()` の持続性（`comp()` 後も残る）を doc 明記。
+- `tests/midi/comp.spec.ts`: `quarters`（4分割）の dispatch テスト追加、cell+density 併用 warn のアサート追加。
+
+**テスト**: comp.spec.ts 27件（+1）。全体 1064 passed / 23 skipped。
+
 ### 6.113 Issue #271 — comping rhythm engine `.comp()` / `.cell()` / `.density()`（comp phase C2a） (Jun 14, 2026)
 
 **Date**: 2026-06-14

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -397,6 +397,8 @@ export class Sequence {
    * Select a named comping rhythm cell for {@link comp} (§6.4, C2a): `charleston`,
    * `redgarland`, `offbeats`, `quarters`, `twofour`. A cell is a meter-independent
    * figure (see comp-rhythm.ts); over an odd meter it rides an intentional polymeter.
+   * Like the other setters, this persists on the sequence — it applies to every
+   * later `comp()` until changed.
    */
   cell(name: string): this {
     this._compCell = name
@@ -445,6 +447,14 @@ export class Sequence {
     let cellName: string | undefined
     if (this._compCell !== undefined) {
       cellName = this._compCell
+      // A cell names specific onsets, so a co-set density() has no effect — say so
+      // rather than silently ignore it (a known cell takes precedence).
+      if (this._compDensity !== undefined) {
+        console.warn(
+          `⚠️  Sequence '${name}': both cell("${this._compCell}") and density() are set — ` +
+            `the cell wins; density is ignored.`,
+        )
+      }
     } else if (this._compDensity === undefined) {
       cellName = 'charleston'
     } // else: density mode — cellName stays undefined

--- a/packages/engine/src/midi/comp-rhythm.ts
+++ b/packages/engine/src/midi/comp-rhythm.ts
@@ -74,7 +74,7 @@ export function cellToGrid(
       return onsets
     }
     warn?.(
-      `comp(): unknown cell "${cellName}" — using density ${(density ?? 0.5).toFixed(2)} instead. ` +
+      `comp(): unknown cell "${cellName}" — using density ${density.toFixed(2)} instead. ` +
         `Known cells: ${COMP_CELL_NAMES.join(', ')}.`,
     )
   }

--- a/tests/midi/comp.spec.ts
+++ b/tests/midi/comp.spec.ts
@@ -221,6 +221,13 @@ describe('C2a — comp dispatch (§6.4)', () => {
     expect(relStabTimes(hits)).toEqual([0, 1000])
   })
 
+  it('quarters is a 4-slot flat-four — a stab on every beat (not an 8-grid)', async () => {
+    // 4/4 bar 2000ms / 4 slots → 500ms each. quarters {0,1,2,3} → 0,500,1000,1500.
+    const hits = await compHits('[1,3,5]', (s) => s.cell('quarters'))
+    expect(relStabTimes(hits)).toEqual([0, 500, 1000, 1500])
+    expect(hits).toHaveLength(12) // 3 notes × 4 beats
+  })
+
   it('density 0 lays out — a silent bar (no note-ons)', async () => {
     const hits = await compHits('[1,3,5]', (s) => s.density(0))
     expect(hits).toHaveLength(0)
@@ -247,11 +254,14 @@ describe('C2a — comp dispatch (§6.4)', () => {
     expect(plain.map((h) => h.note)).not.toContain(59)
   })
 
-  it('a named cell wins over density(): cell("twofour").density(1) fires 2 stabs, not 8', async () => {
+  it('a named cell wins over density(): cell("twofour").density(1) fires 2 stabs, not 8 (and warns)', async () => {
     // density(1) alone would hit all 8 slots; the cell must win → twofour {1,3} → 2 stabs.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const hits = await compHits('[1,3,5]', (s) => s.cell('twofour').density(1))
     expect(relStabTimes(hits)).toEqual([0, 1000])
     expect(hits).toHaveLength(6) // 3 notes × 2 stabs
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/the cell wins; density is ignored/))
+    warn.mockRestore()
   })
 
   it('density(1) over 3/4 hits all 8 slots evenly (structural polymeter)', async () => {


### PR DESCRIPTION
## 概要

PR #272（comp C2a）マージ後の claude bot レビュー（5件・全件高品質評価・**Critical 0**）のうち、**有効な軽微指摘**を反映する follow-up（chore）。

## 対応

- **`comp-rhythm.ts`**: 未知セル警告の `density ?? 0.5` を `density` に。`density` param は既定 `0.5` で関数内では常に定義済のため `?? 0.5` はデッドコード。
- **`core/sequence.ts`**: `.cell()` と `.density()` を**併用**したとき `comp()` で warn（cell が優先され density が無視されることを discoverable に。**挙動は不変** = cell 優先のまま）。`cell()` の**持続性**（`comp()` 後もインスタンスに残る）を doc 明記。
- **`tests/midi/comp.spec.ts`**: `quarters`（4分割セル）の dispatch テスト追加 + cell+density 併用 warn のアサート追加。

## 非対象（bot 誤検知）

bot の「multi-line コメント/JSDoc が CLAUDE.md 違反（one short line max）」指摘は**誤検知**。両 CLAUDE.md（global / project）に該当規約は**存在せず**（grep でゼロ件）、既存コードベースは multi-line JSDoc を多用（`parser/types.ts` だけで JSDoc 100 行）。私のコメントは既存慣習に一致するため対応しない。

## テスト

comp.spec.ts 27件（+1）。**全体 1064 passed / 23 skipped**。

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)