### PR TITLE
docs(post-2.0): correct roadmap to engine-first (supersede OrbitStudio-first framing)

### DIFF
--- a/docs/development/POST_2.0_ENGINE_AND_DISTRIBUTION.md
+++ b/docs/development/POST_2.0_ENGINE_AND_DISTRIBUTION.md
@@ -1,6 +1,6 @@
 # Post-2.0 エンジン方針 + ライセンス/配布/収益モデル
 
-> **ステータス: 方向収束 + 次フェーズ・アーキ確定。post-2.0。2026-06-19 engine=Rust 決定 / 2026-06-21（Issue #298）楽器配置・fault・egress 確定 + ロードマップを「土台2本→改良層」に再優先順位化（§2.5）。** A0+S1+S1b（PR #294）+S2（PR #297）実装済。**土台 = ① VSCodium化（OrbitStudio・最初の /goal = 2.0.0 parity・先決）+ ② ネイティブエンジン（α #300〜）／ 改良層（β audio DSL⊇pitch・audio 機能）は土台の後**。`docs/research/NATIVE_ENGINE_TRACKTION_VSCODIUM.md`（Tracktion feasibility）の Tracktion 寄り結論を**本書が更新**する。
+> **ステータス: 方向収束 + 次フェーズ・アーキ確定。post-2.0。2026-06-19 engine=Rust 決定 / 2026-06-21（Issue #298）楽器配置・fault・egress 確定 + ロードマップを **engine-first** に確定（§2.5・#302）。** A0+S1+S1b（PR #294）+S2（PR #297）実装済。**engine-first**: ① native エンジンを `ORBITSCORE_ENGINE=rust` opt-in の裏で育て .vsix で dog-food → cutover #108 → ② **OrbitStudio(VSCodium) を native の上で**（scsynth 載せない・CLI+Claude 拡張必須）→ 改良層（β audio DSL⊇pitch・audio 機能）は後。**最初の `/goal` = engine 第1増分（pan/slice/per-slice gain + α・#300 系）**。`docs/research/NATIVE_ENGINE_TRACKTION_VSCODIUM.md` の Tracktion 寄り結論を**本書が更新**する。
 
 ---
 
@@ -58,13 +58,15 @@
   - **LinkAudio** は **非 DAW / inter-app 補助**（live rig 同期等）に位置づけ降格（便利だが運用が重い）。
 - **設計制約**: **engine を clean に埋め込み可能に保つ（daemon/engine ↔ editor の分離を崩さない）** — b2 の feasibility を担保する。今すぐ作る話ではなく「壊さない」制約。
 
-### 2.5 ロードマップ（2026-06-21 owner 再優先順位化 = 土台2本 → 改良層）
-**今後の様々な改良が載る土台は2本: ① VSCodium化（OrbitStudio）+ ② ネイティブ音声エンジン。** DSL 拡張・audio 機能は**土台が成ってから**（今の `.orbs` DSL は表現力として充分・急がない・やる時はそれに集中する）。
+### 2.5 ロードマップ（2026-06-21 確定・**engine-first**）
+**土台は ① ネイティブ音声エンジン + ② VSCodium化（OrbitStudio）の2本だが、順序は engine-first**（OrbitStudio は native エンジンの上で動かし、**scsynth は載せない**）。DSL 拡張・audio 機能は土台の後（今の `.orbs` DSL は表現力として充分・急がない・やる時はそれに集中する）。
 
