### PR TITLE
feat(engine): native audio parity — pan / slice / per-slice gain (#304)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -46,7 +46,9 @@ post-2.0 engine-first の第1増分（最初の `/goal`）。S2 で defer した
 
 **SC parity 検証（owner）**: `ORBITSCORE_ENGINE=rust` で examples/22・pan sweep（-60→+60 等パワー）・per-slice gain 階段を ear 確認 → いずれも SC 同等（「パワー感も変わらない」= equal-power 一致）。さらに SC 既定経路を `ORBIT_SCSYNTH_PATH` で起動し、SC が scsynth に送る `/s_new`（amp/pan/startPos/duration）と rust が daemon `playAt` に送る値が**バイト一致**することを OSC ログで観測（耳の A/B 以上に厳密なパラメータ parity）。
 
-**残**: time-stretch / LinkAudio / α recovery floor は後続増分。examples/22 が `RUN`（one-shot ≈2秒）で audition しづらい点は polish 候補（本増分の Done には非該当）。
+**Done のスコープ線引き（owner 確認 2026-06-21）**: audio parity（pan/slice/per-slice gain）は **CLI 経路**（`node cli-audio.js` + `ORBITSCORE_ENGINE=rust`）で実証。CLI と .vsix は同一の `RustEnginePlayer`→daemon コードを通るため音は同等だが、**パッケージ済み .vsix からのゼロ設定 daemon 解決は未対応**（`resolveDaemonBinary` は repo 相対パス + `ORBIT_AUDIO_DAEMON_PATH` を探索。.vsix は env 未設定だと未解決。build:copy-engine も daemon 未同梱）。これは distribution 課題として **#306** へ分離（最終形 OrbitStudio/VSCodium の配布で扱う。.vsix は途中の dog-food シェル）。暫定 dog-food は `ORBIT_AUDIO_DAEMON_PATH` 設定で可能。
+
+**残**: time-stretch / LinkAudio / α recovery floor は後続増分。daemon の .vsix/OrbitStudio 解決は **#306**。examples/22 が `RUN`（one-shot ≈2秒）で audition しづらい点は polish 候補（本増分の Done には非該当）。
 
 **post-review cleanup（/simplify）**: 4観点 cleanup agent の指摘を behavior-preserving に適用 —
 slice 長 clamp を core の `resolve_slice_region` に集約し scheduler の render 尺と daemon の

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -48,7 +48,7 @@ post-2.0 engine-first の第1増分（最初の `/goal`）。S2 で defer した
 
 **残**: time-stretch / LinkAudio / α recovery floor は後続増分。examples/22 が `RUN`（one-shot ≈2秒）で audition しづらい点は polish 候補（本増分の Done には非該当）。
 
-**Commit**: [PENDING]
+**Commit**: d3be514
 
 ### 6.151 docs(post-2.0): correct roadmap to engine-first (supersede OrbitStudio-first framing) (#302) (Jun 21, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,39 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.152 feat(engine): native audio parity increment — pan / slice / per-slice gain (#304) (Jun 21, 2026)
+
+**Date**: 2026-06-21
+**Status**: ✅ 実装 + 自動テスト全緑（cargo --workspace / npm）+ owner ear verdict 取得（pan/slice/per-slice gain いずれも rust で SC 同等に可聴）+ OSC 実値 parity 観測
+**Branch**: `304-audio-parity-increment`
+
+post-2.0 engine-first の第1増分（最初の `/goal`）。S2 で defer した audio gap のうち **pan / chop 領域再生 / per-slice gain** を native daemon 経路に実装し、`ORBITSCORE_ENGINE=rust` opt-in の裏で dog-food 可能にした。SC 既定経路は無改変。
+
+- **pan**（SC `Pan2` と同じ equal-power 則・中央 = -3dB / 1√2）: core scheduler render に等パワー定位を実装。daemon PlayAt の `pan`（既に protocol 仕様化済み・実装が追いついていなかった）を配線。TS は DSL の -100..100 を daemon の [-1,1] へ変換して送る。`scheduleEvent` の「pan 未対応」warn を撤去。
+- **chop 領域再生**（region-only・rate=1.0）: PlayAt に `offset_sec` / `duration_sec` を追加（spec 先行で `ENGINE_DAEMON_PROTOCOL.md` 更新）。core は ActiveSample に slice 領域（start/len）を持ち、領域だけを読む。SC `orbitPlayBuf` と同じ末尾 fadeout（`min(8ms, dur×4%)` 線形 release）でクリック防止。TS `scheduleSliceEvent` を実装（slice 領域は lazy load 後に `executePlayback` で解決）。物理 slice ファイル（`audioSlicer`）は live 未使用の dead path のため native では再現しない（startPos 領域読みのみ）。
+- **per-slice gain**: 各 slice event の gainDb が daemon PlayAt の gain に独立反映され、core render の per-event `active.gain` で適用される（新機構不要）。
+- **rate≠1.0（slice 尺→スロット尺の varispeed = time-stretch）は本増分の対象外**。検出時は 1 回 warn し、slice は自然尺（rate=1.0）で鳴らす（time-stretch 増分 #213/#239 へ defer）。`chop()` は「現状 scsynth 仕様をそのまま採用」（owner）が、rate フィットは roadmap の time-stretch 境界に従い defer。
+
+**用語整理（owner 確認）**: `chop()` = n 等分（既存・本増分）。`slice()`（`recycle()` でも可）= Re-Cycle 型のトランジェント/無音検出による文節切り = #239（将来 β）・本増分対象外。
+
+**主な変更ファイル**:
+- Rust: `orbit-audio-core/src/scheduler.rs`（pan equal-power + slice 領域 + fadeout）, `engine.rs`, `orbit-audio-daemon/src/engine_wrap.rs`（slice 出力尺で PlayEnded 補正）, `session.rs`（offset/duration parse + 検証）
+- TS: `rust-engine/daemon-client.ts`, `rust-engine/rust-engine-player.ts`（pan/slice 配線 + `resolveSliceRegion`）
+- docs: `docs/research/ENGINE_DAEMON_PROTOCOL.md`（PlayAt に offset_sec/duration_sec）
+- tests: core に pan 4件 + slice 3件、`rust-engine-player.spec.ts` を pan/slice 新仕様へ更新
+
+**テスト結果**:
+- cargo --workspace: 全緑（core 21 / daemon protocol 13 / smoke 1 / native 16 / clap 7）
+- npm test: 1153 passed, 25 skipped, 0 failed（回帰なし・SC 既定無改変）
+
+**並行成果**: DAW 標準機能リサーチ（`docs/research/DAW_AUDIO_ARCHITECTURE.md`）= 基礎後の routing/effects 層 roadmap 入力（insert 順序 = engine core の graph 管理 / EQ 等 = CLAP plugin / PDC が insert 順と不可分）。
+
+**SC parity 検証（owner）**: `ORBITSCORE_ENGINE=rust` で examples/22・pan sweep（-60→+60 等パワー）・per-slice gain 階段を ear 確認 → いずれも SC 同等（「パワー感も変わらない」= equal-power 一致）。さらに SC 既定経路を `ORBIT_SCSYNTH_PATH` で起動し、SC が scsynth に送る `/s_new`（amp/pan/startPos/duration）と rust が daemon `playAt` に送る値が**バイト一致**することを OSC ログで観測（耳の A/B 以上に厳密なパラメータ parity）。
+
+**残**: time-stretch / LinkAudio / α recovery floor は後続増分。examples/22 が `RUN`（one-shot ≈2秒）で audition しづらい点は polish 候補（本増分の Done には非該当）。
+
+**Commit**: [PENDING]
+
 ### 6.151 docs(post-2.0): correct roadmap to engine-first (supersede OrbitStudio-first framing) (#302) (Jun 21, 2026)
 
 **Date**: 2026-06-21

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -62,7 +62,13 @@ silent-failure-hunter（`ensureLoaded` が sampleRate 不正時に無言で slic
 comment-analyzer（slice の旧「skip」コメントを領域再生実装済みへ更新）/ pr-test-analyzer（`resolve_slice_region`
 境界・ステレオ slice の channel stride・`duration_sec<0` 拒否の3テスト追加）。検証: cargo 61 緑 / npm 1153 緑。
 
-**Commit**: d3be514（実装）, 9282e6c（log ref）, +simplify cleanup, +pr-review fixes
+**pr-review-team（round 2）**: round-1 修正を独立再レビュー。code-reviewer/comment-analyzer/pr-test-analyzer は
+0 件（#R1 の effective_len_frames は全ケースで render/PlayEnded 一致・3 新テストも算術的に正しく load-bearing と確認）。
+silent-failure-hunter が sibling edge を 1 件検出（`ensureLoaded` が sample_rate のみ検証し `frames` 未検証 →
+`frames=NaN` だと `NaN<=0===false` で fallback guard 素通り）→ `frames` 有限・非負も検証 + `resolveSliceRegion`
+guard に `!Number.isFinite` を defense-in-depth 追加。検証: npm 1153 緑。
+
+**Commit**: d3be514（実装）, 9282e6c（log ref）, +simplify cleanup, +pr-review fixes（round 1/2）
 
 ### 6.151 docs(post-2.0): correct roadmap to engine-first (supersede OrbitStudio-first framing) (#302) (Jun 21, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -56,7 +56,13 @@ session.rs の PlayAt param 抽出を `param_f64` ヘルパーで集約 / 旧 sp
 `gainDbToAmplitude` に置換。SKIP: TS slice 数式/pan の SC `event-scheduler.ts` との共通化（保護対象の
 SC 経路を触るため follow-up）。検証: cargo --workspace 58 緑 / npm 1153 緑 / 変更ファイル clippy クリーン。
 
-**Commit**: d3be514（実装）, 9282e6c（log ref）, +simplify cleanup
+**pr-review-team（round 1）修正**: code-reviewer の Important（engine_wrap が生 `requested_len_frames` を
+scheduler へ渡していた → clamp 済 `effective_len_frames` を渡し render/PlayEnded の一致を call site で保証）/
+silent-failure-hunter（`ensureLoaded` が sampleRate 不正時に無言で slice→全体再生 degrade → ソースで warn）/
+comment-analyzer（slice の旧「skip」コメントを領域再生実装済みへ更新）/ pr-test-analyzer（`resolve_slice_region`
+境界・ステレオ slice の channel stride・`duration_sec<0` 拒否の3テスト追加）。検証: cargo 61 緑 / npm 1153 緑。
+
+**Commit**: d3be514（実装）, 9282e6c（log ref）, +simplify cleanup, +pr-review fixes
 
 ### 6.151 docs(post-2.0): correct roadmap to engine-first (supersede OrbitStudio-first framing) (#302) (Jun 21, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -48,7 +48,15 @@ post-2.0 engine-first の第1増分（最初の `/goal`）。S2 で defer した
 
 **残**: time-stretch / LinkAudio / α recovery floor は後続増分。examples/22 が `RUN`（one-shot ≈2秒）で audition しづらい点は polish 候補（本増分の Done には非該当）。
 
-**Commit**: d3be514
+**post-review cleanup（/simplify）**: 4観点 cleanup agent の指摘を behavior-preserving に適用 —
+slice 長 clamp を core の `resolve_slice_region` に集約し scheduler の render 尺と daemon の
+PlayEnded 尺の単一情報源化 / 等パワーパンを `schedule()` で precompute して RT render から
+trig（sin/cos）と output_channels 分岐を排除 / render の `gain*env` を frame 単位へ hoist /
+session.rs の PlayAt param 抽出を `param_f64` ヘルパーで集約 / 旧 spec の `Math.pow` を
+`gainDbToAmplitude` に置換。SKIP: TS slice 数式/pan の SC `event-scheduler.ts` との共通化（保護対象の
+SC 経路を触るため follow-up）。検証: cargo --workspace 58 緑 / npm 1153 緑 / 変更ファイル clippy クリーン。
+
+**Commit**: d3be514（実装）, 9282e6c（log ref）, +simplify cleanup
 
 ### 6.151 docs(post-2.0): correct roadmap to engine-first (supersede OrbitStudio-first framing) (#302) (Jun 21, 2026)
 

--- a/docs/research/DAW_AUDIO_ARCHITECTURE.md
+++ b/docs/research/DAW_AUDIO_ARCHITECTURE.md
@@ -1,0 +1,226 @@
+# 標準 DAW オーディオ信号経路アーキテクチャ調査
+
+**調査日**: 2026-06-21  
+**目的**: post-2.0 native Rust オーディオエンジン（orbit-audio）の routing・effects・multi-out 設計 backlog への roadmap 入力。標準 DAW の確立された慣習を OrbitScore 確定アーキ（`docs/development/POST_2.0_ENGINE_AND_DISTRIBUTION.md` §2）にマップする。  
+**方法**: context7 MCP（`/free-audio/clap` ライブラリ）/ WebSearch（Ableton・Logic・Reaper・Bitwig 公式マニュアル、定評ある教材サイト）/ OrbitScore docs 精読。  
+**位置づけ**: アーキ §2（確定済）を再設計しない。機能の「居場所」を確定アーキにマップし、実装含意と増分順序を提示することが成果物。
+
+---
+
+## 1. 標準 DAW の信号経路概観
+
+```
+  ┌──────────────────────────────────────────────────────────┐
+  │  Instrument Track / Audio Track                          │
+  │  [Sound Source / Clip] → [Insert FX Chain] → [Fader]   │
+  │                              │ (pre-fader send)         │
+  │                              │         ↓                │
+  │                              │   [Return/Aux Track]     │
+  │                              │   [Insert FX (e.g. Reverb)]
+  │                              │         ↓                │
+  │                         (post-fader send)               │
+  │                              │                          │
+  └──────────────────────────────┼──────────────────────────┘
+                                 │
+  ┌──────────────────────────────▼──────────────────────────┐
+  │  Group / Bus Track (サブミックス)                        │
+  │  [受け取った複数トラックのミックス] → [Insert FX] → [Fader]│
+  └──────────────────────────────┬──────────────────────────┘
+                                 │
+  ┌──────────────────────────────▼──────────────────────────┐
+  │  Master Bus                                              │
+  │  [全トラック合流] → [Insert FX (Limiter等)] → [Master Fader]│
+  └──────────────────────────────┬──────────────────────────┘
+                                 │
+  ┌──────────────────────────────▼──────────────────────────┐
+  │  Hardware Output Routing                                 │
+  │  Output Bus 1→2 → Audio Interface ch 1/2 (Main)         │
+  │  Output Bus 3→4 → Audio Interface ch 3/4 (DJ Cue 等)    │
+  └──────────────────────────────────────────────────────────┘
+
+  ※ Sidechain: コンプ等の非メイン入力ポートに別トラックをルーティング
+  ※ PFL (Pre-Fader Listen): フェーダー前の信号をモニター/Cue に送る
+```
+
+### 各 DAW のモデル差異（「標準の共通項」の限界）
+
+- **Ableton Live**: Return トラック（Aux）は固定。Group トラック（通称 Bus）は複数トラックを入れ子にするサブミックス専用。両者は明確に区別される。Send は1トラック内でレターグループ（A, B, C…）単位で pre/post-fader を切り替え可能（個々の send ごとにバラバラには切れない）。デフォルトは **post-fader**。
+- **Logic Pro**: Aux Channel Strip が Return 相当、Bus はルーティング先バス番号で指定。Logic 8 以降、内部的に Aux と Bus は同一実装（ワークフロー上の意味が異なるのみ）。
+- **Bitwig Studio**: デバイスチェーン内に Instrument・FX・Note エフェクトの概念があり、signal flow が他 DAW よりフレキシブル。Post-fader がデフォルト。
+- **Reaper**: 「ラベル付きバスが存在せず、任意のトラックから任意のトラックへ直接ルーティング可能」な統一トラックモデル。Pro Tools と対照的に最も柔軟。
+- **Pro Tools**: バス名と信号経路を明示的に設定する固定型（Aux Input トラックへのバスアサイン方式）。named buses + aux tracks の固定モデルが標準の最小公倍数に近い。
+
+> **含意**: 「標準 DAW」の共通項は「**insert chain → send/return → group → master → hardware out の層構造**」と「**pre/post-fader の tap 点の概念**」であり、具体的なルーティング UI は OrbitScore 固有設計に委ねられる。Reaper のフレキシブルモデルは OrbitScore の graph-based routing 設計に概念的に近い。
+
+> 出典: forum.ableton.com / musicguymixing.com / blackghostaudio.com / soundonsound.com / audeobox.com / reaper.blog（詳細 URL は §7 参照）
+
+---
+
+## 2. 機能 → OrbitScore での居場所マッピング表
+
+> **居場所の定義**:
+> - **① engine core routing**: engine が RT で管理。graph トポロジー・tap 点・ゲイン・バス割り当てを所有。
+> - **② CLAP プラグイン**: out-of-process sandbox（未来の γ フェーズ）または現在の in-process CLAP ホスト（S1/S1b）。pure audio→audio DSP。
+> - **③ DSL 表現面**: OrbitScore `.orbs` DSL からユーザーが記述・制御する層。
+
+| # | 機能 | 標準 DAW での挙動 | 居場所 | 実装含意 |
+|---|------|------------------|-------|--------|
+| 1 | **insert チェーン**（直列 FX） | トラックの signal path にプラグインを直列挿入。音源→insert 1→insert 2→...→fader の順。Ableton は上→下の順序が signal flow。 | **① + ②**: チェーンのグラフトポロジーを ① core が所有。個々のノードは ② CLAP プラグイン。挿入・削除・順序変更は ① が graph を書き換える。 | RT 安全なグラフ更新（lock-free or double-buffer）が必要。プラグインは順序を知らない。core がチェーンの実行順を決定。 |
+| 2 | **insert 順序の制御**（最重要） | drag & drop でプラグインスロットを並び替え可能（Ableton・Logic・Bitwig 共通）。順序変更は即時反映。 | **① engine core routing** | §4 で独立詳述。RT 中の graph 変更は原子的でなければならない（次フレームから有効など）。 |
+| 3 | **send（pre-fader）** | フェーダー前の信号を別トラック（Return/Aux）へ分岐。フェーダーを下げても send 量は変わらない。Cue モニター・ヘッドフォンモニタリング（PFL）の一般的な接続方法。 | **① engine core routing** | tap point = insert chain 直後・fader 前。send level は ① が管理するゲインパラメータ。DSL からは `send :amount, :to` 等の表現で制御予定（③ 将来）。 |
+| 4 | **send（post-fader）** | フェーダー後の信号を分岐。フェーダー操作に send 量が追従。空間系 FX（Reverb・Delay）の一般的な接続方法。Ableton・Logic・Bitwig でデフォルト。 | **① engine core routing** | tap point = fader 後。pre/post の tap 切り替えは ① 内の接続設定。Ableton は1トラック内でレターグループ単位の pre/post 切り替えをサポート（ゲインレベルとは別パラメータ）。RT 安全な tap 切り替えが要る。 |
+| 5 | **複数 send** | 1トラックから複数の Return/Aux に同時 send 可能（例: Reverb Bus + Delay Bus に並行送り）。 | **① engine core routing** | グラフの分岐（fan-out）。① が複数の送り先へのゲインセットを管理。DAG（非循環）制約を ① が強制。 |
+| 6 | **aux / return トラック** | send の受け取り専用トラック（Ableton の Return Track / Logic の Aux Channel Strip）。1以上のトラックからの send を受け、自身の insert FX を通して Master に流す。 | **① + ②**: バスのトポロジーは ①。aux に挿入される FX は ②（CLAP）。 | Return トラック = ① 内の混合ノード + FX チェーン。Group との区別: Group は「入力元が直接ルーティング」、Aux は「send で来る」。 |
+| 7 | **group / bus トラック** | 複数トラックをサブグループとしてまとめ、サブミックス用 FX（コンプ・EQ）を一括適用（Ableton の Group Track / Logic の Buss / Reaper の子トラック）。 | **① + ②**: サブミックスの sum は ①。Group に挿入する FX は ②。 | Group = sum ノード + FX チェーン。Reaper の「全トラックが Bus」モデルは OrbitScore のフレキシブル graph 設計に近く、参考になる。 |
+| 8 | **sidechain ルーティング** | コンプ等の「非メイン」入力ポートに別トラックの音を入力。例: キックドラムでベースのコンプを叩く。Ableton: Compressor の "Audio From" でソーストラックを選択（Pre-FX 推奨: ソーストラックの FX をバイパスした素の信号を使う）。Logic: Compressor の Side Chain ドロップダウンで入力 ch を指定。サイドチェーン信号は通常の insert chain を通らない「別ポート」経由。 | **① engine core routing**（接続）+ **② CLAP プラグイン**（処理） | サイドチェーン = プラグインの非メイン入力ポートへの接続。CLAP では `audio-ports` extension で入力ポートを複数宣言可能（CLAP_AUDIO_PORT_IS_MAIN でないポートがサイドチェーン）。ルーティング接続は ① が管理。DAG cycle に注意（サイドチェーンが循環するとデッドロック）。 |
+| 9 | **master bus / 最終出力** | 全トラックが合流するフィナルミックス段。Limiter・Meter・Mastering FX 等を insert。Master Fader が全体音量を制御。 | **① engine core routing**（master sum + fader）+ **②**（insert FX） | orbit-audio-core の既存 `master_gain` が相当。Master への FX チェーンは ② CLAP。 |
+| 10 | **ハードウェアマルチアウト** | 出力バス（stereo pair 等）をオーディオインターフェースの物理 ch に割り当て。例: Bus 1/2→ch 1/2（Main）/ Bus 3/4→ch 3/4（Cue / DJ B deckへ）。 | **① engine core routing** | cpal の device output mapping に相当。① が出力バスと cpal デバイス ch の対応を管理。OrbitScore の dance/DJ 運用で重要。 |
+| 11 | **DJ Cue / PFL (Pre-Fader Listen)** | フェーダー前の信号をヘッドフォン/モニターに送る（PFL）。「フェーダーを下げてもCueで聴ける」。AFL(After Fader Listen)はフェーダー後。DAW では Cue Bus に signal を tap する形で実装。 | **① engine core routing**（tap + Cue Bus） | PFL tap = insert chain 後・fader 前の信号を Cue 出力バスに分岐。マルチアウトで物理 ch を確保してから実装可能。DJ ミキサーに繋ぐ場合はマルチアウトが前提（次項）。 |
+| 12 | **DJ A/B 切り替え / クロスフェード** | 2 deckの信号を crossfader で A→B にブレンド（DJ ミキサーモデル）。DAW 内の代表的な実装例: **Ableton Live** の Session View にある A/B クロスフェーダー（トラックごとに A/B/なし を割り当て、Session Crossfader で混合比を制御）。OrbitScore の主運用は「マルチアウト→外部 DJ ミキサー」。 | **① engine core routing**（内部実装の場合）or **マルチアウト経由で外部処理** | 内部 crossfade = ① の gain ノード2系統をクロスフェード係数で補間（Ableton Session Crossfader 参考）。外部 DJ ミキサー運用 = ① で Bus A / Bus B を物理 ch に出力し、ハードウェア側で操作。OrbitScore の確定アーキでは「マルチアウト→外部 DJ ミキサー」が主案（owner 明示）。内部 A/B クロスフェードは追加の gain ノードで実現可能（① のみ）。※ 調査済: Ableton 公式 Session crossfader が DAW 内 DJ A/B の標準例。Bitwig 独自クロスフェード器の有無は未確認。 |
+
+---
+
+## 3. insert 順序制御の設計含意（最重要）
+
+### 標準 DAW の慣習
+
+標準 DAW（Ableton Live・Logic Pro・Bitwig・Reaper）では、insert スロットの物理的な並び順が signal flow 順と一致する。Ableton では上から下、Logic では左から右にチェーンされる。ユーザーは drag & drop でスロット位置を変更でき、変更は通常「次フレーム or 次バッファ」から有効になる（再生中断なし）。「pre/post」の概念はチェーン内ではなくチェーン全体に対する fader の位置（pre-insert / post-insert = after all inserts）として使われる。
+
+> **出典**: Ableton Live 12 Manual, "Audio Effects" section — <https://www.ableton.com/en/packs/audio-effects/>; Logic Pro Manual, "Signal flow in a channel strip" — <https://support.apple.com/guide/logicpro/welcome/mac>  
+> ※ 公式マニュアルの該当 URL は要確認（下記 §7 参照）。一般的な DAW 慣習として高確度、マニュアル直 URL は「未確認・要確認」とマークする。
+
+### OrbitScore での実装含意
+
+**graph は engine core (①) が所有し、プラグインは順序を知らない。**
+
+CLAP プラグイン自体は自身が insert chain の何番目かを知らない。host（engine core）が処理グラフの有向辺（A→B→C）を管理し、各フレームで宣言順に `process()` を呼ぶ。insert 順序の制御 = **グラフのエッジ書き換え**（core の仕事）。
+
+**RT 中の順序変更**は以下の方針が必要:
+- **double-buffer / shadow graph**: 現行グラフを RT スレッドが使用中に、新グラフを main スレッドで構築。ポインタ原子交換で切り替え。
+- **次バッファ境界で有効**: 変更はバッファ境界までは旧グラフで処理し、次バッファから新グラフに切り替える（可聴アーティファクト最小化）。
+- **DAG 制約の強制**: エッジ追加時にサイクル検出（sidechain を含む）。フィードバックループは許可しない（DAG = 非循環有向グラフを厳守）。
+
+**PDC（Plugin Delay Compensation）**:
+CLAP の `latency` extension により、各プラグインは処理レイテンシを samples 単位で報告する（`clap_plugin_latency_t::get()`）。ホスト（engine core）は insert chain 内の各プラグインのレイテンシを合計し、並行するトラック（例: Dry 信号・別 Bus）にディレイを挿入して整合させる（Plugin Delay Compensation = PDC）。insert 順序が変わるとチェーン合計レイテンシが変化するため、**順序変更のたびに PDC 再計算が必要**。PDC は ① engine core の責務。  
+> 出典: context7 `/free-audio/clap` — `render-latency-extensions.md`: *"Used by the host for audio alignment, recording offsets, and latency compensation."*
+
+**pre/post の概念（tap point の3階層）**:
+
+標準 DAW の send には「insert の後、fader の前後」という2軸があり、さらに「insert 以前」の特殊 tap を合わせて3種の tap point がある:
+
+| tap 名 | 位置 | 用途 |
+|--------|------|------|
+| **pre-FX（pre-insert）** | insert chain より前（dry 信号） | サイドチェーン入力用（Ableton Compressor の "Audio From: Pre-FX"）。send の tap としては特殊。 |
+| **pre-fader（post-insert）** | insert chain 通過後・fader 前 | Cue モニター・PFL。フェーダーを下げても send 量が変わらない。**row 3 の tap point**。 |
+| **post-fader** | fader 通過後 | 空間系 FX（Reverb・Delay）への send。フェーダー操作に send 量が追従。Ableton・Logic・Bitwig のデフォルト。**row 4 の tap point**。 |
+
+- **重要**: "pre-fader send" = insert chain 通過後・fader 前（post-insert / pre-fader）。"pre-insert（pre-FX）" は別の概念でサイドチェーン専用。誤って同一視しないこと。
+- tap point は ① core がグラフ内の接続点として管理（プラグインは関知しない）。Ableton では pre/post-fader はレターグループ（A, B, C…）単位で切り替え可能（個別 send ごとには切れない）。
+- 出典: musicguymixing.com / gear4music.com（Ableton sidechain pre-FX 説明）/ Ableton forum
+
+---
+
+## 4. CLAP routing 能力と out-of-process 境界の含意
+
+### CLAP の routing 能力
+
+CLAP プラグインは **ports** を宣言し、**ホストが接続する**設計である。プラグインは自身のグラフ上の位置を知らない。
+
+| CLAP Extension | 機能 | OrbitScore での意味 |
+|----------------|------|---------------------|
+| `audio-ports` | プラグインが持つ入出力オーディオポートを宣言。`CLAP_AUDIO_PORT_IS_MAIN` フラグで主ポートを識別。非メインポートがサイドチェーン入力に使える。 | サイドチェーン接続 = 非メイン入力ポートへの接続を ① core が確立する。マルチアウト = プラグインが複数出力ポートを宣言。 |
+| `note-ports` | MIDI / CLAP ネイティブ note イベント / MIDI 2.0 / MPE のうちサポートする dialect を宣言。`note_id` で per-note 識別。 | in-process 楽器の DSL 表現力（per-note/per-slice）と密接。out-of-process effects には note ports 不要なことが多い。 |
+| `latency` | プラグインが導入するサンプル数レイテンシを報告（`get()` は main-thread のみ・activate 中は不変）。 | ① core が PDC を実装するための情報源。 |
+| `params` | パラメータ自動化・sample-accurate な parameter sweep をサポート。 | insert チェーン内の FX パラメータを DSL や transport から制御する将来機能の基盤。 |
+| `transport-control` | host transport（再生/停止/BPM/拍子）をプラグインへ供給。**README が "draft" と明記**。 | BPM-sync FX（オートワウ等）に将来必要。draft 段階のため安定 API として扱わない。 |
+
+**重要原則**: *CLAP ホスト（= engine core ①）が routing のすべてを所有する。プラグインはポートを宣言するだけ。insert 順・send 接続・サイドチェーン接続はすべて host side の graph 管理。*
+
+> 出典: context7 `/free-audio/clap` — `audio-ports-extension.md`, `note-ports-extension.md`, `render-latency-extensions.md`
+
+### out-of-process 境界（γ フェーズ）の含意
+
+**現状（S1/S1b 完了）**: effects は in-process CLAP ホスト（clack-host）でロードされる。out-of-process sandbox はまだ未構築（§2.2 fault ②「γ」= open）。
+
+**γ 実装時の含意**:
+- effects プラグインプロセスへのオーディオ転送に **shared-memory IPC**（零コピー）が必要（WebSocket は RT には不適）。
+- insert チェーンの1ノードが out-of-process になると **往復 1 frame + process time のレイテンシ**が追加される。PDC でこれを補正。
+- out-of-process プラグインが crash しても engine core は生存し、そのスロットを bypass 扱いにする watchdog が必要（§2.2 fault ② の核心）。
+- **DAG 制約はプロセス境界をまたいでも必要**（サイドチェーンが out-of-process プラグインをまたぐ場合、デッドロックリスクがある。送受信の順序を厳密に設計する）。
+- **RT-safe event IPC**: パラメータ・note イベントも out-of-process 境界を越える。lock-free ring buffer over shared memory が定石（Bitwig / Studio One の既知手法）。
+
+---
+
+## 5. 増分順序の提案
+
+> **前提**: §2.5（engine-first ロードマップ）を尊重する。確定済ロードマップの修正案ではなく、routing/FX 機能を **§2.5 の後続増分にどう積むか** の提案。変更を要する場合は「提案」として明示。
+
+### 基礎（現行 第1増分・§2.5）
+- **pan / slice / per-slice gain** + **α recovery floor**: 現在進行中（issue #300 系）。
+- これが完了すると「core routing の基礎ノード」（gain、基本ミックス）が使える状態になる。
+
+### 推奨増分順序（routing・FX・multi-out・DJ）
+
+| 段 | 内容 | 依存 | 備考 |
+|----|------|------|------|
+| **R1** | **送り先（Return/Aux バス）の sum ノード** をコアに追加。簡単な send (post-fader) を DSL で記述できるようにする。 | 第1増分完了 | グラフに fan-out エッジを追加する最初の一歩。PDC は R1 では不要（レイテンシゼロの理想ノードから始める）。 |
+| **R2** | **group / bus トラック**（sub-sum ノード）。複数トラックのサブミックスを core で実現。 | R1 | R1 と構造が近い（sum ノードの再利用）。大和さんが評価する「資産再利用」に沿う。 |
+| **R3** | **insert チェーン（CLAP プラグイン1本）** の接続。in-process CLAP ホストは S1/S1b 完了済みなので接続 API と graph への組み込みが主作業。 | R2 + S1/S1b | 最初は1スロット固定で良い。順序変更・PDC は後続へ。 |
+| **R4** | **insert チェーン複数スロット + 順序変更**。RT 安全なグラフ更新（double-buffer）と PDC 再計算。 | R3 | §3 で詳述した設計が必要になるタイミング。 |
+| **R5** | **マルチアウト（cpal 物理 ch マッピング）**。出力バスを cpal デバイスの ch ペアに割り当て。 | R4 | DJ 運用の前提。cpal は既存資産（orbit-audio-native）。 |
+| **R6** | **Cue / PFL**（DJ モニター）と **DJ A/B（内部 crossfade またはマルチアウト経由）**。 | R5 | R5 のマルチアウトが実装されると「Bus A を ch 1/2、Bus B を ch 3/4 に出す」で外部 DJ ミキサー運用が実現する。内部 crossfade は追加の gain ノード。 |
+| **R7** | **out-of-process sandbox（γ）**。shared-mem IPC + watchdog + PDC 補正。3rd-party CLAP プラグインの安全なホスティング。 | R4 + α完了 | §2.2 fault ② 相当。R4 の insert 基盤が固まってから。 |
+| **R8** | **サイドチェーンルーティング**（非メイン入力ポートへの接続）。 | R4 + R7 (out-of-process が必要な場合) | in-process CLAP なら R4 後から可能。DAG cycle 検出の実装が必要。 |
+| **R9** | **pre-fader send**（tap point 切り替え）。 | R1 | R1 で post-fader send を実装した後、tap 切り替え機能を追加。 |
+
+### リスク
+
+| リスク | 内容 | 軽減策 |
+|--------|------|--------|
+| γ(out-of-process) の複雑度 | shared-mem IPC + RT safety + watchdog は §8 caveat 通り未構築で工数未知 | R3-R4 の in-process insert で効果を先に使えるようにし、γ を別スパイクで充分に設計する |
+| PDC の複雑度 | insert チェーン合計レイテンシの変動・out-of-process の追加レイテンシ | R4 着手前に PDC 設計をドキュメント化してから実装 |
+| DAG サイクル（sidechain） | サイドチェーン接続がフィードバックループになる可能性 | cycle detection を graph 更新のすべてのパスで強制（insert・send・sidechain 共通）|
+| transport-control CLAP extension が draft | BPM-sync FX の実装が CLAP の安定 API に依存できない | この機能は CLAP 仕様が stable になるまで defer |
+| clack-host pre-1.0 breaking changes | R3-R4 の insert 実装が clack の API 変更で破損するリスク | clack の changelog を定期的に追う。抽象ラッパーで内部 API 変更を隔離 |
+
+---
+
+## 6. 参照
+
+### OrbitScore 内部ドキュメント
+- `docs/development/POST_2.0_ENGINE_AND_DISTRIBUTION.md` §2 — アーキ正本（居場所判定の一次根拠）
+- `docs/research/RUST_PLUGIN_HOSTING.md` — CLAP/VST3/AU hosting feasibility 調査（2026-06-19）
+- `docs/research/ENGINE_DAEMON_PROTOCOL.md` — daemon/IPC 設計
+
+### CLAP（context7 `/free-audio/clap`）
+- Audio Ports Extension — <https://github.com/free-audio/clap/blob/main/_autodocs/api-reference/audio-ports-extension.md>
+- Note Ports Extension — <https://github.com/free-audio/clap/blob/main/_autodocs/api-reference/note-ports-extension.md>
+- Render & Latency Extension — <https://github.com/free-audio/clap/blob/main/_autodocs/api-reference/render-latency-extensions.md>
+- CLAP GitHub リポジトリ — <https://github.com/free-audio/clap>
+
+### DAW 公式・準公式リソース
+- Ableton Live 12 Manual — <https://www.ableton.com/en/manual/ableton-live-intro-manual/>（Return Track・Send 説明）
+- Ableton pre/post-fader 説明（forum） — <https://forum.ableton.com/viewtopic.php?t=168437>
+- Pre-fader vs Post-fader 解説 — <https://www.musicguymixing.com/pre-fader-post-fader/>
+- Logic Pro User Guide — <https://support.apple.com/guide/logicpro/welcome/mac>（Channel Strip signal flow）
+- Logic Aux/Bus/Send の違い — <https://musictech.com/tutorials/logic-pro/using-bus-sends-and-aux-channels-in-logic-pro-x/>
+- Aux vs Bus vs Send vs Return の区別 — <https://www.blackghostaudio.com/blog/the-difference-between-buses-auxes-sends-and-returns>
+- Sound On Sound: Logic sends/buses/auxes — <https://www.soundonsound.com/techniques/logic-pro-sends-buses-auxes>
+- Reaper User Guide — <https://www.reaper.fm/userguide.php>
+- Reaper フレキシブルルーティング解説 — <https://www.audeobox.com/learn/reaper/routing-and-sends-guide/> / <https://reaper.blog/2016/06/audio-routing-explained/>
+- Bitwig Studio Manual — <https://www.bitwig.com/support/documentation/>
+- Pro Tools Reference Guide — <https://resources.avid.com/SupportFiles/PT/Pro%20Tools%20Reference%20Guide.pdf>
+- PFL (Pre-Fader Listen) — <https://www.sweetwater.com/insync/pre-fade-listen-pfl/> / <https://www.soundonsound.com/sound-advice/q-what-do-solo-pfl-and-afl-do>
+- Sidechain in Ableton — <https://www.gear4music.com/blog/how-to-sidechain-in-ableton-live/>
+- DAW insert chain の order of operations — <https://www.izotope.com/en/learn/signal-chain-order-of-operations.html> / <https://www.izotope.com/en/learn/understanding-audio-signal-flow-in-a-daw.html>
+
+> **注意**: DAW マニュアルの individual section permalink は「概略 URL のみ確認・セクション URL は未確認」とマークする。CLAP extension ドキュメントは context7 経由で一次情報確認済。forum / 教材サイトの URL は調査時点での確認済み。
+
+### Rust ライブラリ
+- `clack-host` crate — <https://docs.rs/clack-host/latest/clack_host/>
+- `clack` GitHub — <https://github.com/prokopyl/clack>
+- MeadowlarkDAW/Dropseed (CLAP ホスト実例) — <https://github.com/MeadowlarkDAW/Dropseed>
+
+---
+
+*本ドキュメントは post-2.0 roadmap 入力用リサーチであり、§2（アーキ確定済）を再設計するものではない。増分提案は確定アーキの範囲内での優先度提案。*

--- a/docs/research/ENGINE_DAEMON_PROTOCOL.md
+++ b/docs/research/ENGINE_DAEMON_PROTOCOL.md
@@ -228,7 +228,9 @@ JSON-RPC 2.0 の影響を受けた独自形式:
     "time_sec": 0.5,
     "sample_id": "s-7b4e",
     "gain": 1.0,
-    "pan": 0.0
+    "pan": 0.0,
+    "offset_sec": 0.0,
+    "duration_sec": 0.0
   }
 }
 
