### PR TITLE
verify(audio): retroactively self-verify #304 (examples/22 params) via harness — close #307

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,28 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.157 verify(audio): retroactively self-verify #304 (examples/22 params) via harness — close #307 (#316) (Jun 21, 2026)
+
+**Date**: 2026-06-21
+**Status**: ✅ 実装 + 全テスト緑（cargo daemon verify_schedule_pcm 4 / verify 30 / npm 1161 passed）。#307 の受け入れ基準（examples/22 を耳なし PCM 検証）を達成
+**Branch**: `316-verify-examples22-goal1`
+
+**背景**: harness epic #307 の受け入れ基準に「examples/22（pan/slice/per-slice gain）を capture して PCM アサーションで #304 を遡及的に自己検証（耳に依存しない裏付け）」がある。phase 1〜3（#310/#312/#314）でハーネス・assertion lib・tier-c・librosa grounding は揃ったが、**#304 の実 deliverable を耳なし検証する最終増分が未達**だった。本増分でこれを満たし #307 をクローズ（完了済み phase-2 #311 も併せて）。
+
+**examples/22 の制約**: `examples/22_rust_engine_parity.orbs` は 4 voice 同時並行の dog-food デモで、各拍に複数 voice が重畳し L/R RMS がミックスになり per-event の pan/gain を分離不能（研究 §4.4）。→ **生ファイルに per-event assert を当てない**。
+
+**設計（advisor 承認・(A) offline）**: examples/22 と同じ素材（kick/snare/hihat/arpeggio）+ #304 の実パラメータ（pan -0.6/+0.6/0/+0.2・gain -3/-6/-9/-4・chop(1) 全体 と chop(2) 領域）を **de-overlap した検証 fixture** `examples22_parity.orbs` に組み、phase-2 の 2 本足で検証。tempo 120 / length 4 / 16 要素 → 0.5s grid（spec: length(2)→8要素 と同型・subdivision は play 要素数で決まり chop と独立）。kick@0s / snare@2s / hat@4s / chopd slice1@6s・slice2@7s（rate=1.0）。
+
+**2 本足**: Leg 2（TS）= InterpreterV2 schedule vs **手書き独立オラクル**（onset/gainDb/pan/slice を .orbs+DSL 仕様から導出・トートロジー回避）。**length>1 を harness で初めて通したが独立オラクルと一致**（interpreter が length>1 を正しく処理）。Leg 1（Rust）= golden → 実 `EngineWrap::play_at` offline render → PCM で **pan を atan2 独立逆算（kick -0.6 / snare +0.6 / hat 0 / chopd +0.2）+ chop(2) 領域 + イベント間無音** を検証。
+
+**gain の扱い（正直に）**: gain 値（-3/-6/-9/-4）は**異なるサンプル間で RMS 比較不能**（固有レベルが違う）ため Leg 1 では検証しない。gain は Leg 2（gainDb/linear の計算）+ phase-2 per_event_gain（同一サンプルの dB 差を実レンダで）でカバー済み。
+
+**スコープ外**: 生 examples/22 の literal smoke（examples/ 配下・別パス・重畳で friction 高く弱い検証）は見送り、de-overlap fixture で acceptance を満たす。CLI `play --capture`（#307 ②・重い）は /goal2（#300）へ defer（#307 が「capture は respawn 後の可聴ギャップ計測に効く」と明記）。
+
+**意義**: 以後の audio 増分（#239 slice / #213 time-stretch / effects）が「耳」でなく PCM で機械検証可能に。#307 が「capture は daemon respawn 後の可聴ギャップを PCM で測れる → goal2 検証に効く」と明記しており、goal2（#300 recovery floor）への橋にもなる。
+
+**Commit**: [PENDING]
+
 ### 6.156 feat(verify): phase-3 — ground measurement primitives against librosa (blind cross-check) (#313) (Jun 21, 2026)
 
 **Date**: 2026-06-21

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -37,7 +37,9 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **意義**: 以後の audio 増分（#239 slice / #213 time-stretch / effects）が「耳」でなく PCM で機械検証可能に。#307 が「capture は daemon respawn 後の可聴ギャップを PCM で測れる → goal2 検証に効く」と明記しており、goal2（#300 recovery floor）への橋にもなる。
 
