### PR TITLE
feat(verify): phase-2 tier-c — interpreter schedule vs rendered PCM (two-leg) (#311)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,35 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.155 feat(verify): phase-2 tier-c — interpreter schedule vs rendered PCM (two-leg) (#311) (Jun 21, 2026)
+
+**Date**: 2026-06-21
+**Status**: ✅ 実装 + 自動テスト全緑（cargo --workspace / npm）+ clippy clean。tier(c) を end-to-end で閉じる第2増分
+**Branch**: `311-audio-verification-phase2-tier-c`
+
+**背景**: phase 1（#307/PR#310・6.154）は core レンダラ（Scheduler）を直接検証した。phase 2 は **interpreter が .orbs から計算したスケジュール（native 経路）を2本足で検証**し、tier(c)（レンダリング音 ↔ DSL 意味的スケジュール）を engine 層から閉じる。研究記録 = #308。
+
+**2本足（advisor 指摘で循環の罠を断つ）**:
+- **Leg 2（interpreter の計算が正しいか）**: `RecordingScheduler` 注入の `InterpreterV2` で fixture .orbs を実行 → 生の構造スケジュール（onset/gainDb/pan/slice index・total）を **.orbs + DSL 仕様から手書きした音楽単位オラクル**と比較。解決済み daemon param 同士の比較はトートロジー（slice offset/duration が両者同式）になるため**生のまま**比較。`calculateEventTiming` + DSL→schedule を直接テスト。
+- **Leg 1（renderer が忠実に再生するか）**: 構造スケジュール → 本番共有 `toDaemonParams` で解決 → golden JSON → Rust が実 `EngineWrap::play_at` でオフライン決定論レンダ → phase-1 analysis で PCM 検証。pan は atan2 独立逆算、**slice 領域は golden の offset/duration を再導出しない**（GRM 独立性）。
+
+**seam（本番経路と共有・drift 防止）**:
+- TS `RustEnginePlayer`: 発音変換を private `toDaemonParams` に lift（executePlayback と検証で**同一変換**: gainDbToAmplitude / pan÷100 / resolveSliceRegion）。`seedDuration` + `DaemonPlayParams` 型 + `ScheduledPlay`/`SliceSpec` export。behavior-preserving（rust-engine 24 + daemon-client 10 緑）。
+- TS `InterpreterV2`: audioEngine 注入 option（既定不変・SC 経路無改変）。
+- Rust `EngineWrap::render_offline`: cpal 不使用の block 駆動。play_at の sec→frame / resolve_slice_region を経た出力を捕捉（phase-1 が飛ばした層）。
+
+**決定論化の発見**: `preparePlayback` が `scheduler.isRunning` を要求（RecordingScheduler.start で立てる）、`runSequence` が `baseTime = (Date.now()-startTime)+100`（RUN 先読み）→ **fake timers で Date.now() 凍結**し記録 time = musical onset + 100 を決定論化。
+
+**fixture（3機能・判別力）**: `pan_three_voices`（hard-left/中間-50/hard-right・中間値が線形則を判別）/ `chop_region`（chop(2) grid 一致 rate=1.0・slice 領域の出力/無音）/ `per_event_gain`（gainDb -3/-9 の 6dB 差）。golden JSON は committed・staleness guard（`UPDATE_GOLDEN=1` で再生成）。
+
+**検証**: TS Leg 2 **6 passed**（pan/chop/gain × 2）+ Rust Leg 1 **3 passed**（verify_schedule_pcm）。cargo --workspace 全緑 / npm test 1159 passed / **0 failed**（SC 既定 `SuperColliderPlayer` / `event-scheduler.ts` + daemon 実時間経路 + audio play() 意味論 無改変）。clippy clean。
+
+**委譲**: Opus = seam（toDaemonParams lift / InterpreterV2 注入 / render_offline / 2本足構造）+ pan spine の end-to-end 疎通（決定論化の発見含む）。Sonnet = chop/gain fixture の複製。
+
+**スコープ外（後続）**: CLI `play --capture out.wav`（daemon offline render-to-WAV）/ librosa 相当 blind cross-check / 広い DSL 機能網羅。
+
+**Commit**: 301338e (spine) / 16e6434 (chop+gain)
+
 ### 6.154 feat(verify): audio output verification harness — capture + PCM assertion lib (#307) (Jun 21, 2026)
 
 **Date**: 2026-06-21

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -567,7 +567,8 @@ export class RustEnginePlayer implements AudioEngineBackend {
    * slice 領域は load 済み尺（`this.durations`）に依存する。本番は `ensureLoaded` が尺を
    * 設定済み、検証は `seedDuration` で seed しておくこと。発音時刻は実時間 anchor 依存で
    * 非決定論なので含めない（呼び出し側が付与する）。
-   * @internal 検証ハーネス専用。本番経路は executePlayback から呼ぶ。
+   * @internal 本番 dispatch（executePlayback）と検証ハーネス（#311）が共有する変換。
+   *   `@internal` = 外部公開 API ではない、の意（テスト専用ではない）。
    */
   toDaemonParams(play: ScheduledPlay): DaemonPlayParams {
     // DSL pan（-100..100）を daemon の [-1,1] へ変換。範囲外は daemon 側で clamp。

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -89,7 +89,7 @@ export interface DaemonPlayParams {
   pan: number
   /** slice 領域開始（秒）。0 = 先頭。 */
   offsetSec: number
-  /** slice 領域長（秒）。0 = `offset` 以降すべて。 */
+  /** slice 領域長（秒）。0 = `offsetSec` 以降すべて。 */
   durationSec: number
 }
 

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -53,7 +53,7 @@ import { DaemonConnectionError } from './errors'
 type GapKind = 'slice' | 'outputChannel' | 'masterEffect'
 
 /** chop slice 情報。`scheduleSliceEvent` 由来。発火時に領域（offset/duration）へ解決する。 */
-interface SliceSpec {
+export interface SliceSpec {
   /** slice 番号（1 始まり）。 */
   index: number
   /** 分割数（`chop(n)` の n）。 */
@@ -63,7 +63,7 @@ interface SliceSpec {
 }
 
 /** lean scheduler が保持する 1 発音イベント。SC `ScheduledPlay` の daemon 版。 */
-interface ScheduledPlay {
+export interface ScheduledPlay {
   /** 再生開始時刻（`startTime` からの相対 ms）。 */
   time: number
   filepath: string
@@ -74,6 +74,23 @@ interface ScheduledPlay {
   sequenceName: string
   /** chop slice 情報。未指定なら全体再生。発火時に load 済み尺から領域を計算する。 */
   slice?: SliceSpec
+}
+
+/**
+ * daemon `PlayAt` の音響パラメータ（発音時刻を除く）。`toDaemonParams` の戻り値。
+ *
+ * 発火時刻（`timeSec`）は実時間 anchor 依存で非決定論なのでここには含めない。
+ * 検証ハーネス（#311）はこの決定論パラメータ列を schedule として取り出す。
+ */
+export interface DaemonPlayParams {
+  /** linear amplitude（`gainDb` から変換）。 */
+  gain: number
+  /** daemon pan [-1,1]（DSL の -100..100 から変換）。 */
+  pan: number
+  /** slice 領域開始（秒）。0 = 先頭。 */
+  offsetSec: number
+  /** slice 領域長（秒）。0 = `offset` 以降すべて。 */
+  durationSec: number
 }
 
 /** daemon transport clock と TS wall clock の対応点。 */
@@ -410,24 +427,23 @@ export class RustEnginePlayer implements AudioEngineBackend {
     }
 
     const amplitude = gainDbToAmplitude(play.gainDb)
-    if (amplitude <= 0) return // 無音はスキップ（音響的に同一）。
+    if (amplitude <= 0) return // 無音はロード前にスキップ（音響的に同一）。
 
     const sampleId = await this.ensureLoaded(play.filepath)
     // ロード（async round-trip）中に clear された場合の再チェック（mute/stop への応答性）。
     if (play.sequenceName && !this.liveSequences.has(play.sequenceName)) return
-    // chop の slice 領域は load 済み尺から計算する（lazy load のためここで解決）。
-    const { offsetSec, durationSec } = this.resolveSliceRegion(play)
+    // 音響パラメータ（amplitude/pan/slice 領域）は本番発火と検証ハーネス（#311）で共有する
+    // 変換に集約する。slice 領域は ensureLoaded 後の尺（this.durations）を使う（lazy load）。
+    const { gain, pan, offsetSec, durationSec } = this.toDaemonParams(play)
     // daemonNowSec と wallMs は送信「前」に同一瞬間で採取する（onDispatch の lead/drift 計測が
     // coherent になるよう。playAt の await 後だと round-trip 分ずれる）。
     const wallMs = Date.now()
     const daemonNowSec = this.daemonNowSec()
     const timeSec = daemonNowSec + this.lookaheadSec
-    // DSL pan（-100..100）を daemon の [-1,1] へ変換。範囲外は daemon 側で clamp。
-    const pan = play.pan / 100
     const { playId } = await this.daemon.playAt(
       sampleId,
       timeSec,
-      amplitude,
+      gain,
       pan,
       offsetSec,
       durationSec,
@@ -439,7 +455,7 @@ export class RustEnginePlayer implements AudioEngineBackend {
       wallMs,
       daemonNowSec,
       timeSec,
-      gain: amplitude,
+      gain,
       playId,
     })
   }
@@ -541,6 +557,35 @@ export class RustEnginePlayer implements AudioEngineBackend {
       }
     }
     return { offsetSec, durationSec: sliceDuration }
+  }
+
+  /**
+   * `ScheduledPlay` を daemon `PlayAt` の音響パラメータ（amplitude / pan / slice 領域）へ
+   * 変換する。**本番発火（executePlayback）と検証ハーネス（schedule 抽出 #311）が同一の
+   * 変換を共有**し、片方だけが変わって検証が test double を見て緑になる drift を防ぐ。
+   *
+   * slice 領域は load 済み尺（`this.durations`）に依存する。本番は `ensureLoaded` が尺を
+   * 設定済み、検証は `seedDuration` で seed しておくこと。発音時刻は実時間 anchor 依存で
+   * 非決定論なので含めない（呼び出し側が付与する）。
+   * @internal 検証ハーネス専用。本番経路は executePlayback から呼ぶ。
+   */
+  toDaemonParams(play: ScheduledPlay): DaemonPlayParams {
+    // DSL pan（-100..100）を daemon の [-1,1] へ変換。範囲外は daemon 側で clamp。
+    return {
+      gain: gainDbToAmplitude(play.gainDb),
+      pan: play.pan / 100,
+      ...this.resolveSliceRegion(play),
+    }
+  }
+
+  /**
+   * 検証ハーネス（#311）用: slice 領域解決に使うサンプル尺（秒）を seed する。本番は
+   * `ensureLoaded` が daemon の LoadSample メタから設定するが、検証は daemon を立てずに
+   * `toDaemonParams` を呼ぶため、既知の fixture 尺をここで与える。
+   * @internal
+   */
+  seedDuration(filepath: string, seconds: number): void {
+    this.durations.set(filepath, seconds)
   }
 
   private warnOnce(kind: GapKind, message: string): void {

--- a/packages/engine/src/interpreter/interpreter-v2.ts
+++ b/packages/engine/src/interpreter/interpreter-v2.ts
@@ -32,9 +32,15 @@ export class InterpreterV2 {
   /** §L1: guards installing the Global transport hooks exactly once per session. */
   private sessionHooksInstalled = false
 
-  constructor() {
+  /**
+   * @param opts.audioEngine テスト/検証用に音声バックエンドを注入する（既定は env 由来の
+   *   `createAudioEngine()`）。未指定時の挙動は不変で SC 既定経路は無改変。#311 の schedule
+   *   抽出ハーネスが recording scheduler を差し込み、SC/daemon を立てずに `.orbs` を実行して
+   *   interpreter の計算スケジュールを取り出すために使う。
+   */
+  constructor(opts?: { audioEngine?: AudioEngineBackend }) {
     this.state = {
-      audioEngine: createAudioEngine(),
+      audioEngine: opts?.audioEngine ?? createAudioEngine(),
       globals: new Map(),
       sequences: new Map(),
       currentGlobal: undefined,
@@ -234,6 +240,6 @@ export class InterpreterV2 {
  * await interpreter.execute(ir)
  * ```
  */
-export function createInterpreter(): InterpreterV2 {
-  return new InterpreterV2()
+export function createInterpreter(opts?: { audioEngine?: AudioEngineBackend }): InterpreterV2 {
+  return new InterpreterV2(opts)
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -896,6 +896,7 @@ dependencies = [
  "futures-util",
  "orbit-audio-core",
  "orbit-audio-native",
+ "orbit-audio-verify",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/rust/crates/orbit-audio-daemon/Cargo.toml
+++ b/rust/crates/orbit-audio-daemon/Cargo.toml
@@ -30,3 +30,6 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+# #311 phase 2 Leg 1: golden schedule を play_at でオフラインレンダし PCM を解析する検証に
+# phase-1 の assertion lib を再利用する（test-only）。
+orbit-audio-verify = { path = "../orbit-audio-verify" }

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -263,6 +263,33 @@ impl EngineWrap {
         self.engine.now_sec().unwrap_or_else(|| self.uptime_sec())
     }
 
+    /// 検証ハーネス（#311 phase 2）用: スケジュール済みイベントを cpal を介さず
+    /// オフラインで `total_frames` 分 render し、interleaved f32 PCM を返す。
+    ///
+    /// 本番経路（cpal callback）とは独立した test-only API。`Engine::render` は内部で
+    /// `try_lock` するが、オフライン単スレッド駆動では競合がなく常に成功する。`block_frames`
+    /// 単位で回すことで、実 callback と同様にイベントが block 境界をまたぐ経路も通す。
+    /// `play_at` 由来の sec→frame 変換 / `resolve_slice_region` を経た出力を捕捉できる
+    /// （phase 1 の Scheduler 直接駆動が飛ばした層）。
+    ///
+    /// `block_frames == 0` は panic（テストハーネス用途なので不正設定は早期に落とす）。
+    #[doc(hidden)]
+    pub fn render_offline(&self, total_frames: usize, block_frames: usize) -> Vec<f32> {
+        assert!(block_frames > 0, "render_offline: block_frames must be > 0");
+        let channels = self.channels as usize;
+        let mut data = Vec::with_capacity(total_frames * channels);
+        let mut block = vec![0.0f32; block_frames * channels];
+        let mut rendered = 0usize;
+        while rendered < total_frames {
+            let this_frames = block_frames.min(total_frames - rendered);
+            let buf = &mut block[..this_frames * channels];
+            self.engine.render(buf);
+            data.extend_from_slice(buf);
+            rendered += this_frames;
+        }
+        data
+    }
+
     /// マスターゲインを設定する。`ramp_sec` が 0 以下なら即時。
     pub fn set_global_gain(&self, value: f32, ramp_sec: f64) -> Result<(), WrapError> {
         self.engine

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -153,8 +153,9 @@ impl EngineWrap {
     /// `pan` は [-1.0, 1.0]（0.0 = 中央、範囲外は core で clamp）。
     /// `offset_sec` / `duration_sec` は再生領域（`chop` の slice）。`duration_sec <= 0` で
     /// 「offset 以降すべて」。いずれもサンプル端で clamp。
-    /// 戻り値の `duration_sec` は **slice の実尺**（全体ではなく）なので、呼び出し側は
-    /// PlayEnded を slice 終端に合わせて遅延送信できる。
+    /// 戻り値の `duration_sec` は **実際に再生される区間の尺**（slice 指定時は slice 長、
+    /// whole-file 時はサンプル全尺）なので、呼び出し側は PlayEnded を再生終端に合わせて
+    /// 遅延送信できる。
     #[allow(clippy::too_many_arguments)]
     pub fn play_at(
         &self,

--- a/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
@@ -1,0 +1,150 @@
+//! #311 phase 2 tier(c) — Leg 1（renderer がスケジュールを忠実に再生するか）。
+//!
+//! TS 側（Leg 2）が interpreter の計算スケジュールを **production `toDaemonParams`** で解決し
+//! commit した golden schedule JSON を読み込み、各イベントを実 `EngineWrap::play_at` で
+//! オフライン決定論レンダ（`render_offline`）して、出力 PCM を phase-1 の analysis で検証する。
+//!
+//! これにより、phase-1（Scheduler 直接駆動）が飛ばした **`play_at` の sec→frame 変換 +
+//! `resolve_slice_region`** を経た出力を、interpreter の意図したスケジュール通りに鳴っているか
+//! として裏付ける。
+//!
+//! GRM 独立性: pan は L/R RMS から `atan2` で独立逆算（renderer は cos/sin）。**slice 領域は
+//! golden の offsetSec/durationSec をそのまま `play_at` に渡し、Rust 側で再導出しない**。
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use orbit_audio_daemon::engine_wrap::EngineWrap;
+use orbit_audio_daemon::backend::StubBackend;
+use orbit_audio_verify::{channel_rms, pan_from_lr_rms, region_rms, CapturedAudio, PAN_TOLERANCE};
+use serde::Deserialize;
+
+const BLOCK_FRAMES: usize = 512;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GoldenSchedule {
+    #[allow(dead_code)]
+    fixture: String,
+    sample_rate: u32,
+    events: Vec<GoldenEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GoldenEvent {
+    onset_sec: f64,
+    sample: String,
+    gain: f32,
+    pan: f32,
+    offset_sec: f64,
+    duration_sec: f64,
+    #[allow(dead_code)]
+    gain_db: f64,
+    #[allow(dead_code)]
+    pan_raw: f64,
+    #[allow(dead_code)]
+    sequence_name: String,
+}
+
+fn repo_path(rel: &str) -> PathBuf {
+    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../..")).join(rel)
+}
+
+fn load_golden(fixture: &str) -> GoldenSchedule {
+    let path = repo_path(&format!("test-assets/verify-fixtures/{fixture}.schedule.json"));
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("golden JSON {} を読めない: {e}", path.display()));
+    serde_json::from_str(&raw).expect("golden JSON parse")
+}
+
+/// golden schedule をオフラインレンダして PCM を返す。各 sample をロードし、各イベントを
+/// 実 `play_at` でスケジュールしてから `total_frames` 分 render する。
+fn render_golden(golden: &GoldenSchedule) -> (CapturedAudio, HashMap<String, usize>) {
+    let (wrap, _guard) = EngineWrap::start_with(StubBackend {
+        sample_rate: golden.sample_rate,
+        channels: 2,
+    })
+    .expect("EngineWrap start_with StubBackend");
+
+    // sample 名 → (sample_id, frames)。重複ロードを避ける。
+    let mut sample_ids: HashMap<String, String> = HashMap::new();
+    let mut sample_frames: HashMap<String, usize> = HashMap::new();
+    for ev in &golden.events {
+        if sample_ids.contains_key(&ev.sample) {
+            continue;
+        }
+        let wav = repo_path(&format!("test-assets/audio/{}", ev.sample));
+        let info = wrap
+            .load_sample(wav.clone())
+            .unwrap_or_else(|e| panic!("load_sample {}: {e}", wav.display()));
+        sample_frames.insert(ev.sample.clone(), info.frames);
+        sample_ids.insert(ev.sample.clone(), info.sample_id);
+    }
+
+    // 各イベントを実 play_at でスケジュール（sec→frame / resolve_slice_region を通す）。
+    let mut last_end_frame = 0usize;
+    for ev in &golden.events {
+        let sample_id = &sample_ids[&ev.sample];
+        wrap.play_at(
+            sample_id,
+            ev.onset_sec,
+            ev.gain,
+            ev.pan,
+            ev.offset_sec,
+            ev.duration_sec,
+        )
+        .expect("play_at");
+        // 出力尺の見積もり（whole=サンプル尺 / slice=duration_sec）。
+        let play_frames = if ev.duration_sec > 0.0 {
+            (ev.duration_sec * golden.sample_rate as f64).round() as usize
+        } else {
+            sample_frames[&ev.sample]
+        };
+        let end = (ev.onset_sec * golden.sample_rate as f64).round() as usize + play_frames;
+        last_end_frame = last_end_frame.max(end);
+    }
+
+    let total_frames = last_end_frame + golden.sample_rate as usize / 4; // +0.25s 余白
+    let data = wrap.render_offline(total_frames, BLOCK_FRAMES);
+    (
+        CapturedAudio::new(data, 2, golden.sample_rate),
+        sample_frames,
+    )
+}
+
+#[test]
+fn pan_three_voices_render_matches_schedule() {
+    let golden = load_golden("pan_three_voices");
+    let (cap, sample_frames) = render_golden(&golden);
+    let sr = golden.sample_rate as f64;
+
+    for ev in &golden.events {
+        let onset = (ev.onset_sec * sr).round() as usize;
+        // whole-file 再生（duration_sec=0）。body 窓は onset 後 256 〜 末尾 fade 前。
+        let play_frames = sample_frames[&ev.sample];
+        let w_start = onset + 256;
+        let w_end = onset + play_frames - 600; // 末尾 fade（≤384）+ 余裕を除外
+        let l = region_rms(&cap, 0, w_start, w_end);
+        let r = region_rms(&cap, 1, w_start, w_end);
+        assert!(
+            l.max(r) > 1e-3,
+            "seq {} に信号が必要（L={l:.5}, R={r:.5}）",
+            ev.sequence_name
+        );
+        // 出力 pan を atan2 で独立逆算し、スケジュールの pan と突き合わせる。
+        let measured = pan_from_lr_rms(l, r);
+        assert!(
+            (measured - ev.pan).abs() <= PAN_TOLERANCE,
+            "seq {}: schedule pan {} → measured {measured} (L={l:.5}, R={r:.5})",
+            ev.sequence_name,
+            ev.pan
+        );
+    }
+
+    // イベント間（left 終端 0.6s 〜 mid 開始 2.1s の中央あたり）は無音。
+    let gap = region_rms(&cap, 0, (1.0 * sr) as usize, (1.8 * sr) as usize);
+    assert!(gap < 1e-5, "イベント間は無音のはず（RMS={gap:.6}）");
+    // 公開 API の軽い疎通。
+    let _ = channel_rms(&cap, 0);
+}

--- a/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
@@ -99,12 +99,13 @@ fn render_golden(golden: &GoldenSchedule) -> (CapturedAudio, HashMap<String, usi
         )
         .expect("play_at");
         // 出力尺の見積もり（whole=サンプル尺 / slice=duration_sec）。
+        let sr = golden.sample_rate as f64;
         let play_frames = if ev.duration_sec > 0.0 {
-            (ev.duration_sec * golden.sample_rate as f64).round() as usize
+            frame_at(ev.duration_sec, sr)
         } else {
             sample_frames[&ev.sample]
         };
-        let end = (ev.onset_sec * golden.sample_rate as f64).round() as usize + play_frames;
+        let end = frame_at(ev.onset_sec, sr) + play_frames;
         last_end_frame = last_end_frame.max(end);
     }
 
@@ -116,6 +117,18 @@ fn render_golden(golden: &GoldenSchedule) -> (CapturedAudio, HashMap<String, usi
     )
 }
 
+/// 秒 → フレーム位置（四捨五入）。
+fn frame_at(sec: f64, sr: f64) -> usize {
+    (sec * sr).round() as usize
+}
+
+/// body 窓 `[onset+256, onset+span-tail_trim)`。onset 直後の block straddle と末尾 fade を
+/// 除外する。`span` は再生尺フレーム（whole=サンプル尺 / slice=領域尺）、`tail_trim` は
+/// fixture 固有の末尾除外幅（fade 尺に依存）。
+fn body_window(onset: usize, span: usize, tail_trim: usize) -> (usize, usize) {
+    (onset + 256, onset + span.saturating_sub(tail_trim))
+}
+
 #[test]
 fn pan_three_voices_render_matches_schedule() {
     let golden = load_golden("pan_three_voices");
@@ -123,11 +136,11 @@ fn pan_three_voices_render_matches_schedule() {
     let sr = golden.sample_rate as f64;
 
     for ev in &golden.events {
-        let onset = (ev.onset_sec * sr).round() as usize;
-        // whole-file 再生（duration_sec=0）。body 窓は onset 後 256 〜 末尾 fade 前。
+        let onset = frame_at(ev.onset_sec, sr);
+        // whole-file 再生（duration_sec=0）。body 窓は onset 後 256 〜 末尾 fade 前
+        // （fade ≤384 + 余裕を除外）。
         let play_frames = sample_frames[&ev.sample];
-        let w_start = onset + 256;
-        let w_end = onset + play_frames - 600; // 末尾 fade（≤384）+ 余裕を除外
+        let (w_start, w_end) = body_window(onset, play_frames, 600);
         let l = region_rms(&cap, 0, w_start, w_end);
         let r = region_rms(&cap, 1, w_start, w_end);
         assert!(
@@ -167,11 +180,10 @@ fn chop_region_render_matches_schedule() {
     for ev in &golden.events {
         // slice 領域: [onset, onset+durationSec]（durationSec > 0 = slice）。
         assert!(ev.duration_sec > 0.0, "chop fixture は slice を持つはず");
-        let onset = (ev.onset_sec * sr).round() as usize;
-        // 信号確認: onset 後 256 frame 〜 slice 終端 600 frame 前を本体窓とする。
-        let slice_end = onset + (ev.duration_sec * sr).round() as usize;
-        let w_start = onset + 256;
-        let w_end = slice_end.saturating_sub(600);
+        let onset = frame_at(ev.onset_sec, sr);
+        // 信号確認: onset 後 256 〜 slice 終端 600 frame 前を本体窓とする。
+        let slice_frames = frame_at(ev.duration_sec, sr);
+        let (w_start, w_end) = body_window(onset, slice_frames, 600);
         assert!(w_start < w_end, "slice 窓が狭すぎる: [{w_start}, {w_end})");
         // pan=0 → L/R ほぼ等しい。少なくとも max(L,R) > 1e-3 を確認。
         let l = region_rms(&cap, 0, w_start, w_end);
@@ -206,10 +218,9 @@ fn per_event_gain_render_matches_schedule() {
     let mut rms_by_gain: Vec<(f64, f32)> = Vec::new(); // (gainDb, rms)
 
     for ev in &golden.events {
-        let onset = (ev.onset_sec * sr).round() as usize;
+        let onset = frame_at(ev.onset_sec, sr);
         let play_frames = sample_frames[&ev.sample];
-        let w_start = onset + 256;
-        let w_end = onset + play_frames - 256; // kick は短いので余裕を小さく
+        let (w_start, w_end) = body_window(onset, play_frames, 256); // kick は短いので余裕を小さく
         assert!(w_start < w_end, "onset={:.3}s の body 窓が狭すぎる", ev.onset_sec);
         let l = region_rms(&cap, 0, w_start, w_end);
         let r = region_rms(&cap, 1, w_start, w_end);

--- a/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
@@ -141,6 +141,7 @@ fn pan_three_voices_render_matches_schedule() {
         // （fade ≤384 + 余裕を除外）。
         let play_frames = sample_frames[&ev.sample];
         let (w_start, w_end) = body_window(onset, play_frames, 600);
+        assert!(w_start < w_end, "pan body 窓が狭すぎる: [{w_start}, {w_end})");
         let l = region_rms(&cap, 0, w_start, w_end);
         let r = region_rms(&cap, 1, w_start, w_end);
         assert!(
@@ -220,7 +221,9 @@ fn per_event_gain_render_matches_schedule() {
     for ev in &golden.events {
         let onset = frame_at(ev.onset_sec, sr);
         let play_frames = sample_frames[&ev.sample];
-        let (w_start, w_end) = body_window(onset, play_frames, 256); // kick は短いので余裕を小さく
+        // kick 0.5s も fade は最大 384 frames（min(0.5*0.04, 0.008)*48000）なので pan と同じ
+        // 600 で除外する。dB 差は fade 不変だが、窓に fade を混ぜないよう揃える。
+        let (w_start, w_end) = body_window(onset, play_frames, 600);
         assert!(w_start < w_end, "onset={:.3}s の body 窓が狭すぎる", ev.onset_sec);
         let l = region_rms(&cap, 0, w_start, w_end);
         let r = region_rms(&cap, 1, w_start, w_end);
@@ -243,4 +246,9 @@ fn per_event_gain_render_matches_schedule() {
         "quiet/loud の dB 差: 期待 {expected_diff:.1} dB、計測 {measured_diff:.2} dB \
          (rms_loud={rms_loud:.5}, rms_quiet={rms_quiet:.5})"
     );
+
+    // イベント間（loud 終端 0.6s 〜 quiet 開始 3.1s の 1.0〜2.5s）は無音。両イベントが
+    // 誤って onset=0 にレンダされる回帰（加算 RMS になり dB 差が崩れる）を捕まえる。
+    let gap = region_rms(&cap, 0, (1.0 * sr) as usize, (2.5 * sr) as usize);
+    assert!(gap < 1e-5, "per_event_gain イベント間は無音のはず（RMS={gap:.6}）");
 }

--- a/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
@@ -16,7 +16,10 @@ use std::path::PathBuf;
 
 use orbit_audio_daemon::engine_wrap::EngineWrap;
 use orbit_audio_daemon::backend::StubBackend;
-use orbit_audio_verify::{channel_rms, pan_from_lr_rms, region_rms, CapturedAudio, PAN_TOLERANCE};
+use orbit_audio_verify::{
+    channel_rms, db_difference, pan_from_lr_rms, region_rms, CapturedAudio, GAIN_DB_TOLERANCE,
+    PAN_TOLERANCE,
+};
 use serde::Deserialize;
 
 const BLOCK_FRAMES: usize = 512;
@@ -147,4 +150,86 @@ fn pan_three_voices_render_matches_schedule() {
     assert!(gap < 1e-5, "イベント間は無音のはず（RMS={gap:.6}）");
     // 公開 API の軽い疎通。
     let _ = channel_rms(&cap, 0);
+}
+
+#[test]
+fn chop_region_render_matches_schedule() {
+    //! Leg 1 — chop_region。
+    //! golden: arpeggio_c.wav 1.0s / chop(2) / tempo 120 / 4拍 / length 1。
+    //!   slice1: onset=0.1s, offset=0.0s, duration=0.5s（前半）
+    //!   slice2: onset=1.1s, offset=0.5s, duration=0.5s（後半）
+    //! 各 slice 窓 [onset, onset+durationSec] に信号あり。
+    //! イベント間（slice1 終端 0.6s 〜 slice2 開始 1.1s の中央 0.85s あたり）は無音。
+    let golden = load_golden("chop_region");
+    let (cap, _sample_frames) = render_golden(&golden);
+    let sr = golden.sample_rate as f64;
+
+    for ev in &golden.events {
+        // slice 領域: [onset, onset+durationSec]（durationSec > 0 = slice）。
+        assert!(ev.duration_sec > 0.0, "chop fixture は slice を持つはず");
+        let onset = (ev.onset_sec * sr).round() as usize;
+        // 信号確認: onset 後 256 frame 〜 slice 終端 600 frame 前を本体窓とする。
+        let slice_end = onset + (ev.duration_sec * sr).round() as usize;
+        let w_start = onset + 256;
+        let w_end = slice_end.saturating_sub(600);
+        assert!(w_start < w_end, "slice 窓が狭すぎる: [{w_start}, {w_end})");
+        // pan=0 → L/R ほぼ等しい。少なくとも max(L,R) > 1e-3 を確認。
+        let l = region_rms(&cap, 0, w_start, w_end);
+        let r = region_rms(&cap, 1, w_start, w_end);
+        assert!(
+            l.max(r) > 1e-3,
+            "onset={:.3}s の slice 窓に信号が必要（L={l:.5}, R={r:.5}）",
+            ev.onset_sec
+        );
+    }
+
+    // イベント間（slice1 終端 0.6s 〜 slice2 開始 1.1s の中央 0.85s）は無音。
+    let gap_start = (0.65 * sr) as usize;
+    let gap_end   = (0.95 * sr) as usize;
+    let gap = region_rms(&cap, 0, gap_start, gap_end);
+    assert!(gap < 1e-5, "chop イベント間は無音のはず（RMS={gap:.6}）");
+}
+
+#[test]
+fn per_event_gain_render_matches_schedule() {
+    //! Leg 1 — per_event_gain。
+    //! golden: kick.wav 0.5s / slice 無し / tempo 60 / 4拍 / length 1。
+    //!   loud : onset=0.1s, gainDb=-3, pan=0（中央）
+    //!   quiet: onset=3.1s, gainDb=-9, pan=0（中央）
+    //! 期待 dB 差 = -9 - (-3) = -6.0 dB（quiet が loud より 6dB 小さい）。
+    let golden = load_golden("per_event_gain");
+    let (cap, sample_frames) = render_golden(&golden);
+    let sr = golden.sample_rate as f64;
+
+    // 各イベントの body 窓 RMS を取得（gainDb 昇順に並んでいるとは限らないので gain_db で判別）。
+    assert_eq!(golden.events.len(), 2, "per_event_gain は 2 イベントのはず");
+    let mut rms_by_gain: Vec<(f64, f32)> = Vec::new(); // (gainDb, rms)
+
+    for ev in &golden.events {
+        let onset = (ev.onset_sec * sr).round() as usize;
+        let play_frames = sample_frames[&ev.sample];
+        let w_start = onset + 256;
+        let w_end = onset + play_frames - 256; // kick は短いので余裕を小さく
+        assert!(w_start < w_end, "onset={:.3}s の body 窓が狭すぎる", ev.onset_sec);
+        let l = region_rms(&cap, 0, w_start, w_end);
+        let r = region_rms(&cap, 1, w_start, w_end);
+        // pan=0 → L/R ほぼ等しい。平均 RMS を使う。
+        let rms = (l + r) / 2.0;
+        assert!(rms > 1e-4, "onset={:.3}s に信号が必要（RMS={rms:.5}）", ev.onset_sec);
+        rms_by_gain.push((ev.gain_db, rms));
+    }
+
+    // gainDb で並べて loud(-3) / quiet(-9) を識別する。
+    rms_by_gain.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap()); // 降順 = loud first
+    let rms_loud  = rms_by_gain[0].1;
+    let rms_quiet = rms_by_gain[1].1;
+
+    // db_difference(quiet, loud) = 20*log10(quiet/loud) ≈ -6.0 dB。
+    let measured_diff = db_difference(rms_quiet, rms_loud);
+    let expected_diff = -6.0_f32; // -9 - (-3) = -6 dB
+    assert!(
+        (measured_diff - expected_diff).abs() <= GAIN_DB_TOLERANCE,
+        "quiet/loud の dB 差: 期待 {expected_diff:.1} dB、計測 {measured_diff:.2} dB \
+         (rms_loud={rms_loud:.5}, rms_quiet={rms_quiet:.5})"
+    );
 }

--- a/test-assets/verify-fixtures/chop_region.orbs
+++ b/test-assets/verify-fixtures/chop_region.orbs
@@ -1,0 +1,17 @@
+// #311 phase 2 tier(c) — chop 領域検証 fixture
+// tempo 120 / 4-4 / length 1 → bar 2.0s、4 subdivisions = 0.5s 刻み。
+// arpeggio_c.wav = 1.0s mono / chop(2) → sliceDur 0.5s = slot → rate=1.0。
+// play(1, 0, 2, 0): slice1@0s, rest@0.5s, slice2@1.0s, rest@1.5s。
+// イベント間（各 slice は 0.5s、onset 差 1.0s）に無音が生じ、領域外無音を検証できる。
+var global = init GLOBAL
+global.tempo(120)
+global.beat(4 by 4)
+
+var chop = init global.seq
+chop.length(1)
+chop.audio("../audio/arpeggio_c.wav").chop(2)
+chop.defaultGain(-3).defaultPan(0)
+chop.play(1, 0, 2, 0)
+
+global.start()
+RUN(chop)

--- a/test-assets/verify-fixtures/chop_region.schedule.json
+++ b/test-assets/verify-fixtures/chop_region.schedule.json
@@ -1,0 +1,28 @@
+{
+  "fixture": "chop_region",
+  "sampleRate": 48000,
+  "events": [
+    {
+      "onsetSec": 0.1,
+      "sample": "arpeggio_c.wav",
+      "gain": 0.7079457843841379,
+      "pan": 0,
+      "offsetSec": 0,
+      "durationSec": 0.5,
+      "gainDb": -3,
+      "panRaw": 0,
+      "sequenceName": "chop"
+    },
+    {
+      "onsetSec": 1.1,
+      "sample": "arpeggio_c.wav",
+      "gain": 0.7079457843841379,
+      "pan": 0,
+      "offsetSec": 0.5,
+      "durationSec": 0.5,
+      "gainDb": -3,
+      "panRaw": 0,
+      "sequenceName": "chop"
+    }
+  ]
+}

--- a/test-assets/verify-fixtures/pan_three_voices.orbs
+++ b/test-assets/verify-fixtures/pan_three_voices.orbs
@@ -1,0 +1,31 @@
+// #311 phase 2 tier(c) — pan 検証 fixture
+// tempo 60 / 4-4 / length 1 → bar 4.0s、4 subdivisions = 1.0s 刻み（onset 0/1/2/3s）。
+// 3 voices を時間分離し pan を判別:
+//   left  = hard-left (-100) @ 0s
+//   mid   = intermediate (-50) @ 2s   ← 中間値（等パワー則を線形則から判別する鍵）
+//   right = hard-right (+100) @ 3s
+// kick.wav は 0.5s mono → イベント間に無音。grid 一致で rate=1.0。
+var global = init GLOBAL
+global.tempo(60)
+global.beat(4 by 4)
+
+var left = init global.seq
+left.length(1)
+left.audio("../audio/kick.wav").chop(1)
+left.defaultGain(-3).defaultPan(-100)
+left.play(1, 0, 0, 0)
+
+var mid = init global.seq
+mid.length(1)
+mid.audio("../audio/kick.wav").chop(1)
+mid.defaultGain(-3).defaultPan(-50)
+mid.play(0, 0, 1, 0)
+
+var right = init global.seq
+right.length(1)
+right.audio("../audio/kick.wav").chop(1)
+right.defaultGain(-3).defaultPan(100)
+right.play(0, 0, 0, 1)
+
+global.start()
+RUN(left, mid, right)

--- a/test-assets/verify-fixtures/pan_three_voices.schedule.json
+++ b/test-assets/verify-fixtures/pan_three_voices.schedule.json
@@ -1,0 +1,39 @@
+{
+  "fixture": "pan_three_voices",
+  "sampleRate": 48000,
+  "events": [
+    {
+      "onsetSec": 0.1,
+      "sample": "kick.wav",
+      "gain": 0.7079457843841379,
+      "pan": -1,
+      "offsetSec": 0,
+      "durationSec": 0,
+      "gainDb": -3,
+      "panRaw": -100,
+      "sequenceName": "left"
+    },
+    {
+      "onsetSec": 2.1,
+      "sample": "kick.wav",
+      "gain": 0.7079457843841379,
+      "pan": -0.5,
+      "offsetSec": 0,
+      "durationSec": 0,
+      "gainDb": -3,
+      "panRaw": -50,
+      "sequenceName": "mid"
+    },
+    {
+      "onsetSec": 3.1,
+      "sample": "kick.wav",
+      "gain": 0.7079457843841379,
+      "pan": 1,
+      "offsetSec": 0,
+      "durationSec": 0,
+      "gainDb": -3,
+      "panRaw": 100,
+      "sequenceName": "right"
+    }
+  ]
+}

--- a/test-assets/verify-fixtures/per_event_gain.orbs
+++ b/test-assets/verify-fixtures/per_event_gain.orbs
@@ -1,0 +1,23 @@
+// #311 phase 2 tier(c) — per-event gain 検証 fixture
+// tempo 60 / 4-4 / length 1 → bar 4.0s、4 subdivisions = 1.0s 刻み。
+// kick.wav = 0.5s mono / slice 無し / pan 中央(0)。
+// 2 sequence、defaultGain だけ変える（loud=-3 / quiet=-9 → 6dB 差）。
+// play(1,0,0,0) で先頭 slot のみ発火、onset 差 3.0s（kick 0.5s < 間隔）で十分な無音。
+var global = init GLOBAL
+global.tempo(60)
+global.beat(4 by 4)
+
+var loud = init global.seq
+loud.length(1)
+loud.audio("../audio/kick.wav")
+loud.defaultGain(-3).defaultPan(0)
+loud.play(1, 0, 0, 0)
+
+var quiet = init global.seq
+quiet.length(1)
+quiet.audio("../audio/kick.wav")
+quiet.defaultGain(-9).defaultPan(0)
+quiet.play(0, 0, 0, 1)
+
+global.start()
+RUN(loud, quiet)

--- a/test-assets/verify-fixtures/per_event_gain.schedule.json
+++ b/test-assets/verify-fixtures/per_event_gain.schedule.json
@@ -1,0 +1,28 @@
+{
+  "fixture": "per_event_gain",
+  "sampleRate": 48000,
+  "events": [
+    {
+      "onsetSec": 0.1,
+      "sample": "kick.wav",
+      "gain": 0.7079457843841379,
+      "pan": 0,
+      "offsetSec": 0,
+      "durationSec": 0,
+      "gainDb": -3,
+      "panRaw": 0,
+      "sequenceName": "loud"
+    },
+    {
+      "onsetSec": 3.1,
+      "sample": "kick.wav",
+      "gain": 0.35481338923357547,
+      "pan": 0,
+      "offsetSec": 0,
+      "durationSec": 0,
+      "gainDb": -9,
+      "panRaw": 0,
+      "sequenceName": "quiet"
+    }
+  ]
+}

--- a/tests/audio/verify/leg2-chop-region.spec.ts
+++ b/tests/audio/verify/leg2-chop-region.spec.ts
@@ -61,6 +61,14 @@ describe('#311 Leg 2 — chop_region: interpreter schedule vs hand oracle', () =
   it('golden schedule JSON matches committed (Leg 1 GRM・staleness guard)', async () => {
     const recorded = await recordSchedule(FIXTURE, DURATIONS)
     const golden = resolveGolden(FIXTURE, recorded, DURATIONS)
+    // resolveSliceRegion の出力（offset/duration）を**手計算定数**で直接検証する。
+    // golden staleness（toEqual）は committed が toDaemonParams 由来＝自己参照のため、式バグが
+    // UPDATE_GOLDEN で焼き込まれても緑のまま。手計算定数で式バグを GRM 独立に捕まえる。
+    // arpeggio_c 1.0s / chop(2): slice1 offset=(1-1)*0.5=0.0s, slice2=(2-1)*0.5=0.5s、各 dur 0.5s。
+    expect(golden.events[0].offsetSec).toBeCloseTo(0.0, 5)
+    expect(golden.events[1].offsetSec).toBeCloseTo(0.5, 5)
+    expect(golden.events[0].durationSec).toBeCloseTo(0.5, 5)
+    expect(golden.events[1].durationSec).toBeCloseTo(0.5, 5)
     const { updated, committed } = reconcileGolden(golden)
     if (updated) return // UPDATE_GOLDEN=1 で再生成した場合は突き合わせをスキップ。
     expect(committed, 'golden JSON missing — run with UPDATE_GOLDEN=1 to generate').not.toBeNull()

--- a/tests/audio/verify/leg2-chop-region.spec.ts
+++ b/tests/audio/verify/leg2-chop-region.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * #311 phase 2 tier(c) — Leg 2（interpreter がスケジュールを正しく計算するか）。
+ *
+ * fixture `chop_region.orbs` を RecordingScheduler 注入の InterpreterV2 で実行し、
+ * 生の構造スケジュールを **.orbs と DSL 仕様から人手で導いた音楽単位オラクル** と突き合わせる。
+ * あわせて Leg 1 用の golden schedule JSON を本番共有の `toDaemonParams` で生成し、
+ * committed と一致するか検証する。
+ *
+ * オラクルの手計算（.orbs を読んで）:
+ *   tempo 120 / beat 4/4 / length 1 → bar = 4 beats × (60/120)s = 2.0s、play() 4 要素 →
+ *   subdivision = 0.5s。
+ *   arpeggio_c.wav = 1.0s / chop(2) → sliceDur = 1.0 / 2 = 0.5s = slot → rate=1.0。
+ *   play(1, 0, 2, 0):
+ *     step0 = 0ms   → slice index=1 / gainDb -3 / pan 0（中央）
+ *     step1 = 500ms → 0（rest・記録なし）
+ *     step2 = 1000ms → slice index=2 / gainDb -3 / pan 0
+ *     step3 = 1500ms → 0（rest・記録なし）
+ *   記録 time = musical onset + RUN_SCHEDULE_BUFFER_MS(100)。
+ *   golden offsetSec: slice1=(1-1)*0.5=0.0s、slice2=(2-1)*0.5=0.5s。durationSec=0.5s 各。
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+import {
+  recordSchedule,
+  resolveGolden,
+  reconcileGolden,
+  RUN_SCHEDULE_BUFFER_MS,
+} from './schedule-golden'
+
+const FIXTURE = 'chop_region'
+/** arpeggio_c.wav = 1.0s mono 48k。slice scheduling が getAudioDuration を要求する。 */
+const DURATIONS = { '../audio/arpeggio_c.wav': 1.0 }
+
+/** .orbs + DSL 仕様から手書きした期待スケジュール（interpreter で計算しない）。 */
+const ORACLE = [
+  { onsetMs: 0, gainDb: -3, pan: 0, sliceIndex: 1, sliceTotal: 2 },
+  { onsetMs: 1000, gainDb: -3, pan: 0, sliceIndex: 2, sliceTotal: 2 },
+]
+
+describe('#311 Leg 2 — chop_region: interpreter schedule vs hand oracle', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('records the structurally-correct schedule (onset / gainDb / pan / slice index+total)', async () => {
+    const recorded = await recordSchedule(FIXTURE, DURATIONS)
+
+    expect(recorded).toHaveLength(ORACLE.length)
+    recorded.forEach((play, i) => {
+      const exp = ORACLE[i]
+      // onset: 記録 time === 音楽 onset + RUN buffer（fake timers で厳密）。
+      expect(play.time).toBe(exp.onsetMs + RUN_SCHEDULE_BUFFER_MS)
+      expect(play.gainDb).toBe(exp.gainDb)
+      expect(play.pan).toBe(exp.pan)
+      // slice が付いていること（chop(2) → scheduleSliceEvent）。
+      expect(play.slice).toBeDefined()
+      expect(play.slice!.index).toBe(exp.sliceIndex)
+      expect(play.slice!.total).toBe(exp.sliceTotal)
+    })
+  })
+
+  it('golden schedule JSON matches committed (Leg 1 GRM・staleness guard)', async () => {
+    const recorded = await recordSchedule(FIXTURE, DURATIONS)
+    const golden = resolveGolden(FIXTURE, recorded, DURATIONS)
+    const { updated, committed } = reconcileGolden(golden)
+    if (updated) return // UPDATE_GOLDEN=1 で再生成した場合は突き合わせをスキップ。
+    expect(committed, 'golden JSON missing — run with UPDATE_GOLDEN=1 to generate').not.toBeNull()
+    expect(golden).toEqual(committed)
+  })
+})

--- a/tests/audio/verify/leg2-pan-three-voices.spec.ts
+++ b/tests/audio/verify/leg2-pan-three-voices.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * #311 phase 2 tier(c) — Leg 2（interpreter がスケジュールを正しく計算するか）。
+ *
+ * fixture `pan_three_voices.orbs` を RecordingScheduler 注入の InterpreterV2 で実行し、
+ * 生の構造スケジュールを **.orbs と DSL 仕様から人手で導いた音楽単位オラクル** と突き合わせる
+ * （解決済み daemon param には変換しない＝トートロジー回避・GRM 独立性）。あわせて Leg 1 用の
+ * golden schedule JSON を本番共有の `toDaemonParams` で生成し、committed と一致するか検証する。
+ *
+ * オラクルの手計算（.orbs を読んで）:
+ *   tempo 60 / beat 4/4 / length 1 → bar = 4 beats × (60/60)s = 4.0s、play() 4 要素 →
+ *   subdivision = 1.0s。各 voice の play パターン:
+ *     left  play(1,0,0,0) → step0 = 0ms   / gainDb -3 / pan -100（hard-left）
+ *     mid   play(0,0,1,0) → step2 = 2000ms / gainDb -3 / pan -50（中間・判別の鍵）
+ *     right play(0,0,0,1) → step3 = 3000ms / gainDb -3 / pan +100（hard-right）
+ *   記録 time = musical onset + RUN_SCHEDULE_BUFFER_MS(100)（RUN one-shot の先読み）。
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+import {
+  recordSchedule,
+  resolveGolden,
+  reconcileGolden,
+  RUN_SCHEDULE_BUFFER_MS,
+} from './schedule-golden'
+
+const FIXTURE = 'pan_three_voices'
+/** kick.wav = 0.5s mono（slice 無しなので尺は使わないが seed 経路を通す）。 */
+const DURATIONS = { '../audio/kick.wav': 0.5 }
+
+/** .orbs + DSL 仕様から手書きした期待スケジュール（interpreter で計算しない）。 */
+const ORACLE = [
+  { onsetMs: 0, gainDb: -3, pan: -100, sequenceName: 'left' },
+  { onsetMs: 2000, gainDb: -3, pan: -50, sequenceName: 'mid' },
+  { onsetMs: 3000, gainDb: -3, pan: 100, sequenceName: 'right' },
+]
+
+describe('#311 Leg 2 — pan_three_voices: interpreter schedule vs hand oracle', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('records the structurally-correct schedule (onset / gainDb / pan / no-slice)', async () => {
+    const recorded = await recordSchedule(FIXTURE, DURATIONS)
+
+    expect(recorded).toHaveLength(ORACLE.length)
+    recorded.forEach((play, i) => {
+      const exp = ORACLE[i]
+      // onset: 記録 time === 音楽 onset + RUN buffer（fake timers で厳密）。
+      expect(play.time).toBe(exp.onsetMs + RUN_SCHEDULE_BUFFER_MS)
+      expect(play.gainDb).toBe(exp.gainDb)
+      expect(play.pan).toBe(exp.pan)
+      expect(play.sequenceName).toBe(exp.sequenceName)
+      // chop(1) = 全体再生なので slice は付かない。
+      expect(play.slice).toBeUndefined()
+    })
+  })
+
+  it('golden schedule JSON matches committed (Leg 1 GRM・staleness guard)', async () => {
+    const recorded = await recordSchedule(FIXTURE, DURATIONS)
+    const golden = resolveGolden(FIXTURE, recorded, DURATIONS)
+    const { updated, committed } = reconcileGolden(golden)
+    if (updated) return // UPDATE_GOLDEN=1 で再生成した場合は突き合わせをスキップ。
+    expect(committed, 'golden JSON missing — run with UPDATE_GOLDEN=1 to generate').not.toBeNull()
+    expect(golden).toEqual(committed)
+  })
+})

--- a/tests/audio/verify/leg2-per-event-gain.spec.ts
+++ b/tests/audio/verify/leg2-per-event-gain.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * #311 phase 2 tier(c) — Leg 2（interpreter がスケジュールを正しく計算するか）。
+ *
+ * fixture `per_event_gain.orbs` を RecordingScheduler 注入の InterpreterV2 で実行し、
+ * 生の構造スケジュールを **.orbs と DSL 仕様から人手で導いた音楽単位オラクル** と突き合わせる。
+ * あわせて Leg 1 用の golden schedule JSON を本番共有の `toDaemonParams` で生成し、
+ * committed と一致するか検証する。
+ *
+ * オラクルの手計算（.orbs を読んで）:
+ *   tempo 60 / beat 4/4 / length 1 → bar = 4 beats × (60/60)s = 4.0s、play() 4 要素 →
+ *   subdivision = 1.0s。
+ *   loud  sequence: play(1,0,0,0) → step0 = 0ms、gainDb -3、pan 0（中央）
+ *   quiet sequence: play(0,0,0,1) → step3 = 3000ms、gainDb -9、pan 0（中央）
+ *   記録 time = musical onset + RUN_SCHEDULE_BUFFER_MS(100)。
+ *   kick.wav = 0.5s → loud 終端 0.5s, quiet 開始 3.0s → 2.5s 以上の無音あり。
+ *   slice 無し: scheduleEvent が呼ばれる（play.slice は undefined）。
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+import {
+  recordSchedule,
+  resolveGolden,
+  reconcileGolden,
+  RUN_SCHEDULE_BUFFER_MS,
+} from './schedule-golden'
+
+const FIXTURE = 'per_event_gain'
+/** kick.wav = 0.5s mono 48k。 */
+const DURATIONS = { '../audio/kick.wav': 0.5 }
+
+/** .orbs + DSL 仕様から手書きした期待スケジュール（interpreter で計算しない）。 */
+const ORACLE = [
+  { onsetMs: 0, gainDb: -3, pan: 0, sequenceName: 'loud' },
+  { onsetMs: 3000, gainDb: -9, pan: 0, sequenceName: 'quiet' },
+]
+
+describe('#311 Leg 2 — per_event_gain: interpreter schedule vs hand oracle', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('records the structurally-correct schedule (onset / gainDb / pan / no-slice)', async () => {
+    const recorded = await recordSchedule(FIXTURE, DURATIONS)
+
+    expect(recorded).toHaveLength(ORACLE.length)
+    recorded.forEach((play, i) => {
+      const exp = ORACLE[i]
+      // onset: 記録 time === 音楽 onset + RUN buffer（fake timers で厳密）。
+      expect(play.time).toBe(exp.onsetMs + RUN_SCHEDULE_BUFFER_MS)
+      expect(play.gainDb).toBe(exp.gainDb)
+      expect(play.pan).toBe(exp.pan)
+      expect(play.sequenceName).toBe(exp.sequenceName)
+      // slice 無し: scheduleEvent が呼ばれる。
+      expect(play.slice).toBeUndefined()
+    })
+  })
+
+  it('golden schedule JSON matches committed (Leg 1 GRM・staleness guard)', async () => {
+    const recorded = await recordSchedule(FIXTURE, DURATIONS)
+    const golden = resolveGolden(FIXTURE, recorded, DURATIONS)
+    const { updated, committed } = reconcileGolden(golden)
+    if (updated) return // UPDATE_GOLDEN=1 で再生成した場合は突き合わせをスキップ。
+    expect(committed, 'golden JSON missing — run with UPDATE_GOLDEN=1 to generate').not.toBeNull()
+    expect(golden).toEqual(committed)
+  })
+})

--- a/tests/audio/verify/recording-scheduler.ts
+++ b/tests/audio/verify/recording-scheduler.ts
@@ -29,11 +29,6 @@ export class RecordingScheduler implements AudioEngineBackend {
     }
   }
 
-  /** slice 解決などで尺が要る場合に既知 fixture 尺を seed する。 */
-  seedDuration(filepath: string, seconds: number): void {
-    this.durations.set(filepath, seconds)
-  }
-
   /** 記録した発音スケジュール（time 昇順のコピー）。 */
   getRecorded(): ScheduledPlay[] {
     return [...this.recorded].sort((a, b) => a.time - b.time)

--- a/tests/audio/verify/recording-scheduler.ts
+++ b/tests/audio/verify/recording-scheduler.ts
@@ -1,0 +1,102 @@
+/**
+ * 検証ハーネス（#311 phase 2・tier(c) Leg 2）用の音声バックエンド。
+ *
+ * SuperCollider / daemon を一切立てずに、interpreter が `.orbs` から計算した発音
+ * スケジュール（`scheduleEvent` / `scheduleSliceEvent` の引数）を**そのまま記録**する。
+ * `boot()` は no-op なので `InterpreterV2.execute()` が device 無しで完走し、`execute()`
+ * 後に `getRecorded()` で生の構造スケジュール（onset / gainDb / pan / slice）を得られる。
+ *
+ * これが Leg 2 の DUT（= interpreter の計算）であり、手書きの音楽単位オラクルと突き合わせる。
+ * **発火（start/poll）はしない** — 記録だけが目的。
+ */
+
+import type { AudioEngineBackend } from '../../../packages/engine/src/audio/engine-backend'
+import type { ScheduledPlay } from '../../../packages/engine/src/audio/rust-engine/rust-engine-player'
+
+export class RecordingScheduler implements AudioEngineBackend {
+  isRunning = false
+  startTime = 0
+
+  private readonly recorded: ScheduledPlay[] = []
+  /** filepath → 尺（秒）。slice scheduling が `getAudioDuration` を要求する場合に返す。 */
+  private readonly durations = new Map<string, number>()
+
+  constructor(durations?: Record<string, number>) {
+    if (durations) {
+      for (const [filepath, seconds] of Object.entries(durations)) {
+        this.durations.set(filepath, seconds)
+      }
+    }
+  }
+
+  /** slice 解決などで尺が要る場合に既知 fixture 尺を seed する。 */
+  seedDuration(filepath: string, seconds: number): void {
+    this.durations.set(filepath, seconds)
+  }
+
+  /** 記録した発音スケジュール（time 昇順のコピー）。 */
+  getRecorded(): ScheduledPlay[] {
+    return [...this.recorded].sort((a, b) => a.time - b.time)
+  }
+
+  // --- Scheduler 面（記録のみ・RustEnginePlayer.scheduleEvent と同じ引数） ---
+
+  scheduleEvent(
+    filepath: string,
+    time: number,
+    gainDb: number,
+    pan: number,
+    sequenceName: string,
+    _outputChannel?: string,
+  ): void {
+    this.recorded.push({ time, filepath, gainDb, pan, sequenceName })
+  }
+
+  scheduleSliceEvent(
+    filepath: string,
+    time: number,
+    sliceIndex: number,
+    totalSlices: number,
+    eventDurationMs: number | undefined,
+    gainDb: number,
+    pan: number,
+    sequenceName: string,
+    _outputChannel?: string,
+  ): void {
+    this.recorded.push({
+      time,
+      filepath,
+      gainDb,
+      pan,
+      sequenceName,
+      slice: { index: sliceIndex, total: totalSlices, eventDurationMs },
+    })
+  }
+
+  getAudioDuration(filepath: string): number {
+    return this.durations.get(filepath) ?? 0
+  }
+
+  // --- 発火しないので no-op（記録のみ） ---
+  // ただし start() は isRunning を立てる: preparePlayback が `scheduler.isRunning` を
+  // 要求し、false だと run() が早期 return して何も記録されないため。startTime も設定する
+  // （runSequence の baseTime = (Date.now() - startTime) + 100 に効く。テストは fake timers
+  // で Date.now() を凍結し baseTime を決定論化する）。
+  start(): void {
+    this.isRunning = true
+    this.startTime = Date.now()
+  }
+  stop(): void {
+    this.isRunning = false
+  }
+  stopAll(): void {}
+  clearSequenceEvents(_name: string): void {}
+  reinitializeSequenceTracking(_name: string): void {}
+  async loadBuffer(_filepath: string): Promise<{ sampleId: string }> {
+    return { sampleId: 'recording' }
+  }
+
+  // --- AudioEngineBackend 面（no-op・device/daemon 不要） ---
+  async boot(_outputDevice?: string): Promise<void> {}
+  async quit(): Promise<void> {}
+}

--- a/tests/audio/verify/schedule-golden.ts
+++ b/tests/audio/verify/schedule-golden.ts
@@ -1,0 +1,147 @@
+/**
+ * #311 phase 2 tier(c) 検証ハーネスの共有ユーティリティ。
+ *
+ * - fixture `.orbs` を RecordingScheduler 注入の InterpreterV2 で実行し、生の構造スケジュール
+ *   （= Leg 2 の DUT）を得る。
+ * - その構造スケジュールを RustEnginePlayer の **production `toDaemonParams`**（本番発火と
+ *   共有の変換）で解決し、golden schedule JSON（= Leg 1 の GRM）を組み立てる。
+ * - golden JSON は committed。Leg 2 テストが「生成 == コミット済み」を assert して drift を
+ *   検出する。`UPDATE_GOLDEN=1` で上書き生成する（標準 golden パターン）。
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { basename, dirname, resolve } from 'node:path'
+
+import { vi } from 'vitest'
+
+import { parseAudioDSL } from '../../../packages/engine/src/parser/audio-parser'
+import { InterpreterV2 } from '../../../packages/engine/src/interpreter/interpreter-v2'
+import {
+  RustEnginePlayer,
+  type ScheduledPlay,
+} from '../../../packages/engine/src/audio/rust-engine/rust-engine-player'
+
+import { RecordingScheduler } from './recording-scheduler'
+
+/**
+ * RUN()（one-shot）が付与する先読みバッファ（ms）。`runSequence` の `currentTime + 100`
+ * 由来で、fake timers で `Date.now()` を凍結すると `currentTime=0` になり、記録される
+ * `time` = `musical onset + 100` の定数オフセットになる。Leg 2 オラクルはこの定数を足す。
+ */
+export const RUN_SCHEDULE_BUFFER_MS = 100
+
+/** 凍結する system time（任意の固定値。fake timers で決定論化するための anchor）。 */
+const FROZEN_NOW_MS = 1_000_000
+
+export const VERIFY_FIXTURES_DIR = resolve(__dirname, '../../../test-assets/verify-fixtures')
+
+/** golden schedule JSON の 1 イベント（Leg 1 が消費する解決済み daemon params）。 */
+export interface GoldenEvent {
+  /** 発音 onset（秒・相対）。`time/1000`。 */
+  onsetSec: number
+  /** WAV の basename（Rust は test-assets/audio/<sample> で解決）。 */
+  sample: string
+  /** linear amplitude（`toDaemonParams` 経由）。 */
+  gain: number
+  /** daemon pan [-1,1]。 */
+  pan: number
+  /** slice 領域開始（秒）。0 = 先頭。 */
+  offsetSec: number
+  /** slice 領域長（秒）。0 = offset 以降すべて。 */
+  durationSec: number
+  /** トレーサビリティ用の生値。 */
+  gainDb: number
+  panRaw: number
+  sequenceName: string
+}
+
+export interface GoldenSchedule {
+  fixture: string
+  sampleRate: number
+  events: GoldenEvent[]
+}
+
+/**
+ * fixture を RecordingScheduler 注入で実行し、生の構造スケジュール（time 昇順）を返す。
+ * fake timers で `Date.now()` を凍結し、記録 `time` を決定論化する。呼び出し側は
+ * `vi.useRealTimers()` を afterEach 等で戻すこと。
+ */
+export async function recordSchedule(
+  fixtureName: string,
+  durations: Record<string, number>,
+): Promise<ScheduledPlay[]> {
+  vi.useFakeTimers()
+  vi.setSystemTime(FROZEN_NOW_MS)
+  const fixturePath = resolve(VERIFY_FIXTURES_DIR, `${fixtureName}.orbs`)
+  const source = readFileSync(fixturePath, 'utf8')
+  const ir = parseAudioDSL(source)
+  // durations は絶対パス（audio() が documentDirectory 基準で絶対化する）で seed する。
+  const absDurations: Record<string, number> = {}
+  for (const [rel, sec] of Object.entries(durations)) {
+    absDurations[resolve(VERIFY_FIXTURES_DIR, rel)] = sec
+  }
+  const recording = new RecordingScheduler(absDurations)
+  const interp = new InterpreterV2({ audioEngine: recording })
+  await interp.execute(ir, { documentDirectory: dirname(fixturePath) })
+  return recording.getRecorded()
+}
+
+/**
+ * 構造スケジュールを RustEnginePlayer の `toDaemonParams`（本番共有変換）で解決し、
+ * golden schedule を組み立てる。**領域・gain・pan の変換は本番経路と同一コード**を通すので、
+ * 検証が test double を見て緑になる drift を防ぐ（GRM 独立性は Leg 2 のオラクルが担保）。
+ */
+export function resolveGolden(
+  fixtureName: string,
+  recorded: ScheduledPlay[],
+  durations: Record<string, number>,
+  sampleRate = 48_000,
+): GoldenSchedule {
+  const player = new RustEnginePlayer()
+  for (const [rel, sec] of Object.entries(durations)) {
+    player.seedDuration(resolve(VERIFY_FIXTURES_DIR, rel), sec)
+  }
+  const events: GoldenEvent[] = recorded.map((play) => {
+    const { gain, pan, offsetSec, durationSec } = player.toDaemonParams(play)
+    return {
+      onsetSec: play.time / 1000,
+      sample: basename(play.filepath),
+      gain,
+      pan,
+      offsetSec,
+      durationSec,
+      gainDb: play.gainDb,
+      panRaw: play.pan,
+      sequenceName: play.sequenceName,
+    }
+  })
+  return { fixture: fixtureName, sampleRate, events }
+}
+
+/** golden JSON のパス。 */
+export function goldenPath(fixtureName: string): string {
+  return resolve(VERIFY_FIXTURES_DIR, `${fixtureName}.schedule.json`)
+}
+
+/**
+ * golden を committed JSON と突き合わせる（staleness 検出）。`UPDATE_GOLDEN=1` の時は
+ * 上書き生成する。戻り値は「committed と一致したか」（UPDATE 時は常に true）。
+ */
+export function reconcileGolden(golden: GoldenSchedule): {
+  updated: boolean
+  committed: GoldenSchedule | null
+} {
+  const path = goldenPath(golden.fixture)
+  const serialized = JSON.stringify(golden, null, 2) + '\n'
+  if (process.env.UPDATE_GOLDEN === '1') {
+    writeFileSync(path, serialized)
+    return { updated: true, committed: golden }
+  }
+  let committed: GoldenSchedule | null = null
+  try {
+    committed = JSON.parse(readFileSync(path, 'utf8')) as GoldenSchedule
+  } catch {
+    committed = null
+  }
+  return { updated: false, committed }
+}

--- a/tests/audio/verify/schedule-golden.ts
+++ b/tests/audio/verify/schedule-golden.ts
@@ -35,6 +35,16 @@ const FROZEN_NOW_MS = 1_000_000
 
 export const VERIFY_FIXTURES_DIR = resolve(__dirname, '../../../test-assets/verify-fixtures')
 
+/**
+ * fixture 相対の尺キーを絶対パスに直す（audio() が documentDirectory 基準で絶対化するため、
+ * seed 側も絶対パスで揃える）。`recordSchedule` と `resolveGolden` が共有する。
+ */
+function toAbsDurations(durations: Record<string, number>): Record<string, number> {
+  return Object.fromEntries(
+    Object.entries(durations).map(([rel, sec]) => [resolve(VERIFY_FIXTURES_DIR, rel), sec]),
+  )
+}
+
 /** golden schedule JSON の 1 イベント（Leg 1 が消費する解決済み daemon params）。 */
 export interface GoldenEvent {
   /** 発音 onset（秒・相対）。`time/1000`。 */
@@ -75,12 +85,7 @@ export async function recordSchedule(
   const fixturePath = resolve(VERIFY_FIXTURES_DIR, `${fixtureName}.orbs`)
   const source = readFileSync(fixturePath, 'utf8')
   const ir = parseAudioDSL(source)
-  // durations は絶対パス（audio() が documentDirectory 基準で絶対化する）で seed する。
-  const absDurations: Record<string, number> = {}
-  for (const [rel, sec] of Object.entries(durations)) {
-    absDurations[resolve(VERIFY_FIXTURES_DIR, rel)] = sec
-  }
-  const recording = new RecordingScheduler(absDurations)
+  const recording = new RecordingScheduler(toAbsDurations(durations))
   const interp = new InterpreterV2({ audioEngine: recording })
   await interp.execute(ir, { documentDirectory: dirname(fixturePath) })
   return recording.getRecorded()
@@ -98,8 +103,8 @@ export function resolveGolden(
   sampleRate = 48_000,
 ): GoldenSchedule {
   const player = new RustEnginePlayer()
-  for (const [rel, sec] of Object.entries(durations)) {
-    player.seedDuration(resolve(VERIFY_FIXTURES_DIR, rel), sec)
+  for (const [abs, sec] of Object.entries(toAbsDurations(durations))) {
+    player.seedDuration(abs, sec)
   }
   const events: GoldenEvent[] = recorded.map((play) => {
     const { gain, pan, offsetSec, durationSec } = player.toDaemonParams(play)

--- a/tests/audio/verify/schedule-golden.ts
+++ b/tests/audio/verify/schedule-golden.ts
@@ -139,14 +139,29 @@ export function reconcileGolden(golden: GoldenSchedule): {
   const path = goldenPath(golden.fixture)
   const serialized = JSON.stringify(golden, null, 2) + '\n'
   if (process.env.UPDATE_GOLDEN === '1') {
+    // CI で誤って UPDATE_GOLDEN が立つと staleness 検出が無言で死に、committed を
+    // 上書きしてしまう。意図（ローカル再生成専用）を機械強制し、ローカルでも上書きはログに残す。
+    if (process.env.CI) {
+      throw new Error(
+        'UPDATE_GOLDEN=1 は CI では使用不可です（golden staleness 検出を無効化し commit を上書きするため）',
+      )
+    }
+    console.warn(`[UPDATE_GOLDEN] committed golden を上書き: ${path}`)
     writeFileSync(path, serialized)
     return { updated: true, committed: golden }
   }
   let committed: GoldenSchedule | null = null
   try {
     committed = JSON.parse(readFileSync(path, 'utf8')) as GoldenSchedule
-  } catch {
-    committed = null
+  } catch (err) {
+    // ENOENT（未生成）は null で正しい。それ以外（JSON 破損 / truncate / merge conflict
+    // marker 等）を null 扱いすると「破損」を「未生成」と取り違え、UPDATE_GOLDEN でバグを
+    // 焼き込む経路になるため re-throw して loud に落とす。
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      committed = null
+    } else {
+      throw err
+    }
   }
   return { updated: false, committed }
 }


### PR DESCRIPTION
## 概要

#307 phase 1（PR #310・`orbit-audio-verify`）が core レンダラ（Scheduler）を直接検証したのに続き、**interpreter が .orbs から計算したスケジュール（native 経路）を2本足で検証**して tier(c)（レンダリング音 ↔ DSL 意味的スケジュール）を engine 層から閉じる第2増分。研究記録 = #308。

Refs #311

## 2本足（advisor 指摘で循環の罠を断つ）

interpreter の PlayAt 列だけを GRM にすると GRM も DUT も interpreter の下流で循環し interpreter バグが緑になる。よって:

- **Leg 2（interpreter の計算が正しいか）**: `RecordingScheduler` 注入の `InterpreterV2` で fixture .orbs を実行 → 生の構造スケジュール（onset/gainDb/pan/slice index・total）を **.orbs + DSL 仕様から手書きした音楽単位オラクル**と比較（解決済み param 比較のトートロジー回避）。`calculateEventTiming` + DSL→schedule を直接テスト。
- **Leg 1（renderer が忠実に再生するか）**: 構造スケジュール → 本番共有 `toDaemonParams` で解決 → golden JSON → Rust が実 `EngineWrap::play_at` でオフライン決定論レンダ → phase-1 analysis で PCM 検証。pan は atan2 独立逆算、**slice 領域は golden の offset/duration を再導出しない**（GRM 独立性）。

## seam（本番経路と共有・drift 防止）

- TS `RustEnginePlayer`: 発音変換を private `toDaemonParams` に lift（executePlayback と検証で**同一変換** = gainDbToAmplitude / pan÷100 / resolveSliceRegion）。`seedDuration` + `DaemonPlayParams` 型 + `ScheduledPlay`/`SliceSpec` export。behavior-preserving（rust-engine 24 + daemon-client 10 緑）。
- TS `InterpreterV2`: audioEngine 注入 option（既定不変・**SC 経路無改変**）。
- Rust `EngineWrap::render_offline`: cpal 不使用の block 駆動。play_at の sec→frame / resolve_slice_region を経た出力を捕捉（phase-1 が飛ばした層）。

## 決定論化

`preparePlayback` が `scheduler.isRunning` を要求 / `runSequence` が `baseTime=(Date.now()-startTime)+100`（RUN 先読み）→ **fake timers で Date.now() 凍結**し記録 time = musical onset + 100 を決定論化。golden JSON は committed・staleness guard（`UPDATE_GOLDEN=1` で再生成）。

## fixture（#304 の3機能・判別力）

- `pan_three_voices`: hard-left(-100)/中間(-50)/hard-right(+100)。中間値が等パワー則を線形則から判別。
- `chop_region`: arpeggio_c chop(2) grid 一致 rate=1.0。slice 領域の出力 + 領域外無音。
- `per_event_gain`: gainDb -3/-9 の 6dB 差を PCM の db_difference で検証。

## 検証

- **TS Leg 2**: tests/audio/verify **6 passed**（pan/chop/gain × 2）。
- **Rust Leg 1**: verify_schedule_pcm **3 passed**。
- cargo --workspace 全緑 / npm test 1159 passed / **0 failed**（SC 既定 `SuperColliderPlayer` / `event-scheduler.ts` + daemon 実時間経路 + audio `play()` 意味論 無改変）。clippy clean。`/simplify` 適用済み。

## スコープ外（後続増分）

CLI `play --capture out.wav`（daemon offline render-to-WAV）/ librosa 相当 blind cross-check / 広い DSL 機能網羅（polymeter/quantize の onset timing 等）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)