### PR TITLE
feat(session-log): session log writer .orbslog (Phase 1-L1)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,30 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.115 Issue #229 — session log writer `.orbslog`（Phase 1-L1） (Jun 15, 2026)
+
+**Date**: 2026-06-15
+**Status**: ✅ 実装完了（L1。/simplify + /code:pr-review-team 予定）
+**Issue**: signalcompose/orbitscore#229 / 親 Epic #224 / 正本 SESSION_LOG_SPEC_v1
+**Branch**: `229-session-log-writer`
+
+**概要**: 評価の因果記録 `.orbslog` の書き出し層 L1。フライトレコーダー方式（常時ローリングバッファ → `global.start()` でファイル生成 + meta + preamble + 以降追記）。傍受点定義は main、writer 本体は自己完結。
+
+**設計の確定（advisor 検証 + コード確認で spec 曖昧点を解消、正本 §3/§3.1 に反映）**:
+- **傍受点 = `InterpreterV2.execute()`**（全 eval 経路の単一 funnel）。`options.source/sourceFile/evalSource` を thread。
+- **wall 原点** = engine/buffer 起動、発生時スタンプ（§3 文言修正）。
+- **start/stop フックは Global.start()/stop() 境界**: `global.stop()` は `transportCommands` に stop が無く method 経路を通るため、両者が必ず通る Global 境界でフック（process-statement ではない）。
+- **writer は opt-in**（実エントリのみ装着）→ 既存テストはファイル生成なし。
+- **effect は LOOP のみ**（`nextQuantizedTime` 流用、Phase 0-2 確認済）/ **命名は CLI 完全・editor は untitled** / **tempo 二重記録は follow-up**（§3.1 に明記）。
+
+**実装**:
+- `core/session-log/session-log-writer.ts`（新規）: ローリング preamble バッファ・行単位 `appendFileSync`（kill-9 で最大1行）・命名（同一秒衝突は連番）・stop・再start=新ファイル。純 I/O。
+- `core/global.ts`: `getTransportPosition()`/`getQuantizedEffectPosition()`/`msToBarBeat()` + opt-in `setTransportHooks()`。
+- `interpreter/`: `enableSessionLog()` + execute() で eval 記録 + `installSessionHooks()`。
+- `cli/play-mode.ts`・`repl-mode.ts`: 実エントリで `enableSessionLog` + source 供給。
+
+**テスト**: writer 単体 9件 + interpreter 統合 6件（preamble 完全性 / 三重スタンプ整合 / 複数ファイル sourceFile / kill-9 行耐性 / 再start / inert）。全体 1079 passed / 23 skipped（既存回帰なし）。
+
 ### 6.114 Issue #273 — comp C2a polish（PR #272 bot レビュー反映） (Jun 14, 2026)
 
 **Date**: 2026-06-14

--- a/docs/specs-v2/SESSION_LOG_SPEC_v1.html
+++ b/docs/specs-v2/SESSION_LOG_SPEC_v1.html
@@ -364,7 +364,7 @@ Lifecycle (フライトレコーダー方式)</h2>
 <tbody>
 <tr class="odd">
 <td><code>wall</code></td>
-<td>セッション開始(メタヘッダ書き出し)からの壁時計ミリ秒</td>
+<td>エンジン/ローリングバッファ起動からの壁時計ミリ秒。各レコードは<strong>発生時刻でスタンプ</strong>する(プリアンブルを flush 時に再スタンプしない)。よってプリアンブルの <code>wall</code> は start レコードより小さい(例: preamble <code>wall:0</code> &lt; start <code>wall:3500</code>)。メタヘッダの <code>startedAt</code> は <code>global.start()</code> 時刻の ISO</td>
 </tr>
 <tr class="even">
 <td><code>transport</code></td>
@@ -404,6 +404,15 @@ Lifecycle (フライトレコーダー方式)</h2>
 quantize 境界の前後 10ms
 の差が反映小節を丸ごとずらし、再現が壊れる。<code>effect</code>
 は検証とログの可読性(「この差し替えは何小節目から効いたか」)のため。テンポ変更自体がログイベントなので、音楽時間の参照系はログ内で自己完結する。</p>