@@ -242,6 +244,8 @@ JSON-RPC 2.0 の影響を受けた独自形式:
 - `time_sec`: daemon 内部 transport の基準時刻（起動時に 0.0 からスタート、`ResetTransport` で reset 可能 / Phase 2 で検討）。詳細はセクション 11 の Open Questions 参照
 - `gain`: `[0.0, ∞)`。範囲外（負値）は `PARAM_OUT_OF_RANGE` で reject。上限超過はクリッピング前提で accept
 - `pan`: `[-1.0, 1.0]`。範囲外は自動 clamp（UX 優先、reject しない）、省略時は 0.0
+- `offset_sec`: `[0.0, ∞)`。サンプル内の再生開始位置（秒）。省略時は 0.0（先頭）。`chop` の slice 開始位置に対応。負値は `PARAM_OUT_OF_RANGE` で reject
+- `duration_sec`: `[0.0, ∞)`。`offset_sec` から再生する長さ（秒）。0 または省略で「offset 以降すべて」。`chop` の slice 長に対応（natural rate=1.0 で再生）。負値は `PARAM_OUT_OF_RANGE` で reject。サンプル端を超える指定は端で clamp
 
 ### Stop
 

--- a/examples/22_rust_engine_parity.orbs
+++ b/examples/22_rust_engine_parity.orbs
@@ -1,0 +1,46 @@
+// Rust engine parity dog-food (#304) — pan / chop 領域再生 / per-slice gain
+//
+// 使い方:
+//   - 既定 (SuperCollider): そのまま再生
+//   - native Rust エンジン: ORBITSCORE_ENGINE=rust を付けて再生し、SC と聴き比べる
+//
+// 注: rate≠1.0（slice 尺をイベントスロット尺へ詰める varispeed = time-stretch）は本増分
+//     対象外。下の chop は grid 一致（sliceDur=eventDur → rate=1.0）にしてあるので、
+//     native でも warn なしで SC と同等に鳴るはず。
+
+var global = init GLOBAL
+global.tempo(120)
+global.beat(4 by 4)
+
+// === pan + per-slice gain（chop(1) = 全体再生・rate なし）===
+// kick=左 / snare=右 / hihat=中央 で定位差、gain で音量差を確認する。
+var kick = init global.seq
+kick.length(1)
+kick.audio("../test-assets/audio/kick.wav").chop(1)
+kick.defaultGain(-3).defaultPan(-60)
+kick.play(1, 0, 1, 0)
+
+var snare = init global.seq
+snare.length(1)
+snare.audio("../test-assets/audio/snare.wav").chop(1)
+snare.defaultGain(-6).defaultPan(60)
+snare.play(0, 1, 0, 1)
+
+var hat = init global.seq
+hat.length(1)
+hat.audio("../test-assets/audio/hihat_closed.wav").chop(1)
+hat.defaultGain(-9).defaultPan(0)
+hat.play(1, 1, 1, 1)
+
+// === chop 領域再生（grid 一致 → rate=1.0）===
+// arpeggio_c.wav = 1.0 秒。tempo 120 / 4-4 / length 1 → barDur=2.0 秒。
+// chop(2) で sliceDur=0.5 秒。play 4 要素 → eventDur=2.0/4=0.5 秒 = sliceDur → rate=1.0。
+// slice1→slice2→slice1→slice2 を領域読み（startPos/duration）で再生する。
+var chopd = init global.seq
+chopd.beat(4 by 4).length(1)
+chopd.audio("../test-assets/audio/arpeggio_c.wav").chop(2)
+chopd.defaultGain(-4).defaultPan(20)
+chopd.play(1, 2, 1, 2)
+
+global.start()
+RUN(kick, snare, hat, chopd)