-**Commit**: [PENDING]
+**/simplify（4観点並列）**: reuse/efficiency は重複・無駄なし（既存 phase-2 パターン踏襲）。altitude の 1 件のみ適用 = Rust `tail_trim` を動的式 `(span/4).min(600)`（本 fixture では全 span≥2400 で常に 600）から既存 fixture と対称な固定 `600` に簡約（挙動同一）。chopd assert のループ化等は「明示の方が読みやすい」で leave-as-is。
+
+**Commit**: b763abc（実装）+ /simplify cleanup follow-up
 
 ### 6.156 feat(verify): phase-3 — ground measurement primitives against librosa (blind cross-check) (#313) (Jun 21, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -39,7 +39,9 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **/simplify（4観点並列）**: reuse/efficiency は重複・無駄なし（既存 phase-2 パターン踏襲）。altitude の 1 件のみ適用 = Rust `tail_trim` を動的式 `(span/4).min(600)`（本 fixture では全 span≥2400 で常に 600）から既存 fixture と対称な固定 `600` に簡約（挙動同一）。chopd assert のループ化等は「明示の方が読みやすい」で leave-as-is。
 
-**Commit**: b763abc（実装）+ /simplify cleanup follow-up
+**/code:pr-review-team（4専門・1 round 収束）**: Critical/Important=0。code-reviewer がオラクル全値（onset/gain linear+dB/pan raw+daemon/chop offset/sentinel）を .orbs+DSL 仕様から**独立再導出して一致確認**（循環でない裏付け）。Minor 3件適用: ① Leg1 ループ前に `assert_eq!(events.len(),5)` ガード追加（兄弟 per_event_gain テストと対称・golden truncation 時の vacuous green 防止）② `.orbs` の無音間隔表記を正確化（chopd slice1-slice2 間は 0.5s）③ slice 領域「内容」正しさは `chop_region_real_wav.rs` が担う旨の layering 注記。bot は新規外部主張なしで skip（advisor カリブレーション = verify 系は proportional）。
+
+**Commit**: b763abc（実装）+ /simplify cleanup + pr-review-team follow-up
 
 ### 6.156 feat(verify): phase-3 — ground measurement primitives against librosa (blind cross-check) (#313) (Jun 21, 2026)
 