-- **土台① OrbitStudio（VSCodium）→ 2.0.0 parity（近期 focus・先決）**: 既存 SC スタックで動くアプリを VSCodium で（Track B / B1 rebrand rebuild）。**engine 非依存**（2.0.0 は SC 既定）なので ② と別コードベース＝並行可だが、focus は ① に置く。
-- **土台② ネイティブ音声エンジン（Rust）**: S1/S2 済 → **α recovery floor（fault ①・issue #300）** → 成熟（**γ out-of-process sandbox（fault ②・3rd-party + effects）** → **δ 3rd-party VST3/AU** → 既定 cutover #108）。
+- **① native エンジンを opt-in の裏で育てる**: `ORBITSCORE_ENGINE=rust` opt-in（S2 で配線済）の裏で育て、**今の .vsix で dog-food**（scsynth 同梱なし・OrbitStudio 非依存・**throwaway ゼロ**）。engine の Studio 向け範囲 = **サンプラー(in-process) + plugin host(effects)**・**scsynth 同等ではない**。
+  - **第1増分（最初の `/goal`・issue #300 系）**: S2-defer の **pan / slice / per-slice gain** を埋める + **α recovery floor（fault ①）**。
+  - 後続増分: **time-stretch** / **LinkAudio（A4）** / **γ out-of-process sandbox（fault ②・effects + 3rd-party）** / **δ 3rd-party VST3/AU** → **cutover #108（default 切替・scsynth 退役）**。
+- **② OrbitStudio（VSCodium）を native エンジンの上で（cutover 後）**: scsynth は載せない・**CLI + Claude 拡張が動く**こと必須。engine 非依存な殻（VSCodium リブランド / node ランタイム / 署名 CI）は再利用可で並行着手も可だが、audio が使えるのは engine 後。
 - **改良層（土台の後・集中して）**: **β audio DSL ⊇ pitch DSL（+ #213 `fixpitch()`/`time()`・in-process・C1 pitch spec 先行が前提）** / audio 機能（slice #239 / audio `[ ]` #238）。
-- **旧版（α→β→γ→δ 一直線）からの変更**: **VSCodium を土台として前倒し**（master plan の「Track B は engine の後（A1–A2 後）」を撤回）/ **β を改良層へ後置**（engine 土台が成る後）。fault と features-as-plugin の分離性は維持（staging の自由度）。
+- **収束の経緯（#302）**: 一時「土台2本・OrbitStudio 先・2.0.0 parity on scsynth」と整理したが、「最終的に native が乗るのに scsynth を Studio に同梱する工数は無駄」（owner）+ opt-in dog-food で「使える」と「無駄ゼロ」が両立するため **engine-first に収束**（master plan 本来の方針）。アーキ §2.1–2.4 は不変。
 
 ### 2.6 売り物化 = DSP を共有 crate に
 - stretch / sampler DSP を再利用可能 crate にし、**engine ノード（DSL 駆動・in-process）**と、任意の **standalone サンプラー製品（MIDI/標準駆動・他 DAW・単体販売）**の2フロントエンドで共有。engine を plugin 境界に通さずに製品も作れる。1st-party プラグイン shell = **nih-plug（Rust・ISC・CLAP+VST3 を1コードベース）**。
@@ -102,17 +104,15 @@
 - **pitch/song 再設計はアプリ優先**、必要なら `.vsix` に backport（VS Code 利用者カバーは二次目標）。
 - 命名: **OrbitScore = 言語（拡張でもアプリでも中で生きる）/ OrbitStudio = 専用アプリ（候補名）**。移調は `transpose()`（`transport` は再生ヘッド連想で不可）。
 
-## 7. 次の一手（スパイク完了 → 土台2本 → 改良層・§2.5 と同一）
+## 7. 次の一手（スパイク完了 → engine-first・§2.5 と同一）
 
 **完了**: feasibility research（`docs/research/RUST_PLUGIN_HOSTING.md`）→ **A0+S1+S1b（PR #294）= CLAP hosting が RT 安全に成立**（in-process clack-host）→ **S2（PR #297）= daemon dispatch seam parity**。詳細 `POST_2.0_A0_RT_INTEGRATION_DESIGN.md`。
 