--- a/packages/engine/src/audio/rust-engine/daemon-client.ts
+++ b/packages/engine/src/audio/rust-engine/daemon-client.ts
@@ -194,11 +194,23 @@ export class DaemonClient extends EventEmitter {
     }
   }
 
-  async playAt(sampleId: string, timeSec: number, gain: number): Promise<{ playId: string }> {
+  async playAt(
+    sampleId: string,
+    timeSec: number,
+    gain: number,
+    pan = 0,
+    offsetSec = 0,
+    durationSec = 0,
+  ): Promise<{ playId: string }> {
     const result = await this.request('PlayAt', {
       sample_id: sampleId,
       time_sec: timeSec,
       gain,
+      // pan は [-1.0, 1.0]（daemon 仕様）。範囲外は daemon 側で clamp。
+      pan,
+      // offset_sec / duration_sec は再生領域（chop の slice）。0/0 で全体再生。
+      offset_sec: offsetSec,
+      duration_sec: durationSec,
     })
     return { playId: String(result.play_id) }
   }

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -24,12 +24,13 @@
  *    フォールバック）。これで anchor を毎秒補正し audio/wall drift を吸収する。boot 直後は
  *    `GetStatus.uptime_sec`(≈transport) で暫定 anchor を置き、初回 StreamStats で精緻化する。
  *
- *  - **feature gap は boundary で明示**（見かけの parity を作らない・A0 方針）:
- *    pan≠0 → 1回 warn して中央定位で発音（pan drop）/ slice → 1回 warn して skip /
- *    outputChannel(LinkAudio) → 1回 warn して hardware 発音（SC の plugin-missing fallback と同形）/
- *    master effects（compressor/limiter/normalizer）→ 1回 warn して no-op。
- *    いずれも §6 確定の後続フェーズ（pan=小タスク・rate/slice=A3・LinkAudio/effects=A4 era）。
- *    内部 `ScheduledPlay` は pan を保持（param-complete）し、後の pan 追加を配線だけにする。
+ *  - **pan は #304 で実装済み**（daemon PlayAt の pan・equal-power = SC `Pan2` 一致）。
+ *    発火時に DSL の -100..100 を daemon の [-1,1] へ変換して送る。
+ *
+ *  - **残る feature gap は boundary で明示**（見かけの parity を作らない・A0 方針）:
+ *    slice → 1回 warn して skip / outputChannel(LinkAudio) → 1回 warn して hardware 発音
+ *    （SC の plugin-missing fallback と同形）/ master effects（compressor/limiter/normalizer）→
+ *    1回 warn して no-op。いずれも後続フェーズ（rate/slice=time-stretch 増分・LinkAudio/effects=A4 era）。
  */
 
 import { gainDbToAmplitude } from '../audio-gain-utils'
@@ -39,8 +40,18 @@ import type { AudioDevice } from '../supercollider/types'
 import { DaemonClient } from './daemon-client'
 import { DaemonConnectionError } from './errors'
 
-/** boundary で拒否する feature gap の種別。 */
-type GapKind = 'pan' | 'slice' | 'outputChannel' | 'masterEffect'
+/** boundary で拒否する feature gap の種別。pan は #304 で実装済みのため gap ではない。 */
+type GapKind = 'slice' | 'outputChannel' | 'masterEffect'
+
+/** chop slice 情報。`scheduleSliceEvent` 由来。発火時に領域（offset/duration）へ解決する。 */
+interface SliceSpec {
+  /** slice 番号（1 始まり）。 */
+  index: number
+  /** 分割数（`chop(n)` の n）。 */
+  total: number
+  /** イベントスロット尺（ms）。rate≠1.0 判定に使う（time-stretch 未対応の warn 用）。 */
+  eventDurationMs?: number
+}
 
 /** lean scheduler が保持する 1 発音イベント。SC `ScheduledPlay` の daemon 版。 */
 interface ScheduledPlay {
@@ -49,9 +60,11 @@ interface ScheduledPlay {
   filepath: string
   /** dB ゲイン（`scheduleEvent` の gainDb）。発火時に linear amplitude へ変換。 */
   gainDb: number
-  /** DSL pan（-100..100）。S2 では未適用だが param-complete のため保持。 */
+  /** DSL pan（-100..100）。発火時に daemon の [-1,1] へ変換。 */
   pan: number
   sequenceName: string
+  /** chop slice 情報。未指定なら全体再生。発火時に load 済み尺から領域を計算する。 */
+  slice?: SliceSpec
 }
 
 /** daemon transport clock と TS wall clock の対応点。 */
@@ -105,10 +118,11 @@ const DEFAULT_LOOKAHEAD_SEC = 0.05
 const POLL_INTERVAL_MS = 1
 /** SC EventScheduler と同じく、過大 drift のイベントは古い残骸として skip する閾値。 */
 const MAX_DRIFT_MS = 1000
+/** chop slice の rate が 1.0 からこの幅を超えて外れたら time-stretch 未対応として 1 回 warn する。 */
+const SLICE_RATE_TOLERANCE = 0.01
 
 /** feature gap warning の初期状態（フィールド初期化子で arm・stopAll で再 arm に使う）。 */
 const freshWarned = (): Record<GapKind, boolean> => ({
-  pan: false,
   slice: false,
   outputChannel: false,
   masterEffect: false,
@@ -269,35 +283,46 @@ export class RustEnginePlayer implements AudioEngineBackend {
         `⚠️  [rust-engine] outputChannel="${outputChannel}" (LinkAudio) is not supported yet (A4) — playing on the hardware bus.`,
       )
     }
-    if (pan !== 0) {
-      this.warnOnce(
-        'pan',
-        `⚠️  [rust-engine] pan is not supported yet — events play centered. (Deferred follow-up; daemon PlayAt has no pan.)`,
-      )
-    }
+    // pan は daemon PlayAt で実装済み（#304・equal-power = SC Pan2 一致）。発火時に
+    // executePlayback が DSL の -100..100 を daemon の [-1,1] へ変換して送る。
     this.enqueue({ time, filepath, gainDb, pan, sequenceName })
   }
 
   /**
-   * slice/chop（rate/startPos/duration）は A3（time-stretch）/ #239 の担当。daemon の
-   * PlayAt は全体再生のみなので、誤った全体再生で見かけの parity を作らないよう
-   * 1 回 warn して skip する。
+   * chop の slice を領域再生（startPos/duration の切り出し・rate=1.0）でスケジュールする（#304）。
+   *
+   * slice 領域（offset/長さ）はサンプル尺に依存するが、daemon の load は lazy（初回発火時）
+   * のため、領域は `executePlayback` で load 完了後に計算する。ここでは slice 仕様だけ保持する。
+   *
+   * rate≠1.0（slice 尺をイベントスロット尺へ詰める varispeed = time-stretch）は本増分の対象外。
+   * 発火時に rate≠1.0 を検出したら 1 回 warn し、slice は自然尺（rate=1.0）で鳴らす
+   * （time-stretch 増分 #213/#239 へ defer）。per-slice gain は各 slice の gainDb がそのまま効く。
    */
   scheduleSliceEvent(
-    _filepath: string,
-    _time: number,
-    _sliceIndex: number,
-    _totalSlices: number,
-    _eventDurationMs: number | undefined,
-    _gainDb = 0,
-    _pan = 0,
-    _sequenceName = '',
-    _outputChannel?: string,
+    filepath: string,
+    time: number,
+    sliceIndex: number,
+    totalSlices: number,
+    eventDurationMs: number | undefined,
+    gainDb = 0,
+    pan = 0,
+    sequenceName = '',
+    outputChannel?: string,
   ): void {
-    this.warnOnce(
-      'slice',
-      `⚠️  [rust-engine] slice/chop playback is not supported yet (A3 time-stretch / #239) — these events are skipped on the rust engine.`,
-    )
+    if (outputChannel) {
+      this.warnOnce(
+        'outputChannel',
+        `⚠️  [rust-engine] outputChannel="${outputChannel}" (LinkAudio) is not supported yet (A4) — playing on the hardware bus.`,
+      )
+    }
+    this.enqueue({
+      time,
+      filepath,
+      gainDb,
+      pan,
+      sequenceName,
+      slice: { index: sliceIndex, total: totalSlices, eventDurationMs },
+    })
   }
 
   start(): void {
@@ -381,12 +406,23 @@ export class RustEnginePlayer implements AudioEngineBackend {
     const sampleId = await this.ensureLoaded(play.filepath)
     // ロード（async round-trip）中に clear された場合の再チェック（mute/stop への応答性）。
     if (play.sequenceName && !this.liveSequences.has(play.sequenceName)) return
+    // chop の slice 領域は load 済み尺から計算する（lazy load のためここで解決）。
+    const { offsetSec, durationSec } = this.resolveSliceRegion(play)
     // daemonNowSec と wallMs は送信「前」に同一瞬間で採取する（onDispatch の lead/drift 計測が
     // coherent になるよう。playAt の await 後だと round-trip 分ずれる）。
     const wallMs = Date.now()
     const daemonNowSec = this.daemonNowSec()
     const timeSec = daemonNowSec + this.lookaheadSec
-    const { playId } = await this.daemon.playAt(sampleId, timeSec, amplitude)
+    // DSL pan（-100..100）を daemon の [-1,1] へ変換。範囲外は daemon 側で clamp。
+    const pan = play.pan / 100
+    const { playId } = await this.daemon.playAt(
+      sampleId,
+      timeSec,
+      amplitude,
+      pan,
+      offsetSec,
+      durationSec,
+    )
     this.onDispatch?.({
       filepath: play.filepath,
       sampleId,
@@ -443,6 +479,41 @@ export class RustEnginePlayer implements AudioEngineBackend {
   /** TS wall clock から daemon transport now_sec を推定する（anchor + 経過時間）。 */
   private daemonNowSec(): number {
     return this.clockAnchor.daemonSec + (Date.now() - this.clockAnchor.tsMs) / 1000
+  }
+
+  /**
+   * chop の slice 領域（offset/長さ・秒）を load 済みサンプル尺から計算する。
+   *
+   * 全体再生（slice なし）は `{0, 0}`（= daemon は全体再生）。slice の場合は
+   * `sliceDuration = totalDuration / total`、`offset = (index-1) * sliceDuration` を返す。
+   * 尺が未取得（lazy load で frames/SR が 0）の場合は全体再生にフォールバックする。
+   *
+   * rate≠1.0（slice 尺をイベントスロット尺に詰める time-stretch）は本増分の対象外なので、
+   * 検出したら 1 回 warn する（slice 自体は自然尺 rate=1.0 で鳴る）。
+   */
+  private resolveSliceRegion(play: ScheduledPlay): { offsetSec: number; durationSec: number } {
+    const spec = play.slice
+    if (!spec) return { offsetSec: 0, durationSec: 0 }
+    const totalDuration = this.durations.get(play.filepath) ?? 0
+    if (totalDuration <= 0 || spec.total <= 0) {
+      // 尺不明 → 全体再生フォールバック（誤った領域で無音を作らない）。
+      return { offsetSec: 0, durationSec: 0 }
+    }
+    const sliceDuration = totalDuration / spec.total
+    const offsetSec = (spec.index - 1) * sliceDuration
+    // time-stretch（rate≠1.0）は未対応。slice 尺がスロット尺と一致しない場合のみ warn。
+    if (spec.eventDurationMs && spec.eventDurationMs > 0) {
+      const rate = (sliceDuration * 1000) / spec.eventDurationMs
+      if (Math.abs(rate - 1) > SLICE_RATE_TOLERANCE) {
+        this.warnOnce(
+          'slice',
+          `⚠️  [rust-engine] chop slice rate=${rate.toFixed(3)} (slice length ≠ event slot) — ` +
+            `time-stretch is not supported yet; the slice plays at natural length (rate=1.0). ` +
+            `Deferred to the time-stretch increment (#213/#239).`,
+        )
+      }
+    }
+    return { offsetSec, durationSec: sliceDuration }
   }
 
   private warnOnce(kind: GapKind, message: string): void {

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -27,10 +27,13 @@
  *  - **pan は #304 で実装済み**（daemon PlayAt の pan・equal-power = SC `Pan2` 一致）。
  *    発火時に DSL の -100..100 を daemon の [-1,1] へ変換して送る。
  *
+ *  - **slice（chop 領域再生）は #304 で実装済み**（offset/duration の領域読み・rate=1.0）。
+ *    rate≠1.0（slice 尺をスロット尺へ詰める time-stretch）のみ 1回 warn し、slice 自体は
+ *    自然尺（rate=1.0）で発音する（skip しない）。time-stretch は #213/#239 へ defer。
+ *
  *  - **残る feature gap は boundary で明示**（見かけの parity を作らない・A0 方針）:
- *    slice → 1回 warn して skip / outputChannel(LinkAudio) → 1回 warn して hardware 発音
- *    （SC の plugin-missing fallback と同形）/ master effects（compressor/limiter/normalizer）→
- *    1回 warn して no-op。いずれも後続フェーズ（rate/slice=time-stretch 増分・LinkAudio/effects=A4 era）。
+ *    outputChannel(LinkAudio) → 1回 warn して hardware 発音（SC の plugin-missing fallback と同形）/
+ *    master effects（compressor/limiter/normalizer）→ 1回 warn して no-op。いずれも A4 era。
  */
 
 import { gainDbToAmplitude } from '../audio-gain-utils'
@@ -40,7 +43,13 @@ import type { AudioDevice } from '../supercollider/types'
 import { DaemonClient } from './daemon-client'
 import { DaemonConnectionError } from './errors'
 
-/** boundary で拒否する feature gap の種別。pan は #304 で実装済みのため gap ではない。 */
+/**
+ * boundary で明示する制約の種別。
+ * - `slice`: chop 領域再生は実装済み。rate≠1.0（time-stretch）未対応の warn 用で、slice 自体は
+ *   rate=1.0 で発音する（拒否しない）。
+ * - `outputChannel`(LinkAudio) / `masterEffect`: 未対応 feature gap（A4 era）。
+ * pan は #304 で実装済みのため gap ではない。
+ */
 type GapKind = 'slice' | 'outputChannel' | 'masterEffect'
 
 /** chop slice 情報。`scheduleSliceEvent` 由来。発火時に領域（offset/duration）へ解決する。 */
@@ -448,7 +457,10 @@ export class RustEnginePlayer implements AudioEngineBackend {
       this.stop()
       return
     }
-    console.error(`❌ [rust-engine] playback error for ${play.sequenceName}:`, err)
+    console.error(
+      `❌ [rust-engine] playback error for ${play.sequenceName} (${play.filepath}):`,
+      err,
+    )
   }
 
   /** filepath を daemon にロードし sample_id を返す（キャッシュ + single-flight）。 */
@@ -463,8 +475,15 @@ export class RustEnginePlayer implements AudioEngineBackend {
       .loadSample(filepath)
       .then((res) => {
         this.sampleIds.set(filepath, res.sampleId)
-        if (res.sampleRate > 0) {
+        if (res.sampleRate > 0 && Number.isFinite(res.sampleRate)) {
           this.durations.set(filepath, res.frames / res.sampleRate)
+        } else {
+          // 尺が取れないと chop の領域が計算できず、slice が無言で全体再生に degrade する
+          // （#304 で durations が slice 再生に load-bearing 化した）。ソースで warn する。
+          console.warn(
+            `⚠️  [rust-engine] LoadSample for "${filepath}" returned invalid sample_rate=` +
+              `${res.sampleRate} — chop slice 領域を計算できず、slice は全体再生に degrade します。`,
+          )
         }
         return res.sampleId
       })

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -475,14 +475,21 @@ export class RustEnginePlayer implements AudioEngineBackend {
       .loadSample(filepath)
       .then((res) => {
         this.sampleIds.set(filepath, res.sampleId)
-        if (res.sampleRate > 0 && Number.isFinite(res.sampleRate)) {
+        // 尺計算には sample_rate と frames の両方が有限・正である必要がある。どちらかが
+        // 不正だと chop の領域が計算できず slice が無言で全体再生に degrade する
+        // （#304 で durations が slice 再生に load-bearing 化した）。ソースで warn する。
+        if (
+          res.sampleRate > 0 &&
+          Number.isFinite(res.sampleRate) &&
+          Number.isFinite(res.frames) &&
+          res.frames >= 0
+        ) {
           this.durations.set(filepath, res.frames / res.sampleRate)
         } else {
-          // 尺が取れないと chop の領域が計算できず、slice が無言で全体再生に degrade する
-          // （#304 で durations が slice 再生に load-bearing 化した）。ソースで warn する。
           console.warn(
-            `⚠️  [rust-engine] LoadSample for "${filepath}" returned invalid sample_rate=` +
-              `${res.sampleRate} — chop slice 領域を計算できず、slice は全体再生に degrade します。`,
+            `⚠️  [rust-engine] LoadSample for "${filepath}" returned invalid metadata ` +
+              `(sample_rate=${res.sampleRate}, frames=${res.frames}) — ` +
+              `chop slice 領域を計算できず、slice は全体再生に degrade します。`,
           )
         }
         return res.sampleId
@@ -514,7 +521,8 @@ export class RustEnginePlayer implements AudioEngineBackend {
     const spec = play.slice
     if (!spec) return { offsetSec: 0, durationSec: 0 }
     const totalDuration = this.durations.get(play.filepath) ?? 0
-    if (totalDuration <= 0 || spec.total <= 0) {
+    // NaN <= 0 は JS では false。尺が NaN/非有限でも確実に全体再生フォールバックへ落とす。
+    if (!Number.isFinite(totalDuration) || totalDuration <= 0 || spec.total <= 0) {
       // 尺不明 → 全体再生フォールバック（誤った領域で無音を作らない）。
       return { offsetSec: 0, durationSec: 0 }
     }

--- a/rust/crates/orbit-audio-core/src/engine.rs
+++ b/rust/crates/orbit-audio-core/src/engine.rs
@@ -46,10 +46,19 @@ impl Engine {
     }
 
     /// `play_id` 付きでスケジュールする。後で `stop` で個別停止できる。
+    ///
+    /// `pan` は [-1.0, 1.0]（0.0 = 中央）。render 時に等パワー則（SC `Pan2` 一致）で
+    /// 適用され、範囲外は clamp される。
+    /// `slice_start_frame` / `slice_len_frames` は再生領域（`chop` の slice）。
+    /// `slice_len_frames == 0` で「offset 以降すべて」。サンプル端で clamp される。
+    #[allow(clippy::too_many_arguments)]
     pub fn schedule_with_play_id(
         &self,
         start_sec: f64,
         gain: f32,
+        pan: f32,
+        slice_start_frame: usize,
+        slice_len_frames: usize,
         play_id: String,
         sample: Sample,
     ) -> Result<(), EngineError> {
@@ -57,6 +66,8 @@ impl Engine {
         s.schedule(
             ScheduledSample::new(start_sec, sample)
                 .with_gain(gain)
+                .with_pan(pan)
+                .with_region(slice_start_frame, slice_len_frames)
                 .with_play_id(play_id),
         );
         Ok(())

--- a/rust/crates/orbit-audio-core/src/lib.rs
+++ b/rust/crates/orbit-audio-core/src/lib.rs
@@ -16,4 +16,4 @@ mod scheduler;
 
 pub use engine::{Engine, EngineError};
 pub use sample::Sample;
-pub use scheduler::{ScheduledSample, Scheduler};
+pub use scheduler::{resolve_slice_region, ScheduledSample, Scheduler};

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -69,6 +69,24 @@ fn equal_power_pan(pan: f32) -> (f32, f32) {
     (angle.cos(), angle.sin())
 }
 
+/// 再生領域（slice）をサンプル端で clamp し `(clamped_start, effective_len)` を返す。
+/// `offset_frames` をサンプル長で、`requested_len_frames`（0 = offset 以降すべて）を
+/// 残りフレーム数で clamp する。`Scheduler::schedule`（render 尺）と daemon の
+/// `play_at`（PlayEnded 尺）が同一値になるよう、両者がこの単一式を共有する。
+pub fn resolve_slice_region(
+    total_frames: usize,
+    offset_frames: usize,
+    requested_len_frames: usize,
+) -> (usize, usize) {
+    let start = offset_frames.min(total_frames);
+    let len = if requested_len_frames == 0 {
+        total_frames - start
+    } else {
+        requested_len_frames.min(total_frames - start)
+    };
+    (start, len)
+}
+
 /// スケジュール済みサンプル群を混合するミキサー。
 ///
 /// オーディオコールバック内で使うことを想定し、allocation 無しで
@@ -96,8 +114,10 @@ struct ActiveSample {
     start_frame: u64,
     /// ゲイン
     gain: f32,
-    /// パン定位（[-1.0, 1.0]、0.0 = 中央）。render で等パワー則を適用する。
-    pan: f32,
+    /// 等パワー則で precompute した左右ゲイン。pan は再生中不変なので schedule 時に
+    /// 一度だけ求め、RT render では trig 無しで読むだけにする。ステレオ以外は (1.0, 1.0)。
+    pan_l: f32,
+    pan_r: f32,
     /// 再生領域の開始フレーム（サンプル内オフセット）。`chop` の slice 開始。
     slice_start: usize,
     /// 再生領域の長さ（フレーム数）。サンプル端で clamp 済み。
@@ -152,13 +172,12 @@ impl Scheduler {
         let start_frame = (event.start_sec * self.output_sample_rate as f64).max(0.0) as u64;
 
         // 再生領域（slice）をサンプル端で clamp。len==0 は「offset 以降すべて」。
-        let total_frames = event.sample.frames();
-        let slice_start = event.slice_start_frame.min(total_frames);
-        let slice_len = if event.slice_len_frames == 0 {
-            total_frames - slice_start
-        } else {
-            event.slice_len_frames.min(total_frames - slice_start)
-        };
+        // daemon の PlayEnded 尺計算と同一式を共有する（resolve_slice_region）。
+        let (slice_start, slice_len) = resolve_slice_region(
+            event.sample.frames(),
+            event.slice_start_frame,
+            event.slice_len_frames,
+        );
 
         // 末尾フェードアウト（線形 release）。SC `orbitPlayBuf` の
         // `fadeOut = min(0.008, actualDuration * 0.04)` に一致させクリックを防ぐ。
@@ -167,10 +186,20 @@ impl Scheduler {
         let fade_sec = (out_dur_sec * 0.04).min(0.008);
         let fade_frames = (fade_sec * self.output_sample_rate as f64).round() as usize;
 
+        // 等パワーパンの左右ゲインを schedule 時（cold path）に precompute。pan は再生中
+        // 不変なので RT render から trig（sin/cos）と output_channels 分岐を追い出す。
+        // ステレオ出力でのみ定位し、それ以外（モノ/サラウンド）は素のゲインに戻す。
+        let (pan_l, pan_r) = if self.output_channels == 2 {
+            equal_power_pan(event.pan)
+        } else {
+            (1.0, 1.0)
+        };
+
         self.events.push(ActiveSample {
             start_frame,
             gain: event.gain,
-            pan: event.pan,
+            pan_l,
+            pan_r,
             slice_start,
             slice_len,
             fade_frames,
@@ -228,13 +257,9 @@ impl Scheduler {
             let writable_frames = frames_to_render.saturating_sub(dst_offset_frames);
             let frames_to_copy = writable_frames.min(remaining_src_frames);
 
-            // 等パワーパンの左右ゲイン。ステレオ出力でのみ定位し、それ以外（モノ/サラウンド）は
-            // 定位を適用せず素のゲインに戻す（pan_l == pan_r == 1.0）。SC の Pan2 に一致。
-            let (pan_l, pan_r) = if output_channels == 2 {
-                equal_power_pan(active.pan)
-            } else {
-                (1.0, 1.0)
-            };
+            // 左右ゲインは schedule 時に precompute 済み（RT から trig と output_channels
+            // 分岐を排除）。ステレオ以外では (1.0, 1.0)。SC の Pan2 に一致。
+            let (pan_l, pan_r) = (active.pan_l, active.pan_r);
 
             // 末尾フェードアウトの開始位置（slice 内相対）。fade_frames==0 ならフェードなし。
             let fade_start = active.slice_len.saturating_sub(active.fade_frames);
@@ -243,19 +268,21 @@ impl Scheduler {
                 let slice_pos = active.read_pos + i; // slice 領域内の相対位置
                 let src_frame = active.slice_start + slice_pos; // サンプル内の絶対フレーム
                 let dst_frame = dst_offset_frames + i;
-                // 線形 release エンベロープ（SC `linen` の fadeOut 部）。
-                // slice 末尾でクリックが出ないよう 1.0 → 0.0 へ線形に減衰させる。
+                // 線形 release エンベロープ（SC `linen` の fadeOut 部）。slice 末尾で
+                // クリックが出ないよう 1.0 → 0.0 へ線形に減衰させる。env は frame のみに
+                // 依存するので channel ループの外で 1 回求め、gain と束ねて amp にする。
                 let env = if active.fade_frames > 0 && slice_pos >= fade_start {
                     (active.slice_len - slice_pos) as f32 / active.fade_frames as f32
                 } else {
                     1.0
                 };
+                let amp = active.gain * env;
                 for ch in 0..output_channels {
                     let src_ch = ch.min(src_channels - 1);
                     let src_idx = src_frame * src_channels + src_ch;
                     let dst_idx = dst_frame * output_channels + ch;
                     let pan_mul = if ch == 0 { pan_l } else { pan_r };
-                    out[dst_idx] += active.sample.data[src_idx] * active.gain * pan_mul * env;
+                    out[dst_idx] += active.sample.data[src_idx] * amp * pan_mul;
                 }
             }
             active.read_pos += frames_to_copy;

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -512,6 +512,49 @@ mod tests {
     }
 
     #[test]
+    fn resolve_slice_region_clamps_offset_and_len() {
+        // scheduler の render 尺と daemon の PlayEnded 尺が共有する単一式。境界を直接 pin する。
+        // offset == total → start=total, len=0（`total - start` の usize underflow を防ぐ）
+        assert_eq!(resolve_slice_region(100, 100, 0), (100, 0));
+        assert_eq!(resolve_slice_region(100, 100, 50), (100, 0));
+        // offset > total → total で clamp
+        assert_eq!(resolve_slice_region(100, 150, 10), (100, 0));
+        // offset=0, len=0 → 全体
+        assert_eq!(resolve_slice_region(100, 0, 0), (0, 100));
+        // offset>0, len=0 → offset 以降すべて
+        assert_eq!(resolve_slice_region(100, 30, 0), (30, 70));
+        // requested > remaining → remaining で clamp
+        assert_eq!(resolve_slice_region(100, 30, 1000), (30, 70));
+    }
+
+    #[test]
+    fn slice_region_stereo_source_reads_correct_channel_frames() {
+        // ステレオ素材で frame i の L=i, R=i+0.5。region [4,3] で frame 4,5,6 を読む。
+        // 中央パン（各 ch 1/√2 倍）で、L が L サンプル・R が R サンプルを読む
+        // （channel stride = src_frame*channels + ch が正しい）ことを確認する。
+        let frames = 20usize;
+        let data: Vec<f32> = (0..frames).flat_map(|i| [i as f32, i as f32 + 0.5]).collect();
+        let sample = Sample::new(data, 48_000, 2);
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(
+            ScheduledSample::new(0.0, sample)
+                .with_pan(0.0)
+                .with_region(4, 3),
+        );
+        let mut buf = vec![0.0f32; 40]; // 20 frames stereo
+        s.render(&mut buf);
+        let k = std::f32::consts::FRAC_1_SQRT_2;
+        // 出力 frame 0 = 素材 frame 4: L=4.0, R=4.5（ch を取り違えていれば落ちる）
+        assert!((buf[0] - 4.0 * k).abs() < 1e-4, "f4 L={}", buf[0]);
+        assert!((buf[1] - 4.5 * k).abs() < 1e-4, "f4 R={}", buf[1]);
+        // 出力 frame 1 = 素材 frame 5: L=5.0
+        assert!((buf[2] - 5.0 * k).abs() < 1e-4, "f5 L={}", buf[2]);
+        // 出力 frame 3 は region（3 フレーム）外 → 無音
+        assert!(buf[6].abs() < 1e-5, "f7 L (region 後)={}", buf[6]);
+        assert_eq!(s.active_count(), 0);
+    }
+
+    #[test]
     fn set_global_gain_ramps_linearly_to_target() {
         let mut s = Scheduler::new(48_000, 2);
         // 直流 1.0 のモノラルサンプルを想定して 1ch 出力にすると計算が容易。

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -9,6 +9,12 @@ pub struct ScheduledSample {
     pub start_sec: f64,
     /// ゲイン係数（線形、1.0 = unity）
     pub gain: f32,
+    /// パン定位（[-1.0, 1.0]、0.0 = 中央）。SC の `Pan2` と同じ等パワー則で適用する。
+    pub pan: f32,
+    /// 再生開始フレーム（サンプル内オフセット）。0 = 先頭。`chop` の slice 開始位置。
+    pub slice_start_frame: usize,
+    /// 再生フレーム数（slice 長）。0 = `slice_start_frame` 以降すべて。`chop` の slice 長。
+    pub slice_len_frames: usize,
     /// サンプル本体
     pub sample: Sample,
     /// Stop 命令での個別停止用識別子。`None` なら停止不可（fire-and-forget）。
@@ -20,6 +26,9 @@ impl ScheduledSample {
         Self {
             start_sec,
             gain: 1.0,
+            pan: 0.0,
+            slice_start_frame: 0,
+            slice_len_frames: 0,
             sample,
             play_id: None,
         }
@@ -30,10 +39,34 @@ impl ScheduledSample {
         self
     }
 
+    /// パン定位を設定する（[-1.0, 1.0]、範囲外は render 時に clamp）。
+    pub fn with_pan(mut self, pan: f32) -> Self {
+        self.pan = pan;
+        self
+    }
+
+    /// 再生領域（slice）を設定する。`start_frame` はサンプル内オフセット、
+    /// `len_frames` は再生フレーム数（0 = `start_frame` 以降すべて）。`chop` 用。
+    /// スケジュール時にサンプル端で clamp される。
+    pub fn with_region(mut self, start_frame: usize, len_frames: usize) -> Self {
+        self.slice_start_frame = start_frame;
+        self.slice_len_frames = len_frames;
+        self
+    }
+
     pub fn with_play_id(mut self, play_id: String) -> Self {
         self.play_id = Some(play_id);
         self
     }
+}
+
+/// 等パワー（equal-power）パン則。SC の `Pan2` と同じく pan=0（中央）で各チャンネル
+/// 1/√2 (≈0.707, -3dB)、pan=-1 で左 unity・右 0、pan=+1 で逆。`pan` は範囲外を clamp。
+/// 戻り値は (左ゲイン, 右ゲイン)。ステレオ出力以外では呼び出し側で適用しない。
+fn equal_power_pan(pan: f32) -> (f32, f32) {
+    let pan01 = (pan.clamp(-1.0, 1.0) + 1.0) * 0.5; // [-1,1] -> [0,1]
+    let angle = pan01 * std::f32::consts::FRAC_PI_2;
+    (angle.cos(), angle.sin())
 }
 
 /// スケジュール済みサンプル群を混合するミキサー。
@@ -63,9 +96,17 @@ struct ActiveSample {
     start_frame: u64,
     /// ゲイン
     gain: f32,
+    /// パン定位（[-1.0, 1.0]、0.0 = 中央）。render で等パワー則を適用する。
+    pan: f32,
+    /// 再生領域の開始フレーム（サンプル内オフセット）。`chop` の slice 開始。
+    slice_start: usize,
+    /// 再生領域の長さ（フレーム数）。サンプル端で clamp 済み。
+    slice_len: usize,
+    /// 末尾フェードアウトのフレーム数（クリック防止・SC `orbitPlayBuf` 一致）。
+    fade_frames: usize,
     /// サンプル本体
     sample: Sample,
-    /// このサンプル内で次に読むフレーム位置
+    /// 再生領域内で次に読むフレーム位置（0..slice_len の相対位置）
     read_pos: usize,
     /// 個別停止用識別子
     play_id: Option<String>,
@@ -109,9 +150,30 @@ impl Scheduler {
     /// サンプルを予約する。時刻は秒。
     pub fn schedule(&mut self, event: ScheduledSample) {
         let start_frame = (event.start_sec * self.output_sample_rate as f64).max(0.0) as u64;
+
+        // 再生領域（slice）をサンプル端で clamp。len==0 は「offset 以降すべて」。
+        let total_frames = event.sample.frames();
+        let slice_start = event.slice_start_frame.min(total_frames);
+        let slice_len = if event.slice_len_frames == 0 {
+            total_frames - slice_start
+        } else {
+            event.slice_len_frames.min(total_frames - slice_start)
+        };
+
+        // 末尾フェードアウト（線形 release）。SC `orbitPlayBuf` の
+        // `fadeOut = min(0.008, actualDuration * 0.04)` に一致させクリックを防ぐ。
+        // rate=1.0 再生なので出力尺 = slice_len / sample_rate。
+        let out_dur_sec = slice_len as f64 / self.output_sample_rate as f64;
+        let fade_sec = (out_dur_sec * 0.04).min(0.008);
+        let fade_frames = (fade_sec * self.output_sample_rate as f64).round() as usize;
+
         self.events.push(ActiveSample {
             start_frame,
             gain: event.gain,
+            pan: event.pan,
+            slice_start,
+            slice_len,
+            fade_frames,
             sample: event.sample,
             read_pos: 0,
             play_id: event.play_id,
@@ -148,12 +210,11 @@ impl Scheduler {
             let src_channels = active.sample.channels as usize;
             if src_channels == 0 {
                 // 0ch の不正なサンプルはスキップ（`src_channels - 1` のアンダーフロー回避）
-                active.read_pos = active.sample.frames();
+                active.read_pos = active.slice_len;
                 continue;
             }
-            let total_src_frames = active.sample.frames();
-            if active.read_pos >= total_src_frames {
-                continue; // 再生済み
+            if active.read_pos >= active.slice_len {
+                continue; // 再生済み（slice 領域を読み終えた）
             }
 
             // 出力バッファ内での書き込み開始位置（フレーム単位）
@@ -163,18 +224,38 @@ impl Scheduler {
                 0
             };
 
-            let remaining_src_frames = total_src_frames - active.read_pos;
+            let remaining_src_frames = active.slice_len - active.read_pos;
             let writable_frames = frames_to_render.saturating_sub(dst_offset_frames);
             let frames_to_copy = writable_frames.min(remaining_src_frames);
 
+            // 等パワーパンの左右ゲイン。ステレオ出力でのみ定位し、それ以外（モノ/サラウンド）は
+            // 定位を適用せず素のゲインに戻す（pan_l == pan_r == 1.0）。SC の Pan2 に一致。
+            let (pan_l, pan_r) = if output_channels == 2 {
+                equal_power_pan(active.pan)
+            } else {
+                (1.0, 1.0)
+            };
+
+            // 末尾フェードアウトの開始位置（slice 内相対）。fade_frames==0 ならフェードなし。
+            let fade_start = active.slice_len.saturating_sub(active.fade_frames);
+
             for i in 0..frames_to_copy {
-                let src_frame = active.read_pos + i;
+                let slice_pos = active.read_pos + i; // slice 領域内の相対位置
+                let src_frame = active.slice_start + slice_pos; // サンプル内の絶対フレーム
                 let dst_frame = dst_offset_frames + i;
+                // 線形 release エンベロープ（SC `linen` の fadeOut 部）。
+                // slice 末尾でクリックが出ないよう 1.0 → 0.0 へ線形に減衰させる。
+                let env = if active.fade_frames > 0 && slice_pos >= fade_start {
+                    (active.slice_len - slice_pos) as f32 / active.fade_frames as f32
+                } else {
+                    1.0
+                };
                 for ch in 0..output_channels {
                     let src_ch = ch.min(src_channels - 1);
                     let src_idx = src_frame * src_channels + src_ch;
                     let dst_idx = dst_frame * output_channels + ch;
-                    out[dst_idx] += active.sample.data[src_idx] * active.gain;
+                    let pan_mul = if ch == 0 { pan_l } else { pan_r };
+                    out[dst_idx] += active.sample.data[src_idx] * active.gain * pan_mul * env;
                 }
             }
             active.read_pos += frames_to_copy;
@@ -200,9 +281,9 @@ impl Scheduler {
         }
 
         self.cursor_frames += frames_to_render as u64;
-        // 再生完了したもの（= すべてのフレームを読み終えたもの）をドロップ。
+        // 再生完了したもの（= slice 領域を読み終えたもの）をドロップ。
         // まだ開始時刻に到達していないイベントは read_pos == 0 のため自然に保持される。
-        self.events.retain(|a| a.read_pos < a.sample.frames());
+        self.events.retain(|a| a.read_pos < a.slice_len);
     }
 
     /// 現在の出力ストリーム時刻（秒）
@@ -291,9 +372,116 @@ mod tests {
         let mut buf = vec![0.0f32; 200];
         s.render(&mut buf);
 
-        // 元々 0.1 のサンプルが 0.5x でスケール → ~0.05。ランプ無しなので一定。
+        // 0.1 のサンプルが 0.5x global gain でスケールし、さらに pan=0（中央）の等パワー則で
+        // 1/√2 ≈ 0.707 が掛かる → 0.1 * 0.5 * 0.7071 ≈ 0.03536。ランプ無しなので一定。
         let peak = buf.iter().cloned().fold(0.0f32, f32::max);
-        assert!((peak - 0.05).abs() < 1e-5, "peak={peak}");
+        let expected = 0.1 * 0.5 * std::f32::consts::FRAC_1_SQRT_2;
+        assert!((peak - expected).abs() < 1e-5, "peak={peak}");
+    }
+
+    #[test]
+    fn pan_center_applies_equal_power_minus_3db() {
+        // pan=0（既定）→ 各チャンネル 0.1 * 1/√2 ≈ 0.0707（SC Pan2 中央 = -3dB）
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(ScheduledSample::new(0.0, mk_sample_stereo(100)));
+        let mut buf = vec![0.0f32; 200];
+        s.render(&mut buf);
+        let expected = 0.1 * std::f32::consts::FRAC_1_SQRT_2;
+        assert!((buf[0] - expected).abs() < 1e-5, "L={}", buf[0]);
+        assert!((buf[1] - expected).abs() < 1e-5, "R={}", buf[1]);
+    }
+
+    #[test]
+    fn pan_hard_left_silences_right_channel() {
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(ScheduledSample::new(0.0, mk_sample_stereo(100)).with_pan(-1.0));
+        let mut buf = vec![0.0f32; 200];
+        s.render(&mut buf);
+        assert!((buf[0] - 0.1).abs() < 1e-5, "L={}", buf[0]); // 左 unity
+        assert!(buf[1].abs() < 1e-6, "R={}", buf[1]); // 右 無音
+    }
+
+    #[test]
+    fn pan_hard_right_silences_left_channel() {
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(ScheduledSample::new(0.0, mk_sample_stereo(100)).with_pan(1.0));
+        let mut buf = vec![0.0f32; 200];
+        s.render(&mut buf);
+        assert!(buf[0].abs() < 1e-6, "L={}", buf[0]); // 左 無音
+        assert!((buf[1] - 0.1).abs() < 1e-5, "R={}", buf[1]); // 右 unity
+    }
+
+    #[test]
+    fn pan_clamps_out_of_range_to_hard_left() {
+        // pan < -1 は -1 に clamp → hard left（reject せず UX 優先・protocol 仕様）
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(ScheduledSample::new(0.0, mk_sample_stereo(100)).with_pan(-2.0));
+        let mut buf = vec![0.0f32; 200];
+        s.render(&mut buf);
+        assert!((buf[0] - 0.1).abs() < 1e-5, "L={}", buf[0]);
+        assert!(buf[1].abs() < 1e-6, "R={}", buf[1]);
+    }
+
+    /// フレーム値 = フレーム番号のモノラルサンプル（slice 領域の同定に使う）。
+    fn mk_sample_mono_ramp(frames: usize) -> Sample {
+        Sample::new((0..frames).map(|i| i as f32).collect(), 48_000, 1)
+    }
+
+    #[test]
+    fn slice_region_plays_only_the_requested_window() {
+        // frame 値 = frame 番号のモノラル素材を region [50, 4] で再生。
+        // hard-left（pan=-1）で L = 素材値そのまま、R = 0 になり領域を同定できる。
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(
+            ScheduledSample::new(0.0, mk_sample_mono_ramp(200))
+                .with_pan(-1.0)
+                .with_region(50, 4),
+        );
+        let mut buf = vec![0.0f32; 20]; // 10 frames
+        s.render(&mut buf);
+        // L 出力は素材の frame 50,51,52,53、その後は無音。
+        assert!((buf[0] - 50.0).abs() < 1e-4, "f0 L={}", buf[0]);
+        assert!((buf[2] - 51.0).abs() < 1e-4, "f1 L={}", buf[2]);
+        assert!((buf[4] - 52.0).abs() < 1e-4, "f2 L={}", buf[4]);
+        assert!((buf[6] - 53.0).abs() < 1e-4, "f3 L={}", buf[6]);
+        assert!(buf[8].abs() < 1e-6, "f4 L (region 後)={}", buf[8]);
+        assert!(buf[1].abs() < 1e-6, "f0 R (hard-left)={}", buf[1]);
+        // 4 フレームの slice を読み終えてイベントは掃除される。
+        assert_eq!(s.active_count(), 0);
+    }
+
+    #[test]
+    fn slice_region_clamps_to_sample_end() {
+        // region [195, 100] は素材端（200）で len=5 に clamp され panic しない。
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(
+            ScheduledSample::new(0.0, mk_sample_mono_ramp(200))
+                .with_pan(-1.0)
+                .with_region(195, 100),
+        );
+        let mut buf = vec![0.0f32; 40]; // 20 frames
+        s.render(&mut buf);
+        assert!((buf[0] - 195.0).abs() < 1e-4, "f0 L={}", buf[0]);
+        assert!((buf[8] - 199.0).abs() < 1e-4, "f4 L={}", buf[8]); // 末尾フレーム
+        assert!(buf[10].abs() < 1e-6, "f5 L (clamp 後)={}", buf[10]);
+        assert_eq!(s.active_count(), 0);
+    }
+
+    #[test]
+    fn slice_tail_is_faded_out() {
+        // len=100 の slice は fade_frames=4（min(8ms, dur*4%)）。末尾 4 フレームが線形減衰。
+        // 定数 1.0 の素材を hard-left で流し、L 出力の末尾が body より小さいことを確認。
+        let mut s = Scheduler::new(48_000, 2);
+        let sample = Sample::new(vec![1.0f32; 100], 48_000, 1);
+        s.schedule(ScheduledSample::new(0.0, sample).with_pan(-1.0).with_region(0, 100));
+        let mut buf = vec![0.0f32; 200]; // 100 frames
+        s.render(&mut buf);
+        // body（fade 開始 96 より前）は 1.0。
+        assert!((buf[0] - 1.0).abs() < 1e-5, "f0 L={}", buf[0]);
+        assert!((buf[2 * 95] - 1.0).abs() < 1e-5, "f95 L={}", buf[2 * 95]);
+        // 末尾フェード: frame97 ≈ 0.75, frame99 ≈ 0.25（線形 1→0）。
+        assert!((buf[2 * 97] - 0.75).abs() < 1e-4, "f97 L={}", buf[2 * 97]);
+        assert!((buf[2 * 99] - 0.25).abs() < 1e-4, "f99 L={}", buf[2 * 99]);
     }
 
     #[test]

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -150,28 +150,60 @@ impl EngineWrap {
     /// sample を現在時刻 + offset でスケジュール。
     ///
     /// `time_sec` は daemon 起動からの経過秒（Engine transport 基準）。
-    /// 戻り値にサンプル再生時間を含めるので、呼び出し側は PlayEnded を
-    /// 遅延送信するためのタイマーを組める。
+    /// `pan` は [-1.0, 1.0]（0.0 = 中央、範囲外は core で clamp）。
+    /// `offset_sec` / `duration_sec` は再生領域（`chop` の slice）。`duration_sec <= 0` で
+    /// 「offset 以降すべて」。いずれもサンプル端で clamp。
+    /// 戻り値の `duration_sec` は **slice の実尺**（全体ではなく）なので、呼び出し側は
+    /// PlayEnded を slice 終端に合わせて遅延送信できる。
+    #[allow(clippy::too_many_arguments)]
     pub fn play_at(
         &self,
         sample_id: &str,
         time_sec: f64,
         gain: f32,
+        pan: f32,
+        offset_sec: f64,
+        duration_sec: f64,
     ) -> Result<PlayHandle, WrapError> {
         let sample = self
             .lock_samples()?
             .get(sample_id)
             .cloned()
             .ok_or_else(|| WrapError::SampleNotFound(sample_id.to_string()))?;
-        let duration_sec = sample.duration_secs();
+        let sr = sample.sample_rate as f64;
+        let total_frames = sample.frames();
+        // サンプル内オフセット（フレーム）。サンプル端で clamp。
+        let offset_frames = ((offset_sec.max(0.0)) * sr) as usize;
+        let offset_frames = offset_frames.min(total_frames);
+        // slice 長（フレーム）。0 = offset 以降すべて。
+        let requested_len_frames = if duration_sec > 0.0 {
+            (duration_sec * sr).round() as usize
+        } else {
+            0
+        };
+        // PlayEnded 用の出力尺は slice の実尺（rate=1.0）。サンプル端で clamp 済みの長さ。
+        let effective_len_frames = if requested_len_frames == 0 {
+            total_frames - offset_frames
+        } else {
+            requested_len_frames.min(total_frames - offset_frames)
+        };
+        let out_duration_sec = effective_len_frames as f64 / sr;
         let play_id = format!("p-{}", short_uuid());
         self.engine
-            .schedule_with_play_id(time_sec, gain, play_id.clone(), sample)
+            .schedule_with_play_id(
+                time_sec,
+                gain,
+                pan,
+                offset_frames,
+                requested_len_frames,
+                play_id.clone(),
+                sample,
+            )
             .map_err(|e| WrapError::Scheduler(e.to_string()))?;
         Ok(PlayHandle {
             play_id,
             start_sec: time_sec,
-            duration_sec,
+            duration_sec: out_duration_sec,
         })
     }
 

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -192,7 +192,9 @@ impl EngineWrap {
                 gain,
                 pan,
                 slice_start_frame,
-                requested_len_frames,
+                // clamp 済みの実尺を渡す。生の requested_len_frames を渡すと、render 尺と
+                // PlayEnded 尺の一致が scheduler 内の再 clamp に依存してしまう（latent な desync）。
+                effective_len_frames,
                 play_id.clone(),
                 sample,
             )

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-use orbit_audio_core::{Engine, Sample};
+use orbit_audio_core::{resolve_slice_region, Engine, Sample};
 use orbit_audio_native::{
     load_sample_resampled, LoaderError, OutputError, OutputStream, ResampleError, StreamStats,
     StreamStatsSnapshot,
@@ -172,21 +172,18 @@ impl EngineWrap {
             .ok_or_else(|| WrapError::SampleNotFound(sample_id.to_string()))?;
         let sr = sample.sample_rate as f64;
         let total_frames = sample.frames();
-        // サンプル内オフセット（フレーム）。サンプル端で clamp。
-        let offset_frames = ((offset_sec.max(0.0)) * sr) as usize;
-        let offset_frames = offset_frames.min(total_frames);
-        // slice 長（フレーム）。0 = offset 以降すべて。
+        // サンプル内オフセット / slice 長（フレーム）。0 = offset 以降すべて。
+        // サンプル端 clamp は resolve_slice_region に集約する。
+        let offset_frames = (offset_sec.max(0.0) * sr) as usize;
         let requested_len_frames = if duration_sec > 0.0 {
             (duration_sec * sr).round() as usize
         } else {
             0
         };
-        // PlayEnded 用の出力尺は slice の実尺（rate=1.0）。サンプル端で clamp 済みの長さ。
-        let effective_len_frames = if requested_len_frames == 0 {
-            total_frames - offset_frames
-        } else {
-            requested_len_frames.min(total_frames - offset_frames)
-        };
+        // 再生領域を clamp。PlayEnded 用の出力尺（slice 実尺・rate=1.0）と、scheduler が
+        // render に使う尺が必ず一致するよう、両者が同一式（resolve_slice_region）を共有する。
+        let (slice_start_frame, effective_len_frames) =
+            resolve_slice_region(total_frames, offset_frames, requested_len_frames);
         let out_duration_sec = effective_len_frames as f64 / sr;
         let play_id = format!("p-{}", short_uuid());
         self.engine
@@ -194,7 +191,7 @@ impl EngineWrap {
                 time_sec,
                 gain,
                 pan,
-                offset_frames,
+                slice_start_frame,
                 requested_len_frames,
                 play_id.clone(),
                 sample,

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -260,15 +260,8 @@ async fn handle_command(
             ),
         },
         "PlayAt" => {
-            let time_sec = params
-                .get("time_sec")
-                .and_then(|v| v.as_f64())
-                .unwrap_or(0.0);
-            let gain = params
-                .get("gain")
-                .and_then(|v| v.as_f64())
-                .map(|x| x as f32)
-                .unwrap_or(1.0);
+            let time_sec = param_f64(&params, "time_sec", 0.0);
+            let gain = param_f64(&params, "gain", 1.0) as f32;
             if gain < 0.0 {
                 return err(
                     &id,
@@ -277,21 +270,11 @@ async fn handle_command(
             }
             // pan は [-1.0, 1.0]。範囲外は reject せず core 側で clamp（protocol 仕様: UX 優先）。
             // 省略時は 0.0（中央）。
-            let pan = params
-                .get("pan")
-                .and_then(|v| v.as_f64())
-                .map(|x| x as f32)
-                .unwrap_or(0.0);
+            let pan = param_f64(&params, "pan", 0.0) as f32;
             // offset_sec / duration_sec は再生領域（chop の slice）。負値は reject、
             // 省略時はそれぞれ 0.0（先頭 / offset 以降すべて）。サンプル端 clamp は core。
-            let offset_sec = params
-                .get("offset_sec")
-                .and_then(|v| v.as_f64())
-                .unwrap_or(0.0);
-            let duration_sec = params
-                .get("duration_sec")
-                .and_then(|v| v.as_f64())
-                .unwrap_or(0.0);
+            let offset_sec = param_f64(&params, "offset_sec", 0.0);
+            let duration_sec = param_f64(&params, "duration_sec", 0.0);
             if offset_sec < 0.0 {
                 return err(
                     &id,
@@ -414,6 +397,12 @@ fn schedule_play_ended(
         );
         let _ = tx.send(to_json_or_fallback(&evt)).await;
     });
+}
+
+/// `params` から f64 を取り出す（欠落 / 非数値は `default`）。PlayAt の time/gain/pan/
+/// offset/duration 抽出が同一の `get().and_then(as_f64).unwrap_or()` 定型だったのを集約する。
+fn param_f64(params: &Value, key: &str, default: f64) -> f64 {
+    params.get(key).and_then(|v| v.as_f64()).unwrap_or(default)
 }
 
 fn ok(id: &str, result: Value) -> Value {

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -275,8 +275,37 @@ async fn handle_command(
                     ProtocolError::new("PARAM_OUT_OF_RANGE", "gain must be >= 0"),
                 );
             }
+            // pan は [-1.0, 1.0]。範囲外は reject せず core 側で clamp（protocol 仕様: UX 優先）。
+            // 省略時は 0.0（中央）。
+            let pan = params
+                .get("pan")
+                .and_then(|v| v.as_f64())
+                .map(|x| x as f32)
+                .unwrap_or(0.0);
+            // offset_sec / duration_sec は再生領域（chop の slice）。負値は reject、
+            // 省略時はそれぞれ 0.0（先頭 / offset 以降すべて）。サンプル端 clamp は core。
+            let offset_sec = params
+                .get("offset_sec")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            let duration_sec = params
+                .get("duration_sec")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            if offset_sec < 0.0 {
+                return err(
+                    &id,
+                    ProtocolError::new("PARAM_OUT_OF_RANGE", "offset_sec must be >= 0"),
+                );
+            }
+            if duration_sec < 0.0 {
+                return err(
+                    &id,
+                    ProtocolError::new("PARAM_OUT_OF_RANGE", "duration_sec must be >= 0"),
+                );
+            }
             match params.get("sample_id").and_then(|v| v.as_str()) {
-                Some(sid) => match engine.play_at(sid, time_sec, gain) {
+                Some(sid) => match engine.play_at(sid, time_sec, gain, pan, offset_sec, duration_sec) {
                     Ok(handle) => {
                         // 遅延タスクを先に spawn して await コストを避ける
                         schedule_play_ended(

--- a/rust/crates/orbit-audio-daemon/tests/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/tests/protocol.rs
@@ -86,6 +86,43 @@ async fn play_at_then_play_started_and_play_ended() {
     assert!(saw_ended, "PlayEnded event missing");
 }
 
+/// PlayAt の duration_sec が負値の場合は PARAM_OUT_OF_RANGE で拒否する。
+/// engine_wrap は負 duration を `if duration_sec > 0.0 { .. } else { 0 }` で「0 = 全体再生」へ
+/// 潰すため、protocol 層のこの拒否は冗長な防御ではなく load-bearing（無言の全体再生を防ぐ）。
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn play_at_rejects_negative_duration_sec() {
+    let daemon = TestDaemon::start().await;
+    let mut ws = daemon.connect().await;
+    let _hs = TestDaemon::recv_handshake(&mut ws).await;
+
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let wav_path = format!("{manifest_dir}/../../../test-assets/audio/kick.wav");
+    send_cmd(&mut ws, "l", "LoadSample", json!({ "path": wav_path })).await;
+    let load_resp = recv_reply_for_id(&mut ws, "l").await;
+    let sample_id = load_resp["result"]["sample_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("LoadSample resp missing sample_id: {load_resp}"))
+        .to_string();
+
+    send_cmd(
+        &mut ws,
+        "p",
+        "PlayAt",
+        json!({
+            "sample_id": sample_id,
+            "time_sec": 0.0,
+            "gain": 1.0,
+            "duration_sec": -0.5,
+        }),
+    )
+    .await;
+    let resp = recv_reply_for_id(&mut ws, "p").await;
+    assert_eq!(
+        resp["error"]["code"], "PARAM_OUT_OF_RANGE",
+        "negative duration_sec should be rejected, got: {resp}"
+    );
+}
+
 /// Stop された play_id では PlayEnded が発火しないことを確認する。
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn stop_suppresses_play_ended() {

--- a/tests/audio/rust-engine/rust-engine-player.spec.ts
+++ b/tests/audio/rust-engine/rust-engine-player.spec.ts
@@ -13,6 +13,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { gainDbToAmplitude } from '../../../packages/engine/src/audio/audio-gain-utils'
 import { createAudioEngine } from '../../../packages/engine/src/audio/create-audio-engine'
 import { resolveEngineKind } from '../../../packages/engine/src/audio/engine-backend'
 import { RustEnginePlayer } from '../../../packages/engine/src/audio/rust-engine/rust-engine-player'
@@ -112,7 +113,7 @@ describe('RustEnginePlayer with mock daemon', () => {
     p.scheduleEvent('/audio/snare.wav', 0, -6, 0, 'seqA') // -6 dB ≈ 0.501
     p.start()
     await waitFor(() => playAtRecords().length >= 1)
-    expect(playAtRecords()[0].gain as number).toBeCloseTo(Math.pow(10, -6 / 20), 4)
+    expect(playAtRecords()[0].gain as number).toBeCloseTo(gainDbToAmplitude(-6), 4)
   })
 
   it('PlayAt.time_sec は daemon now（anchor）+ 定数 lookahead', async () => {
@@ -194,7 +195,7 @@ describe('RustEnginePlayer with mock daemon', () => {
     p.start()
     await waitFor(() => playAtRecords().length >= 2)
     expect(playAtRecords()[0].gain as number).toBeCloseTo(1.0, 4)
-    expect(playAtRecords()[1].gain as number).toBeCloseTo(Math.pow(10, -6 / 20), 4)
+    expect(playAtRecords()[1].gain as number).toBeCloseTo(gainDbToAmplitude(-6), 4)
   })
 
   it('slice の rate≠1.0（time-stretch）は 1 回 warn し、自然尺で鳴らす', async () => {

--- a/tests/audio/rust-engine/rust-engine-player.spec.ts
+++ b/tests/audio/rust-engine/rust-engine-player.spec.ts
@@ -154,30 +154,61 @@ describe('RustEnginePlayer with mock daemon', () => {
     expect(loads.length).toBe(1)
   })
 
-  it('pan≠0 は 1 回 warn し、中央定位で PlayAt は出す', async () => {
+  it('pan を daemon の [-1,1] に変換して PlayAt.pan へ渡す（warn しない）', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const p = await boot()
-    p.scheduleEvent('/audio/kick.wav', 0, 0, 50, 'seqA') // pan=50
-    p.scheduleEvent('/audio/kick.wav', 0, 0, 50, 'seqA')
+    p.scheduleEvent('/audio/kick.wav', 0, 0, 50, 'seqA') // DSL pan=50 → daemon 0.5
+    p.scheduleEvent('/audio/snare.wav', 0, 0, -100, 'seqA') // DSL pan=-100 → daemon -1.0
     p.start()
     await waitFor(() => playAtRecords().length >= 2)
+    expect(playAtRecords()[0].pan as number).toBeCloseTo(0.5, 5)
+    expect(playAtRecords()[1].pan as number).toBeCloseTo(-1.0, 5)
+    // pan は #304 で実装済み → 中央 drop の warn は出さない。
     const panWarns = warn.mock.calls.filter((c) => String(c[0]).includes('pan'))
-    expect(panWarns.length).toBe(1) // warn-once
+    expect(panWarns.length).toBe(0)
     warn.mockRestore()
   })
 
-  it('scheduleSliceEvent は 1 回 warn して skip（PlayAt を出さない）', async () => {
+  it('scheduleSliceEvent は slice 領域（offset/duration）を PlayAt で出す', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const p = await boot()
-    p.scheduleSliceEvent('/audio/loop.wav', 0, 1, 4, 250, 0, 0, 'seqA')
-    p.scheduleEvent('/audio/kick.wav', 0, 0, 0, 'seqA') // これは出る
+    // loop.wav は 1.0 秒（mock: 48000 frames / 48000 Hz）。chop(4) の slice3 →
+    // sliceDuration=0.25, offset=(3-1)*0.25=0.5。eventDurationMs=250=sliceDuration → rate=1.0。
+    p.scheduleSliceEvent('/audio/loop.wav', 0, 3, 4, 250, 0, 0, 'seqA')
     p.start()
     await waitFor(() => playAtRecords().length >= 1)
-    // slice は skip されるので PlayAt は kick の 1 件のみ。
-    expect(playAtRecords().length).toBe(1)
-    expect(playAtRecords()[0].sample_id).toBe('s-/audio/kick.wav')
-    const sliceWarns = warn.mock.calls.filter((c) => String(c[0]).includes('slice'))
-    expect(sliceWarns.length).toBe(1)
+    const rec = playAtRecords()[0]
+    expect(rec.sample_id).toBe('s-/audio/loop.wav')
+    expect(rec.offset_sec as number).toBeCloseTo(0.5, 5)
+    expect(rec.duration_sec as number).toBeCloseTo(0.25, 5)
+    // rate=1.0 なので time-stretch warn は出ない。
+    const rateWarns = warn.mock.calls.filter((c) => String(c[0]).includes('rate='))
+    expect(rateWarns.length).toBe(0)
+    warn.mockRestore()
+  })
+
+  it('per-slice gain: 各 slice の gainDb が PlayAt.gain に独立反映される', async () => {
+    const p = await boot()
+    p.scheduleSliceEvent('/audio/loop.wav', 0, 1, 4, 250, 0, 0, 'seqA') // 0 dB → 1.0
+    p.scheduleSliceEvent('/audio/loop.wav', 10, 2, 4, 250, -6, 0, 'seqA') // -6 dB ≈ 0.501
+    p.start()
+    await waitFor(() => playAtRecords().length >= 2)
+    expect(playAtRecords()[0].gain as number).toBeCloseTo(1.0, 4)
+    expect(playAtRecords()[1].gain as number).toBeCloseTo(Math.pow(10, -6 / 20), 4)
+  })
+
+  it('slice の rate≠1.0（time-stretch）は 1 回 warn し、自然尺で鳴らす', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const p = await boot()
+    // chop(8) → sliceDuration=0.125。eventDurationMs=500 → rate=0.25 ≠ 1.0。
+    p.scheduleSliceEvent('/audio/loop.wav', 0, 1, 8, 500, 0, 0, 'seqA')
+    p.scheduleSliceEvent('/audio/loop.wav', 10, 2, 8, 500, 0, 0, 'seqA')
+    p.start()
+    await waitFor(() => playAtRecords().length >= 2)
+    // rate≠1.0 でも slice は自然尺（duration=sliceDuration=0.125）で鳴る。
+    expect(playAtRecords()[0].duration_sec as number).toBeCloseTo(0.125, 5)
+    const rateWarns = warn.mock.calls.filter((c) => String(c[0]).includes('rate='))
+    expect(rateWarns.length).toBe(1) // warn-once
     warn.mockRestore()
   })
 
@@ -281,15 +312,17 @@ describe('RustEnginePlayer with mock daemon', () => {
   it('stopAll は warn-once を再 arm する（次セッションで再び warn）', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const p = await boot()
-    p.scheduleEvent('/audio/kick.wav', 0, 0, 50, 'seqA') // pan=50
+    // outputChannel(LinkAudio) は未対応 gap（A4）として 1 回 warn する。pan は実装済みで
+    // gap ではないため、再 arm の検証には残存 gap である outputChannel を使う。
+    p.scheduleEvent('/audio/kick.wav', 0, 0, 0, 'seqA', 'drums')
     p.start()
     await waitFor(() => playAtRecords().length >= 1)
     p.stopAll()
-    p.scheduleEvent('/audio/kick.wav', 0, 0, 50, 'seqB') // 次セッション
+    p.scheduleEvent('/audio/kick.wav', 0, 0, 0, 'seqB', 'drums') // 次セッション
     p.start()
     await waitFor(() => playAtRecords().length >= 2)
-    const panWarns = warn.mock.calls.filter((c) => String(c[0]).includes('pan'))
-    expect(panWarns.length).toBe(2) // stopAll で再 arm
+    const ocWarns = warn.mock.calls.filter((c) => String(c[0]).includes('outputChannel'))
+    expect(ocWarns.length).toBe(2) // stopAll で再 arm
     warn.mockRestore()
   })
 


### PR DESCRIPTION
## 概要

post-2.0 engine-first の第1増分（最初の `/goal`）。S2 で defer した audio gap のうち
**pan / chop 領域再生 / per-slice gain** を native daemon 経路（`ORBITSCORE_ENGINE=rust` opt-in）に実装し、
opt-in の裏で dog-food 可能にした。**SC 既定経路は無改変**。

Closes #304

## 変更内容

- **pan**（SC `Pan2` と同じ equal-power 則・中央 = −3dB / 1√2）: core scheduler に等パワー定位。
  daemon PlayAt の `pan` を配線。TS は DSL −100..100 → daemon [−1,1] へ変換。
- **chop 領域再生**（region-only・rate=1.0）: PlayAt に `offset_sec` / `duration_sec` を追加
  （spec 先行で `ENGINE_DAEMON_PROTOCOL.md` 更新）。core は ActiveSample に slice 領域を持ち領域だけ読む。
  SC `orbitPlayBuf` と同じ末尾 fadeout（`min(8ms, dur×4%)` 線形 release）でクリック防止。
- **per-slice gain**: 各 slice event の gainDb が daemon PlayAt.gain に独立反映され per-event 適用（新機構不要）。
- **rate≠1.0**（slice 尺→スロット尺の varispeed = time-stretch）は本増分対象外。検出時 1 回 warn し自然尺で鳴らす（#213/#239 へ defer）。

## 検証

- **cargo --workspace**: 58 tests 全緑 / 変更ファイル clippy クリーン
- **npm test**: 1153 passed, 25 skipped, **0 failed**（回帰なし・SC 既定無改変）
- **owner ear verdict**: pan sweep（等パワー一定）/ chop 領域 / per-slice gain 階段、いずれも SC 同等
- **OSC パラメータ parity**: SC を `ORBIT_SCSYNTH_PATH` で起動し、SC の `/s_new`(amp/pan/startPos/duration) と
  rust の daemon `playAt` 値が**バイト一致**することを観測（耳の A/B 以上に厳密）

## post-review cleanup（/simplify）

slice 長 clamp を core の `resolve_slice_region` に集約（render 尺と PlayEnded 尺の単一情報源化）/
等パワーパンを `schedule()` で precompute して RT render から trig を排除 / session.rs の param 抽出を
`param_f64` ヘルパーで集約 / spec の `Math.pow` を `gainDbToAmplitude` に置換。すべて behavior-preserving。

## スコープ外（後続増分）

time-stretch（rate≠1.0）/ LinkAudio / master effects / α recovery floor。
examples/22 が `RUN`（one-shot ≈2秒）で audition しづらい点は polish 候補。

🤖 Generated with [Claude Code](https://claude.com/claude-code)