--- a/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
@@ -261,7 +261,15 @@ fn examples22_parity_render_matches_schedule() {
     //! gain 値（-3/-6/-9/-4）は **異なるサンプル間で RMS 比較できない**（固有レベルが違う）ので
     //! ここでは検証しない。gain は Leg 2（schedule の gainDb/linear）+ phase-2 per_event_gain
     //! （同一サンプルの dB 差を実レンダで）でカバー済み。ここは pan / 領域 / 分離を見る。
+    //! slice の「領域内容」正しさ（slice2 が arpeggio 後半 frame を読むか）は本テストでなく
+    //! orbit-audio-verify の chop_region_real_wav.rs（ramp サンプルで offset+local を frame 単位
+    //! 検証）が担う。ここは領域に信号があり外が無音であることまで。
     let golden = load_golden("examples22_parity");
+    assert_eq!(
+        golden.events.len(),
+        5,
+        "examples22_parity は 5 イベントのはず (kick/snare/hat/chopd×2)"
+    );
     let (cap, sample_frames) = render_golden(&golden);
     let sr = golden.sample_rate as f64;
 

--- a/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
@@ -273,9 +273,9 @@ fn examples22_parity_render_matches_schedule() {
         } else {
             sample_frames[&ev.sample]
         };
-        // 末尾 trim は span の 1/4 を上限 600 で。hat(0.05s=2400fr)でも窓が潰れない。
-        let tail_trim = (span / 4).min(600);
-        let (w_start, w_end) = body_window(onset, span, tail_trim);
+        // 末尾 trim は既存 fixture と同じ固定 600（fade ≤384 + 余裕を除外）。最短の
+        // hat(0.05s=2400fr)でも窓は [onset+256, onset+1800) = 1544fr 幅で潰れない。
+        let (w_start, w_end) = body_window(onset, span, 600);
         assert!(
             w_start < w_end,
             "seq {} の body 窓が狭すぎる: [{w_start}, {w_end})",

--- a/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
@@ -252,3 +252,61 @@ fn per_event_gain_render_matches_schedule() {
     let gap = region_rms(&cap, 0, (1.0 * sr) as usize, (2.5 * sr) as usize);
     assert!(gap < 1e-5, "per_event_gain イベント間は無音のはず（RMS={gap:.6}）");
 }
+
+#[test]
+fn examples22_parity_render_matches_schedule() {
+    //! #316 Leg 1 — examples/22 (#304 dog-food) を de-overlap した parity fixture。
+    //! kick(pan -0.6)/snare(+0.6)/hat(0)/chopd(+0.2・chop(2) slice1+slice2) を per-event 検証。
+    //! 各イベントは無音で分離 → L/R RMS が単一 voice になり pan を atan2 で独立逆算できる。
+    //! gain 値（-3/-6/-9/-4）は **異なるサンプル間で RMS 比較できない**（固有レベルが違う）ので
+    //! ここでは検証しない。gain は Leg 2（schedule の gainDb/linear）+ phase-2 per_event_gain
+    //! （同一サンプルの dB 差を実レンダで）でカバー済み。ここは pan / 領域 / 分離を見る。
+    let golden = load_golden("examples22_parity");
+    let (cap, sample_frames) = render_golden(&golden);
+    let sr = golden.sample_rate as f64;
+
+    for ev in &golden.events {
+        let onset = frame_at(ev.onset_sec, sr);
+        // span: whole(durationSec=0) = サンプル全尺 / slice = durationSec フレーム。
+        let span = if ev.duration_sec > 0.0 {
+            frame_at(ev.duration_sec, sr)
+        } else {
+            sample_frames[&ev.sample]
+        };
+        // 末尾 trim は span の 1/4 を上限 600 で。hat(0.05s=2400fr)でも窓が潰れない。
+        let tail_trim = (span / 4).min(600);
+        let (w_start, w_end) = body_window(onset, span, tail_trim);
+        assert!(
+            w_start < w_end,
+            "seq {} の body 窓が狭すぎる: [{w_start}, {w_end})",
+            ev.sequence_name
+        );
+        let l = region_rms(&cap, 0, w_start, w_end);
+        let r = region_rms(&cap, 1, w_start, w_end);
+        assert!(
+            l.max(r) > 1e-3,
+            "seq {} に信号が必要（L={l:.5}, R={r:.5}）",
+            ev.sequence_name
+        );
+        // 出力 pan を atan2 で独立逆算し schedule の pan と突き合わせる（GRM 独立）。
+        let measured = pan_from_lr_rms(l, r);
+        assert!(
+            (measured - ev.pan as f32).abs() <= PAN_TOLERANCE,
+            "seq {}: schedule pan {} → measured {measured} (L={l:.5}, R={r:.5})",
+            ev.sequence_name,
+            ev.pan
+        );
+    }
+
+    // イベント間の無音（分離の裏付け）。kick[0.1,0.6]/snare[2.1,2.3]/hat[4.1,4.15]/
+    // chopd slice1[6.1,6.6]/slice2[7.1,7.6] の隙間を各 ch で確認する。
+    for (gap_start, gap_end) in [(1.0, 1.8), (3.0, 3.8), (5.0, 5.8), (6.7, 7.0)] {
+        let gs = (gap_start * sr) as usize;
+        let ge = (gap_end * sr) as usize;
+        let gap = region_rms(&cap, 0, gs, ge).max(region_rms(&cap, 1, gs, ge));
+        assert!(
+            gap < 1e-5,
+            "examples22 イベント間 {gap_start}-{gap_end}s は無音のはず（RMS={gap:.6}）"
+        );
+    }
+}

--- a/test-assets/verify-fixtures/examples22_parity.orbs
+++ b/test-assets/verify-fixtures/examples22_parity.orbs
@@ -1,0 +1,51 @@
+// #316 — examples/22 (#304 dog-food) を de-overlap した parity 検証 fixture。
+//
+// 生 examples/22 は 4 voice 同時並行で、各拍に複数 voice が重畳し per-event の
+// pan/gain を分離できない（研究 §4.4: per-event 検証はイベント分離・無音区間が前提）。
+// そこで同じ素材・同じ #304 パラメータを、イベント分離（十分な無音区間つき）で並べる:
+//   pan  -60 / +60 / 0 / +20（raw → daemon -0.6 / +0.6 / 0 / +0.2）
+//   gain -3 / -6 / -9 / -4 dB
+//   chop(1) 全体（kick/snare/hat）と chop(2) 領域（chopd）
+//
+// tempo 120 / beat 4/4 / length 4 → 8.0s。play 16 要素（= 4 拍 × 4 小節）→ subdivision
+// = 8.0/16 = 0.5s 刻み（spec: length(2)→8要素 と同型。subdivision は play 要素数で決まり
+// chop とは独立）。全サンプル f32 mono 48k: kick 0.5s / snare 0.2s / hihat_closed 0.05s /
+// arpeggio_c 1.0s。
+//   kick  @step0  = 0.0s  pan -60 gain -3  chop(1)全体 → [0.0,0.5]
+//   snare @step4  = 2.0s  pan +60 gain -6  chop(1)全体 → [2.0,2.2]
+//   hat   @step8  = 4.0s  pan  0  gain -9  chop(1)全体 → [4.0,4.05]
+//   chopd @step12 = 6.0s slice1 / @step14 = 7.0s slice2  pan +20 gain -4  chop(2)
+//     arpeggio 1.0s / chop(2) → sliceDur 0.5s = slot 0.5s → rate=1.0（time-stretch 回避）。
+//     slice1 → [6.0,6.5] / slice2 → [7.0,7.5]。
+// 各イベントは >=1s の無音で分離され、L/R RMS が単一 voice になるので pan/領域を per-event
+// で検証できる。
+var global = init GLOBAL
+global.tempo(120)
+global.beat(4 by 4)
+
+var kick = init global.seq
+kick.length(4)
+kick.audio("../audio/kick.wav").chop(1)
+kick.defaultGain(-3).defaultPan(-60)
+kick.play(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+var snare = init global.seq
+snare.length(4)
+snare.audio("../audio/snare.wav").chop(1)
+snare.defaultGain(-6).defaultPan(60)
+snare.play(0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+var hat = init global.seq
+hat.length(4)
+hat.audio("../audio/hihat_closed.wav").chop(1)
+hat.defaultGain(-9).defaultPan(0)
+hat.play(0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0)
+
+var chopd = init global.seq
+chopd.length(4)
+chopd.audio("../audio/arpeggio_c.wav").chop(2)
+chopd.defaultGain(-4).defaultPan(20)
+chopd.play(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0)
+
+global.start()
+RUN(kick, snare, hat, chopd)

--- a/test-assets/verify-fixtures/examples22_parity.orbs
+++ b/test-assets/verify-fixtures/examples22_parity.orbs
@@ -17,8 +17,8 @@
 //   chopd @step12 = 6.0s slice1 / @step14 = 7.0s slice2  pan +20 gain -4  chop(2)
 //     arpeggio 1.0s / chop(2) → sliceDur 0.5s = slot 0.5s → rate=1.0（time-stretch 回避）。
 //     slice1 → [6.0,6.5] / slice2 → [7.0,7.5]。
-// 各イベントは >=1s の無音で分離され、L/R RMS が単一 voice になるので pan/領域を per-event
-// で検証できる。
+// kick/snare/hat/chopd 間は各 1.5s 以上、chopd slice1-slice2 間は 0.5s（同一 pan +20）の無音で
+// 分離され、L/R RMS が単一 voice になるので pan/領域を per-event で検証できる。
 var global = init GLOBAL
 global.tempo(120)
 global.beat(4 by 4)

--- a/test-assets/verify-fixtures/examples22_parity.schedule.json
+++ b/test-assets/verify-fixtures/examples22_parity.schedule.json
@@ -1,0 +1,61 @@
+{
+  "fixture": "examples22_parity",
+  "sampleRate": 48000,
+  "events": [
+    {
+      "onsetSec": 0.1,
+      "sample": "kick.wav",
+      "gain": 0.7079457843841379,
+      "pan": -0.6,
+      "offsetSec": 0,
+      "durationSec": 0,
+      "gainDb": -3,
+      "panRaw": -60,
+      "sequenceName": "kick"
+    },
+    {
+      "onsetSec": 2.1,
+      "sample": "snare.wav",
+      "gain": 0.5011872336272722,
+      "pan": 0.6,
+      "offsetSec": 0,
+      "durationSec": 0,
+      "gainDb": -6,
+      "panRaw": 60,
+      "sequenceName": "snare"
+    },
+    {
+      "onsetSec": 4.1,
+      "sample": "hihat_closed.wav",
+      "gain": 0.35481338923357547,
+      "pan": 0,
+      "offsetSec": 0,
+      "durationSec": 0,
+      "gainDb": -9,
+      "panRaw": 0,
+      "sequenceName": "hat"
+    },
+    {
+      "onsetSec": 6.1,
+      "sample": "arpeggio_c.wav",
+      "gain": 0.6309573444801932,
+      "pan": 0.2,
+      "offsetSec": 0,
+      "durationSec": 0.5,
+      "gainDb": -4,
+      "panRaw": 20,
+      "sequenceName": "chopd"
+    },
+    {
+      "onsetSec": 7.1,
+      "sample": "arpeggio_c.wav",
+      "gain": 0.6309573444801932,
+      "pan": 0.2,
+      "offsetSec": 0.5,
+      "durationSec": 0.5,
+      "gainDb": -4,
+      "panRaw": 20,
+      "sequenceName": "chopd"
+    }
+  ]
+}

--- a/tests/audio/verify/leg2-examples22-parity.spec.ts
+++ b/tests/audio/verify/leg2-examples22-parity.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * #316 Leg 2（interpreter がスケジュールを正しく計算するか）— examples/22 (#304) parity。
+ *
+ * fixture `examples22_parity.orbs`（examples/22 の #304 パラメータを de-overlap したもの）を
+ * RecordingScheduler 注入の InterpreterV2 で実行し、生の構造スケジュールを **.orbs と DSL 仕様
+ * から人手で導いた音楽単位オラクル** と突き合わせる（解決済み daemon param に変換しない＝
+ * トートロジー回避・GRM 独立性）。あわせて Leg 1 用の golden schedule JSON を本番共有の
+ * `toDaemonParams` で生成し committed と一致するか検証する。
+ *
+ * オラクルの手計算（.orbs を読んで）:
+ *   tempo 120 / beat 4/4 / length 4 → 8.0s。play 16 要素 → subdivision = 8.0/16 = 0.5s 刻み
+ *   （spec: length(2)→8要素 と同型。subdivision は play 要素数で決まり chop とは独立）。
+ *     kick  play step0  → onset 0ms    / gainDb -3 / pan -60 / chop(1) 全体（slice なし）
+ *     snare play step4  → onset 2000ms / gainDb -6 / pan +60 / chop(1) 全体
+ *     hat   play step8  → onset 4000ms / gainDb -9 / pan   0 / chop(1) 全体
+ *     chopd play step12 → onset 6000ms / gainDb -4 / pan +20 / chop(2) slice index=1
+ *           play step14 → onset 7000ms / gainDb -4 / pan +20 / chop(2) slice index=2
+ *   記録 time = musical onset + RUN_SCHEDULE_BUFFER_MS(100)（RUN one-shot の先読み）。
+ *   golden offsetSec: slice1=(1-1)*0.5=0.0s、slice2=(2-1)*0.5=0.5s。durationSec=0.5s 各。
+ *   ※ length>1（=4）を harness で初めて通す。interpreter が length>1 を別解釈するなら、この
+ *      独立オラクルとの不一致でここが落ちる（verification が仕事をする）。
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+import {
+  recordSchedule,
+  resolveGolden,
+  reconcileGolden,
+  RUN_SCHEDULE_BUFFER_MS,
+} from './schedule-golden'
+
+const FIXTURE = 'examples22_parity'
+/** 全サンプル尺（f32 mono 48k）。slice scheduling（chopd）が getAudioDuration を要求する。 */
+const DURATIONS = {
+  '../audio/kick.wav': 0.5,
+  '../audio/snare.wav': 0.2,
+  '../audio/hihat_closed.wav': 0.05,
+  '../audio/arpeggio_c.wav': 1.0,
+}
+
+/** .orbs + DSL 仕様から手書きした期待スケジュール（interpreter で計算しない）。time 昇順。 */
+const ORACLE = [
+  { onsetMs: 0, gainDb: -3, pan: -60, sequenceName: 'kick', sliceIndex: undefined },
+  { onsetMs: 2000, gainDb: -6, pan: 60, sequenceName: 'snare', sliceIndex: undefined },
+  { onsetMs: 4000, gainDb: -9, pan: 0, sequenceName: 'hat', sliceIndex: undefined },
+  { onsetMs: 6000, gainDb: -4, pan: 20, sequenceName: 'chopd', sliceIndex: 1 },
+  { onsetMs: 7000, gainDb: -4, pan: 20, sequenceName: 'chopd', sliceIndex: 2 },
+]
+
+describe('#316 Leg 2 — examples22_parity: interpreter schedule vs hand oracle', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('records the structurally-correct schedule (onset / gainDb / pan / slice)', async () => {
+    const recorded = await recordSchedule(FIXTURE, DURATIONS)
+
+    expect(recorded).toHaveLength(ORACLE.length)
+    recorded.forEach((play, i) => {
+      const exp = ORACLE[i]
+      // onset: 記録 time === 音楽 onset + RUN buffer（fake timers で厳密）。
+      expect(play.time).toBe(exp.onsetMs + RUN_SCHEDULE_BUFFER_MS)
+      expect(play.gainDb).toBe(exp.gainDb)
+      expect(play.pan).toBe(exp.pan)
+      expect(play.sequenceName).toBe(exp.sequenceName)
+      if (exp.sliceIndex === undefined) {
+        // chop(1) = 全体再生 → slice は付かない。
+        expect(play.slice).toBeUndefined()
+      } else {
+        expect(play.slice).toBeDefined()
+        expect(play.slice!.index).toBe(exp.sliceIndex)
+        expect(play.slice!.total).toBe(2)
+      }
+    })
+  })
+
+  it('golden schedule JSON matches committed (Leg 1 GRM・staleness guard)', async () => {
+    const recorded = await recordSchedule(FIXTURE, DURATIONS)
+    const golden = resolveGolden(FIXTURE, recorded, DURATIONS)
+    // chopd の slice 領域を**手計算定数**で直接検証する（toDaemonParams 自己参照の式バグを
+    // GRM 独立に捕まえる）。arpeggio_c 1.0s / chop(2): slice1 offset 0.0s / slice2 0.5s、各 dur 0.5s。
+    const chopd = golden.events.filter((e) => e.sequenceName === 'chopd')
+    expect(chopd).toHaveLength(2)
+    expect(chopd[0].offsetSec).toBeCloseTo(0.0, 5)
+    expect(chopd[1].offsetSec).toBeCloseTo(0.5, 5)
+    expect(chopd[0].durationSec).toBeCloseTo(0.5, 5)
+    expect(chopd[1].durationSec).toBeCloseTo(0.5, 5)
+    // chop(1) 全体再生は領域を持たない（offset 0 / dur 0）。
+    const whole = golden.events.filter((e) => e.sequenceName !== 'chopd')
+    whole.forEach((e) => {
+      expect(e.offsetSec).toBeCloseTo(0.0, 5)
+      expect(e.durationSec).toBeCloseTo(0.0, 5)
+    })
+    const { updated, committed } = reconcileGolden(golden)
+    if (updated) return // UPDATE_GOLDEN=1 で再生成した場合は突き合わせをスキップ。
+    expect(committed, 'golden JSON missing — run with UPDATE_GOLDEN=1 to generate').not.toBeNull()
+    expect(golden).toEqual(committed)
+  })
+})


### PR DESCRIPTION
## 概要

harness epic #307 の受け入れ基準「**examples/22（pan/slice/per-slice gain）を PCM アサーションで #304 を遡及的に自己検証（耳に依存しない裏付け）**」を満たす最終増分。phase 1〜3（#310/#312/#314）でハーネス・assertion lib・tier-c・librosa grounding は揃ったが、**#304 の実 deliverable を耳なし検証する最終ピースが未達**だった。本 PR でこれを満たし #307 をクローズ（完了済み phase-2 #311 も併せて）。

Closes #307
Closes #311
Closes #316

## examples/22 の制約 → de-overlap fixture

`examples/22_rust_engine_parity.orbs` は 4 voice 同時並行の dog-food デモで、各拍に複数 voice が重畳し L/R RMS がミックスになり per-event の pan/gain を分離不能（研究 §4.4）。→ **生ファイルに per-event assert を当てず**、同じ素材・同じ #304 パラメータ（pan -0.6/+0.6/0/+0.2・gain -3/-6/-9/-4・chop(1) 全体 と chop(2) 領域）を **de-overlap した検証 fixture** `examples22_parity.orbs` に組む。

- tempo 120 / length 4 / 16 要素 → 0.5s grid（spec: `length(2)→8要素` と同型・subdivision は play 要素数で決まり chop と独立）。
- kick@0s(pan -0.6) / snare@2s(+0.6) / hat@4s(0) / chopd slice1@6s・slice2@7s(+0.2, chop(2), rate=1.0)。
- **length>1 を harness で初めて使用** → 独立オラクルと一致（interpreter が length>1 を正しく処理することを確認）。

## 2 本足検証

- **Leg 2（TS）**: InterpreterV2 schedule vs **手書き独立オラクル**（onset/gainDb/pan/slice を .orbs+DSL 仕様から導出・トートロジー回避）。
- **Leg 1（Rust）**: golden → 実 `EngineWrap::play_at` offline render → PCM で **pan を atan2 独立逆算**（kick -0.6/snare +0.6/hat 0/chopd +0.2）+ **chop(2) 領域** + **イベント間無音** を検証。
- **gain（正直に）**: gain 値（-3/-6/-9/-4）は異なるサンプル間で RMS 比較不能（固有レベルが違う）ため Leg 1 では検証しない。gain は Leg 2（gainDb/linear の計算）+ phase-2 per_event_gain（同一サンプルの dB 差を実レンダで）でカバー済み。

## スコープ外

- 生 examples/22 の literal smoke（別パス・重畳で friction 高く弱い検証）は見送り。
- CLI `play --capture`（#307 ②・重い）は /goal2（#300 recovery floor）へ defer（#307 が「capture は respawn 後の可聴ギャップ計測に効く」と明記）。

## テスト

- cargo `verify_schedule_pcm` 4 / `orbit-audio-verify` 30 全緑。npm 1161 passed / 25 skipped。
- SC 既定・daemon 実時間経路・audio `play()` 意味論 無改変。
- `/simplify`（4観点）適用済み（reuse/efficiency clean・altitude 1件: tail_trim を固定 600 に簡約）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