-**土台層（先に作る・両方が改良の土台）**:
-- **① OrbitStudio（VSCodium）→ 2.0.0 parity（近期 focus・先決・最初の `/goal`・issue #301）** — 既存 SC スタックで動くアプリを VSCodium で（Track B / B1 rebrand rebuild）。engine 非依存。未確証 = VSCodium で既存 .vsix/extension を動かす形 / VST GUI の Electron 共存（着手時に feasibility）。
-- **② ネイティブ音声エンジン（Rust）** — ①と並行可（別コードベース）。S1/S2 済 →
-  - **α recovery floor（fault ①・issue #300）** — daemon supervision + auto-respawn + 最小 recovery contract（接続再確立 + active loops 復帰 / 可聴ギャップ許容 / one-shot drop / transport 再 anchor）。Done = fault-injection kill-test（kill -9 + 故意 segfault プラグイン〔S1b misbehave synth 拡張・再利用〕で liveness + 復旧後 correctness〔transport desync・orphaned play_id 無し〕）+ 既存テスト全緑 / SC 既定無改変。
-  - **γ out-of-process sandbox（fault ②）** — 3rd-party + effects 隔離。shared-mem audio / RT-safe event IPC / watchdog→respawn / +~1 block latency。**最大の未構築サブシステム**。
-  - **δ 3rd-party VST3/AU** — 成熟度順（AU `objc2-avf-audio` / VST3 `vst3` crate MIT・工数最大）。
-  - 既定 cutover（#108・Rust を default audio backend に）。
+**① native エンジンを `ORBITSCORE_ENGINE=rust` opt-in の裏で育てる（今の .vsix で dog-food・scsynth 同梱なし・throwaway ゼロ）**:
+- **第1増分（最初の `/goal`・issue #300 系）** — S2-defer の **pan（daemon 実装）/ slice / per-slice gain** を埋める + **α recovery floor（fault ①）**: daemon supervision + auto-respawn + 最小 recovery contract（接続再確立 + active loops 復帰 / 可聴ギャップ許容 / one-shot drop / transport 再 anchor）。Done = opt-in で現行 .orbs audio が SC 同等に鳴る + **α kill-test**（kill -9 + 故意 segfault プラグイン〔S1b misbehave synth 拡張・再利用〕で liveness + 復旧後 correctness〔transport desync・orphaned play_id 無し〕）+ 既存テスト全緑 / SC 既定無改変。
+- **後続増分**: **time-stretch（Signalsmith）** / **LinkAudio（A4・Rust 隔離 GPL）** / **γ out-of-process sandbox（fault ②・effects + 3rd-party・shared-mem audio / RT-safe event IPC / watchdog）** / **δ 3rd-party VST3/AU** → **cutover #108（Rust を default backend に・scsynth 退役）**。
+
+**② OrbitStudio（VSCodium）を native エンジンの上で（cutover 後・issue #301）**: scsynth は載せない・**CLI + Claude 拡張が動く**こと必須。engine 非依存な殻（VSCodium リブランド / node ランタイム + `@julusian/midi` ABI / 署名 CI）は再利用可で並行着手も可だが、audio が使えるのは engine 後。
 
 **改良層（土台の後・集中して）**:
 - **β audio DSL ⊇ pitch DSL** — `#213 fixpitch()/time()`（今 stub）含む。in-process・S1 基盤。**C1 pitch モデル spec 先行が前提**（pitch を audio の真部分集合に）。

--- a/docs/development/POST_2.0_MASTER_PLAN.html
+++ b/docs/development/POST_2.0_MASTER_PLAN.html
@@ -79,12 +79,12 @@
   <h2>▶ Start here（新規セッションの起点）</h2>
   <div class="callout c-warn">
     <span class="lbl">2026-06-21 UPDATE（Issue #298）— スパイク完了 + 次フェーズ・アーキ確定 + ロードマップ再優先順位化</span>
