### PR TITLE
chore(session-log): L1 polish — atomic log create + single-GLOBAL note (#276)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -30,9 +30,11 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 - **衝突ループの TOCTOU 解消**: `fs.writeFileSync(candidate, meta, { flag: 'wx' })`（原子的排他作成）に置換。`existsSync`→`write` の隙間競合を排し、ループも簡潔化（EEXIST→次候補、他の I/O エラーは disabled で best-effort 維持）。並列 REPL でも既存ログを無音上書きしない。
 - **単一 GLOBAL 前提を明記**: `sessionHooksInstalled` は最初の GLOBAL のみフックする旨を SESSION_LOG_SPEC §3.1 + コードコメントに明記。
 
+**バージョン整合（大和さん確定 2026-06-15）**: v1.1.1 以降 175 コミットで MIDI 出力（新ピラー）+ Pitch DSL + comp + session log が積まれた。すべて追加的（破壊なし）で厳密 semver では 1.2.0 だが、MIDI という新ピラー + 録音の世代交代として **WCTM マイルストーンを 2.0.0 とする**（製品ポジショニング判断）。`version.ts` の `ENGINE_VERSION` を `2.0.0-dev` に整合（`.orbslog` meta の engineVersion）。`DSL_VERSION` は別軸なので `1.1` 維持。package.json 群の bump + タグはリリース時に実施（現状 root 1.1.0 / engine 0.0.1 のドリフトはリリースで解消）。
+
 **deferred（v2 と判断、§7 Future Directions に記録）**:
 - preamble 無上限（素朴な oldest 破棄は init 行を失い因果記録を壊す → 正しい上限設計は v2）
-- version.ts 手動同期（monorepo + dist layout で動的読みが脆い → ビルド時注入/リリーススクリプトの領域）
+- version.ts の package.json からの**自動同期**（monorepo + dist layout で動的読みが脆い → ビルド時注入/リリーススクリプトの領域。値の整合自体は上記で実施済）
 
 **テスト**: 既存ファイルを上書きしない wx 原子性テストを追加（+1）。session-log 26件、全体 1090 passed / 23 skipped。
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,25 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.116 Issue #276 — session log L1 polish（PR #275 bot レビュー反映） (Jun 15, 2026)
+
+**Date**: 2026-06-15
+**Status**: ✅ 実装完了（chore）
+**Issue**: signalcompose/orbitscore#276 / 親 #229（#275 マージ後の follow-up）
+**Branch**: `276-session-log-l1-polish`
+
+**概要**: PR #275（L1）マージ後の claude bot レビューの軽微指摘のうち v1 ハードニング2点を反映。Critical/Important なし。
+
+**対応（v1）**:
+- **衝突ループの TOCTOU 解消**: `fs.writeFileSync(candidate, meta, { flag: 'wx' })`（原子的排他作成）に置換。`existsSync`→`write` の隙間競合を排し、ループも簡潔化（EEXIST→次候補、他の I/O エラーは disabled で best-effort 維持）。並列 REPL でも既存ログを無音上書きしない。
+- **単一 GLOBAL 前提を明記**: `sessionHooksInstalled` は最初の GLOBAL のみフックする旨を SESSION_LOG_SPEC §3.1 + コードコメントに明記。
+
+**deferred（v2 と判断、§7 Future Directions に記録）**:
+- preamble 無上限（素朴な oldest 破棄は init 行を失い因果記録を壊す → 正しい上限設計は v2）
+- version.ts 手動同期（monorepo + dist layout で動的読みが脆い → ビルド時注入/リリーススクリプトの領域）
+
+**テスト**: 既存ファイルを上書きしない wx 原子性テストを追加（+1）。session-log 26件、全体 1090 passed / 23 skipped。
+
 ### 6.115 Issue #229 — session log writer `.orbslog`（Phase 1-L1） (Jun 15, 2026)
 
 **Date**: 2026-06-15

--- a/docs/specs-v2/SESSION_LOG_SPEC_v1.html
+++ b/docs/specs-v2/SESSION_LOG_SPEC_v1.html
@@ -412,6 +412,7 @@ quantize 境界の前後 10ms
 <li><strong>命名/<code>sourceFile</code></strong>: CLI 経路は <code>.orbs</code> パスを持つので basename 命名・<code>sourceFile</code> が完全に機能する。editor 経路は現状エンジンへファイル名を渡さない(<code>setDocumentDirectory</code> はディレクトリのみ)ため v1 は <code>untitled.&lt;timestamp&gt;.orbslog</code> フォールバック。editor からのファイル名伝達(ログに混じらない制御チャネル)は follow-up。</li>
 <li><strong><code>effect</code> 範囲</strong>: v1 は <strong>LOOP 起動</strong>の解決済み境界のみ <code>nextQuantizedTime</code> で算出。走行中ループへの <code>play()</code> 差し替え・<code>tempo/beat/length</code> の次サイクル遅延は <code>effect:null</code>(follow-up)。replay は <code>transport</code> 駆動で再 quantize するため再現性に影響せず、<code>effect</code> は可読性/検証の補助に留まる。</li>
 <li><strong>tempo の二重記録</strong>: v1 は <code>start</code>/<code>stop</code> のみ <code>transport</code> レコード化。<code>tempo</code> 変更は <code>eval</code> レコードとして残す(上の例に一致)。<code>tempo</code> の <code>transport</code> 二重記録は follow-up。</li>
+<li><strong>単一 GLOBAL 前提</strong>: transport フックは最初の <code>GLOBAL</code> に一度だけ装着する。同一セッションで2つ目の <code>init GLOBAL</code> を定義・使用した場合、その global の <code>start()/stop()</code> はログに記録されない。通常 1 セッション = 1 GLOBAL のため v1 ではスコープ外(follow-up)。</li>
 </ul>
 <h2 id="replay">4. Replay</h2>
 <pre><code>orbitscore replay mypiece.20260612-2130.orbslog              # 忠実リプレイ(実時間)
@@ -459,6 +460,8 @@ LLM)の学習素材とする。形式を分けない(原則
 5)ため追加コストなし。別途議論予定。</li>
 <li><strong>セッション間 diff</strong>:
 同一曲の複数セッションの構造比較(リハーサル分析)。</li>
