### PR TITLE
docs(user): translate VitePress MIDI pillar pages to English (#287)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,17 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.140 docs(user): VitePress MIDI ピラー6ページを英訳 (#287) (Jun 19, 2026)
+
+**Date**: 2026-06-19
+**Status**: ✅ ドキュメントのみ（`vitepress build` 緑・dead link 無し）
+**Branch**: `287-translate-midi-en`
+
+#237(PR #286) で追加した JA MIDI ピラー6ページに対し、EN スタブ（`sites/user/en/midi/` の「Translation pending」）を**実英訳に置換**。EN サイトの他10ページは翻訳済みで、かつ `en/reference/methods.md` §6 が `/en/midi/` を full documentation として参照していたため、その穴を解消。
+- 翻訳6ページ: index / pitch-dsl / mode-scale / voicing / link-audio / quantize（計 902 insertions）。sonnet agent に委譲 → main がレビュー。
+- 既存 EN（`en/reference/methods.md` §6・`en/basics/`）の用語・スタイルに整合。**DSL コード構文は不変**、コード内コメントのみ EN 化。frontmatter・`:::` admonition・内部リンク（`/midi/`→`/en/midi/`）・post-2.0 VOLATILE 警告を保持。
+- 監査済みの技術事実（gate 0–1 クランプ / `^r`=-1/0/+1 / `.open()`=close→drop2 / `.mode()`+`.root()` 併用不可 / `^N` の degree 7 例）が翻訳でも正しく保持されていることを spot-check で確認。日本語残り0行・stale `/midi/` 絶対リンク無しも検証。
+
 ### 6.139 docs(user): bot second-opinion で gate(1.2) の誤記を修正 (#237) (Jun 19, 2026)
 
 **Date**: 2026-06-19

--- a/sites/user/en/midi/index.md
+++ b/sites/user/en/midi/index.md
@@ -1,9 +1,151 @@
 ---
 title: MIDI Output
-description: Translation pending — see the Japanese version for now.
+description: How to send MIDI from OrbitScore via IAC, and how to build basic sequences
 ---
 
 # MIDI Output
 
-> **Translation pending.** A full English translation of this section is planned for a future update.
-> In the meantime, please refer to the [Japanese version](/midi/).
+In OrbitScore 2.0.0 you can send MIDI via IAC Bus. Pitch, velocity, and articulation can be delivered directly from the OrbitScore DSL to your synths and software instruments.
+
+## Setting Up IAC
+
+1. Open **Audio MIDI Setup** (Launchpad → Other → Audio MIDI Setup)
+2. In the top menu, choose **Window** → **MIDI Studio**
+3. Double-click **IAC Driver** and check **Device is online**
+4. In the DAW that should receive MIDI (e.g. Ableton Live), set the IAC Driver port as a MIDI input
+
+---
+
+## Switching a Sequence to MIDI
+
+Calling `seq.midi()` turns that sequence into a MIDI sequence. The numbers written in `play()` are interpreted as **degrees** (not slice numbers).
+
+```text
+var global = init GLOBAL
+global.tempo(120)
+global.beat(4 by 4)
+global.key("C")    // set the tonic to C
+global.start()
+
+var piano = init global.seq
+piano.midi("IAC", 1)   // send to the first port whose name contains "IAC", on ch 1
+piano.octave(4)        // degree 1 = C4 (MIDI 60)
+piano.vel(96)          // default velocity (1–127)
+piano.gate(0.8)        // default gate ratio (0.8 = 80% of one slot)
+piano.length(1)
+piano.play(1, 3, 5, 8)  // C E G C(+1 oct)
+
+LOOP(piano)
+```
+
+This example plays degrees 1, 3, 5, and 8 (degree 1 one octave up) of the C major scale.
+
+::: info Difference from audio()
+A sequence declared with `seq.midi()` becomes a MIDI sequence. You cannot use both `audio()` and `midi()` on the same sequence. However, running a MIDI sequence and an audio sequence **as separate variables** in parallel is fine.
+:::
+
+### Specifying the Port Name
+
+The first argument of `midi(portName, channel)` performs a **substring match** against the CoreMIDI output port names.
+
+- `"IAC"` → connects to the first port whose name contains "IAC"
+- If multiple ports match, the first one is used and a warning is shown
+- If no port matches, an error is raised and a list of available port names is displayed
+
+---
+
+## Basic Parameters
+
+### octave() — Base Octave
+
+`seq.octave(N)` sets "the octave that degree 1 belongs to." The default is `4` (C4 = MIDI 60).
+
+```text
+piano.octave(4)   // degree 1 = C4 (default)
+piano.octave(3)   // degree 1 = C3 (one octave lower)
+```
+
+### vel() — Velocity
+
+`seq.vel(N)` sets the default velocity for the entire sequence (1–127; default 96).
+
+```text
+piano.vel(80)    // slightly softer
+piano.vel(110)   // louder
+```
+
+### gate() — Gate Ratio
+
+`seq.gate(N)` sets the fraction of the slot duration for which the note sounds (default 0.8; clamped 0–1).
+
+| Value | Character |
+|---|---|
+| `0.3` | Staccato (short and detached) |
+| `0.8` | Standard (default) |
+| `1.0` | Sounds for the full slot (upper limit) |
+
+::: info Overlapping notes
+`gate` is clamped to 0–1, so a value like `gate(1.2)` becomes `1.0`. To overlap notes (legato), use a `{ }` legato group (see [Pitch DSL](./pitch-dsl.md)).
+:::
+
+---
+
+## global.key() — Setting the Tonic
+
+> ⚠️ **Specification as of 2.0.0 — scheduled for revision post-2.0**
+>
+> The root/key interfaces such as `global.key()` / `seq.root()` are scheduled for a design revision after the 2.0.0 release. The behavior described on this page reflects 2.0.0.
+
+`global.key("C")` sets the tonic (root note name) for the entire file. This is the reference used to resolve degree numbers in MIDI sequences.
+
+```text
+global.key("C")     // C as the root
+global.key("D")     // D as the root
+global.key("F#")    // F# as the root
+global.key("D3")    // D as the tonic, with degree 1 anchored to D3
+```
+
+Adding an octave number as in `global.key("D3")` lets you manage the register of the root note in one place (individual sequences can still override it with `seq.octave()`).
+
+---
+
+## global.midiLatency() — MIDI Latency Compensation
+
+A fixed offset for aligning the timing of SuperCollider's audio output with its MIDI output by ear.
+
+```text
+global.midiLatency(20)  // send MIDI 20 ms early (default 0)
+```
+
+---
+
+## Complete Example
+
+```text
+var global = init GLOBAL
+global.tempo(100)
+global.beat(4 by 4)
+global.key("C")
+global.start()
+
+var piano = init global.seq
+piano.midi("IAC", 1)
+piano.octave(4)
+piano.vel(90)
+piano.gate(0.7)
+piano.length(2)
+piano.play(
+  1, 0, 3, 0,   // bar 1: C · E ·
+  5, 0, 8, 0,   // bar 2: G · C(+1) ·
+)
+
+LOOP(piano)
+```
+
+---
+
+## Next Pages
+
+- Degree notation, register, and chord writing → [Pitch DSL (Degrees & Chords)](./pitch-dsl.md)
+- Modes and scales → [Modes and Scales](./mode-scale.md)
+- Audio output to Ableton Live → [LinkAudio](./link-audio.md)

--- a/sites/user/en/midi/link-audio.md
+++ b/sites/user/en/midi/link-audio.md
@@ -1,9 +1,153 @@
 ---
 title: LinkAudio (Streaming to Ableton Live)
-description: Translation pending — see the Japanese version for now.
+description: How to use global.linkAudio() and seq.output() to send OrbitScore audio directly to Ableton Live
 ---
 
 # LinkAudio (Streaming to Ableton Live)
 
-> **Translation pending.** A full English translation of this section is planned for a future update.
-> In the meantime, please refer to the [Japanese version](/midi/link-audio).
+In OrbitScore 2.0.0, **LinkAudio** lets you send audio directly to Ableton Live. Unlike IAC-based MIDI, it streams audio signals over LAN.
+
+## Prerequisites
+
+- **macOS only**
+- **Ableton Live 12.4 or later** must be running
+- **OrbitLinkAudio.scx** plugin must be installed
+- Live's session sample rate must match OrbitScore's setting (default: 48000 Hz)
+
+---
+
+## Basic Usage
+
+Declare `global.linkAudio()` once at the top of your `.orbs` file. This routes **all audio sequences** in that file through LinkAudio.
+
+```text
+var global = init GLOBAL
+global.tempo(120)
+global.beat(4 by 4)
+global.linkAudio()     // enable LinkAudio mode
+global.start()
+
+var kick = init global.seq
+kick.audio("../audio/kick.wav").output("kick")
+kick.play(1, 0, 1, 0)
+
+var snare = init global.seq
+snare.audio("../audio/snare.wav").output("snare")
+snare.play(0, 1, 0, 1)
+
+LOOP(kick, snare)
+```
+
+On the Live side:
+1. In each audio track's "Audio From" selector, choose the OrbitScore `"kick"` / `"snare"` channel
+2. Enable monitoring and start playback
+
+::: warning LinkAudio and regular audio cannot coexist
+When `global.linkAudio()` is declared, all audio sequences in that file go through LinkAudio. You cannot mix hardware output and LinkAudio in the same file.
+
+However, **MIDI sequences** (using `seq.midi()`) are not subject to this restriction. Even when `global.linkAudio()` is declared, MIDI sequences are still sent to IAC as usual.
+:::
+
+---
+
+## seq.output() — Specifying the Channel Name
+
+`seq.output("name")` sets the channel name that Live uses to receive the audio.
+
+```text
+kick.audio("kick.wav").output("kick")      // received in Live as "kick"
+snare.audio("snare.wav").output("snare")   // received in Live as "snare"
+```
+
+An audio sequence without `output()` causes a runtime error when `global.linkAudio()` is active (strict mode to prevent mixing).
+
+### Summing to the Same Channel
+
+When multiple sequences share the same channel name, they are **summed (mixed)** inside the plugin.
+
+```text
+global.linkAudio()
+
+var hat_c = init global.seq
+hat_c.audio("hihat_closed.wav").output("drums")
+hat_c.play(1, 1, 1, 0)
+
+var hat_o = init global.seq
+hat_o.audio("hihat_open.wav").output("drums")
+hat_o.play(0, 0, 0, 1)
+// both are mixed into the Live "drums" channel
+```
+
+### Combining with gain() / pan()
+
+`gain()` and `pan()` are applied to each sequence before summing.
+
+```text
+var ghost = init global.seq
+ghost.audio("snare.wav").output("drums")
+ghost.gain(-12).pan(-30)
+ghost.play(0, (0, 1), 0, (1, 0))
+```
+
+---
+
+## Setting the Sample Rate
+
+Use `global.linkAudio(SR)` to explicitly match Live's session sample rate.
+
+```text
+global.linkAudio(48000)    // 48000 Hz (this is also the default)
+global.linkAudio(44100)    // change to 44100 Hz
+```
+
+---
+
+## Tempo
+
+In OrbitScore 2.0.0, **OrbitScore acts as the Link tempo leader** (#283).
+
+- The BPM set by `global.tempo()` is pushed to all Link peers
+- Ableton Live follows that tempo
+- **Tempo changes made from Live's side are not reflected back to OrbitScore in 2.0.0**
+
+In practice, you manage tempo from OrbitScore and use Live as a follower.
+
+---
+
+## MIDI and LinkAudio Coexisting
+
+MIDI sequences and LinkAudio audio sequences can run in parallel within the same file.
+
+```text
+var global = init GLOBAL
+global.tempo(120)
+global.beat(4 by 4)
+global.key("C")
+global.linkAudio()   // audio goes through LinkAudio
+global.start()
+
+// MIDI sequence (sent to IAC — outside LinkAudio's scope)
+var piano = init global.seq
+piano.midi("IAC", 1).octave(4).vel(84)
+piano.play(1, 3, 5, 8)
+
+// audio sequence (sent to Live via LinkAudio)
+var kick = init global.seq
+kick.audio("kick.wav").output("kick")
+kick.play(1, 0, 1, 0)
+
+LOOP(piano, kick)
+```
+
+---
+
+## When OrbitLinkAudio.scx Is Not Available
+
+If the plugin is not loaded and `global.linkAudio()` is declared, OrbitScore falls back to hardware output on the first dispatch (playback) and shows a warning.
+
+---
+
+## Next Pages
+
+- Controlling loop launch timing with Launch Quantize → [Launch Quantize](./quantize.md)
+- Method reference → [Reference](../reference/methods.md)

--- a/sites/user/en/midi/mode-scale.md
+++ b/sites/user/en/midi/mode-scale.md
@@ -1,9 +1,136 @@
 ---
 title: Modes & Scales
-description: Translation pending — see the Japanese version for now.
+description: Defining custom pitch lattices with mode(), and applying them to a group with (..).mode(name)
 ---
 
 # Modes & Scales
 
-> **Translation pending.** A full English translation of this section is planned for a future update.
-> In the meantime, please refer to the [Japanese version](/midi/mode-scale).
+In OrbitScore you can define any scale (mode) with `mode()`, and create a group that uses only the pitches of that scale with `(..).mode(name)`.
+
+> ⚠️ **Specification as of 2.0.0 — scheduled for revision post-2.0**
+>
+> Root/key interfaces including `.root()` are scheduled for a design revision after the 2.0.0 release. The `mode()` feature itself is stable, but combinations with `.root()` may change in the future.
+
+---
+
+## Defining a Scale with mode()
+
+The arguments to `mode(...)` are the pitches of the scale written as degrees.
+
+```text
+var dorian = mode(1, 2, b3, 4, 5, 6, b7)   // Dorian scale
+var lydian = mode(1, 2, 3, #4, 5, 6, 7)    // Lydian scale
+var penta  = mode(1, 2, 3, 5, 6)           // Pentatonic (5-note scale)
+```
+
+Mode definitions are written as intervals from the tonic. With `global.key("C")`, Dorian becomes C Dorian (C D Eb F G A Bb).
+
+---
+
+## Applying a Mode to a Group with (..).mode(name)
+
+Apply a mode defined with `mode()` to a group using the `(..).mode(name)` form.
+
+```text
+var global = init GLOBAL
+global.tempo(110)
+global.beat(4 by 4)
+global.key("C")
+global.start()
+
+var dorian = mode(1, 2, b3, 4, 5, 6, b7)
+
+var lead = init global.seq
+lead.midi("IAC", 1)
+lead.octave(4)
+lead.length(1)
+lead.play((1, 3, 5, 7, 8, 7, 5, 3).mode(dorian))
+// In C Dorian: C Eb G Bb C Bb G Eb
+
+LOOP(lead)
+```
+
+Inside a `.mode()` group, "degree 1" is the first pitch of that mode. Because indexing follows the mode's lattice (pitch ordering), the interpretation is separate from the outside context (`global.key()`'s reference scale).
+
+### Custom Period (Microtonal, etc.)
+
+You can explicitly set the pitch range (period) of a scale (default: the next octave boundary above the scale's highest pitch).
+
+```text
+var custom = mode(1, 2, b3, 4, #5, 6, 7, 9).period(19)   // 19-semitone period
+```
+
+---
+
+## Specifying a Group's Root with .root()
+
+Adding `.root()` to a group changes the root note for that group. `seq.root()` also sets the sequence-wide default root.
+
+> ⚠️ **Specification as of 2.0.0 — scheduled for revision post-2.0**
+>
+> The `.root()` interface is scheduled for a design revision after the 2.0.0 release (possible removal of `.root()` or migration to a postfix form). The behavior described on this page reflects 2.0.0.
+
+```text
+var lead = init global.seq
+lead.midi("IAC", 1)
+lead.octave(4)
+lead.root(1)         // sequence default = degree 1 (the tonic of global.key)
+
+lead.play(
+  (1, 3, 5).root(2),    // this group resolves with degree 2 as the root
+  (1, 3, 5).root(F),    // resolve with note name F as the root (group level only)
+  (1, 3, 5),            // default (seq.root(1) = tonic C)
+  (1, 5).oct(1),        // same shape played one octave higher
+)
+```
+
+**Notes**:
+- `seq.root()` accepts **degrees only** (note names are valid at the group level only)
+- `.root()` and `.mode()` cannot both be applied to the same group
+- Groups without an explicit setting fall back to the sequence default (they do not carry over the previous group's state)
+
+---
+
+## Example: Changing the Mode per Group
+
+`.mode()` is applied at the group level. Because `.root()` and `.mode()` cannot be combined on the same group (see above), only mode switching is shown here.
+
+```text
+var global = init GLOBAL
+global.tempo(120)
+global.beat(4 by 4)
+global.key("C")
+global.start()
+
+var dorian = mode(1, 2, b3, 4, 5, 6, b7)
+
+var lead = init global.seq
+lead.midi("IAC", 1)
+lead.octave(4)
+lead.root(1)
+
+// apply dorian per group (no annotation = sequence default)
+lead.play(
+  (1, 3, 5, 7).mode(dorian),   // C Dorian
+  (1, 3, 5, 7),                // no annotation → sequence default (major)
+  (1, 3, 5, 7).mode(dorian),   // C Dorian again
+)
+
+LOOP(lead)
+```
+
+When you want to move the root without changing the mode, use a group with `.root(n)` only (the mode stays at the sequence default):
+
+```text
+lead.play(
+  (1, 3, 5),          // C (seq.root(1))
+  (1, 3, 5).root(2),  // root moves to D
+  (1, 3, 5).root(5),  // root moves to G
+)
+```
+
+---
+
+## Next Page
+
+- Voicing operators, randomness, voice leading → [Voicing & Voice Leading](./voicing.md)

--- a/sites/user/en/midi/pitch-dsl.md
+++ b/sites/user/en/midi/pitch-dsl.md
@@ -1,9 +1,211 @@
 ---
 title: Pitch DSL (Degrees & Chords)
-description: Translation pending — see the Japanese version for now.
+description: Degree notation, chord stacks, octave shifts, pattern variables, and repetition
 ---
 
 # Pitch DSL (Degrees & Chords)
 
-> **Translation pending.** A full English translation of this section is planned for a future update.
-> In the meantime, please refer to the [Japanese version](/midi/pitch-dsl).
+In a MIDI sequence, `play()` takes **degrees** instead of slice numbers. A degree is a number that expresses an interval from the tonic (root note). For example, with `global.key("C")`, degree `1` is C and degree `3` is E.
+
+## Basic Degree Notation
+
+```text
+var global = init GLOBAL
+global.tempo(120)
+global.beat(4 by 4)
+global.key("C")
+global.start()
+
+var piano = init global.seq
+piano.midi("IAC", 1)
+piano.octave(4)
+piano.vel(96)
+piano.length(1)
+piano.play(1, 3, 5, 1)   // C4 E4 G4 C4
+
+LOOP(piano)
+```
+
+Valid degrees are **1–9, 11, 13**. 10, 12, and 14 or higher are not allowed (use the `^N` notation below to change the octave).
+
+| Degree | Note in C major |
+|---|---|
+| `1` | C |
+| `2` | D |
+| `3` | E |
+| `4` | F |
+| `5` | G |
+| `6` | A |
+| `7` | B |
+| `8` | C (same as degree 1 one octave up) |
+| `9` | D (a major ninth above degree 1) |
+| `0` | Rest |
+
+### Accidentals
+
+Flat `b` and sharp `#` can be prepended to a degree.
+
+```text
+piano.play(1, b3, 5, b7)   // minor 3rd and minor 7th (minor-7th chord tones)
+piano.play(1, 3, #5, 7)    // augmented 5th
+```
+
+---
+
+## `^N` — Octave Shift (Sticky)
+
+Appending `^N` to a note shifts it N octaves up (or down). The shift **persists (sticky)**, so it carries over to subsequent notes.
+
+```text
+piano.play(1, 3, 5^+1, 7)
+// 1=C4, 3=E4, 5^+1=G5 (+1 oct), 7=B5 (the prior ^+1 persists)
+```
+
+Write `^0` to return to the base register.
+
+```text
+piano.play(1^+1, 3, 5, 1^0, 3, 5)
+// 1^+1=C5, 3=E5, 5=G5, 1^0=C4 (^0 resets), 3=E4, 5=G4
+```
+
+Use a minus sign to shift downward.
+
+```text
+piano.play(1^-1, 3^-1, 5^-1)   // one octave lower
+```
+
+---
+
+## `[ ]` — Chord Stack (Simultaneous Notes)
+
+Writing multiple degrees inside `[ ]` sounds a **chord** on that beat.
+
+```text
+piano.play([1, 3, 5])         // C triad (C E G)
+piano.play([1, 3, 5, 7])      // Cmaj7 chord
+piano.play([1, b3, 5, b7])    // Cm7 chord
+```
+
+You can line up multiple chords to create a chord progression.
+
+```text
+piano.play([1, 3, 5], [5, 7, 2], [6, 8, 3], [4, 6, 8])
+// C triad → G triad → Am → F
+```
+
+### Storing Chords in Variables
+
+Frequently used chords can be stored in variables for reuse.
+
+```text
+var m7 = [1, b3, 5, b7]     // minor 7th chord
+
+piano.play(m7, 0, m7, 0)    // Cm7 · Cm7 ·
+```
+
+Chord variables use `[ ]` notation, making them "vertical (simultaneous) values." They are distinct from `( )` pattern variables (described below).
+
+### Spread, Adding, and Removing Notes
+
+```text
+var m7    = [1, b3, 5, b7]
+var m7add9 = [m7, 9]         // add a 9th to m7
+var m7omit5 = [m7, -5]       // remove the 5th from m7
+```
+
+### Stdlib Chords
+
+```text
+import chords
+
+piano.play(maj7, m7, dom7)   // Cmaj7, Cm7, C7
+```
+
+`import chords` makes the standard library's predefined chords available (`m7`, `maj7`, `dom7`, `m7b5`, `dim7`, `sus4`, etc.).
+
+---
+
+## `*n` — Repetition
+
+Appending `*n` places that element **n slots** in a row.
+
+```text
+var riff = (1, 5, 8, 5)
+
+bass.play(riff*2)   // riff repeated twice (4 slots × 2 = 8 slots)
+```
+
+::: warning Different from Tidal's `*`
+In OrbitScore, `*n` **occupies n slots** (equivalent to Tidal's `!`). It is not Tidal's `*n` (subdividing one slot into n equal parts). To repeat inside one slot, use nesting such as `(1, 1)`.
+:::
+
+---
+
+## Pattern Variables and Section Variables
+
+Wrapping a pattern in `( )` and assigning it to a variable lets you reuse it to build up the structure of a piece.
+
+```text
+var riff = (1, 5, 8, 5)          // pattern variable (1 cell)
+var sec  = (1, 3, 5), (5, 3, 1)  // section variable (comma-separated = 2 cells)
+
+bass.play(riff*2)                // repeat riff twice
+lead.play(sec, sec)              // lay out the 2 cells of sec twice (e.g. AABA form)
+```
+
+Using variables lets you organize each section (A, B, C, etc.) of a piece cleanly.
+
+::: tip When variables are evaluated
+Variables are expanded when `play()` is evaluated. Redefining a variable does not affect a pattern that is already running. To change the pattern, execute `play()` again.
+:::
+
+---
+
+## `{ }` — Legato (Slur) Group
+
+Notes enclosed in `{ }` overlap slightly with the next note (slur effect).
+
+```text
+piano.play({1, 3, 5, 8})   // 4 notes connected smoothly
+```
+
+---
+
+## `_` — Tie (Extend a Note)
+
+A standalone `_` extends the previous note by one slot (no retrigger).
+
+```text
+piano.play(1, _, 3)   // hold 1 for 2 slots, then 3
+```
+
+To extend an entire chord stack, place `_` immediately after the chord.
+
+```text
+piano.play([1, 3, 5], _)   // hold the C triad for 2 slots
+```
+
+---
+
+## `@v` and `@g` — Per-Note Expression
+
+Use `@v` and `@g` modifiers to vary velocity or gate on individual notes.
+
+```text
+piano.play(5@v110, 3@v60, 1@v80)   // absolute velocity per note
+piano.play(5@v+20, 1@v-10)         // relative to the sequence's vel()
+piano.play(5@g30, 1@g100)          // gate as a percentage (30 = 0.30 = staccato)
+```
+
+`@v` and `@g` can be combined.
+
+```text
+piano.play(5@v110@g30)   // loud + staccato
+```
+
+---
+
+## Next Pages
+
+- Modes and scales → [Modes and Scales](./mode-scale.md)
+- Voicing operators, randomness, voice leading → [Voicing & Voice Leading](./voicing.md)

--- a/sites/user/en/midi/quantize.md
+++ b/sites/user/en/midi/quantize.md
@@ -1,9 +1,97 @@
 ---
 title: Launch Quantize
-description: Translation pending — see the Japanese version for now.
+description: Using global.quantize() and seq.quantize() to align LOOP launch timing to a grid
 ---
 
 # Launch Quantize
 
-> **Translation pending.** A full English translation of this section is planned for a future update.
-> In the meantime, please refer to the [Japanese version](/midi/quantize).
+When switching between sequences during live coding, loops that start at arbitrary moments sound musically unaligned. **Launch Quantize** holds a `LOOP()` launch or a `play()` swap until the next bar boundary, locking it to the grid.
+
+---
+
+## global.quantize() — Global Setting
+
+```text
+global.quantize("bar")   // default — wait until the next bar boundary before launching
+global.quantize("beat")  // align to every beat
+global.quantize("2bar")  // accept only every 2 bars
+global.quantize("4bar")  // every 4 bars
+global.quantize("8bar")  // every 8 bars
+global.quantize("off")   // immediate execution (for a raw, live feel)
+```
+
+The default is `"bar"` (wait one bar). The behavior mirrors Ableton Live's Global Quantization setting.
+
+---
+
+## seq.quantize() — Per-Sequence Setting
+
+Use `seq.quantize()` when you want a specific sequence to move on a different grid. Sequences without an explicit setting inherit the global value.
+
+```text
+global.quantize("bar")    // default: 1-bar wait
+
+var fill = init global.seq
+fill.quantize("off")      // this sequence launches immediately (for drops and fills)
+
+var chord = init global.seq
+chord.quantize("4bar")    // this sequence launches on a 4-bar grid
+```
+
+---
+
+## What Is and Is Not Affected
+
+| Operation | Quantize applies? |
+|---|---|
+| New `LOOP()` launch | ✅ Yes (waits for grid) |
+| `play()` swap inside a LOOP | ✅ Yes (waits for grid) |
+| `RUN()` | ❌ No (**always immediate**) |
+| `gain()` / `pan()` inside a LOOP | ❌ No (always immediate) |
+| `audio()` / `chop()` inside a LOOP | ❌ No (always immediate) |
+
+::: info RUN() is not affected by Quantize
+`RUN()` is a one-shot (plays once), so it always executes immediately. Use `RUN()` when you want to fire a fill on the spot.
+:::
+
+---
+
+## Usage Example
+
+```text
+var global = init GLOBAL
+global.tempo(120)
+global.beat(4 by 4)
+global.quantize("bar")   // align everything to a 1-bar grid
+global.start()
+
+var kick = init global.seq
+kick.audio("kick.wav")
+kick.play(1, 0, 1, 0)
+
+var snare = init global.seq
+snare.audio("snare.wav")
+snare.play(0, 1, 0, 1)
+
+// LOOP launches — will start on the next bar boundary
+LOOP(kick, snare)
+
+// play() swap also waits for the next bar boundary
+kick.play(1, 1, 0, 0)
+
+// fire a fill immediately
+RUN(kick)
+```
+
+---
+
+## Combining with Polymeter
+
+The quantize grid is determined by the global `beat()` × `tempo()`. Sequences with their own time signature (e.g. `seq.beat(5 by 4)`) still use the global bar boundary as their launch reference.
+
+---
+
+## Next Pages
+
+- Method reference → [Reference](../reference/methods.md)
+- Troubleshooting → [Troubleshooting](../troubleshooting.md)

--- a/sites/user/en/midi/voicing.md
+++ b/sites/user/en/midi/voicing.md
@@ -1,9 +1,190 @@
 ---
 title: Voicing & Voice Leading
-description: Translation pending — see the Japanese version for now.
+description: Voicing operators that reshape chord positions, adding randomness, smooth voice leading, and the comp rhythm feature
 ---
 
 # Voicing & Voice Leading
 
-> **Translation pending.** A full English translation of this section is planned for a future update.
-> In the meantime, please refer to the [Japanese version](/midi/voicing).
+Writing a chord alone places all voices in a tight, close-position arrangement. Voicing operators let you express common chord voicings — drop 2, inversions, and more — directly in the DSL. You can then use `.voicelead()` to smooth out voice motion, and `.comp()` to add a jazz comping rhythm.
+
+---
+
+## Voicing Operators
+
+Voicing operators are used as method chains on chord values (`[ ]`). All computations are **deterministic and evaluated at run time** — they do not change between loops.
+
+```text
+import chords
+
+var piano = init global.seq
+piano.midi("IAC", 1)
+piano.octave(4)
+piano.length(1)
+
+piano.play(
+  [1, 3, 5, 7].drop(2),      // Drop 2 (lower the 2nd-from-top voice by one octave)
+  [1, 3, 5, 7].drop(2, 4),   // Drop 2 & 4
+  [1, 3, 5, 7].invert(2),    // Raise the bottom 2 voices by one octave (2nd inversion)
+  maj7.open(),               // Open position
+)
+```
+
+### Operator Reference
+
+| Notation | Effect |
+|---|---|
+| `.drop(n)` | Lower the Nth voice from the top by one octave (Drop 2, etc.) |
+| `.drop(n, m)` | Drop multiple voices (Drop 2 & 4) |
+| `.invert(n)` | Raise the bottom N voices by one octave (inversion) |
+| `.open()` | Close then lower the 2nd-from-top voice by one octave (Drop 2 / open position) |
+| `.close()` | Close position |
+| `.shell()` | Root + 3rd + 7th only (5th omitted — shell voicing) |
+| `.rootless()` | Remove the root (degree 1) |
+
+::: tip Counting "the Nth from the top"
+Voices are counted downward in the order they are written. For `[1, 3, 5, 7]`: position 1 = 7th, position 2 = 5th, position 3 = 3rd, position 4 = root (descending by written order).
+:::
+
+---
+
+## Randomness
+
+The DSL provides three kinds of randomness. All are **re-rolled each cycle** (they change on every loop pass).
+
+### `Xr` — Randomly Sound a Note
+
+```text
+piano.play(1, 3r, 5, 8)   // degree 3 sounds on ~50% of cycles
+```
+
+### `.r` — Chord Thinning
+
+```text
+piano.play([1, 3, 5, 7].r)   // each voice sounds on ~50% of cycles
+                              // all voices can drop out (minimum voice count is not guaranteed)
+```
+
+### `^r` — Random Octave (-1/0/+1)
+
+```text
+piano.play(1, 3, 5^r, 8)    // degree 5 shifts randomly by -1, 0, or +1 octave each cycle (0 = no shift)
+```
+
+::: info Reproducibility
+`.orbslog` (the session log) records execution, but randomness is re-rolled on playback (no fixed seed). In 2.0.0, the session log is off by default (opt-in: `ORBITSCORE_SESSION_LOG=1`).
+:::
+
+---
+
+## `.voicelead()` — Automatic Voice Leading
+
+Adjusts the octave placement between successive chord stacks so that each voice moves by the smallest interval possible.
+
+```text
+var lead = init global.seq
+lead.midi("IAC", 1)
+lead.octave(4)
+lead.length(1)
+
+lead.play(([1, 3, 5], [5, 7, 2], [6, 8, 3], [4, 6, 8]).voicelead())
+// each chord's voices move smoothly to the nearest pitch rather than leaping
+
+LOOP(lead)
+```
+
+`seq.voicelead()` applies voice leading as the sequence default (alias: `seq.vl()`).
+
+```text
+lead.voicelead()
+lead.play([1, 3, 5], [5, 7, 2])   // automatically voice-led
+```
+
+**Behavior**:
+- Deterministic (does not change cycle to cycle). Computed once on first execution
+- The first chord stays exactly as written; subsequent chords move toward the nearest available position
+- Pitch classes (note names) are never changed — only octave choices are adjusted
+- When chords have different voice counts, voice leading is applied to the extent possible
+
+---
+
+## `.comp()` — Comp Rhythm
+
+`.comp()` expands each chord into a rhythmic pattern called a "comping cell." Pass chords as a chord progression: one chord equals one bar of expansion.
+
+```text
+var piano = init global.seq
+piano.midi("IAC", 2)
+piano.octave(4)
+piano.cell("charleston").comp([1, 3, 5], [5, 7, 2])
+// 2 chords → 2 bars (length is set to 2 automatically)
+```
+
+### Cell Types
+
+| Cell name | Rhythmic character |
+|---|---|
+| `"charleston"` | Charleston (default) — classic off-beat pattern in 8 subdivisions |
+| `"quarters"` | Quarter-note based |
+| `"twofour"` | Beats 2 and 4 |
+| `"redgarland"` | Red Garland-style |
+| `"offbeats"` | Off-beat heavy |
+
+The default is `"charleston"`. Omitting the cell also uses charleston.
+
+```text
+piano.comp([1, 3, 5])              // default (charleston)
+piano.cell("quarters").comp([1, 3, 5])   // quarters cell
+```
+
+### density() — Random Comp by Density
+
+Instead of a cell, you can place onsets at a specified density on an eighth-note grid.
+
+```text
+piano.density(0.6).comp([1, 3, 5])   // place attacks on ~60% of eighth-note positions
+piano.density(0)                      // all attacks removed (laying out)
+```
+
+### Combining with .voicelead()
+
+`.comp()` and `.voicelead()` can be used together.
+
+```text
+piano.cell("charleston").comp([1, 3, 5], [5, 7, 2]).voicelead()
+```
+
+---
+
+## Complete Example
+
+```text
+var global = init GLOBAL
+global.tempo(120)
+global.beat(4 by 4)
+global.key("C")
+
+import chords
+
+// chord progression with voice leading
+var lead = init global.seq
+lead.midi("IAC", 1)
+lead.octave(4)
+lead.length(1)
+lead.play(([1, 3, 5], [5, 7, 2], [6, 8, 3], [4, 6, 8]).voicelead())
+
+// charleston comp (2 bars)
+var piano = init global.seq
+piano.midi("IAC", 2)
+piano.octave(4)
+piano.cell("charleston").comp([1, 3, 5], [5, 7, 2])
+
+global.start()
+RUN(lead, piano)
+```
+
+---
+
+## Next Pages
+
+- Audio output to Ableton Live (LinkAudio) → [LinkAudio](./link-audio.md)
+- Method reference → [Reference](../reference/methods.md)


### PR DESCRIPTION
## 概要

#237（PR #286）で VitePress user site に追加した **JA MIDI ピラー6ページ**の英訳。`sites/user/en/midi/` の「Translation pending」スタブを実英訳に置換する。

## 背景

EN サイトは他10ページが翻訳済みで、さらに `en/reference/methods.md` §6 が「full documentation は `/en/midi/` 参照」とリンクしていたが、そのリンク先がプレースホルダだった。この穴を解消する。

## 変更内容

`sites/user/en/midi/` の6ページを実英訳（計 +902 行）:
- `index.md`（MIDI 出力 / IAC）
- `pitch-dsl.md`（度数・コード・`^N`・`{ }`・`@v`/`@g`）
- `mode-scale.md`（mode ラティス・グループ適用・root スコープ）
- `voicing.md`（drop/invert/open/close/shell/rootless・ランダム・voicelead・comp）
- `link-audio.md`（LinkAudio）
- `quantize.md`（Launch Quantize）

## 方針・品質

- 翻訳は sonnet agent に委譲 → main がレビュー。
- 既存 EN（`en/reference/methods.md` §6・`en/basics/`）の**用語・スタイルに整合**。
- **DSL コード構文は不変**（コード内コメントのみ EN 化）。frontmatter・`:::` admonition・内部リンク（`/midi/`→`/en/midi/`）・post-2.0 VOLATILE 警告を保持。
- #237 の正確性監査で修正済みの技術事実（gate 0–1 クランプ / `^r`=-1/0/+1 / `.open()`=close→drop2 / `.mode()`+`.root()` 併用不可 / `^N` の degree 7 例）が翻訳でも正しく保持されていることを spot-check で確認。

## 検証

- `vitepress build`（user site）: 成功・dead link 無し。
- 日本語残り 0 行・stale `/midi/` 絶対リンク無しを検証。
- コード/ロジック変更なし（ドキュメントのみ）。

## 品質ゲート

docs-only（コード変更なし）のため `/simplify`・`/code:pr-review-team` は N/A。希望があれば回す。

Closes #287