-    <strong>A0 + S1 + S1b（PR #294）+ S2（PR #297）は MERGED 済</strong>（CLAP hosting が in-process で RT 安全に成立 + daemon dispatch seam parity）。アーキ確定: <strong>楽器（サンプラー/audio DSL）= in-process（crown jewel）／ effects + 3rd-party = out-of-process sandboxed plugin ／ audio DSL ⊇ pitch DSL ／ egress は楽器でなく音を出す（薄い bridge プラグイン b1 主案）</strong>。<strong>ロードマップ = 土台2本 → 改良層</strong>: 土台 = <strong>① VSCodium化（OrbitStudio・2.0.0 parity が先決・最初の /goal）+ ② ネイティブ音声エンジン（α recovery floor #300 → γ sandbox → δ 3rd-party → cutover）</strong>、改良層（土台の後・集中して）= <strong>β audio DSL⊇pitch（+#213）/ audio 機能（slice/stretch）</strong>。詳細の正本 = <code>POST_2.0_ENGINE_AND_DISTRIBUTION.md §2.5</code>。
+    <strong>A0 + S1 + S1b（PR #294）+ S2（PR #297）は MERGED 済</strong>（CLAP hosting が in-process で RT 安全に成立 + daemon dispatch seam parity）。アーキ確定: <strong>楽器（サンプラー/audio DSL）= in-process（crown jewel）／ effects + 3rd-party = out-of-process sandboxed plugin ／ audio DSL ⊇ pitch DSL ／ egress は楽器でなく音を出す（薄い bridge プラグイン b1 主案）</strong>。<strong>ロードマップ = engine-first</strong>（#302・振り子収束）: ① **native エンジンを <code>ORBITSCORE_ENGINE=rust</code> opt-in の裏で育て .vsix で dog-food**（scsynth 同梱なし・throwaway ゼロ）→ **cutover #108** → ② **OrbitStudio(VSCodium) を native の上で**（scsynth 載せない・CLI+Claude 拡張必須）→ 改良層 = <strong>β audio DSL⊇pitch（+#213）/ audio 機能（slice/stretch）</strong>は後。**最初の /goal = engine 第1増分（pan/slice/per-slice gain + α・#300 系）**。詳細の正本 = <code>POST_2.0_ENGINE_AND_DISTRIBUTION.md §2.5</code>。
   </div>
   <ol>
     <li><strong>必読を順に読む</strong>（下記「必読」）。本書は探索ノートを<em>実行可能な形</em>に変換した入口であり、決定の正本はノート側。</li>
     <li><strong>唯一の不変条件</strong>を頭に入れる → <em>permissive ライセンス規律</em>（§1）。これを破ると freemium 戦略が崩れる。</li>
-    <li><strong>最初の1手</strong>: A0/S1/S1b/S2 は<strong>完了済</strong>。次の `/goal` = <span class="spine">① OrbitStudio 2.0.0 parity（VSCodium 土台・先決）</span>。engine 土台（α #300〜）は並行可、β/機能は土台の後（§3 / §2.5）。</li>
+    <li><strong>最初の1手</strong>: A0/S1/S1b/S2 は<strong>完了済</strong>。次の `/goal` = <span class="spine">engine 第1増分（pan/slice/per-slice gain + α recovery・#300 系）</span>。native を opt-in 裏で育て .vsix で dog-food → cutover #108 → OrbitStudio on native（§3 / §2.5）。</li>
     <li>確定済み決定（§6）は<strong>再議論しない</strong>。より良い代替案は実装せず提案として報告に含める。</li>
   </ol>
   <p class="small" style="color:#9da7b3">本書は engine-first の土台トラック。締切なし。WCTM（Epic #224・締切 2026-08-07）は<strong>並行する別トラック</strong>で、post-2.0 はその時間を侵食しない。</p>
@@ -120,16 +120,16 @@
 <h2 id="spine">§2. 依存スパイン（何が何を待つか）</h2>
 <p>3 トラックの依存関係。<strong>engine（A）が最も多くを gate し、最も未知が大きい</strong>。pitch/song（C）は engine 非依存で<strong>並行可能</strong>。</p>
 <pre>
-2026-06-21 再優先順位化: 土台2本（① VSCodium / ② engine）→ 改良層（DSL/機能）
+2026-06-21 確定: engine-first（#302・振り子収束）
 
-土台① OrbitStudio (VSCodium) ──── ★最初の /goal = 2.0.0 parity（先決・既存SCスタック・engine非依存）
-土台② engine (Rust)         ──── ①と並行可（別コードベース）
+① engine (Rust) を opt-in 裏で育て .vsix で dog-food  ── scsynth 同梱なし・throwaway ゼロ
   A0/S1/S1b CLAP hosting ✅
   S2 daemon seam parity  ✅