+<li><strong>preamble バッファの上限</strong>(#276 deferred): <code>start()</code> を呼ばず eval を延々続けると preamble が無制限に成長する。ただし「oldest を捨てる」は <code>init GLOBAL</code> 等の因果の根を失うため不可。早期 flush 等の正しい上限設計は v2。通常用途では <code>start()</code> を早期に呼ぶため実害なし。</li>
+<li><strong>version の自動同期</strong>(#276 deferred): meta ヘッダの <code>engineVersion</code> は現状 <code>version.ts</code> にハードコード。monorepo(engine パッケージ版 ≠ 製品版)+ dist layout のため動的読みは脆く、ビルド時注入/リリーススクリプトで解くべき v2 事項。</li>
 </ol>
 <h2 id="open-questions">8. Open Questions</h2>
 <ol type="1">

--- a/packages/engine/src/core/session-log/session-log-writer.ts
+++ b/packages/engine/src/core/session-log/session-log-writer.ts
@@ -125,12 +125,6 @@ export class SessionLogWriter {
       ? path.basename(s.sourceFile, path.extname(s.sourceFile))
       : 'untitled'
     const dir = s.sourceFile ? path.dirname(s.sourceFile) : this.cwd
-    // Two sessions opened within the same second collide on the timestamp; add a
-    // counter so a stop→start within one second doesn't overwrite the first file.
-    let candidate = path.join(dir, `${basename}.${s.stamp}.orbslog`)
-    for (let n = 2; fs.existsSync(candidate); n++) {
-      candidate = path.join(dir, `${basename}.${s.stamp}-${n}.orbslog`)
-    }
 
     const metaLine = JSON.stringify({
       type: 'meta',
@@ -144,16 +138,29 @@ export class SessionLogWriter {
     const buffered = this.preamble
     this.preamble = []
     this.disabled = false // a fresh session re-attempts after a prior failure
-    try {
-      // Truncate-create the file with the meta header (a fresh session per start).
-      fs.writeFileSync(candidate, metaLine + '\n')
-    } catch (e) {
-      this.disabled = true
-      this.filePath = null
-      console.warn(
-        `⚠️  session-log: failed to open ${candidate} — logging disabled (playback continues): ${e}`,
-      )
-      return
+
+    // Two sessions sharing the same second collide on the timestamp. Use an
+    // atomic exclusive create (`wx`): EEXIST → try the next `-N` name. This is
+    // race-free (no existsSync→write TOCTOU gap) so a parallel REPL cannot
+    // silently overwrite an existing session log. Any other fs error disables
+    // logging rather than breaking playback (best-effort flight recorder).
+    let candidate = path.join(dir, `${basename}.${s.stamp}.orbslog`)
+    for (let n = 2; ; n++) {
+      try {
+        fs.writeFileSync(candidate, metaLine + '\n', { flag: 'wx' })
+        break
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException)?.code === 'EEXIST') {
+          candidate = path.join(dir, `${basename}.${s.stamp}-${n}.orbslog`)
+          continue
+        }
+        this.disabled = true
+        this.filePath = null
+        console.warn(
+          `⚠️  session-log: failed to open ${candidate} — logging disabled (playback continues): ${e}`,
+        )
+        return
+      }
     }
     this.filePath = candidate
 

--- a/packages/engine/src/interpreter/interpreter-v2.ts
+++ b/packages/engine/src/interpreter/interpreter-v2.ts
@@ -164,6 +164,8 @@ export class InterpreterV2 {
     // §L1: install the session-log transport hooks on the global ONCE, when it
     // first exists. The closures read live state.currentSourceFile at fire time,
     // so a start/stop in a later eval logs against that eval's context.
+    // v1 (§3.1) assumes a SINGLE global per session — a second `init GLOBAL`
+    // would not get hooked, so its transport would go unlogged (out of v1 scope).
     if (this.state.sessionLog && this.state.currentGlobal && !this.sessionHooksInstalled) {
       this.installSessionHooks(this.state.currentGlobal)
       this.sessionHooksInstalled = true

--- a/packages/engine/src/version.ts
+++ b/packages/engine/src/version.ts
@@ -1,7 +1,17 @@
 /**
- * Engine + DSL version identity. Mirrors the root package.json `version`; used
- * for the session-log meta header (SESSION_LOG_SPEC §3) and any other place that
- * needs to stamp the running engine/DSL version. Bump alongside package.json.
+ * Engine + DSL version identity. Used for the session-log meta header
+ * (SESSION_LOG_SPEC §3) and anywhere the running engine/DSL version is stamped.
+ *
+ * v2.0.0 is the WCTM milestone: MIDI output + Pitch DSL + comping + the session
+ * log all landed since v1.1.1. The changes are additive (audio `play()` semantics
+ * preserved), but a whole new MIDI pillar + recording is a generational leap, so
+ * the milestone is cut as a major (product-positioning decision, 2026-06-15).
+ *
+ * `-dev` marks the unreleased development line; at the release, drop the suffix
+ * and bump the package.json files + tag. (Auto-sync from package.json is deferred
+ * — SESSION_LOG_SPEC §7 / #276.)
  */
-export const ENGINE_VERSION = '1.1.0'
+export const ENGINE_VERSION = '2.0.0-dev'
+
+/** DSL spec version (PITCH_DSL_SPEC) — a separate axis from the product version. */
 export const DSL_VERSION = '1.1'

--- a/tests/session-log/session-log-writer.spec.ts
+++ b/tests/session-log/session-log-writer.spec.ts
@@ -170,6 +170,17 @@ describe('L1 — SessionLogWriter (§1/§3)', () => {
     expect(fs.existsSync(path.join(dir, 'mypiece.20260614-213005.orbslog'))).toBe(true)
   })
 
+  it('never overwrites a pre-existing log of the same name (atomic exclusive create)', () => {
+    // A file already at the target name (e.g. written by a parallel REPL) must
+    // not be clobbered — start() takes the next `-N` name instead.
+    const taken = path.join(dir, 'mypiece.20260614-213005.orbslog')
+    fs.writeFileSync(taken, 'PRE-EXISTING\n')
+    const w = new SessionLogWriter(META, dir)
+    w.start(startArgs())
+    expect(w.getFilePath()).toBe(path.join(dir, 'mypiece.20260614-213005-2.orbslog'))
+    expect(fs.readFileSync(taken, 'utf8')).toBe('PRE-EXISTING\n') // untouched
+  })
+
   it('round-trips a non-human evalSource (agent / replay)', () => {
     const w = new SessionLogWriter(META, dir)
     w.start(startArgs())


### PR DESCRIPTION
## 概要

PR #275（.orbslog L1）マージ後の claude bot レビューの**非ブロッキング軽微指摘**のうち、v1 ハードニング2点を反映する follow-up（chore）。

## 対応（v1）

1. **衝突ループの TOCTOU 解消**: `fs.writeFileSync(candidate, meta, { flag: 'wx' })`（原子的排他作成）に置換。`existsSync`→`writeFileSync` の隙間で別プロセスが同名を作る競合を排除し、ループも簡潔化（`EEXIST`→次 `-N` 候補、それ以外の I/O エラーは `disabled` に落として best-effort を維持）。並列 REPL 起動でも既存ログを無音上書きしない。
2. **単一 GLOBAL 前提を明記**: `sessionHooksInstalled` は最初の `GLOBAL` のみフックする。2つ目の `init GLOBAL` の transport は記録されない旨を `SESSION_LOG_SPEC §3.1` + コードコメントに明記。

## deferred（v2 と判断、§7 Future Directions に記録）

- **preamble 無上限**: 素朴な「oldest 破棄」は `init GLOBAL` 等の因果の根を失い記録を壊す。正しい上限設計（早期 flush 等）は v2。通常用途では `start()` を早期に呼ぶため実害なし。
- **version.ts 手動同期**: monorepo（engine パッケージ版 ≠ 製品版）+ dist layout で動的読みが脆く、ビルド時注入/リリーススクリプトで解くべき v2 事項。

## テスト

既存ファイルを上書きしない wx 原子性テストを追加（+1）。session-log 26件、**全体 1090 passed / 23 skipped**。

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)