+<h3 id="v1-implementation-scope">3.1 v1 (L1 #229) 実装スコープと既知の割り切り</h3>
+<p>L1 writer の初版(#229)は以下を確定スコープとする。いずれも因果記録としての正しさは保つ(より細粒度・CLI 完全)が、editor 経路の一部は follow-up に送る。</p>
+<ul>
+<li><strong>writer は opt-in(既定 inert)</strong>: 実エントリ(CLI play / REPL / 拡張)でのみ writer を装着する。ユニットテストが叩く <code>Global</code>/<code>Sequence</code> 構築経路では writer は不在で、<code>global.start()</code> は<strong>ファイルを生成しない</strong>(既存テスト群の汚染防止)。</li>
+<li><strong><code>code</code> 粒度 = <code>execute()</code> 単位</strong>: REPL/editor 経路はパース成立した単位(独立にパース可能なら文ごと)、CLI play はファイル全体が 1 レコード。1 選択 = 1 レコードにする selection-atomic framing は protocol 追加が要るため follow-up(細粒度でも因果記録としては有効)。</li>
+<li><strong>命名/<code>sourceFile</code></strong>: CLI 経路は <code>.orbs</code> パスを持つので basename 命名・<code>sourceFile</code> が完全に機能する。editor 経路は現状エンジンへファイル名を渡さない(<code>setDocumentDirectory</code> はディレクトリのみ)ため v1 は <code>untitled.&lt;timestamp&gt;.orbslog</code> フォールバック。editor からのファイル名伝達(ログに混じらない制御チャネル)は follow-up。</li>
+<li><strong><code>effect</code> 範囲</strong>: v1 は <strong>LOOP 起動</strong>の解決済み境界のみ <code>nextQuantizedTime</code> で算出。走行中ループへの <code>play()</code> 差し替え・<code>tempo/beat/length</code> の次サイクル遅延は <code>effect:null</code>(follow-up)。replay は <code>transport</code> 駆動で再 quantize するため再現性に影響せず、<code>effect</code> は可読性/検証の補助に留まる。</li>
+<li><strong>tempo の二重記録</strong>: v1 は <code>start</code>/<code>stop</code> のみ <code>transport</code> レコード化。<code>tempo</code> 変更は <code>eval</code> レコードとして残す(上の例に一致)。<code>tempo</code> の <code>transport</code> 二重記録は follow-up。</li>
+</ul>
 <h2 id="replay">4. Replay</h2>
 <pre><code>orbitscore replay mypiece.20260612-2130.orbslog              # 忠実リプレイ(実時間)
 orbitscore replay &lt;log&gt; --until 57:1                          # 分岐リプレイ: bar 57 頭まで畳み込み、ライブに引き継ぐ

--- a/packages/engine/src/cli/midi-run.ts
+++ b/packages/engine/src/cli/midi-run.ts
@@ -80,6 +80,7 @@ async function main(): Promise<void> {
     runGroup: new Set(),
     loopGroup: new Set(),
     muteGroup: new Set(),
+    engineT0: Date.now(), // §L1 rolling-buffer origin (no session log enabled on this path)
   }
 
   // Report the DSL to the monitor — honest: this is the exact source the engine

--- a/packages/engine/src/cli/play-mode.ts
+++ b/packages/engine/src/cli/play-mode.ts
@@ -55,7 +55,16 @@ export async function playFile(options: PlayOptions): Promise<PlayResult> {
     console.log('♻️ Reusing existing interpreter')
   }
 
-  await interpreter.execute(ir, { documentDirectory })
+  // §L1 (#229): the CLI is a real entry point — record the session (idempotent;
+  // a reused interpreter keeps its rolling buffer). `untitled` fallback dir = cwd.
+  interpreter.enableSessionLog({ engineVersion: '1.1.0', dslVersion: '1.1', cwd: process.cwd() })
+
+  await interpreter.execute(ir, {
+    documentDirectory,
+    source,
+    sourceFile: path.resolve(filepath),
+    evalSource: 'human',
+  })
 
   // Get final state
   const state = interpreter.getState()

--- a/packages/engine/src/cli/play-mode.ts
+++ b/packages/engine/src/cli/play-mode.ts
@@ -57,7 +57,7 @@ export async function playFile(options: PlayOptions): Promise<PlayResult> {
 
   // §L1 (#229): the CLI is a real entry point — record the session (idempotent;
   // a reused interpreter keeps its rolling buffer). `untitled` fallback dir = cwd.
-  interpreter.enableSessionLog({ engineVersion: '1.1.0', dslVersion: '1.1', cwd: process.cwd() })
+  interpreter.enableSessionLog({ cwd: process.cwd() })
 
   await interpreter.execute(ir, {
     documentDirectory,

--- a/packages/engine/src/cli/repl-mode.ts
+++ b/packages/engine/src/cli/repl-mode.ts
@@ -31,6 +31,13 @@ export async function startREPLMode(options: REPLOptions = {}): Promise<void> {
   // Create a global interpreter
   const globalInterpreter = new InterpreterV2()
 
+  // §L1 (#229): the REPL is a real entry point — record the session (idempotent).
+  globalInterpreter.enableSessionLog({
+    engineVersion: '1.1.0',
+    dslVersion: '1.1',
+    cwd: process.cwd(),
+  })
+
   // Boot SuperCollider once at startup with optional audio device
   await globalInterpreter.boot(options.audioDevice)
 
@@ -94,8 +101,9 @@ export async function startREPL(interpreter: InterpreterV2): Promise<void> {
     // Try to parse and execute the buffer
     // If parsing fails due to incomplete input, keep buffering
     try {
-      const ir = parseAudioDSL(buffer.trim())
-      await interpreter.execute(ir)
+      const code = buffer.trim()
+      const ir = parseAudioDSL(code)
+      await interpreter.execute(ir, { source: code, evalSource: 'human' }) // §L1
       console.log('✓') // Success indicator
       buffer = '' // Reset buffer on success
       if (process.env.ORBITSCORE_DEBUG) {
@@ -136,7 +144,7 @@ export async function startREPL(interpreter: InterpreterV2): Promise<void> {
 
     try {
       const ir = parseAudioDSL(code)
-      await interpreter.execute(ir)
+      await interpreter.execute(ir, { source: code, evalSource: 'human' }) // §L1
       console.log('✓') // Success indicator
     } catch (error: any) {
       console.error(`[ERROR] ${error.message}`)

--- a/packages/engine/src/cli/repl-mode.ts
+++ b/packages/engine/src/cli/repl-mode.ts
@@ -32,11 +32,7 @@ export async function startREPLMode(options: REPLOptions = {}): Promise<void> {
   const globalInterpreter = new InterpreterV2()
 
   // §L1 (#229): the REPL is a real entry point — record the session (idempotent).
-  globalInterpreter.enableSessionLog({
-    engineVersion: '1.1.0',
-    dslVersion: '1.1',
-    cwd: process.cwd(),
-  })
+  globalInterpreter.enableSessionLog({ cwd: process.cwd() })
 
   // Boot SuperCollider once at startup with optional audio device
   await globalInterpreter.boot(options.audioDevice)

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -309,13 +309,24 @@ export class Global {
 
   // Transport control
   start(): this {
+    // §L1: only open a NEW session on an actual stopped→running transition —
+    // transportClock.start() is idempotent, so a redundant start() while running
+    // must not open a second (orphaned) log file.
+    const wasRunning = this.transportClock.running
     // Stamp the shared clock origin FIRST so the audio scheduler (started by
     // transportControl) and the MIDI scheduler share the same Date.now() base.
     this.transportClock.start()
     this.transportControl.start()
     this.effectsManager.setRunningState(true)
     this.midiManager.start()
-    this._onTransportStart?.() // §L1: open the session log (clock origin is set)
+    if (!wasRunning) {
+      // §L1: best-effort — a log-open failure must never break playback.
+      try {
+        this._onTransportStart?.()
+      } catch (e) {
+        console.warn(`⚠️  session-log: start hook failed (playback continues): ${e}`)
+      }
+    }
     return this
   }
 
@@ -329,7 +340,16 @@ export class Global {
   }
 
   stop(): this {
-    this._onTransportStop?.() // §L1: write the stop record BEFORE the clock clears
+    // §L1: write the stop record BEFORE the clock clears, only if actually
+    // running, and never let a log-write error block the note-offs below (a
+    // throw here would otherwise leave MIDI notes hanging — music unstoppable).
+    if (this.transportClock.running) {
+      try {
+        this._onTransportStop?.()
+      } catch (e) {
+        console.warn(`⚠️  session-log: stop hook failed (playback continues): ${e}`)
+      }
+    }
     this.transportControl.stop()
     this.effectsManager.setRunningState(false)
     this.midiManager.stop()
@@ -340,8 +360,8 @@ export class Global {
   /**
    * §L1 (#229 §3 transport): the current musical position as `"bar:beat"`
    * (1-based bar, 1-based fractional beat in the meter's denominator unit), or
-   * null when transport is not running (the session-log preamble phase). Origin
-   * = `global.start()` (transportClock origin); bar 1 beat 1.0 at elapsed 0.
+   * null when transport is not running (before `start()` or after `stop()`).
+   * Origin = `global.start()` (transportClock origin); bar 1 beat 1.0 at elapsed 0.
    */
   getTransportPosition(): string | null {
     if (!this.transportClock.running) return null

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -17,7 +17,7 @@ import { EffectsManager } from './global/effects-manager'
 import { TransportControl } from './global/transport-control'
 import { SequenceRegistry } from './global/sequence-registry'
 import { LinkAudioManager } from './global/link-audio-manager'
-import { QuantizeManager, QuantizeValue } from './global/quantize-manager'
+import { QuantizeManager, QuantizeValue, nextQuantizedTime } from './global/quantize-manager'
 import { MidiManager } from './global/midi-manager'
 import { TransportClock } from './global/transport-clock'
 import { MidiTransportScheduler } from './global/midi-transport-scheduler'
@@ -294,6 +294,19 @@ export class Global {
     return this
   }
 
+  /**
+   * §L1 (#229): optional session-log hooks fired at transport start/stop. Set
+   * ONLY by the interpreter when logging is enabled — unset by default, so a
+   * `Global` constructed in a unit test never writes a `.orbslog`. `onStop` runs
+   * BEFORE the clock is cleared so the stop record can read the transport time.
+   */
+  private _onTransportStart?: () => void
+  private _onTransportStop?: () => void
+  setTransportHooks(hooks: { onStart?: () => void; onStop?: () => void }): void {
+    this._onTransportStart = hooks.onStart
+    this._onTransportStop = hooks.onStop
+  }
+
   // Transport control
   start(): this {
     // Stamp the shared clock origin FIRST so the audio scheduler (started by
@@ -302,6 +315,7 @@ export class Global {
     this.transportControl.start()
     this.effectsManager.setRunningState(true)
     this.midiManager.start()
+    this._onTransportStart?.() // §L1: open the session log (clock origin is set)
     return this
   }
 
@@ -315,11 +329,56 @@ export class Global {
   }
 
   stop(): this {
+    this._onTransportStop?.() // §L1: write the stop record BEFORE the clock clears
     this.transportControl.stop()
     this.effectsManager.setRunningState(false)
     this.midiManager.stop()
     this.transportClock.stop()
     return this
+  }
+
+  /**
+   * §L1 (#229 §3 transport): the current musical position as `"bar:beat"`
+   * (1-based bar, 1-based fractional beat in the meter's denominator unit), or
+   * null when transport is not running (the session-log preamble phase). Origin
+   * = `global.start()` (transportClock origin); bar 1 beat 1.0 at elapsed 0.
+   */
+  getTransportPosition(): string | null {
+    if (!this.transportClock.running) return null
+    return this.msToBarBeat(Date.now() - this.transportClock.startTime)
+  }
+
+  /**
+   * §L1 (#229 §3 effect): the resolved quantize boundary `"bar:beat"` at which a
+   * quantized op evaluated *now* would take effect, or null when transport is
+   * not running or quantize is off. Reuses {@link nextQuantizedTime} (Phase 0-2).
+   */
+  getQuantizedEffectPosition(): string | null {
+    if (!this.transportClock.running) return null
+    const q = this.quantizeManager.getQuantize()
+    if (q === 'off') return null
+    const { tempo, beat } = this.transportParams()
+    const currentMs = Date.now() - this.transportClock.startTime
+    return this.msToBarBeat(nextQuantizedTime(currentMs, q, tempo, beat))
+  }
+
+  /** Tempo + meter in effect now (global defaults; §3 transport reference frame). */
+  private transportParams(): { tempo: number; beat: { numerator: number; denominator: number } } {
+    const state = this.tempoManager.getState()
+    return {
+      tempo: state.tempo ?? 120,
+      beat: state.beat ?? { numerator: 4, denominator: 4 },
+    }
+  }
+
+  /** Convert elapsed transport ms to a `"bar:beat"` string (§3). */
+  private msToBarBeat(elapsedMs: number): string {
+    const { tempo, beat } = this.transportParams()
+    const beatUnitMs = ((60_000 / tempo) * 4) / beat.denominator // one meter-beat
+    const totalBeatUnits = Math.max(0, elapsedMs) / beatUnitMs
+    const bar = Math.floor(totalBeatUnits / beat.numerator) + 1
+    const beatInBar = (totalBeatUnits % beat.numerator) + 1
+    return `${bar}:${beatInBar.toFixed(3)}`
   }
 
   // Sequence management

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -357,9 +357,9 @@ export class Global {
     if (!this.transportClock.running) return null
     const q = this.quantizeManager.getQuantize()
     if (q === 'off') return null
-    const { tempo, beat } = this.transportParams()
+    const params = this.transportParams()
     const currentMs = Date.now() - this.transportClock.startTime
-    return this.msToBarBeat(nextQuantizedTime(currentMs, q, tempo, beat))
+    return this.msToBarBeat(nextQuantizedTime(currentMs, q, params.tempo, params.beat), params)
   }
 
   /** Tempo + meter in effect now (global defaults; §3 transport reference frame). */
@@ -372,8 +372,14 @@ export class Global {
   }
 
   /** Convert elapsed transport ms to a `"bar:beat"` string (§3). */
-  private msToBarBeat(elapsedMs: number): string {
-    const { tempo, beat } = this.transportParams()
+  private msToBarBeat(
+    elapsedMs: number,
+    params: {
+      tempo: number
+      beat: { numerator: number; denominator: number }
+    } = this.transportParams(),
+  ): string {
+    const { tempo, beat } = params
     const beatUnitMs = ((60_000 / tempo) * 4) / beat.denominator // one meter-beat
     const totalBeatUnits = Math.max(0, elapsedMs) / beatUnitMs
     const bar = Math.floor(totalBeatUnits / beat.numerator) + 1

--- a/packages/engine/src/core/session-log/session-log-writer.ts
+++ b/packages/engine/src/core/session-log/session-log-writer.ts
@@ -23,6 +23,15 @@ import * as path from 'path'
 /** Who initiated an eval (§3 `evalSource`). */
 export type EvalSource = 'human' | 'agent' | 'replay'
 
+/** Format a Date as `YYYYMMDD-HHMMSS` (local time) for the log filename (§2). */
+export function formatLogStamp(d: Date): string {
+  const p = (n: number): string => String(n).padStart(2, '0')
+  return (
+    `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}` +
+    `-${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}`
+  )
+}
+
 /** One `eval` record's payload (the triple stamp is filled by the caller). */
 export interface EvalRecord {
   /** Verbatim evaluated source (§3 `code`). */
@@ -103,7 +112,13 @@ export class SessionLogWriter {
       ? path.basename(s.sourceFile, path.extname(s.sourceFile))
       : 'untitled'
     const dir = s.sourceFile ? path.dirname(s.sourceFile) : this.cwd
-    this.filePath = path.join(dir, `${basename}.${s.stamp}.orbslog`)
+    // Two sessions opened within the same second collide on the timestamp; add a
+    // counter so a stop→start within one second doesn't overwrite the first file.
+    let candidate = path.join(dir, `${basename}.${s.stamp}.orbslog`)
+    for (let n = 2; fs.existsSync(candidate); n++) {
+      candidate = path.join(dir, `${basename}.${s.stamp}-${n}.orbslog`)
+    }
+    this.filePath = candidate
 
     const metaLine = JSON.stringify({
       type: 'meta',

--- a/packages/engine/src/core/session-log/session-log-writer.ts
+++ b/packages/engine/src/core/session-log/session-log-writer.ts
@@ -40,7 +40,11 @@ export interface EvalRecord {
   wall: number
   /** Musical time `bar:beat`, or null before transport runs (§3 `transport`). */
   transport: string | null
-  /** Resolved quantize boundary `bar:beat`, or null for immediate ops (§3 `effect`). */
+  /**
+   * Resolved quantize boundary `bar:beat` at which this eval takes effect, else
+   * null. v1 (§3.1): non-null ONLY for LOOP launches; quantized `play()` swaps and
+   * tempo/beat/length changes use null (follow-up). (§3 `effect`)
+   */
   effect: string | null
   /** Originating `.orbs` (relative), or null on the unnamed editor path (§3 `sourceFile`). */
   sourceFile: string | null
@@ -78,6 +82,14 @@ export class SessionLogWriter {
   private preamble: EvalRecord[] = []
   /** Open session file path, or null when no session is active (pre-start / post-stop). */
   private filePath: string | null = null
+  /**
+   * Set after an I/O error: logging is a flight recorder, NOT a music component —
+   * a disk-full / permission failure mid-session must never break playback. Once
+   * an fs write throws, we warn once and go silent for the session (a fresh
+   * `start()` re-attempts). A flag, not `filePath = null`, so `recordEval` does
+   * NOT re-buffer into an unbounded preamble over a long broken-disk session.
+   */
+  private disabled = false
 
   constructor(meta: SessionMeta, cwd: string) {
     this.meta = meta
@@ -94,6 +106,7 @@ export class SessionLogWriter {
    * buffer (stamped at occurrence); after `start()` it is appended immediately.
    */
   recordEval(rec: EvalRecord): void {
+    if (this.disabled) return
     if (this.filePath === null) {
       this.preamble.push(rec)
       return
@@ -118,7 +131,6 @@ export class SessionLogWriter {
     for (let n = 2; fs.existsSync(candidate); n++) {
       candidate = path.join(dir, `${basename}.${s.stamp}-${n}.orbslog`)
     }
-    this.filePath = candidate
 
     const metaLine = JSON.stringify({
       type: 'meta',
@@ -128,15 +140,27 @@ export class SessionLogWriter {
       startedAt: s.startedAtISO,
       sourceFile: s.sourceFile,
     })
-    // Truncate-create the file with the meta header (a fresh session per start).
-    fs.writeFileSync(this.filePath, metaLine + '\n')
+    // Drain the preamble regardless of outcome (don't retain it on failure).
+    const buffered = this.preamble
+    this.preamble = []
+    this.disabled = false // a fresh session re-attempts after a prior failure
+    try {
+      // Truncate-create the file with the meta header (a fresh session per start).
+      fs.writeFileSync(candidate, metaLine + '\n')
+    } catch (e) {
+      this.disabled = true
+      this.filePath = null
+      console.warn(
+        `⚠️  session-log: failed to open ${candidate} — logging disabled (playback continues): ${e}`,
+      )
+      return
+    }
+    this.filePath = candidate
 
     // Preamble: every buffered eval, transport forced null (§1 — transport未走行).
-    for (const rec of this.preamble) {
+    for (const rec of buffered) {
       this.append(this.evalLine({ ...rec, transport: null, effect: null }))
     }
-    this.preamble = []
-
     this.append(JSON.stringify({ type: 'transport', wall: s.wall, event: 'start' }))
   }
 
@@ -164,8 +188,18 @@ export class SessionLogWriter {
     })
   }
 
-  /** Append one line + newline with a per-line fs write (crash loses ≤1 line, §1). */
+  /**
+   * Append one line + newline with a per-line fs write (crash loses ≤1 line, §1).
+   * Best-effort: an fs error disables logging for the session rather than throwing
+   * into the caller — a flight recorder must never break the music.
+   */
   private append(line: string): void {
-    fs.appendFileSync(this.filePath!, line + '\n')
+    if (this.disabled || this.filePath === null) return
+    try {
+      fs.appendFileSync(this.filePath, line + '\n')
+    } catch (e) {
+      this.disabled = true
+      console.warn(`⚠️  session-log: write error — logging disabled (playback continues): ${e}`)
+    }
   }
 }

--- a/packages/engine/src/core/session-log/session-log-writer.ts
+++ b/packages/engine/src/core/session-log/session-log-writer.ts
@@ -1,0 +1,156 @@
+/**
+ * §L1 (#229) — session log writer (.orbslog).
+ *
+ * Spec: docs/specs-v2/SESSION_LOG_SPEC_v1.html (全節 / §3.1 v1 scope)
+ *
+ * Flight-recorder model: every eval is held in a rolling buffer from engine
+ * start; `global.start()` opens the file and flushes (1) a meta header, (2) the
+ * buffered evals as the PREAMBLE (transport: null), (3) a `start` transport
+ * record, then subsequent evals are appended line-by-line (append-only, one
+ * fs write per line → a crash loses at most one partial line). `global.stop()`
+ * writes a `stop` record; a later `start()` opens a NEW file (§1).
+ *
+ * The writer is OFF unless explicitly installed at a real entry point
+ * (CLI / REPL / extension) — unit-test paths construct Global without one, so
+ * `global.start()` produces no file (§3.1). Pure I/O + buffering: the caller
+ * supplies the already-computed triple stamp (wall / transport / effect), so
+ * this module has no engine dependency and is unit-testable in isolation.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+/** Who initiated an eval (§3 `evalSource`). */
+export type EvalSource = 'human' | 'agent' | 'replay'
+
+/** One `eval` record's payload (the triple stamp is filled by the caller). */
+export interface EvalRecord {
+  /** Verbatim evaluated source (§3 `code`). */
+  code: string
+  /** ms from engine/buffer start, stamped at occurrence (§3 `wall`). */
+  wall: number
+  /** Musical time `bar:beat`, or null before transport runs (§3 `transport`). */
+  transport: string | null
+  /** Resolved quantize boundary `bar:beat`, or null for immediate ops (§3 `effect`). */
+  effect: string | null
+  /** Originating `.orbs` (relative), or null on the unnamed editor path (§3 `sourceFile`). */
+  sourceFile: string | null
+  /** Eval provenance (§3 `evalSource`). */
+  evalSource: EvalSource
+}
+
+/** Inputs for opening a session file at `global.start()`. */
+export interface SessionStart {
+  /** ISO timestamp of `global.start()` (§3 meta `startedAt`). */
+  startedAtISO: string
+  /** `YYYYMMDD-HHMMSS` for the filename (derived from the start time by the caller). */
+  stamp: string
+  /** ms from engine/buffer start for the `start` transport record. */
+  wall: number
+  /** The `.orbs` that evaluated `start()` — drives basename + directory. null → `untitled` in cwd. */
+  sourceFile: string | null
+}
+
+/** Engine/version identity for the meta header. */
+export interface SessionMeta {
+  engineVersion: string
+  dslVersion: string
+}
+
+/**
+ * Append-only JSONL writer for one `.orbslog` session at a time. Construct once
+ * per engine; `recordEval` buffers until `start()`, then appends; `stop()` ends
+ * the session and a later `start()` opens a fresh file.
+ */
+export class SessionLogWriter {
+  private readonly meta: SessionMeta
+  private readonly cwd: string
+  /** Rolling preamble buffer: evals seen before the current session's `start()`. */
+  private preamble: EvalRecord[] = []
+  /** Open session file path, or null when no session is active (pre-start / post-stop). */
+  private filePath: string | null = null
+
+  constructor(meta: SessionMeta, cwd: string) {
+    this.meta = meta
+    this.cwd = cwd
+  }
+
+  /** The active log file path (for diagnostics / get_session_tail), or null. */
+  getFilePath(): string | null {
+    return this.filePath
+  }
+
+  /**
+   * Record an eval. Before `start()` it accumulates in the rolling preamble
+   * buffer (stamped at occurrence); after `start()` it is appended immediately.
+   */
+  recordEval(rec: EvalRecord): void {
+    if (this.filePath === null) {
+      this.preamble.push(rec)
+      return
+    }
+    this.append(this.evalLine(rec))
+  }
+
+  /**
+   * Open the session file (§1): write the meta header, flush the buffered
+   * preamble (transport forced to null — transport had not run), then a `start`
+   * transport record. A second `start()` after a `stop()` opens a NEW file and
+   * the evals seen since then become the next preamble.
+   */
+  start(s: SessionStart): void {
+    const basename = s.sourceFile
+      ? path.basename(s.sourceFile, path.extname(s.sourceFile))
+      : 'untitled'
+    const dir = s.sourceFile ? path.dirname(s.sourceFile) : this.cwd
+    this.filePath = path.join(dir, `${basename}.${s.stamp}.orbslog`)
+
+    const metaLine = JSON.stringify({
+      type: 'meta',
+      logVersion: 1,
+      engineVersion: this.meta.engineVersion,
+      dslVersion: this.meta.dslVersion,
+      startedAt: s.startedAtISO,
+      sourceFile: s.sourceFile,
+    })
+    // Truncate-create the file with the meta header (a fresh session per start).
+    fs.writeFileSync(this.filePath, metaLine + '\n')
+
+    // Preamble: every buffered eval, transport forced null (§1 — transport未走行).
+    for (const rec of this.preamble) {
+      this.append(this.evalLine({ ...rec, transport: null, effect: null }))
+    }
+    this.preamble = []
+
+    this.append(JSON.stringify({ type: 'transport', wall: s.wall, event: 'start' }))
+  }
+
+  /**
+   * Write the `stop` transport record and end the session (§1). `transport`
+   * should be computed by the caller BEFORE the transport clock is cleared.
+   * No-op if no session is open. A later `start()` opens a fresh file.
+   */
+  stop(wall: number, transport: string | null): void {
+    if (this.filePath === null) return
+    this.append(JSON.stringify({ type: 'transport', wall, transport, event: 'stop' }))
+    this.filePath = null
+  }
+
+  /** Serialize one `eval` record to a JSONL line (omit-null kept explicit per §3 example). */
+  private evalLine(rec: EvalRecord): string {
+    return JSON.stringify({
+      type: 'eval',
+      wall: rec.wall,
+      transport: rec.transport,
+      effect: rec.effect,
+      code: rec.code,
+      sourceFile: rec.sourceFile,
+      evalSource: rec.evalSource,
+    })
+  }
+
+  /** Append one line + newline with a per-line fs write (crash loses ≤1 line, §1). */
+  private append(line: string): void {
+    fs.appendFileSync(this.filePath!, line + '\n')
+  }
+}

--- a/packages/engine/src/interpreter/interpreter-v2.ts
+++ b/packages/engine/src/interpreter/interpreter-v2.ts
@@ -8,6 +8,12 @@
 
 import { AudioIR } from '../parser/audio-parser'
 import { SuperColliderPlayer } from '../audio/supercollider-player'
+import { Global } from '../core/global'
+import {
+  SessionLogWriter,
+  EvalSource,
+  formatLogStamp,
+} from '../core/session-log/session-log-writer'
 
 import { InterpreterState } from './types'
 import { processGlobalInit, processSequenceInit } from './process-initialization'
@@ -33,7 +39,50 @@ export class InterpreterV2 {
       runGroup: new Set(),
       loopGroup: new Set(),
       muteGroup: new Set(),
+      // §L1: the rolling-buffer origin (§3 wall). The writer itself stays absent
+      // until enableSessionLog() — so logging is inert in unit-test paths.
+      engineT0: Date.now(),
     }
+  }
+
+  /**
+   * §L1 (#229): install a session-log writer (opt-in — call ONLY at a real entry
+   * point: CLI / REPL). Until called, `global.start()` writes no `.orbslog`, so
+   * the engine's own test suite stays file-free. `cwd` is the untitled-fallback
+   * directory; `engineVersion`/`dslVersion` go in the meta header.
+   */
+  enableSessionLog(opts: { engineVersion: string; dslVersion: string; cwd: string }): void {
+    if (this.state.sessionLog) return // idempotent — keep the existing rolling buffer
+    this.state.sessionLog = new SessionLogWriter(
+      { engineVersion: opts.engineVersion, dslVersion: opts.dslVersion },
+      opts.cwd,
+    )
+  }
+
+  /**
+   * §L1: wire the global's transport start/stop to the session log. Closures
+   * read live `state` (sourceFile / engineT0) so each start/stop logs against
+   * the context of the eval that triggered it.
+   */
+  private installSessionHooks(global: Global): void {
+    const state = this.state
+    global.setTransportHooks({
+      onStart: () => {
+        const now = new Date()
+        state.sessionLog!.start({
+          startedAtISO: now.toISOString(),
+          stamp: formatLogStamp(now),
+          wall: Date.now() - (state.engineT0 ?? Date.now()),
+          sourceFile: state.currentSourceFile ?? null,
+        })
+      },
+      onStop: () => {
+        state.sessionLog!.stop(
+          Date.now() - (state.engineT0 ?? Date.now()),
+          global.getTransportPosition(),
+        )
+      },
+    })
   }
 
   /**
@@ -61,9 +110,38 @@ export class InterpreterV2 {
    */
   async execute(
     ir: AudioIR,
-    options?: { skipTransportCommands?: boolean; documentDirectory?: string },
+    options?: {
+      skipTransportCommands?: boolean
+      documentDirectory?: string
+      /** §L1: the verbatim evaluated source (the `code` field). */
+      source?: string
+      /** §L1: the originating `.orbs` (drives `sourceFile` + filename). */
+      sourceFile?: string | null
+      /** §L1: who evaluated this (default `human`). */
+      evalSource?: EvalSource
+    },
   ): Promise<void> {
     const skipTransport = options?.skipTransportCommands ?? false
+
+    // §L1 (#229): record this eval at occurrence. The interceptor is HERE — the
+    // single funnel every eval path passes through. `recordEval` buffers until
+    // global.start() (preamble) then appends; the start/stop transport records
+    // are emitted by the Global transport hooks (installSessionHooks). Guarded by
+    // `sessionLog` so the engine test suite (which never enables it) is unaffected.
+    this.state.currentSourceFile = options?.sourceFile ?? null
+    this.state.currentEvalSource = options?.evalSource ?? 'human'
+    if (this.state.sessionLog && options?.source !== undefined) {
+      const g = this.state.currentGlobal
+      const hasLoop = ir.statements.some((s) => s.type === 'transport' && s.command === 'loop')
+      this.state.sessionLog.recordEval({
+        code: options.source,
+        wall: Date.now() - (this.state.engineT0 ?? Date.now()),
+        transport: g?.getTransportPosition() ?? null,
+        effect: hasLoop ? (g?.getQuantizedEffectPosition() ?? null) : null,
+        sourceFile: this.state.currentSourceFile,
+        evalSource: this.state.currentEvalSource,
+      })
+    }
 
     // Ensure SuperCollider is booted
     await this.ensureBooted()
@@ -71,6 +149,13 @@ export class InterpreterV2 {
     // Process global initialization
     if (ir.globalInit) {
       await processGlobalInit(ir.globalInit, this.state)
+    }
+
+    // §L1: install the session-log transport hooks on the global once it exists.
+    // The closures read live state (sourceFile / engineT0) at fire time, so a
+    // start/stop in a later eval logs against that eval's context. Idempotent.
+    if (this.state.sessionLog && this.state.currentGlobal) {
+      this.installSessionHooks(this.state.currentGlobal)
     }
 
     // Set documentDirectory on global so audioPath() / audio() can resolve relative paths

--- a/packages/engine/src/interpreter/interpreter-v2.ts
+++ b/packages/engine/src/interpreter/interpreter-v2.ts
@@ -131,10 +131,12 @@ export class InterpreterV2 {
     const skipTransport = options?.skipTransportCommands ?? false
 
     // §L1 (#229): record this eval at occurrence. The interceptor is HERE — the
-    // single funnel every eval path passes through. `recordEval` buffers until
-    // global.start() (preamble) then appends; the start/stop transport records
-    // are emitted by the Global transport hooks (installSessionHooks). Guarded by
-    // `sessionLog` so the engine test suite (which never enables it) is unaffected.
+    // funnel every InterpreterV2.execute() caller passes through (CLI play / REPL;
+    // midi-run.ts drives the interpreter modules directly and is not logged in v1).
+    // `recordEval` buffers until global.start() (preamble) then appends; the
+    // start/stop transport records are emitted by the Global transport hooks
+    // (installSessionHooks). Guarded by `sessionLog` so the engine test suite
+    // (which never enables it) is unaffected.
     this.state.currentSourceFile = options?.sourceFile ?? null
     if (this.state.sessionLog && options?.source !== undefined) {
       const g = this.state.currentGlobal

--- a/packages/engine/src/interpreter/interpreter-v2.ts
+++ b/packages/engine/src/interpreter/interpreter-v2.ts
@@ -14,6 +14,7 @@ import {
   EvalSource,
   formatLogStamp,
 } from '../core/session-log/session-log-writer'
+import { ENGINE_VERSION, DSL_VERSION } from '../version'
 
 import { InterpreterState } from './types'
 import { processGlobalInit, processSequenceInit } from './process-initialization'
@@ -27,6 +28,8 @@ import { processStatement } from './process-statement'
  */
 export class InterpreterV2 {
   private state: InterpreterState
+  /** §L1: guards installing the Global transport hooks exactly once per session. */
+  private sessionHooksInstalled = false
 
   constructor() {
     this.state = {
@@ -51,36 +54,40 @@ export class InterpreterV2 {
    * the engine's own test suite stays file-free. `cwd` is the untitled-fallback
    * directory; `engineVersion`/`dslVersion` go in the meta header.
    */
-  enableSessionLog(opts: { engineVersion: string; dslVersion: string; cwd: string }): void {
+  enableSessionLog(opts: { cwd: string; engineVersion?: string; dslVersion?: string }): void {
     if (this.state.sessionLog) return // idempotent — keep the existing rolling buffer
     this.state.sessionLog = new SessionLogWriter(
-      { engineVersion: opts.engineVersion, dslVersion: opts.dslVersion },
+      {
+        engineVersion: opts.engineVersion ?? ENGINE_VERSION,
+        dslVersion: opts.dslVersion ?? DSL_VERSION,
+      },
       opts.cwd,
     )
   }
 
+  /** §L1 / §3 wall: ms since the rolling-buffer origin (interpreter construction). */
+  private wallMs(): number {
+    return Date.now() - this.state.engineT0
+  }
+
   /**
    * §L1: wire the global's transport start/stop to the session log. Closures
-   * read live `state` (sourceFile / engineT0) so each start/stop logs against
-   * the context of the eval that triggered it.
+   * read live `state.currentSourceFile` so a start/stop logs against the eval
+   * that triggered it (start/stop fire synchronously within that eval).
    */
   private installSessionHooks(global: Global): void {
-    const state = this.state
     global.setTransportHooks({
       onStart: () => {
         const now = new Date()
-        state.sessionLog!.start({
+        this.state.sessionLog!.start({
           startedAtISO: now.toISOString(),
           stamp: formatLogStamp(now),
-          wall: Date.now() - (state.engineT0 ?? Date.now()),
-          sourceFile: state.currentSourceFile ?? null,
+          wall: this.wallMs(),
+          sourceFile: this.state.currentSourceFile ?? null,
         })
       },
       onStop: () => {
-        state.sessionLog!.stop(
-          Date.now() - (state.engineT0 ?? Date.now()),
-          global.getTransportPosition(),
-        )
+        this.state.sessionLog!.stop(this.wallMs(), global.getTransportPosition())
       },
     })
   }
@@ -129,17 +136,18 @@ export class InterpreterV2 {
     // are emitted by the Global transport hooks (installSessionHooks). Guarded by
     // `sessionLog` so the engine test suite (which never enables it) is unaffected.
     this.state.currentSourceFile = options?.sourceFile ?? null
-    this.state.currentEvalSource = options?.evalSource ?? 'human'
     if (this.state.sessionLog && options?.source !== undefined) {
       const g = this.state.currentGlobal
+      // §3.1 v1: `effect` is stamped for LOOP launches only (other quantized
+      // swaps are follow-up; replay re-quantizes regardless).
       const hasLoop = ir.statements.some((s) => s.type === 'transport' && s.command === 'loop')
       this.state.sessionLog.recordEval({
         code: options.source,
-        wall: Date.now() - (this.state.engineT0 ?? Date.now()),
+        wall: this.wallMs(),
         transport: g?.getTransportPosition() ?? null,
         effect: hasLoop ? (g?.getQuantizedEffectPosition() ?? null) : null,
         sourceFile: this.state.currentSourceFile,
-        evalSource: this.state.currentEvalSource,
+        evalSource: options?.evalSource ?? 'human',
       })
     }
 
@@ -151,11 +159,12 @@ export class InterpreterV2 {
       await processGlobalInit(ir.globalInit, this.state)
     }
 
-    // §L1: install the session-log transport hooks on the global once it exists.
-    // The closures read live state (sourceFile / engineT0) at fire time, so a
-    // start/stop in a later eval logs against that eval's context. Idempotent.
-    if (this.state.sessionLog && this.state.currentGlobal) {
+    // §L1: install the session-log transport hooks on the global ONCE, when it
+    // first exists. The closures read live state.currentSourceFile at fire time,
+    // so a start/stop in a later eval logs against that eval's context.
+    if (this.state.sessionLog && this.state.currentGlobal && !this.sessionHooksInstalled) {
       this.installSessionHooks(this.state.currentGlobal)
+      this.sessionHooksInstalled = true
     }
 
     // Set documentDirectory on global so audioPath() / audio() can resolve relative paths

--- a/packages/engine/src/interpreter/process-statement.ts
+++ b/packages/engine/src/interpreter/process-statement.ts
@@ -284,7 +284,10 @@ export async function processTransportStatement(
     return
   }
 
-  // Handle global commands (e.g., g.start() where g is a global variable)
+  // Handle global commands (e.g., g.start() where g is a global variable).
+  // Note: §L1 session-log start/stop hooks live on Global.start()/stop() (the
+  // boundary both `start` (transport-routed) and `stop` (method-routed) pass
+  // through), not here — so they fire regardless of how the command is parsed.
   const global = state.globals.get(target)
   if (global) {
     await handleGlobalTransportCommand(global, command)

--- a/packages/engine/src/interpreter/types.ts
+++ b/packages/engine/src/interpreter/types.ts
@@ -5,7 +5,7 @@
 import { Global } from '../core/global'
 import { Sequence } from '../core/sequence'
 import { SuperColliderPlayer } from '../audio/supercollider-player'
-import { SessionLogWriter, EvalSource } from '../core/session-log/session-log-writer'
+import { SessionLogWriter } from '../core/session-log/session-log-writer'
 
 /**
  * Interpreter state containing globals and sequences
@@ -25,9 +25,10 @@ export interface InterpreterState {
   // §L1 (#229) session log — present ONLY when explicitly enabled at a real
   // entry point (CLI / REPL). Absent in unit-test paths, so logging is inert.
   sessionLog?: SessionLogWriter
-  engineT0?: number // epoch ms at interpreter construction = rolling-buffer origin (§3 wall)
-  currentSourceFile?: string | null // the .orbs the current eval came from (§3 sourceFile / §2 naming)
-  currentEvalSource?: EvalSource // provenance of the current eval (§3 evalSource)
+  engineT0: number // epoch ms at interpreter construction = rolling-buffer origin (§3 wall)
+  // The .orbs the current eval came from — read by the transport-hook closures
+  // when start()/stop() fire synchronously within that eval (§3 sourceFile / §2 naming).
+  currentSourceFile?: string | null
 }
 
 /**

--- a/packages/engine/src/interpreter/types.ts
+++ b/packages/engine/src/interpreter/types.ts
@@ -5,6 +5,7 @@
 import { Global } from '../core/global'
 import { Sequence } from '../core/sequence'
 import { SuperColliderPlayer } from '../audio/supercollider-player'
+import { SessionLogWriter, EvalSource } from '../core/session-log/session-log-writer'
 
 /**
  * Interpreter state containing globals and sequences
@@ -20,6 +21,13 @@ export interface InterpreterState {
   runGroup: Set<string> // Sequences in RUN playback
   loopGroup: Set<string> // Sequences in LOOP playback
   muteGroup: Set<string> // Sequences with MUTE flag ON (persistent)
+
+  // §L1 (#229) session log — present ONLY when explicitly enabled at a real
+  // entry point (CLI / REPL). Absent in unit-test paths, so logging is inert.
+  sessionLog?: SessionLogWriter
+  engineT0?: number // epoch ms at interpreter construction = rolling-buffer origin (§3 wall)
+  currentSourceFile?: string | null // the .orbs the current eval came from (§3 sourceFile / §2 naming)
+  currentEvalSource?: EvalSource // provenance of the current eval (§3 evalSource)
 }
 
 /**

--- a/packages/engine/src/version.ts
+++ b/packages/engine/src/version.ts
@@ -1,0 +1,7 @@
+/**
+ * Engine + DSL version identity. Mirrors the root package.json `version`; used
+ * for the session-log meta header (SESSION_LOG_SPEC §3) and any other place that
+ * needs to stamp the running engine/DSL version. Bump alongside package.json.
+ */
+export const ENGINE_VERSION = '1.1.0'
+export const DSL_VERSION = '1.1'

--- a/tests/session-log/helpers.ts
+++ b/tests/session-log/helpers.ts
@@ -1,0 +1,10 @@
+import * as fs from 'fs'
+
+/** Read a `.orbslog` (absolute path) back as parsed JSONL records (§3). */
+export function readOrbsLog(file: string): any[] {
+  return fs
+    .readFileSync(file, 'utf8')
+    .split('\n')
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l))
+}

--- a/tests/session-log/session-log-integration.spec.ts
+++ b/tests/session-log/session-log-integration.spec.ts
@@ -7,6 +7,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
 import { InterpreterV2 } from '../../packages/engine/src/interpreter/interpreter-v2'
 
+import { readOrbsLog } from './helpers'
+
 /**
  * L1 (#229) integration — the interpreter is the single eval-path interceptor.
  * With session logging enabled, driving real evals through `execute()` must
@@ -40,12 +42,7 @@ describe('L1 — session log via the interpreter (§1/§3)', () => {
     await interpreter.execute(parseAudioDSL(src), { source: src, sourceFile, evalSource: 'human' })
   }
   const logFiles = () => fs.readdirSync(dir).filter((f) => f.endsWith('.orbslog'))
-  const readLog = (f: string) =>
-    fs
-      .readFileSync(path.join(dir, f), 'utf8')
-      .split('\n')
-      .filter((l) => l.length > 0)
-      .map((l) => JSON.parse(l))
+  const readLog = (f: string) => readOrbsLog(path.join(dir, f))
 
   it('no .orbslog exists until global.start()', async () => {
     await run('var global = init GLOBAL', orbs('p.orbs'))

--- a/tests/session-log/session-log-integration.spec.ts
+++ b/tests/session-log/session-log-integration.spec.ts
@@ -1,0 +1,121 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+import { InterpreterV2 } from '../../packages/engine/src/interpreter/interpreter-v2'
+
+/**
+ * L1 (#229) integration — the interpreter is the single eval-path interceptor.
+ * With session logging enabled, driving real evals through `execute()` must
+ * produce a `.orbslog` whose preamble, triple stamp, multi-file `sourceFile`,
+ * and per-line durability match the spec. SuperCollider is mocked away.
+ * Spec: SESSION_LOG_SPEC_v1 (§1/§3/§3.1).
+ */
+
+describe('L1 — session log via the interpreter (§1/§3)', () => {
+  let interpreter: InterpreterV2
+  let dir: string
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbslog-int-'))
+    interpreter = new InterpreterV2()
+    const audioEngine = interpreter.audioEngine as any
+    audioEngine.boot = vi.fn().mockResolvedValue(undefined)
+    audioEngine.getCurrentTime = vi.fn().mockReturnValue(0)
+    audioEngine.scheduleEvent = vi.fn()
+    audioEngine.scheduleSliceEvent = vi.fn()
+    audioEngine.getMasterGainDb = vi.fn().mockReturnValue(0)
+    interpreter.enableSessionLog({ engineVersion: '1.1.0', dslVersion: '1.1', cwd: dir })
+    await interpreter.boot()
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  const orbs = (name: string) => path.join(dir, name)
+  async function run(src: string, sourceFile: string): Promise<void> {
+    await interpreter.execute(parseAudioDSL(src), { source: src, sourceFile, evalSource: 'human' })
+  }
+  const logFiles = () => fs.readdirSync(dir).filter((f) => f.endsWith('.orbslog'))
+  const readLog = (f: string) =>
+    fs
+      .readFileSync(path.join(dir, f), 'utf8')
+      .split('\n')
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l))
+
+  it('no .orbslog exists until global.start()', async () => {
+    await run('var global = init GLOBAL', orbs('p.orbs'))
+    await run('global.tempo(120)', orbs('p.orbs'))
+    expect(logFiles()).toHaveLength(0) // buffered as preamble, not yet flushed
+  })
+
+  it('global.start() opens the file with meta + preamble (transport null) + start record', async () => {
+    await run('var global = init GLOBAL', orbs('mypiece.orbs'))
+    await run('global.tempo(120)\nglobal.beat(4 by 4)', orbs('mypiece.orbs'))
+    await run('global.start()', orbs('mypiece.orbs'))
+
+    const files = logFiles()
+    expect(files).toHaveLength(1)
+    expect(files[0]).toMatch(/^mypiece\.\d{8}-\d{6}\.orbslog$/) // <basename>.<stamp>.orbslog
+    const recs = readLog(files[0]!)
+    expect(recs[0]).toMatchObject({ type: 'meta', logVersion: 1, sourceFile: orbs('mypiece.orbs') })
+    // every preamble eval (incl. the start() call) carries transport: null
+    const preamble = recs.filter((r) => r.type === 'eval')
+    expect(preamble.length).toBeGreaterThanOrEqual(3)
+    preamble.forEach((r) => expect(r.transport).toBeNull())
+    expect(recs.some((r) => r.type === 'transport' && r.event === 'start')).toBe(true)
+  })
+
+  it('post-start evals carry a real bar:beat transport (triple stamp), stop carries its own', async () => {
+    await run('var global = init GLOBAL', orbs('p.orbs'))
+    await run('global.start()', orbs('p.orbs'))
+    await run('global.tempo(132)', orbs('p.orbs'))
+    await run('global.stop()', orbs('p.orbs'))
+
+    const recs = readLog(logFiles()[0]!)
+    const postStart = recs.find((r) => r.type === 'eval' && r.code === 'global.tempo(132)')
+    expect(postStart).toBeDefined()
+    expect(postStart.transport).toMatch(/^\d+:\d+\.\d+$/) // bar:beat, transport now running
+    expect(postStart.wall).toBeGreaterThanOrEqual(0)
+    const stop = recs[recs.length - 1]
+    expect(stop).toMatchObject({ type: 'transport', event: 'stop' })
+    expect(stop.transport).toMatch(/^\d+:\d+\.\d+$/) // captured before the clock cleared
+  })
+
+  it('records the originating sourceFile per eval (multi-file session)', async () => {
+    await run('var global = init GLOBAL', orbs('main.orbs'))
+    await run('global.start()', orbs('main.orbs'))
+    await run('global.tempo(140)', orbs('voices.orbs')) // a second file drives the same engine
+
+    const recs = readLog(logFiles()[0]!)
+    expect(logFiles()[0]).toMatch(/^main\./) // naming follows the start() file
+    const fromVoices = recs.find((r) => r.type === 'eval' && r.code === 'global.tempo(140)')
+    expect(fromVoices.sourceFile).toBe(orbs('voices.orbs'))
+    const fromMain = recs.find((r) => r.type === 'eval' && r.code === 'var global = init GLOBAL')
+    expect(fromMain.sourceFile).toBe(orbs('main.orbs'))
+  })
+
+  it('is append-only with per-line flush: the file is fully parseable mid-session (kill-9 safe)', async () => {
+    await run('var global = init GLOBAL', orbs('p.orbs'))
+    await run('global.start()', orbs('p.orbs'))
+    await run('global.tempo(132)', orbs('p.orbs'))
+    // simulate inspecting the file WITHOUT a stop record (process killed mid-session):
+    const raw = fs.readFileSync(path.join(dir, logFiles()[0]!), 'utf8')
+    expect(raw.endsWith('\n')).toBe(true) // last completed line is terminated
+    const lines = raw.split('\n').filter((l) => l.length > 0)
+    expect(() => lines.forEach((l) => JSON.parse(l))).not.toThrow()
+    expect(lines.some((l) => l.includes('"event":"stop"'))).toBe(false) // no stop = valid truncated session
+  })
+
+  it('a second global.start() after stop opens a fresh file', async () => {
+    await run('var global = init GLOBAL', orbs('p.orbs'))
+    await run('global.start()', orbs('p.orbs'))
+    await run('global.stop()', orbs('p.orbs'))
+    await run('global.start()', orbs('p.orbs'))
+    expect(logFiles()).toHaveLength(2) // two distinct sessions
+  })
+})

--- a/tests/session-log/session-log-integration.spec.ts
+++ b/tests/session-log/session-log-integration.spec.ts
@@ -108,6 +108,26 @@ describe('L1 — session log via the interpreter (§1/§3)', () => {
     expect(lines.some((l) => l.includes('"event":"stop"'))).toBe(false) // no stop = valid truncated session
   })
 
+  it('a LOOP launch stamps a non-null effect (resolved quantize boundary)', async () => {
+    await run('var global = init GLOBAL', orbs('p.orbs'))
+    await run('var kick = init global.seq', orbs('p.orbs'))
+    await run('global.start()', orbs('p.orbs'))
+    await run('LOOP(kick)', orbs('p.orbs')) // quantized → effect = next boundary
+
+    const recs = readLog(logFiles()[0]!)
+    const loopRec = recs.find((r) => r.type === 'eval' && r.code === 'LOOP(kick)')
+    expect(loopRec).toBeDefined()
+    expect(loopRec.effect).toMatch(/^\d+:\d+\.\d+$/) // a resolved bar:beat, not null
+  })
+
+  it('a non-LOOP eval leaves effect null (v1 §3.1: LOOP launches only)', async () => {
+    await run('var global = init GLOBAL', orbs('p.orbs'))
+    await run('global.start()', orbs('p.orbs'))
+    await run('global.tempo(132)', orbs('p.orbs'))
+    const recs = readLog(logFiles()[0]!)
+    expect(recs.find((r) => r.code === 'global.tempo(132)').effect).toBeNull()
+  })
+
   it('a second global.start() after stop opens a fresh file', async () => {
     await run('var global = init GLOBAL', orbs('p.orbs'))
     await run('global.start()', orbs('p.orbs'))

--- a/tests/session-log/session-log-writer.spec.ts
+++ b/tests/session-log/session-log-writer.spec.ts
@@ -1,0 +1,180 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+import {
+  SessionLogWriter,
+  EvalRecord,
+} from '../../packages/engine/src/core/session-log/session-log-writer'
+
+/**
+ * L1 (#229) — `.orbslog` session log writer. The writer is pure I/O + buffering:
+ * the caller supplies the triple stamp, so these assert the file lifecycle —
+ * preamble flush, naming, JSONL shape, stop record, re-start = new file — by
+ * reading the written file back. Spec: SESSION_LOG_SPEC_v1 (§1/§3/§3.1).
+ */
+
+const META = { engineVersion: '1.1.0', dslVersion: '1.1' }
+
+function ev(over: Partial<EvalRecord> = {}): EvalRecord {
+  return {
+    code: 'x',
+    wall: 0,
+    transport: null,
+    effect: null,
+    sourceFile: 'mypiece.orbs',
+    evalSource: 'human',
+    ...over,
+  }
+}
+
+/** Read a written .orbslog back as parsed JSONL records. */
+function readLog(file: string): any[] {
+  return fs
+    .readFileSync(file, 'utf8')
+    .split('\n')
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l))
+}
+
+describe('L1 — SessionLogWriter (§1/§3)', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbslog-'))
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  const startArgs = (over: object = {}) => ({
+    startedAtISO: '2026-06-14T21:30:05+09:00',
+    stamp: '20260614-213005',
+    wall: 3500,
+    sourceFile: path.join(dir, 'mypiece.orbs'),
+    ...over,
+  })
+
+  it('buffers pre-start evals and flushes them as the preamble (transport forced null)', () => {
+    const w = new SessionLogWriter(META, dir)
+    w.recordEval(ev({ code: 'var global = init GLOBAL', wall: 0 }))
+    w.recordEval(ev({ code: 'kick.midi("IAC", 1)', wall: 1204 }))
+    w.start(startArgs())
+
+    const file = path.join(dir, 'mypiece.20260614-213005.orbslog')
+    const recs = readLog(file)
+    expect(recs[0]).toMatchObject({
+      type: 'meta',
+      logVersion: 1,
+      startedAt: startArgs().startedAtISO,
+    })
+    expect(recs[1]).toMatchObject({
+      type: 'eval',
+      code: 'var global = init GLOBAL',
+      wall: 0,
+      transport: null,
+    })
+    expect(recs[2]).toMatchObject({
+      type: 'eval',
+      code: 'kick.midi("IAC", 1)',
+      wall: 1204,
+      transport: null,
+    })
+    expect(recs[3]).toMatchObject({ type: 'transport', event: 'start', wall: 3500 })
+  })
+
+  it('a preamble eval that carried a transport is still recorded with transport null', () => {
+    const w = new SessionLogWriter(META, dir)
+    w.recordEval(ev({ transport: '2:1.0', effect: '3:1.0' })) // shouldn't happen pre-start, but force null
+    w.start(startArgs())
+    const recs = readLog(path.join(dir, 'mypiece.20260614-213005.orbslog'))
+    expect(recs[1]).toMatchObject({ type: 'eval', transport: null, effect: null })
+  })
+
+  it('appends post-start evals with the full triple stamp preserved', () => {
+    const w = new SessionLogWriter(META, dir)
+    w.start(startArgs())
+    w.recordEval(
+      ev({
+        code: 'kick.play(1,0,3,5).root(2)',
+        wall: 12040,
+        transport: '2:3.482',
+        effect: '3:1.0',
+      }),
+    )
+    const recs = readLog(path.join(dir, 'mypiece.20260614-213005.orbslog'))
+    const last = recs[recs.length - 1]
+    expect(last).toMatchObject({
+      type: 'eval',
+      wall: 12040,
+      transport: '2:3.482',
+      effect: '3:1.0',
+      code: 'kick.play(1,0,3,5).root(2)',
+      evalSource: 'human',
+    })
+  })
+
+  it('names the file <basename>.<stamp>.orbslog next to the .orbs', () => {
+    const w = new SessionLogWriter(META, dir)
+    w.start(startArgs())
+    expect(w.getFilePath()).toBe(path.join(dir, 'mypiece.20260614-213005.orbslog'))
+    expect(fs.existsSync(path.join(dir, 'mypiece.20260614-213005.orbslog'))).toBe(true)
+  })
+
+  it('falls back to untitled.<stamp>.orbslog in cwd when there is no source file', () => {
+    const w = new SessionLogWriter(META, dir)
+    w.start(startArgs({ sourceFile: null }))
+    expect(w.getFilePath()).toBe(path.join(dir, 'untitled.20260614-213005.orbslog'))
+    const recs = readLog(w.getFilePath()!)
+    expect(recs[0]).toMatchObject({ type: 'meta', sourceFile: null })
+  })
+
+  it('writes a stop record with the supplied transport, then closes the session', () => {
+    const w = new SessionLogWriter(META, dir)
+    w.start(startArgs())
+    w.stop(98000, '24:4.0')
+    const recs = readLog(path.join(dir, 'mypiece.20260614-213005.orbslog'))
+    expect(recs[recs.length - 1]).toMatchObject({
+      type: 'transport',
+      event: 'stop',
+      wall: 98000,
+      transport: '24:4.0',
+    })
+    expect(w.getFilePath()).toBeNull()
+  })
+
+  it('a second start() opens a NEW file; evals between stop and start become its preamble', () => {
+    const w = new SessionLogWriter(META, dir)
+    w.start(startArgs())
+    w.stop(5000, '2:1.0')
+    w.recordEval(ev({ code: 'after stop', wall: 6000 })) // buffered for the next session
+    w.start(startArgs({ stamp: '20260614-220000' }))
+    const file2 = path.join(dir, 'mypiece.20260614-220000.orbslog')
+    const recs = readLog(file2)
+    expect(recs[0].type).toBe('meta')
+    expect(recs[1]).toMatchObject({ type: 'eval', code: 'after stop', transport: null })
+    // first file still has its own stop record, untouched
+    const recs1 = readLog(path.join(dir, 'mypiece.20260614-213005.orbslog'))
+    expect(recs1[recs1.length - 1]).toMatchObject({ event: 'stop' })
+  })
+
+  it('recordEval before any start does not create a file (inert until start)', () => {
+    const w = new SessionLogWriter(META, dir)
+    w.recordEval(ev())
+    expect(w.getFilePath()).toBeNull()
+    expect(fs.readdirSync(dir)).toHaveLength(0)
+  })
+
+  it('every written line is valid standalone JSON (strict JSONL)', () => {
+    const w = new SessionLogWriter(META, dir)
+    w.recordEval(ev({ code: 'pre', wall: 0 }))
+    w.start(startArgs())
+    w.recordEval(ev({ code: 'post', wall: 100, transport: '1:1.0' }))
+    w.stop(200, '1:2.0')
+    const raw = fs.readFileSync(path.join(dir, 'mypiece.20260614-213005.orbslog'), 'utf8')
+    const lines = raw.split('\n').filter((l) => l.length > 0)
+    expect(() => lines.forEach((l) => JSON.parse(l))).not.toThrow()
+    expect(raw.endsWith('\n')).toBe(true) // line-terminated (append-only)
+  })
+})

--- a/tests/session-log/session-log-writer.spec.ts
+++ b/tests/session-log/session-log-writer.spec.ts
@@ -161,6 +161,37 @@ describe('L1 — SessionLogWriter (§1/§3)', () => {
     expect(fs.readdirSync(dir)).toHaveLength(0)
   })
 
+  it('two sessions with the same stamp get distinct files (collision counter)', () => {
+    const w = new SessionLogWriter(META, dir)
+    w.start(startArgs())
+    w.stop(1000, '1:1.000')
+    w.start(startArgs()) // same stamp, same source → must not overwrite the first
+    expect(w.getFilePath()).toBe(path.join(dir, 'mypiece.20260614-213005-2.orbslog'))
+    expect(fs.existsSync(path.join(dir, 'mypiece.20260614-213005.orbslog'))).toBe(true)
+  })
+
+  it('round-trips a non-human evalSource (agent / replay)', () => {
+    const w = new SessionLogWriter(META, dir)
+    w.start(startArgs())
+    w.recordEval(ev({ code: 'a', evalSource: 'agent' }))
+    w.recordEval(ev({ code: 'r', evalSource: 'replay' }))
+    const recs = readLog(path.join(dir, 'mypiece.20260614-213005.orbslog'))
+    expect(recs.find((r) => r.code === 'a').evalSource).toBe('agent')
+    expect(recs.find((r) => r.code === 'r').evalSource).toBe('replay')
+  })
+
+  it('a file-open failure disables logging WITHOUT throwing (a flight recorder must not break playback)', () => {
+    const w = new SessionLogWriter(META, dir)
+    // a sourceFile in a non-existent directory → writeFileSync throws ENOENT
+    expect(() =>
+      w.start(startArgs({ sourceFile: path.join(dir, 'no', 'such', 'dir', 'x.orbs') })),
+    ).not.toThrow()
+    expect(w.getFilePath()).toBeNull() // disabled, no open session
+    expect(() => w.recordEval(ev())).not.toThrow() // subsequent evals are silently dropped
+    expect(() => w.stop(1, '1:1.0')).not.toThrow()
+    expect(fs.readdirSync(dir)).toHaveLength(0)
+  })
+
   it('every written line is valid standalone JSON (strict JSONL)', () => {
     const w = new SessionLogWriter(META, dir)
     w.recordEval(ev({ code: 'pre', wall: 0 }))

--- a/tests/session-log/session-log-writer.spec.ts
+++ b/tests/session-log/session-log-writer.spec.ts
@@ -9,6 +9,8 @@ import {
   EvalRecord,
 } from '../../packages/engine/src/core/session-log/session-log-writer'
 
+import { readOrbsLog } from './helpers'
+
 /**
  * L1 (#229) — `.orbslog` session log writer. The writer is pure I/O + buffering:
  * the caller supplies the triple stamp, so these assert the file lifecycle —
@@ -30,14 +32,7 @@ function ev(over: Partial<EvalRecord> = {}): EvalRecord {
   }
 }
 
-/** Read a written .orbslog back as parsed JSONL records. */
-function readLog(file: string): any[] {
-  return fs
-    .readFileSync(file, 'utf8')
-    .split('\n')
-    .filter((l) => l.length > 0)
-    .map((l) => JSON.parse(l))
-}
+const readLog = readOrbsLog
 
 describe('L1 — SessionLogWriter (§1/§3)', () => {
   let dir: string

--- a/tests/session-log/transport-stamp.spec.ts
+++ b/tests/session-log/transport-stamp.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { Global } from '../../packages/engine/src/core/global'
+import { MidiManager } from '../../packages/engine/src/core/global/midi-manager'
+import { MidiOutput } from '../../packages/engine/src/midi/midi-output'
+
+/**
+ * L1 (#229) — the bar:beat math behind the session-log triple stamp
+ * (`Global.getTransportPosition` / `getQuantizedEffectPosition`). Asserted by
+ * VALUE with fake timers (not just shape), so a regression in the meter-beat
+ * formula or the 1-based bar/beat indexing is caught. Spec §3.
+ */
+
+const T0 = 1_000_000
+function midiOutput(): MidiOutput {
+  return {
+    ensurePort: vi.fn((q: string) => q),
+    noteOn: vi.fn(),
+    noteOff: vi.fn(),
+    pitchBend: vi.fn(),
+    releaseOwner: vi.fn(),
+    panic: vi.fn(),
+    getActiveNotes: vi.fn(() => []),
+    listPorts: vi.fn(() => []),
+    closeAll: vi.fn(),
+  }
+}
+function mockScheduler() {
+  return {
+    isRunning: true,
+    startTime: T0,
+    getCurrentTime: () => 0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(),
+    clearSequenceEvents: vi.fn(),
+    reinitializeSequenceTracking: vi.fn(),
+    getMasterGainDb: () => 0,
+  } as never
+}
+function makeGlobal(): Global {
+  return new Global(mockScheduler(), new MidiManager(() => midiOutput()))
+}
+
+describe('L1 — transport bar:beat math (§3)', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('returns null before start() and after stop() (preamble / stopped)', () => {
+    const g = makeGlobal()
+    expect(g.getTransportPosition()).toBeNull()
+    vi.setSystemTime(T0)
+    g.start()
+    expect(g.getTransportPosition()).not.toBeNull()
+    g.stop()
+    expect(g.getTransportPosition()).toBeNull()
+  })
+
+  it('4/4 @120bpm: 3000ms after start = bar 2, beat 3.0', () => {
+    const g = makeGlobal()
+    g.tempo(120) // quarter = 500ms; 4/4 bar = 2000ms
+    vi.setSystemTime(T0)
+    g.start()
+    vi.advanceTimersByTime(3000) // 6 beats in → bar 2 (beats 5,6,7,8), beat 3
+    expect(g.getTransportPosition()).toBe('2:3.000')
+  })
+
+  it('3/4 @120bpm: 1500ms after start = bar 2, beat 1.0 (meter-beat math)', () => {
+    const g = makeGlobal()
+    g.tempo(120)
+    g.beat(3, 4) // beat unit = 500ms; bar = 1500ms
+    vi.setSystemTime(T0)
+    g.start()
+    vi.advanceTimersByTime(1500) // exactly one 3/4 bar → bar 2, beat 1.0
+    expect(g.getTransportPosition()).toBe('2:1.000')
+  })
+
+  it('getQuantizedEffectPosition resolves the next bar boundary (quantize "bar")', () => {
+    const g = makeGlobal()
+    g.tempo(120) // 4/4 bar = 2000ms
+    g.quantize('bar')
+    vi.setSystemTime(T0)
+    g.start()
+    vi.advanceTimersByTime(500) // 0.25 bar in → next "bar" boundary is bar 2 beat 1.0
+    expect(g.getQuantizedEffectPosition()).toBe('2:1.000')
+  })
+
+  it('getQuantizedEffectPosition is null when quantize is off', () => {
+    const g = makeGlobal()
+    g.quantize('off')
+    vi.setSystemTime(T0)
+    g.start()
+    vi.advanceTimersByTime(500)
+    expect(g.getQuantizedEffectPosition()).toBeNull()
+  })
+})


### PR DESCRIPTION
## 概要

評価の因果記録 `.orbslog` の書き出し層 **L1**（Issue #229 / Epic #224 / 正本 `SESSION_LOG_SPEC_v1`）。フライトレコーダー方式: 常時ローリングバッファ → `global.start()` でファイル生成 + meta + preamble 書き出し → 以降を時刻付き追記。

## 傍受点（単一）

`InterpreterV2.execute()` — 全 eval 経路（editor stdin→REPL / CLI play / 将来の replayer）が通る唯一の funnel。`options` に `source`/`sourceFile`/`evalSource` を thread。

## 三重スタンプ

`Global.getTransportPosition()`（bar:beat）/ `getQuantizedEffectPosition()`（LOOP の解決済み境界、`nextQuantizedTime` 流用＝Phase 0-2 確認済）を追加。`wall` は engine 起動からの ms（発生時スタンプ）。

## start/stop フック

`Global.start()`/`stop()` 境界にオプトインの transport フック。`global.stop()` は `transportCommands` に stop が無く method 経路を通るため、**両者が必ず通る Global 境界**でフックする設計（process-statement ではなく）。`onStop` はクロック解除前に transport を読む。

## opt-in（テスト隔離）

writer は `enableSessionLog()` を呼ぶ実エントリ（play-mode / REPL）でのみ装着。`Global`/`Sequence` を直接使うユニットテストは writer 不在＝**ファイル生成なし**（既存 1079 テスト回帰ゼロ）。

## spec の v1 スコープ確定（§3 wall 修正 + 新 §3.1）

advisor 検証 + コード確認で曖昧点を解消: wall 原点 / code 粒度 = execute() 単位 / 命名は CLI 完全・editor は untitled / effect は LOOP のみ / tempo 二重記録は follow-up。

## テスト

- writer 単体 9件（preamble flush / 三重スタンプ passthrough / 命名 / untitled / stop / 再start新ファイル / inert / strict JSONL）
- interpreter 統合 6件（preamble 完全性 / 三重スタンプ整合 / 複数ファイル sourceFile / **kill-9 行耐性** / 再start / start 前は無ファイル）
- **全体 1079 passed / 23 skipped**

## レビュー

`/simplify`（4観点）適用済（engineT0 必須化・デッド state 除去・hook 1回化・version 定数化・テストヘルパー共有）。`/code:pr-review-team` はこの後実施。

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)