-  α recovery floor (fault①) #300
-  γ out-of-proc sandbox (fault②)
-  δ 3rd-party VST3/AU
-  cutover #108（Rust を既定 backend に）
+  ★最初の /goal = 第1増分: pan/slice/per-slice gain + α recovery floor (fault①) #300
+  後続: time-stretch / LinkAudio(A4) / γ out-of-proc sandbox(fault②) / δ 3rd-party VST3/AU
+  → cutover #108（Rust を既定 backend に・scsynth 退役）
+② OrbitStudio (VSCodium) ──── cutover 後・native の上で（scsynth 載せない・CLI+Claude 拡張必須）
+  殻(リブランド/node ランタイム/署名 CI)は engine 非依存で並行可・audio は engine 後
 
 改良層（土台の後・集中して）
   β audio DSL ⊇ pitch DSL (+#213)  ← C1 pitch spec が前提・in-process
@@ -147,12 +147,12 @@ Track C（pitch / song）  ──── engine 非依存・先行可
   <span><span class="badge b-tent">TENTATIVE</span> 暫定・使って検証</span>
 </p>
 
-<h2 id="firststep">§3. 最初の1手（A0/S1/S2 完了済 → 土台2本 → 改良層）</h2>
+<h2 id="firststep">§3. 最初の1手（A0/S1/S2 完了済 → engine-first）</h2>
 <div class="callout c-warn">
-  <span class="lbl">▶ 最初の /goal = ① OrbitStudio 2.0.0 parity（VSCodium 土台・先決）</span>
+  <span class="lbl">▶ 最初の /goal = engine 第1増分（pan/slice/per-slice gain + α recovery・#300 系）</span>
   <strong>完了済</strong>: A0+S1+S1b（PR #294・in-process CLAP hosting が RT 安全に成立）/ S2（PR #297・daemon dispatch seam parity）。<br />
-  <strong>2026-06-21 owner 再優先順位化</strong>: 今後の改良が載る土台は2本（① VSCodium化 + ② ネイティブ音声エンジン）。DSL 拡張・audio 機能は土台の後（今の .orbs DSL は表現力充分・やる時は集中）。<br />
-  <strong>最初の <code>/goal</code> = ① OrbitStudio 2.0.0 parity</strong>（既存 SC スタックで動くアプリを VSCodium で・Track B / B1）。<strong>② engine 土台</strong>（α recovery floor #300 → γ sandbox → δ → cutover）は別コードベースで並行可。<strong>改良層</strong>（β audio DSL⊇pitch・slice/stretch）は土台の後・集中して。
+  <strong>2026-06-21 確定（#302・engine-first）</strong>: ① **native エンジンを <code>ORBITSCORE_ENGINE=rust</code> opt-in の裏で育て、今の .vsix で dog-food**（scsynth 同梱なし・OrbitStudio 非依存・throwaway ゼロ）→ **cutover #108**（現行 audio DSL を鳴らせたら default 切替・scsynth 退役）→ ② **OrbitStudio(VSCodium) を native の上で**（scsynth 載せない・CLI+Claude 拡張必須・殻は engine 非依存で並行可だが audio は engine 後）→ ③ **改良層（β audio DSL⊇pitch・slice/stretch）は後**。<br />
+  <strong>最初の <code>/goal</code></strong> = engine 第1増分: S2-defer の <strong>pan / slice / per-slice gain</strong> を埋める + <strong>α recovery floor（#300）</strong>。
 </div>
 <p><strong>資産再利用</strong>: ゼロから DAW を書くのではなく、既にある orbit-audio スケジューラ/ミキサー + S1 の in-process hosting 基盤に「足す」。詳細の正本 = <code>POST_2.0_ENGINE_AND_DISTRIBUTION.md §2</code>（楽器配置・fault 3層・egress・§2.5 ロードマップ）。</p>
 
@@ -168,17 +168,17 @@ Track C（pitch / song）  ──── engine 非依存・先行可
     <tr><td><strong>A0</strong></td><td>RT 統合設計（cpal callback + daemon への RT 安全な統合方式）</td><td>✅ 完了（PR #294）</td></tr>
     <tr><td><strong>S1 / S1b</strong></td><td>CLAP ホスティング: <code>clack-host</code> を既存 cpal callback に統合 → 実プラグイン発音 → tap（in-process・RT 安全）。S1b = 低レイテンシ + dynamic hot-install</td><td>✅ 完了（PR #294 `813802f`）</td></tr>
     <tr><td><strong>S2</strong></td><td>音声ディスパッチ seam を SC OSC→Rust daemon に差し替え可能化（parity proof・SC 既定）</td><td>✅ 完了（PR #297 `06cf131`）</td></tr>
-    <tr><td><strong>α</strong> <span class="badge b-decided">土台②</span></td><td>recovery floor（fault ①・issue #300）: daemon supervision + auto-respawn + 最小 recovery contract（接続再確立 + active loops 復帰 / 可聴ギャップ許容 / one-shot drop / transport 再 anchor）</td><td>kill-test で Done / SC 無改変</td></tr>
-    <tr><td><strong>γ</strong> <span class="badge b-decided">土台②</span></td><td>out-of-process sandbox（fault ②）: 3rd-party + effects を子プロセス隔離（shared-mem audio / RT-safe event IPC / watchdog→respawn）</td><td>最大の未構築サブシステム</td></tr>
-    <tr><td><strong>δ</strong> <span class="badge b-decided">土台②</span></td><td>3rd-party VST3/AU ホスティング（sandbox 内）。AU（<code>objc2-avf-audio</code>）→ VST3（<code>vst3</code> crate, MIT・工数最大）</td><td>成熟度順・最後</td></tr>
-    <tr><td><strong>β</strong> <span class="badge b-tent">改良層</span></td><td>audio DSL ⊇ pitch DSL（+ #213 <code>fixpitch()</code>/<code>time()</code>・in-process・S1 基盤）。Signalsmith stretch を native 楽器に。<strong>土台の後・集中して</strong></td><td>C1 pitch spec 先行 + 土台が成った後</td></tr>
-    <tr><td>A4→egress</td><td>LinkAudio を Rust 隔離 GPL モジュール化 + lock-free。egress（§2.4）= b1 bridge プラグイン主案 / b2 engine 埋め込み</td><td>license 規律 §1</td></tr>
+    <tr><td><strong>α</strong> <span class="badge b-decided">★最初の /goal</span></td><td>engine 第1増分: S2-defer の <strong>pan / slice / per-slice gain</strong> を埋める + recovery floor（fault ①・issue #300）: daemon supervision + auto-respawn + 最小 recovery contract（接続再確立 / active loops 復帰 / 可聴ギャップ許容 / one-shot drop / transport 再 anchor）。opt-in 裏で dog-food</td><td>opt-in で SC 同等再生 + kill-test / SC 無改変</td></tr>
+    <tr><td>後続</td><td>time-stretch（Signalsmith）/ LinkAudio（A4・Rust 隔離 GPL）/ <strong>γ</strong> out-of-process sandbox（fault ②・effects + 3rd-party・shared-mem audio / RT-safe IPC / watchdog）/ <strong>δ</strong> 3rd-party VST3/AU（AU <code>objc2-avf-audio</code> → VST3 <code>vst3</code> MIT）</td><td>→ cutover #108</td></tr>
+    <tr><td><strong>cutover</strong></td><td>#108: Rust を default audio backend に・scsynth 退役。以降 OrbitStudio が native を載せる</td><td>現行 audio DSL 全 parity 後</td></tr>
+    <tr><td><strong>β</strong> <span class="badge b-tent">改良層</span></td><td>audio DSL ⊇ pitch DSL（+ #213 <code>fixpitch()</code>/<code>time()</code>・in-process）。<strong>土台の後・集中して</strong></td><td>C1 pitch spec 先行 + engine 土台後</td></tr>
+    <tr><td>egress</td><td>egress（§2.4）= b1 bridge プラグイン主案 / b2 engine 埋め込み / LinkAudio は非DAW補助</td><td>license 規律 §1</td></tr>
   </table>
 </div>
 
 <div class="track b">
-  <h3>Track B — OrbitStudio アプリ（VSCodium） <span class="badge b-decided">DECIDED（専用アプリ化）</span> <span class="badge b-decided">土台①・最初の /goal</span></h3>
-  <p><strong>2026-06-21 更新</strong>: 旧版の「engine に足が付いてから（A1–A2 後）」を撤回し、<strong>土台①として前倒し</strong>。<strong>最初の `/goal` = 2.0.0 parity</strong>（既存 SC スタックで動くアプリを VSCodium で・engine 非依存）。理由 = 今後の改良が載る土台（engine と並ぶ2本柱）であり、現 .orbs DSL は表現力充分なので DSL 拡張より先に「動くアプリ」を出すのが先決（owner 判断）。VSCodium は fork ではなく上流 vscode の rebuild スクリプト群なので、<strong>段階選択</strong>できる:</p>
+  <h3>Track B — OrbitStudio アプリ（VSCodium） <span class="badge b-decided">DECIDED（専用アプリ化）</span> <span class="badge b-decided">native engine の上・cutover 後</span></h3>
+  <p><strong>2026-06-21 確定（#302・engine-first）</strong>: OrbitStudio は <strong>native エンジンの上で動かす（scsynth は載せない）</strong>。よって audio で使い物になるのは <strong>engine cutover（#108）後</strong>（最初の /goal ではない・issue #301）。理由 = 最終的に native が乗るのに今の scsynth を Studio に同梱する工数は無駄（owner）。<strong>CLI + Claude 拡張が動く</strong>ことが必須条件（VSCodium=Code-OSS が VS Code 拡張互換最良）。engine 非依存な殻（リブランド / node ランタイム + <code>@julusian/midi</code> ABI / 署名 CI）は再利用可で並行着手も可。VSCodium は fork ではなく上流 vscode の rebuild スクリプト群なので、<strong>段階選択</strong>できる:</p>
   <ol>
     <li><strong>B1 リブランド rebuild</strong>（低保守）から始める</li>
     <li><strong>B2 patch 付き rebuild</strong>（VST GUI 共存などの要求分だけ）</li>
@@ -275,8 +275,9 @@ Track C（pitch / song）  ──── engine 非依存・先行可
       <li>A0 / S1 / S1b CLAP hosting（PR #294）✅</li>
       <li>S2 daemon dispatch seam parity（PR #297）✅</li>
       <li>#298 アーキ決定記録 + spec 反映（PR #299・docs-only）✅作業中</li>
-      <li><strong>土台① B1 OrbitStudio（VSCodium）→ 2.0.0 parity（issue #301）</strong> — <strong>★最初の /goal・先決</strong>（既存 SC スタック・engine 非依存）</li>
-      <li><strong>土台② α</strong> recovery floor（fault ①・issue #300）→ <strong>γ</strong> out-of-process sandbox（fault ②）→ <strong>δ</strong> 3rd-party VST3/AU → cutover #108。①と並行可</li>
+      <li><strong>★最初の /goal = engine 第1増分（#300 系）</strong>: native を opt-in 裏で育て .vsix で dog-food — <strong>pan/slice/per-slice gain + α recovery floor</strong></li>
+      <li><strong>engine 後続</strong>: time-stretch / LinkAudio(A4) / <strong>γ</strong> out-of-process sandbox(fault②) / <strong>δ</strong> 3rd-party VST3/AU → <strong>cutover #108</strong>（scsynth 退役）</li>
+      <li><strong>OrbitStudio（#301）</strong>: cutover 後・native の上で（scsynth 載せない・CLI+Claude 拡張必須）</li>
       <li><strong>改良層 β</strong> audio DSL ⊇ pitch DSL（+ #213 / #239 / #238）— C1 前提・<strong>土台の後</strong></li>
       <li>A4 LinkAudio Rust 隔離 + lock-free / egress（b1 bridge・b2 engine 埋め込み）</li>
       <li>C1 pitch モデル再設計（spec 先行・β 前提・engine 非依存で先行可）/ C2 song/arrange 層（"使って検証" / 暫定）</li>

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -32,7 +32,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 - **関連 issue 再整理**: #301（OrbitStudio）= native の上・cutover 後・最初の /goal でない / #300（α）= engine 第1増分の構成要素 / #302（本訂正）。
 - **最初の `/goal`** = engine 第1増分（pan/slice/per-slice gain + α recovery floor）。owner が /goal セット済。
 
-**Commit**: （後で記入）
+**Commit**: dd5412b（PR #302）
 
 ### 6.150 docs(post-2.0): record engine architecture decision — in-process instruments + sandboxed plugins + audio egress (#298) (Jun 21, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,23 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.151 docs(post-2.0): correct roadmap to engine-first (supersede OrbitStudio-first framing) (#302) (Jun 21, 2026)
+
+**Date**: 2026-06-21
+**Status**: ✅ docs/spec のみ（HTML タグバランス検証済・残存矛盾なし）
+**Branch**: `302-roadmap-engine-first`（PR 予定・docs-only）
+
+6.150（#298/#299）で記録したアーキ §2.1–2.4（楽器=in-process / effects+3rd-party=plugin / audio DSL⊇pitch / egress）は**不変**。だが #299 のロードマップ框（土台2本・OrbitStudio 先・2.0.0 parity on scsynth）が **SUPERSEDED** となったため engine-first に訂正。
+
+- **振り子の収束（advisor 整理）**: 「OrbitStudio 2.0.0 parity 先決」を「scsynth を Studio に同梱」と誤読（2.0.0 の*体験*と*実装 scsynth* を混同）したのが原因で engine-first ⇄ OrbitStudio-first を往復した。**確定 = engine-first**（master plan 本来の方針）。
+- **緊張を解く鍵**: `ORBITSCORE_ENGINE=rust` opt-in が既にある（S2）→ native を opt-in の裏で育て **今の .vsix で dog-food**（scsynth 同梱なし・throwaway ゼロ）→ cutover #108 → OrbitStudio が native を載せる。「使える」と「無駄ゼロ」が両立。
+- **確定ロードマップ**: ① native を opt-in 裏で育てる（第1増分 = pan/slice/per-slice gain + α recovery floor #300）→ time-stretch/LinkAudio/γ sandbox/δ 3rd-party → cutover #108 → ② OrbitStudio(VSCodium) on native（scsynth 載せない・CLI+Claude 拡張必須・#301）→ ③ β audio DSL⊇pitch / audio 機能は後。engine の Studio 向け範囲 = サンプラー(in-process)+plugin host(effects)・scsynth 同等ではない。
+- **更新ファイル**: POST_2.0_ENGINE_AND_DISTRIBUTION.md（§2.5 / §7 / status banner）, POST_2.0_MASTER_PLAN.html（banner / spine / §3 / Track A 表 / Track B / §9）。
+- **関連 issue 再整理**: #301（OrbitStudio）= native の上・cutover 後・最初の /goal でない / #300（α）= engine 第1増分の構成要素 / #302（本訂正）。
+- **最初の `/goal`** = engine 第1増分（pan/slice/per-slice gain + α recovery floor）。owner が /goal セット済。
+
+**Commit**: （後で記入）
+
 ### 6.150 docs(post-2.0): record engine architecture decision — in-process instruments + sandboxed plugins + audio egress (#298) (Jun 21, 2026)
 
 **Date**: 2026-06-21


### PR DESCRIPTION
Closes #302 ／ 親 Epic #292

#298/#299 で記録したアーキ **§2.1–2.4（楽器=in-process / effects+3rd-party=plugin / audio DSL⊇pitch / egress）は不変**。だが #299 のロードマップ框（**土台2本・OrbitStudio 先・2.0.0 parity on scsynth**）が **SUPERSEDED** となったため engine-first に訂正する。

## なぜ（振り子の収束・advisor 整理）
owner との議論で engine-first ⇄ OrbitStudio-first を往復してしまった。原因 = **「2.0.0 parity」を「scsynth を OrbitStudio に同梱」と誤読**（2.0.0 の*体験*と*実装 scsynth*の混同）。owner の指摘「最終的に native が乗るのに今の scsynth を Studio に同梱する工数は無駄」+ `ORBITSCORE_ENGINE=rust` opt-in が既にある（S2）→ **「使える」と「無駄ゼロ」が両立** → **engine-first に収束**（master plan 本来の方針）。

## 確定ロードマップ（engine-first）
1. **native エンジンを opt-in の裏で育て、今の .vsix で dog-food**（scsynth 同梱なし・throwaway ゼロ）
2. 現行 audio DSL を鳴らせたら **cutover #108**（default 切替・scsynth 退役）
3. **OrbitStudio(VSCodium) を native の上で**（scsynth 載せない・CLI+Claude 拡張必須・#301）
4. **β audio DSL⊇pitch / audio 機能は後**（native サンプラー上）
- engine の Studio 向け範囲 = **サンプラー(in-process) + plugin host(effects)**・scsynth 同等ではない
- **最初の /goal = engine 第1増分**: S2-defer の pan/slice/per-slice gain + α recovery floor（#300 系）

## 変更ファイル（docs のみ）
- `POST_2.0_ENGINE_AND_DISTRIBUTION.md`: §2.5 / §7 / status banner
- `POST_2.0_MASTER_PLAN.html`: banner / 依存スパイン / §3 / Track A 表 / Track B / §9
- `WORK_LOG.md`: 6.151

## レビュー方針
docs-only（CLAUDE.md で full レビュー不要）。決定は owner 主導 + advisor 整理。アーキ §2.1–2.4 は不変。HTML タグバランス検証済・残存矛盾なし・TS テスト/build は pre-commit フックで緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
