### PR TITLE
feat(engine): slice varispeed parity — chop rate≠1.0 on rust engine (post-2.0 A3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,9 +277,9 @@ In-repo USER_MANUAL files are **deprecated** (historical reference only):
 npm test
 ```
 
-**1129 passed, 23 skipped (1152 total) — 2.0.0**
+**1168 passed, 27 skipped (1195 total) — post-2.0 (A3 slice varispeed)**
 
-Run `npm test` to see the current breakdown. 23 tests are skipped (SuperCollider integration tests require a local environment).
+Run `npm test` to see the current breakdown. Skipped tests are SuperCollider / real-daemon integration tests that require a local environment.
 
 ## Getting Started
 

--- a/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
+++ b/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
@@ -233,6 +233,24 @@ seq1.play(1,1,1,1, 2,2,2,2)     // Repeat slices
 seq1.play(8,7,6,5, 4,3,2,1)     // Reverse order
 ```
 
+### Slice-to-Slot Fitting (varispeed)
+
+A chop slice has a **natural length** (`fileDuration / chopDivisions`), but `play()` nesting
+and `length()` decide the **event slot** the slice is scheduled into. When those two differ,
+the slice is **time-scaled to fill its slot by varispeed** (a playback-rate change), exactly
+like SuperCollider's `PlayBuf.ar(rate:)`:
+
+- `rate = sliceNaturalDuration / eventSlotDuration`.
+- `rate > 1` → the slice plays **faster** (shorter, **higher** pitch);
+  `rate < 1` → **slower** (longer, **lower** pitch).
+- **Pitch moves with the rate.** This is varispeed (like a turntable / sampler), *not*
+  pitch-preserving time-stretch. A `rate = 2.0` slice sounds one octave up; `rate = 0.5`
+  one octave down.
+
+This is the default slot-fitting behavior for **both** the SuperCollider engine and the Rust
+engine (`ORBITSCORE_ENGINE=rust`); the two stay in parity. A *pitch-preserving* fit would
+require time-stretch — see `fixpitch()` / `time()` / `stretch()` in §12.
+
 ---
 
 ## 4. Playback and Structure
@@ -1185,8 +1203,22 @@ Epic #224 phases 1/2/3/R/4:
 ### Not Yet Implemented 📋
 
 #### Audio Manipulation
-- **fixpitch()**: Pitch shift in semitones
-- **time()**: Time stretch/compression
+
+These per-slice modifiers (`seq.play(1.fixpitch(7), 2.time(0.5), ...)`) are recognized by the
+parser but currently throw "not yet implemented" (#213). Their **semantics are fixed** below so
+the two time/pitch axes stay orthogonal and consistent with the chop slice-fit varispeed (§3):
+
+- **fixpitch(semitones)**: shift pitch by N semitones, **duration preserved** (pitch-preserving
+  pitch-shift — the *pitch* axis moves, time held). Requires a pitch-preserving DSP
+  (permissive Signalsmith, not GPL Rubber Band).
+- **time(factor)**: change playback speed by `factor` — **varispeed, pitch moves with speed**
+  (`0.5` = half speed / one octave down, `2.0` = double speed / one octave up). The *time* axis
+  moves, pitch follows. Reuses the same rate primitive as chop slice-fit (§3); **not**
+  pitch-preserving. (#213)
+- **stretch(factor)** *(reserved name, unspecified for implementation)*: pitch-preserving
+  time-stretch (duration changes, **pitch held**) — the complement of `time()`. Pitch-preserving
+  time-stretch is also obtainable by composing `time()` (varispeed) with `fixpitch()` (inverse
+  shift), so a first-class `stretch()` is sugar, deferred until a concrete need.
 - **offset()**: Start position adjustment
 - **reverse()**: Reverse playback
 - **fade()**: Fade in/out

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -20,7 +20,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 ### 6.159 feat(engine): slice varispeed parity — chop rate≠1.0 on rust engine (post-2.0 A3 / #319) (Jun 22, 2026)
 
 **Date**: 2026-06-22
-**Status**: ✅ 実装 + 全テスト緑（npm 全緑・cargo workspace 全緑。varispeed core 単体4 + 統合1 + StopAll protocol1 + TS rate/stopAll/Gap5）
+**Status**: ✅ 実装 + 全テスト緑（npm 全緑・cargo workspace 全緑。core 単体6 = varispeed 5〔rate=1.0 ビット同一 / 倍 / 半 / invalid / fade*rate〕+ stop_all 1、統合 varispeed 1、StopAll protocol 1、TS rate/stopAll/Gap5。PR レビューで fade*rate テスト + stopAll エラー可視化を追加）
 **Branch**: `319-slice-varispeed`
 
 **背景**: post-2.0 engine-first の次フェーズ（cutover #108 までの parity gap 充填の1つ目 = A3）。#304（PR #305）が「見かけの parity を作らない」ために rate≠1.0 を 1回 warn + 自然尺に倒した箇所を、実機で尺合わせ再生する。正本: `POST_2.0_NEXT_STEPS.html §4 A3`。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,33 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.159 feat(engine): slice varispeed parity — chop rate≠1.0 on rust engine (post-2.0 A3 / #319) (Jun 22, 2026)
+
+**Date**: 2026-06-22
+**Status**: ✅ 実装 + 全テスト緑（npm 全緑・cargo workspace 全緑。varispeed core 単体4 + 統合1 + StopAll protocol1 + TS rate/stopAll/Gap5）
+**Branch**: `319-slice-varispeed`
+
+**背景**: post-2.0 engine-first の次フェーズ（cutover #108 までの parity gap 充填の1つ目 = A3）。#304（PR #305）が「見かけの parity を作らない」ために rate≠1.0 を 1回 warn + 自然尺に倒した箇所を、実機で尺合わせ再生する。正本: `POST_2.0_NEXT_STEPS.html §4 A3`。
+
+**Step0（2 spike + advisor + owner 決定）**: ① **Signalsmith Rust binding spike** = `signalsmith-stretch`(MIT) が存在し proceed 可（早期採用・production 実績は自前）。② **DSL 意味論 spike**（spec + SC 一次資料）で **核心の再構成**: slice rate≠1.0 の SC parity は SC `PlayBuf.ar(rate: sliceDur/slotDur)` = **純 varispeed（ピッチも動く）**で、pitch-preserving stretch は SC 経路に存在しない → **parity を埋めるのに Signalsmith は不要**。一方 `fixpitch()`/`time()` は SC 未実装の **net-new #213 機能**（Signalsmith FFI + license gate 新設 = 高リスク）。③ 前提誤り訂正: 「cargo deny / deny.toml 前例あり」は事実誤認（リポジトリに不在）。
+
+**owner 決定（2026-06-22・blast radius が決め手）**:
+- **Q1 = varispeed-only**。A3 = slice rate≠1.0 varispeed（Rust 内部完結・SC 経路/共有 DSL 表面に非接触・新依存ゼロ）+ 織り込み3件。**fixpitch()/time()/Signalsmith/cargo-deny は #213 follow-on へ分離**（手戻りゼロ: varispeed primitive を後で再利用）。
+- **Q2 = time()=varispeed + 将来 stretch() 予約**（spec 方向を記録）。「rate 変化=varispeed」一貫。pitch-preserving は fixpitch+time の合成で得られる。
+
+**varispeed 設計（advisor 承認）**: `ScheduledSample.rate` + 分数読み位置 `read_pos: f64` を導入し、core render を「source を `rate` 倍歩幅で分数走査 + 線形補間」に変更。**rate=1.0 で frac=0 → 元サンプルにビット同一**（既存 slice/pan/fade テスト無改変で通る厳密な一般化）。fade は出力時間（slice_len/rate）で数える。`rate = sliceDuration / eventSlotDuration`（SC `calculatePlaybackRate` と同形）を TS 側で計算し daemon へ送る。出力尺 = `effective_len_frames / sr / rate`（PlayEnded もこの出力終端）。
+
+**seam（TS→daemon→core を一貫）**: `rust-engine-player.ts`（`resolveSliceRegion` を warn から rate 算出へ・`toDaemonParams`/`executePlayback` が rate を渡す・GapKind から `slice` 除去）→ `daemon-client.ts`/`protocol-types.ts`（PlayAt に rate）→ `session.rs`（rate 解析・pan 同様 reject せず 1.0 丸め）→ `engine_wrap.rs`（出力尺 /rate）→ `engine.rs`/`scheduler.rs`（varispeed render）。spec-first で `INSTRUCTION_ORBITSCORE_DSL.md`（slice-fit varispeed §3 + time()/fixpitch()/stretch() §12）と `ENGINE_DAEMON_PROTOCOL.md`（PlayAt rate + StopAll）を先に更新。
+
+**織り込みフォローアップ3件**:
+- **daemon hard-stop-all（global）**: core `Scheduler::stop_all()` + daemon `StopAll` コマンド + TS `stopAll()` 配線（disposed/respawning/未接続では skip）。varispeed の rate<1.0 長尺 voice が global stop を跨いで鳴り続けるのを断つ。**per-sequence selective stop（`clearSequenceEvents` の play_id 追跡）は明示 defer**（balloon 厳禁・要 owner 判断＝#319 コメント記録）。
+- **Gap5**: quit-during-respawn の CI テスト（mock・respawn backoff 中の quit が clean に終わる）。
+- **bot Finding 2**: connect 時 error の二重ログ修正（永続 onError を open 後に attach・connect once を open で detach）。
+
+**検証（Done 基準＝offline 決定論 PCM）**: core 単体（rate=2.0 で倍勾配・rate=0.5 で補間・rate=1.0 ビット同一・invalid rate 丸め）+ **統合**（`verify_schedule_pcm.rs`: 同一 slice を rate=1.0/2.0 で実 `play_at`→render し rate=2.0 が半尺で終わることを PCM の信号終端比で確認）+ StopAll protocol + TS（rate 送信・stopAll・Gap5）。capture seam は含めない（offline で足りる・#300 Step0 の決定を維持）。
+
+**明示 defer**: fixpitch()/time()/Signalsmith/cargo-deny → #213 / capture seam / A4 LinkAudio / γ / cutover #108 / per-sequence hard-stop。
+
 ### 6.158 feat(engine): recovery floor — daemon supervision + auto-respawn + 最小 recovery contract (post-2.0 α / #300) (Jun 22, 2026)
 
 **Date**: 2026-06-22

--- a/docs/research/ENGINE_DAEMON_PROTOCOL.md
+++ b/docs/research/ENGINE_DAEMON_PROTOCOL.md
@@ -247,7 +247,7 @@ JSON-RPC 2.0 の影響を受けた独自形式:
 - `pan`: `[-1.0, 1.0]`。範囲外は自動 clamp（UX 優先、reject しない）、省略時は 0.0
 - `offset_sec`: `[0.0, ∞)`。サンプル内の再生開始位置（秒）。省略時は 0.0（先頭）。`chop` の slice 開始位置に対応。負値は `PARAM_OUT_OF_RANGE` で reject
 - `duration_sec`: `[0.0, ∞)`。`offset_sec` から再生する**ソース**長（秒）。0 または省略で「offset 以降すべて」。`chop` の slice 長に対応。負値は `PARAM_OUT_OF_RANGE` で reject。サンプル端を超える指定は端で clamp
-- `rate`: varispeed 再生レート（#319）。省略時 1.0（自然尺）。`>1` で速く短く高ピッチ、`<1` で遅く長く低ピッチ（ピッチも動く varispeed = SC `PlayBuf.ar(rate:)` 一致）。`<=0` / 非有限は `pan` 同様 reject せず 1.0 に丸める（UX 優先）。出力尺 = `duration_sec / rate`（PlayEnded はこの出力終端で発火）
+- `rate`: varispeed 再生レート（#319）。省略時 1.0（自然尺）。`>1` で速く短く高ピッチ、`<1` で遅く長く低ピッチ（ピッチも動く varispeed = SC `PlayBuf.ar(rate:)` 一致）。`<=0` / 非有限は `pan` 同様 reject せず 1.0 に丸める（UX 優先）。出力尺 = `実ソース尺 / rate`（`duration_sec > 0` なら `duration_sec / rate`、`duration_sec = 0` なら `offset` 以降のサンプル実尺 / rate）。PlayEnded はこの出力終端で発火
 
 ### Stop
 

--- a/docs/research/ENGINE_DAEMON_PROTOCOL.md
+++ b/docs/research/ENGINE_DAEMON_PROTOCOL.md
@@ -230,7 +230,8 @@ JSON-RPC 2.0 の影響を受けた独自形式:
     "gain": 1.0,
     "pan": 0.0,
     "offset_sec": 0.0,
-    "duration_sec": 0.0
+    "duration_sec": 0.0,
+    "rate": 1.0
   }
 }
 
@@ -245,7 +246,8 @@ JSON-RPC 2.0 の影響を受けた独自形式:
 - `gain`: `[0.0, ∞)`。範囲外（負値）は `PARAM_OUT_OF_RANGE` で reject。上限超過はクリッピング前提で accept
 - `pan`: `[-1.0, 1.0]`。範囲外は自動 clamp（UX 優先、reject しない）、省略時は 0.0
 - `offset_sec`: `[0.0, ∞)`。サンプル内の再生開始位置（秒）。省略時は 0.0（先頭）。`chop` の slice 開始位置に対応。負値は `PARAM_OUT_OF_RANGE` で reject
-- `duration_sec`: `[0.0, ∞)`。`offset_sec` から再生する長さ（秒）。0 または省略で「offset 以降すべて」。`chop` の slice 長に対応（natural rate=1.0 で再生）。負値は `PARAM_OUT_OF_RANGE` で reject。サンプル端を超える指定は端で clamp
+- `duration_sec`: `[0.0, ∞)`。`offset_sec` から再生する**ソース**長（秒）。0 または省略で「offset 以降すべて」。`chop` の slice 長に対応。負値は `PARAM_OUT_OF_RANGE` で reject。サンプル端を超える指定は端で clamp
+- `rate`: varispeed 再生レート（#319）。省略時 1.0（自然尺）。`>1` で速く短く高ピッチ、`<1` で遅く長く低ピッチ（ピッチも動く varispeed = SC `PlayBuf.ar(rate:)` 一致）。`<=0` / 非有限は `pan` 同様 reject せず 1.0 に丸める（UX 優先）。出力尺 = `duration_sec / rate`（PlayEnded はこの出力終端で発火）
 
 ### Stop
 
@@ -265,6 +267,27 @@ JSON-RPC 2.0 の影響を受けた独自形式:
   "result": { "play_id": "p-a9f2", "status": "stopped" | "already_stopped" | "not_found" }
 }
 ```
+
+### StopAll
+
+全アクティブ再生（発音中 + 開始待機中）を即時停止する hard-stop-all（#319・冪等）。respawn / `stopAll` で in-flight voice（varispeed の `rate<1.0` で長尺化した slice を含む）を断つのに使う。`play_id` を取らず、daemon が保持する全 voice を drop して停止件数を返す。
+
+```json
+// Request
+{
+  "id": "u5",
+  "method": "StopAll",
+  "params": {}
+}
+
+// Response
+{
+  "id": "u5",
+  "result": { "stopped": 3 }
+}
+```
+
+- `stopped`: 停止した voice 数（空でも 0 を返す冪等動作）
 
 ### SetGlobalGain
 

--- a/packages/engine/src/audio/rust-engine/daemon-client.ts
+++ b/packages/engine/src/audio/rust-engine/daemon-client.ts
@@ -222,6 +222,7 @@ export class DaemonClient extends EventEmitter {
     pan = 0,
     offsetSec = 0,
     durationSec = 0,
+    rate = 1,
   ): Promise<{ playId: string }> {
     const result = await this.request('PlayAt', {
       sample_id: sampleId,
@@ -232,6 +233,8 @@ export class DaemonClient extends EventEmitter {
       // offset_sec / duration_sec は再生領域（chop の slice）。0/0 で全体再生。
       offset_sec: offsetSec,
       duration_sec: durationSec,
+      // rate は varispeed（1.0 = 自然尺）。<=0/非有限は daemon 側で 1.0 に丸め。
+      rate,
     })
     return { playId: String(result.play_id) }
   }
@@ -239,6 +242,12 @@ export class DaemonClient extends EventEmitter {
   async stop(playId: string): Promise<boolean> {
     const result = await this.request('Stop', { play_id: playId })
     return result.status === 'stopped'
+  }
+
+  /** daemon の全アクティブ再生を即時停止する（hard-stop-all）。停止件数を返す。 */
+  async stopAll(): Promise<number> {
+    const result = await this.request('StopAll', {})
+    return Number(result.stopped ?? 0)
   }
 
   async setGlobalGain(value: number, rampSec = 0): Promise<void> {
@@ -500,12 +509,16 @@ export class DaemonClient extends EventEmitter {
     const onMessage = (data: WebSocket.RawData) => this.handleFrame(data.toString())
     ws.on('message', onMessage)
     // daemon を kill -9 / segfault すると、socket は 'close' の前に 'error'（ECONNRESET 等）を
-    // emit しうる。connect 用の once('error') が消費済みだと 'error' に listener が無くなり、
-    // Node の EventEmitter が unhandled 'error' を throw して TS プロセスごと巻き込む。recovery
-    // floor の要は「daemon の死で app を落とさない」ことなので、永続 error listener で吸収する
-    // （実際の cleanup / respawn 駆動は 'close' ハンドラが行う）。
+    // emit しうる。listener が無いと Node の EventEmitter が unhandled 'error' を throw して TS
+    // プロセスごと巻き込む。recovery floor の要は「daemon の死で app を落とさない」ことなので、
+    // 永続 error listener で吸収する（実際の cleanup / respawn 駆動は 'close' ハンドラが行う）。
+    //
+    // ただし **connect 中は下の `onConnectError`（once）が error を担う**ので、`onError` は
+    // open 後にだけ attach する。connect 前から両方を付けると、connect 失敗時に onError の warn と
+    // connect reject が **二重ログ**になる（bot Finding 2）。open で onConnectError を detach し
+    // onError に引き継ぐことで、connect 失敗は単一経路（reject）に、post-connect の死は onError に
+    // 集約される。
     const onError = (err: Error): void => {
-      // listener が存在すること自体が第一の目的（unhandled 'error' の throw を防ぐ）。さらに
       // 詳細（ECONNRESET 等）を console.warn で必ず可視化する — 'close' ハンドラの daemon-died
       // 通知だけでは socket レベルの死因が消えるため。実際の cleanup / respawn 駆動は 'close' が行う。
       console.warn(
@@ -513,7 +526,6 @@ export class DaemonClient extends EventEmitter {
         err,
       )
     }
-    ws.on('error', onError)
     ws.on('close', () => {
       // running を倒す前に「起動成功後だったか」を捕まえる（死の判定に使う）。
       const wasRunning = this.running
@@ -540,14 +552,20 @@ export class DaemonClient extends EventEmitter {
     })
     await new Promise<void>((resolve, reject) => {
       const to = setTimeout(() => reject(new Error(`ws connect timeout: ${url}`)), timeoutMs)
-      ws.once('open', () => {
-        clearTimeout(to)
-        resolve()
-      })
-      ws.once('error', (err) => {
+      // connect 中の error 担当（once）。open 成功時に detach し、以後は永続 onError に引き継ぐ。
+      const onConnectError = (err: Error): void => {
         clearTimeout(to)
         reject(err)
+      }
+      ws.once('open', () => {
+        clearTimeout(to)
+        // connect 成功 → connect 用 error listener を外し、永続 onError に引き継ぐ
+        // （二重ログ防止・unhandled 'error' 防止の両立）。
+        ws.off('error', onConnectError)
+        ws.on('error', onError)
+        resolve()
       })
+      ws.once('error', onConnectError)
     })
   }
 

--- a/packages/engine/src/audio/rust-engine/protocol-types.ts
+++ b/packages/engine/src/audio/rust-engine/protocol-types.ts
@@ -20,6 +20,8 @@ export type CommandMethod =
   | 'UnloadSample'
   | 'PlayAt'
   | 'Stop'
+  // 全アクティブ再生の即時停止（hard-stop-all）。respawn / stopAll で in-flight voice を断つ。
+  | 'StopAll'
   | 'SetGlobalGain'
   | 'GetStatus'
   | 'Ping'

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -456,14 +456,16 @@ export class RustEnginePlayer implements AudioEngineBackend {
   }
 
   /**
-   * chop の slice を領域再生（startPos/duration の切り出し・rate=1.0）でスケジュールする（#304）。
+   * chop の slice を領域再生（offset/duration の切り出し + varispeed rate）でスケジュールする
+   * （#304 領域・#319 varispeed）。
    *
    * slice 領域（offset/長さ）はサンプル尺に依存するが、daemon の load は lazy（初回発火時）
-   * のため、領域は `executePlayback` で load 完了後に計算する。ここでは slice 仕様だけ保持する。
+   * のため、領域と rate は `executePlayback`（`resolveSliceRegion`）で load 完了後に計算する。
+   * ここでは slice 仕様（index/total/eventDurationMs）だけ保持する。
    *
-   * rate≠1.0（slice 尺をイベントスロット尺へ詰める varispeed = time-stretch）は本増分の対象外。
-   * 発火時に rate≠1.0 を検出したら 1 回 warn し、slice は自然尺（rate=1.0）で鳴らす
-   * （time-stretch 増分 #213/#239 へ defer）。per-slice gain は各 slice の gainDb がそのまま効く。
+   * rate≠1.0（slice 尺をイベントスロット尺へ詰める）は `rate = sliceDuration / eventSlotDuration`
+   * で varispeed 発音（SC `PlayBuf.ar(rate:)` 一致・ピッチも動く）。per-slice gain は各 slice の
+   * gainDb がそのまま効く。pitch-preserving な time-stretch（fixpitch/time）は別物で #213 へ defer。
    */
   scheduleSliceEvent(
     filepath: string,

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -27,9 +27,10 @@
  *  - **pan は #304 で実装済み**（daemon PlayAt の pan・equal-power = SC `Pan2` 一致）。
  *    発火時に DSL の -100..100 を daemon の [-1,1] へ変換して送る。
  *
- *  - **slice（chop 領域再生）は #304 で実装済み**（offset/duration の領域読み・rate=1.0）。
- *    rate≠1.0（slice 尺をスロット尺へ詰める time-stretch）のみ 1回 warn し、slice 自体は
- *    自然尺（rate=1.0）で発音する（skip しない）。time-stretch は #213/#239 へ defer。
+ *  - **slice（chop 領域再生）は #304 で実装済み**（offset/duration の領域読み）。
+ *    rate≠1.0（slice 尺をイベントスロット尺へ詰める varispeed）は #319 で実装済み（daemon
+ *    PlayAt の rate・SC `PlayBuf.ar(rate:)` 一致＝ピッチも動く）。pitch-preserving な
+ *    time-stretch（fixpitch/time）は別物で #213 へ defer。
  *
  *  - **残る feature gap は boundary で明示**（見かけの parity を作らない・A0 方針）:
  *    outputChannel(LinkAudio) → 1回 warn して hardware 発音（SC の plugin-missing fallback と同形）/
@@ -44,13 +45,11 @@ import { DaemonClient } from './daemon-client'
 import { DaemonConnectionError, DaemonQuitError } from './errors'
 
 /**
- * boundary で明示する制約の種別。
- * - `slice`: chop 領域再生は実装済み。rate≠1.0（time-stretch）未対応の warn 用で、slice 自体は
- *   rate=1.0 で発音する（拒否しない）。
- * - `outputChannel`(LinkAudio) / `masterEffect`: 未対応 feature gap（A4 era）。
- * pan は #304 で実装済みのため gap ではない。
+ * boundary で明示する未対応 feature gap の種別（A4 era）。
+ * - `outputChannel`(LinkAudio) / `masterEffect`: 未対応 feature gap。
+ * pan / slice 領域 / slice varispeed（rate≠1.0）は実装済みのため gap ではない。
  */
-type GapKind = 'slice' | 'outputChannel' | 'masterEffect'
+type GapKind = 'outputChannel' | 'masterEffect'
 
 /** chop slice 情報。`scheduleSliceEvent` 由来。発火時に領域（offset/duration）へ解決する。 */
 export interface SliceSpec {
@@ -58,7 +57,10 @@ export interface SliceSpec {
   index: number
   /** 分割数（`chop(n)` の n）。 */
   total: number
-  /** イベントスロット尺（ms）。rate≠1.0 判定に使う（time-stretch 未対応の warn 用）。 */
+  /**
+   * イベントスロット尺（ms）。varispeed レート算出に使う
+   * （`rate = sliceDuration / eventSlotDuration`）。未指定 / 0 以下なら rate=1.0（自然尺）。
+   */
   eventDurationMs?: number
 }
 
@@ -91,6 +93,12 @@ export interface DaemonPlayParams {
   offsetSec: number
   /** slice 領域長（秒）。0 = `offsetSec` 以降すべて。 */
   durationSec: number
+  /**
+   * varispeed レート（1.0 = 自然尺）。chop slice 尺をイベントスロット尺へ詰める際に
+   * `rate = sliceDuration / eventSlotDuration` を送る（SC `calculatePlaybackRate` 一致）。
+   * >1 = 速く短く高ピッチ、<1 = 遅く長く低ピッチ（pitch も動く varispeed）。
+   */
+  rate: number
 }
 
 /** daemon transport clock と TS wall clock の対応点。 */
@@ -144,8 +152,6 @@ const DEFAULT_LOOKAHEAD_SEC = 0.05
 const POLL_INTERVAL_MS = 1
 /** SC EventScheduler と同じく、過大 drift のイベントは古い残骸として skip する閾値。 */
 const MAX_DRIFT_MS = 1000
-/** chop slice の rate が 1.0 からこの幅を超えて外れたら time-stretch 未対応として 1 回 warn する。 */
-const SLICE_RATE_TOLERANCE = 0.01
 /** daemon が死んだとき respawn を試みる最大回数。枯渇したら recovery を断念し poll を止める。 */
 const MAX_RESPAWN_ATTEMPTS = 5
 /** respawn 試行間の固定バックオフ（crash loop 緩和 + port 解放待ち）。 */
@@ -153,7 +159,6 @@ const RESPAWN_BACKOFF_MS = 150
 
 /** feature gap warning の初期状態（フィールド初期化子で arm・stopAll で再 arm に使う）。 */
 const freshWarned = (): Record<GapKind, boolean> => ({
-  slice: false,
   outputChannel: false,
   masterEffect: false,
 })
@@ -519,8 +524,14 @@ export class RustEnginePlayer implements AudioEngineBackend {
     this.scheduledPlays = []
     this.liveSequences.clear()
     this.warned = freshWarned()
-    // 注: 既に daemon へ送信済み（発音中）の voice は自然減衰で終わる。即時 hard-stop は
-    // play_id 追跡 or daemon 側 StopAll コマンドが要る後続課題（短サンプル前提で proof は許容）。
+    // daemon 側の in-flight voice（varispeed の rate<1.0 で長尺化した slice 含む）も即時
+    // hard-stop する（#319）。stopAll は同期契約なので fire-and-forget。失敗（接続喪失）は
+    // supervisor 任せで静かに drop する。teardown(quit)/respawn 中は対象が無い/置換されるので
+    // skip する（quit は daemon.quit() が、respawn は新 daemon が空であることが各々始末する）。
+    if (!this.disposed && !this.respawning && this.daemon.isRunning()) {
+      // 接続喪失（DaemonConnectionError 等）は想定内 — 死んだ daemon に stop は不要。
+      void this.daemon.stopAll().catch(() => {})
+    }
   }
 
   clearSequenceEvents(sequenceName: string): void {
@@ -576,7 +587,7 @@ export class RustEnginePlayer implements AudioEngineBackend {
     if (play.sequenceName && !this.liveSequences.has(play.sequenceName)) return
     // 音響パラメータ（amplitude/pan/slice 領域）は本番発火と検証ハーネス（#311）で共有する
     // 変換に集約する。slice 領域は ensureLoaded 後の尺（this.durations）を使う（lazy load）。
-    const { gain, pan, offsetSec, durationSec } = this.toDaemonParams(play)
+    const { gain, pan, offsetSec, durationSec, rate } = this.toDaemonParams(play)
     // daemonNowSec と wallMs は送信「前」に同一瞬間で採取する（onDispatch の lead/drift 計測が
     // coherent になるよう。playAt の await 後だと round-trip 分ずれる）。
     const wallMs = Date.now()
@@ -589,6 +600,7 @@ export class RustEnginePlayer implements AudioEngineBackend {
       pan,
       offsetSec,
       durationSec,
+      rate,
     )
     this.onDispatch?.({
       filepath: play.filepath,
@@ -673,39 +685,37 @@ export class RustEnginePlayer implements AudioEngineBackend {
   }
 
   /**
-   * chop の slice 領域（offset/長さ・秒）を load 済みサンプル尺から計算する。
+   * chop の slice 領域（offset/長さ・秒）と varispeed レートを load 済みサンプル尺から計算する。
    *
-   * 全体再生（slice なし）は `{0, 0}`（= daemon は全体再生）。slice の場合は
+   * 全体再生（slice なし）は `{0, 0, 1}`（= daemon は全体再生・自然尺）。slice の場合は
    * `sliceDuration = totalDuration / total`、`offset = (index-1) * sliceDuration` を返す。
    * 尺が未取得（lazy load で frames/SR が 0）の場合は全体再生にフォールバックする。
    *
-   * rate≠1.0（slice 尺をイベントスロット尺に詰める time-stretch）は本増分の対象外なので、
-   * 検出したら 1 回 warn する（slice 自体は自然尺 rate=1.0 で鳴る）。
+   * varispeed: slice 自然尺をイベントスロット尺へ詰める `rate = sliceDuration / eventSlotDuration`
+   * を返す（SC `calculatePlaybackRate` 一致・>1 で速く高ピッチ、<1 で遅く低ピッチ）。
+   * `eventDurationMs` 未指定 / 0 以下なら自然尺（rate=1.0）。
    */
-  private resolveSliceRegion(play: ScheduledPlay): { offsetSec: number; durationSec: number } {
+  private resolveSliceRegion(play: ScheduledPlay): {
+    offsetSec: number
+    durationSec: number
+    rate: number
+  } {
     const spec = play.slice
-    if (!spec) return { offsetSec: 0, durationSec: 0 }
+    if (!spec) return { offsetSec: 0, durationSec: 0, rate: 1 }
     const totalDuration = this.durations.get(play.filepath) ?? 0
     // NaN <= 0 は JS では false。尺が NaN/非有限でも確実に全体再生フォールバックへ落とす。
     if (!Number.isFinite(totalDuration) || totalDuration <= 0 || spec.total <= 0) {
-      // 尺不明 → 全体再生フォールバック（誤った領域で無音を作らない）。
-      return { offsetSec: 0, durationSec: 0 }
+      // 尺不明 → 全体再生フォールバック（rate=1.0・誤った領域で無音を作らない）。
+      return { offsetSec: 0, durationSec: 0, rate: 1 }
     }
     const sliceDuration = totalDuration / spec.total
     const offsetSec = (spec.index - 1) * sliceDuration
-    // time-stretch（rate≠1.0）は未対応。slice 尺がスロット尺と一致しない場合のみ warn。
-    if (spec.eventDurationMs && spec.eventDurationMs > 0) {
-      const rate = (sliceDuration * 1000) / spec.eventDurationMs
-      if (Math.abs(rate - 1) > SLICE_RATE_TOLERANCE) {
-        this.warnOnce(
-          'slice',
-          `⚠️  [rust-engine] chop slice rate=${rate.toFixed(3)} (slice length ≠ event slot) — ` +
-            `time-stretch is not supported yet; the slice plays at natural length (rate=1.0). ` +
-            `Deferred to the time-stretch increment (#213/#239).`,
-        )
-      }
-    }
-    return { offsetSec, durationSec: sliceDuration }
+    // varispeed レート（SC calculatePlaybackRate と同形）。eventDurationMs 不在 / 0 以下は自然尺。
+    const rate =
+      spec.eventDurationMs && spec.eventDurationMs > 0
+        ? (sliceDuration * 1000) / spec.eventDurationMs
+        : 1
+    return { offsetSec, durationSec: sliceDuration, rate }
   }
 
   /**

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -531,8 +531,14 @@ export class RustEnginePlayer implements AudioEngineBackend {
     // supervisor 任せで静かに drop する。teardown(quit)/respawn 中は対象が無い/置換されるので
     // skip する（quit は daemon.quit() が、respawn は新 daemon が空であることが各々始末する）。
     if (!this.disposed && !this.respawning && this.daemon.isRunning()) {
-      // 接続喪失（DaemonConnectionError 等）は想定内 — 死んだ daemon に stop は不要。
-      void this.daemon.stopAll().catch(() => {})
+      void this.daemon.stopAll().catch((err) => {
+        // 接続喪失（DaemonConnectionError / DaemonQuitError）は想定内 — 死んだ / 終了中の
+        // daemon に stop は不要なので静かに drop。それ以外（例: scheduler mutex poisoned 由来の
+        // DaemonProtocolError）は daemon の実不具合を示すので握り潰さず可視化する
+        // （onPlaybackError と同じ判別方針）。
+        if (err instanceof DaemonConnectionError || err instanceof DaemonQuitError) return
+        console.warn('⚠️  [rust-engine] stopAll() failed unexpectedly:', err)
+      })
     }
   }
 

--- a/rust/crates/orbit-audio-core/src/engine.rs
+++ b/rust/crates/orbit-audio-core/src/engine.rs
@@ -51,6 +51,7 @@ impl Engine {
     /// 適用され、範囲外は clamp される。
     /// `slice_start_frame` / `slice_len_frames` は再生領域（`chop` の slice）。
     /// `slice_len_frames == 0` で「offset 以降すべて」。サンプル端で clamp される。
+    /// `rate` は varispeed（1.0 = 自然尺・`<=0`/非有限は 1.0 に丸め）。
     #[allow(clippy::too_many_arguments)]
     pub fn schedule_with_play_id(
         &self,
@@ -59,6 +60,7 @@ impl Engine {
         pan: f32,
         slice_start_frame: usize,
         slice_len_frames: usize,
+        rate: f64,
         play_id: String,
         sample: Sample,
     ) -> Result<(), EngineError> {
@@ -68,6 +70,7 @@ impl Engine {
                 .with_gain(gain)
                 .with_pan(pan)
                 .with_region(slice_start_frame, slice_len_frames)
+                .with_rate(rate)
                 .with_play_id(play_id),
         );
         Ok(())
@@ -77,6 +80,12 @@ impl Engine {
     pub fn stop(&self, play_id: &str) -> Result<bool, EngineError> {
         let mut s = self.inner.lock().map_err(|_| EngineError::Poisoned)?;
         Ok(s.stop(play_id))
+    }
+
+    /// 全イベントを即時停止する hard-stop-all。停止件数を返す（respawn / stopAll で使う）。
+    pub fn stop_all(&self) -> Result<usize, EngineError> {
+        let mut s = self.inner.lock().map_err(|_| EngineError::Poisoned)?;
+        Ok(s.stop_all())
     }
 
     /// スケジュール中のイベント数（実時間で active な再生数）。

--- a/rust/crates/orbit-audio-core/src/lib.rs
+++ b/rust/crates/orbit-audio-core/src/lib.rs
@@ -16,4 +16,4 @@ mod scheduler;
 
 pub use engine::{Engine, EngineError};
 pub use sample::Sample;
-pub use scheduler::{resolve_slice_region, ScheduledSample, Scheduler};
+pub use scheduler::{resolve_slice_region, sanitize_rate, ScheduledSample, Scheduler};

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -332,7 +332,9 @@ impl Scheduler {
 
                 // fade 開始 source 位置に達したら 1.0→0.0 へ線形減衰（残り出力幅 / fade 幅）。
                 // common path（fade 前 / fade 無し）は比較1つで division しない。rate=1.0 では
-                // env = (slice_len-pos)/fade_frames となり従来の fade とビット一致する。
+                // env = (slice_len-pos)/fade_frames となり従来の fade と数値的に一致する（f64 中間
+                // 値経由のため fade tail は ≤1 ULP 差・PCM 許容内。sample 値の補間は frac=0 で厳密
+                // ビット同一）。fade*rate の正しさは varispeed_fade_width_scales_with_rate で pin。
                 let env = if fading && pos >= fade_start_src {
                     (((slice_len_f - pos) / fade_span_src) as f32).clamp(0.0, 1.0)
                 } else {
@@ -682,6 +684,38 @@ mod tests {
         // 出力 8 フレーム（4/0.5）で読み切り → f8 以降は無音。
         assert!(buf[16].abs() < 1e-6, "f8 L (読み切り後)={}", buf[16]);
         assert_eq!(s.active_count(), 0);
+    }
+
+    #[test]
+    fn varispeed_fade_width_scales_with_rate() {
+        // fade を **出力時間**で数える `fade_span_src = fade_frames * rate` を pin する
+        // （`* rate` を落とす regression = fade 開始位置と幅がズレて click を生む）。
+        // 2400 フレーム定数 1.0 を rate=2.0・hard-left で流す → 出力 1200 フレーム。
+        //   out_dur = 2400/(48000*2) = 0.025s → fade_sec = min(0.001, 0.008) = 0.001s
+        //   → fade_frames = round(0.001*48000) = 48（出力フレーム）。
+        //   fade_span_src = 48*2 = 96、fade_start_src = 2400-96 = 2304。
+        //   出力フレーム k では source pos = 2k。env = (2400 - 2k)/96（pos>=2304＝k>=1152）。
+        let mut s = Scheduler::new(48_000, 2);
+        let sample = Sample::new(vec![1.0f32; 2400], 48_000, 1);
+        s.schedule(
+            ScheduledSample::new(0.0, sample)
+                .with_pan(-1.0)
+                .with_region(0, 2400)
+                .with_rate(2.0),
+        );
+        let mut buf = vec![0.0f32; 2600]; // 1300 frames stereo（出力 1200 を覆う）
+        s.render(&mut buf);
+        // body（k=1100・pos=2200 < fade 開始）は env=1.0。
+        assert!((buf[2 * 1100] - 1.0).abs() < 1e-4, "body L={}", buf[2 * 1100]);
+        // fade 領域 k=1160（pos=2320）: env=(2400-2320)/96 ≈ 0.8333。`* rate` を落とすと
+        // fade_start=2352 となり pos=2320 はまだ fade 前で env=1.0 → ここで分岐を検出する。
+        assert!(
+            (buf[2 * 1160] - 0.8333).abs() < 0.01,
+            "fade L={} (rate 欠落 regression なら 1.0)",
+            buf[2 * 1160]
+        );
+        // 末尾 k=1199（pos=2398）: env=(2400-2398)/96 ≈ 0.0208 → 十分小さい。
+        assert!(buf[2 * 1199] < 0.1, "末尾 fade L={}", buf[2 * 1199]);
     }
 
     #[test]

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -15,6 +15,10 @@ pub struct ScheduledSample {
     pub slice_start_frame: usize,
     /// 再生フレーム数（slice 長）。0 = `slice_start_frame` 以降すべて。`chop` の slice 長。
     pub slice_len_frames: usize,
+    /// 再生レート（varispeed）。1.0 = 自然尺、>1 = 速く（短く・高ピッチ）、<1 = 遅く（長く・
+    /// 低ピッチ）。source を `rate` 倍の歩幅で分数走査し線形補間する（SC `PlayBuf.ar(rate:)`
+    /// 一致）。chop slice をイベントスロット尺へ詰める際に `rate = sliceNatural/slot` を渡す。
+    pub rate: f64,
     /// サンプル本体
     pub sample: Sample,
     /// Stop 命令での個別停止用識別子。`None` なら停止不可（fire-and-forget）。
@@ -29,6 +33,7 @@ impl ScheduledSample {
             pan: 0.0,
             slice_start_frame: 0,
             slice_len_frames: 0,
+            rate: 1.0,
             sample,
             play_id: None,
         }
@@ -36,6 +41,13 @@ impl ScheduledSample {
 
     pub fn with_gain(mut self, gain: f32) -> Self {
         self.gain = gain;
+        self
+    }
+
+    /// 再生レート（varispeed）を設定する。`<= 0` は無効なので 1.0 に丸める（無音化や逆再生を
+    /// 誤って起こさない）。逆再生は別 modifier（`reverse()`・#213 系）の領分。
+    pub fn with_rate(mut self, rate: f64) -> Self {
+        self.rate = if rate.is_finite() && rate > 0.0 { rate } else { 1.0 };
         self
     }
 
@@ -122,12 +134,16 @@ struct ActiveSample {
     slice_start: usize,
     /// 再生領域の長さ（フレーム数）。サンプル端で clamp 済み。
     slice_len: usize,
-    /// 末尾フェードアウトのフレーム数（クリック防止・SC `orbitPlayBuf` 一致）。
+    /// 末尾フェードアウトの **出力フレーム数**（クリック防止・SC `orbitPlayBuf` 一致）。
+    /// varispeed では出力尺 = slice_len/rate なので、source ではなく出力時間で数える。
     fade_frames: usize,
+    /// 再生レート（varispeed）。出力 1 フレームごとに `read_pos` を `rate` 進める。
+    rate: f64,
     /// サンプル本体
     sample: Sample,
-    /// 再生領域内で次に読むフレーム位置（0..slice_len の相対位置）
-    read_pos: usize,
+    /// 再生領域内で次に読む **分数**フレーム位置（0.0..slice_len の相対位置）。varispeed の
+    /// 分数走査のため f64。線形補間の基準点になる。
+    read_pos: f64,
     /// 個別停止用識別子
     play_id: Option<String>,
 }
@@ -179,10 +195,19 @@ impl Scheduler {
             event.slice_len_frames,
         );
 
+        // varispeed レート（<=0/非有限は 1.0 に丸め済み・with_rate 保証だが直接 schedule
+        // 経路でも安全側に倒す）。
+        let rate = if event.rate.is_finite() && event.rate > 0.0 {
+            event.rate
+        } else {
+            1.0
+        };
+
         // 末尾フェードアウト（線形 release）。SC `orbitPlayBuf` の
         // `fadeOut = min(0.008, actualDuration * 0.04)` に一致させクリックを防ぐ。
-        // rate=1.0 再生なので出力尺 = slice_len / sample_rate。
-        let out_dur_sec = slice_len as f64 / self.output_sample_rate as f64;
+        // varispeed では出力尺 = slice_len / (sample_rate * rate)。fade は **出力**フレーム
+        // 数で数える（render では出力残フレームで判定する）。
+        let out_dur_sec = slice_len as f64 / (self.output_sample_rate as f64 * rate);
         let fade_sec = (out_dur_sec * 0.04).min(0.008);
         let fade_frames = (fade_sec * self.output_sample_rate as f64).round() as usize;
 
@@ -203,8 +228,9 @@ impl Scheduler {
             slice_start,
             slice_len,
             fade_frames,
+            rate,
             sample: event.sample,
-            read_pos: 0,
+            read_pos: 0.0,
             play_id: event.play_id,
         });
     }
@@ -215,6 +241,15 @@ impl Scheduler {
         self.events
             .retain(|a| a.play_id.as_deref() != Some(play_id));
         self.events.len() < before
+    }
+
+    /// 全イベント（発音中 + 開始待機中）を即時削除する hard-stop-all。削除件数を返す。
+    /// varispeed の長尺 voice が respawn / stopAll を跨いで鳴り続けるのを断つ
+    /// （TS 側はスケジュールの権威を保持し、必要なら再 dispatch する）。
+    pub fn stop_all(&mut self) -> usize {
+        let n = self.events.len();
+        self.events.clear();
+        n
     }
 
     /// 出力バッファにアクティブなサンプル群を加算する。
@@ -239,10 +274,10 @@ impl Scheduler {
             let src_channels = active.sample.channels as usize;
             if src_channels == 0 {
                 // 0ch の不正なサンプルはスキップ（`src_channels - 1` のアンダーフロー回避）
-                active.read_pos = active.slice_len;
+                active.read_pos = active.slice_len as f64;
                 continue;
             }
-            if active.read_pos >= active.slice_len {
+            if active.read_pos >= active.slice_len as f64 {
                 continue; // 再生済み（slice 領域を読み終えた）
             }
 
@@ -253,39 +288,57 @@ impl Scheduler {
                 0
             };
 
-            let remaining_src_frames = active.slice_len - active.read_pos;
             let writable_frames = frames_to_render.saturating_sub(dst_offset_frames);
-            let frames_to_copy = writable_frames.min(remaining_src_frames);
 
             // 左右ゲインは schedule 時に precompute 済み（RT から trig と output_channels
             // 分岐を排除）。ステレオ以外では (1.0, 1.0)。SC の Pan2 に一致。
             let (pan_l, pan_r) = (active.pan_l, active.pan_r);
 
-            // 末尾フェードアウトの開始位置（slice 内相対）。fade_frames==0 ならフェードなし。
-            let fade_start = active.slice_len.saturating_sub(active.fade_frames);
+            let slice_len = active.slice_len;
+            let rate = active.rate;
+            // 補間の上端 clamp（slice 末尾フレーム）。floor+1 が slice をはみ出さないようにする。
+            let last_src = slice_len.saturating_sub(1);
 
-            for i in 0..frames_to_copy {
-                let slice_pos = active.read_pos + i; // slice 領域内の相対位置
-                let src_frame = active.slice_start + slice_pos; // サンプル内の絶対フレーム
+            // 出力フレームを 1 つずつ生成し、source を rate 倍の歩幅で分数走査する（varispeed）。
+            // rate=1.0 のときは read_pos が整数列を辿り frac=0 で補間が元サンプルに一致するため、
+            // 既存 rate=1.0 経路とビット同一になる（厳密な一般化）。出力尺 = slice_len/rate。
+            for i in 0..writable_frames {
+                let pos = active.read_pos; // slice 相対の分数読み位置
+                if pos >= slice_len as f64 {
+                    break; // source 読み切り（残り出力枠は無音にせず発音終了）
+                }
+                // 線形補間: floor と floor+1 を frac で混合。上端は slice 末尾で clamp。
+                let i0 = pos.floor();
+                let frac = (pos - i0) as f32;
+                let s0 = i0 as usize; // slice 相対の整数フレーム
+                let s1 = (s0 + 1).min(last_src);
+                let src_frame0 = active.slice_start + s0; // サンプル内の絶対フレーム
+                let src_frame1 = active.slice_start + s1;
                 let dst_frame = dst_offset_frames + i;
-                // 線形 release エンベロープ（SC `linen` の fadeOut 部）。slice 末尾で
-                // クリックが出ないよう 1.0 → 0.0 へ線形に減衰させる。env は frame のみに
-                // 依存するので channel ループの外で 1 回求め、gain と束ねて amp にする。
-                let env = if active.fade_frames > 0 && slice_pos >= fade_start {
-                    (active.slice_len - slice_pos) as f32 / active.fade_frames as f32
+
+                // 末尾フェードアウト（線形 release・SC `linen` の fadeOut 部）。**出力時間**で
+                // 数える: 残り出力フレーム数が fade_frames 以下で 1.0→0.0 へ線形減衰。
+                // rate=1.0 では remaining = slice_len-pos となり従来条件と一致する。
+                let out_frames_remaining = ((slice_len as f64 - pos) / rate).ceil() as usize;
+                let env = if active.fade_frames > 0 && out_frames_remaining <= active.fade_frames {
+                    out_frames_remaining as f32 / active.fade_frames as f32
                 } else {
                     1.0
                 };
                 let amp = active.gain * env;
                 for ch in 0..output_channels {
                     let src_ch = ch.min(src_channels - 1);
-                    let src_idx = src_frame * src_channels + src_ch;
+                    let s0_idx = src_frame0 * src_channels + src_ch;
+                    let s1_idx = src_frame1 * src_channels + src_ch;
+                    // 線形補間した source 値（rate=1.0 では frac=0 で data[s0_idx] と一致）。
+                    let sample_val = active.sample.data[s0_idx] * (1.0 - frac)
+                        + active.sample.data[s1_idx] * frac;
                     let dst_idx = dst_frame * output_channels + ch;
                     let pan_mul = if ch == 0 { pan_l } else { pan_r };
-                    out[dst_idx] += active.sample.data[src_idx] * amp * pan_mul;
+                    out[dst_idx] += sample_val * amp * pan_mul;
                 }
+                active.read_pos += rate;
             }
-            active.read_pos += frames_to_copy;
         }
 
         // 混合後の出力バッファにフレーム単位のマスターゲインを適用する。
@@ -309,8 +362,8 @@ impl Scheduler {
 
         self.cursor_frames += frames_to_render as u64;
         // 再生完了したもの（= slice 領域を読み終えたもの）をドロップ。
-        // まだ開始時刻に到達していないイベントは read_pos == 0 のため自然に保持される。
-        self.events.retain(|a| a.read_pos < a.slice_len);
+        // まだ開始時刻に到達していないイベントは read_pos == 0.0 のため自然に保持される。
+        self.events.retain(|a| a.read_pos < a.slice_len as f64);
     }
 
     /// 現在の出力ストリーム時刻（秒）
@@ -555,6 +608,88 @@ mod tests {
     }
 
     #[test]
+    fn varispeed_rate_one_is_sample_exact() {
+        // rate=1.0 を明示しても frac=0 の補間で元サンプルにビット一致する（厳密な一般化）。
+        // ramp[i]=i を hard-left（L=源値）で流し、L 出力 = 0,1,2,...,9 を確認。
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(
+            ScheduledSample::new(0.0, mk_sample_mono_ramp(10))
+                .with_pan(-1.0)
+                .with_region(0, 10)
+                .with_rate(1.0),
+        );
+        let mut buf = vec![0.0f32; 40]; // 20 frames
+        s.render(&mut buf);
+        for i in 0..10 {
+            assert!((buf[2 * i] - i as f32).abs() < 1e-4, "f{i} L={}", buf[2 * i]);
+        }
+        assert_eq!(s.active_count(), 0);
+    }
+
+    #[test]
+    fn varispeed_double_rate_halves_output_and_steps_by_two() {
+        // rate=2.0: source を 2 フレーム歩幅で読む → 出力尺が半分、L 出力 = 0,2,4,6
+        // （= source[0,2,4,6]）。pitch が 1 オクターブ上がる varispeed の直接検証。
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(
+            ScheduledSample::new(0.0, mk_sample_mono_ramp(8))
+                .with_pan(-1.0)
+                .with_region(0, 8)
+                .with_rate(2.0),
+        );
+        let mut buf = vec![0.0f32; 40]; // 20 frames
+        s.render(&mut buf);
+        assert!((buf[0] - 0.0).abs() < 1e-4, "f0 L={}", buf[0]);
+        assert!((buf[2] - 2.0).abs() < 1e-4, "f1 L={}", buf[2]);
+        assert!((buf[4] - 4.0).abs() < 1e-4, "f2 L={}", buf[4]);
+        assert!((buf[6] - 6.0).abs() < 1e-4, "f3 L={}", buf[6]);
+        // 出力 4 フレーム（ceil(8/2)）で source 読み切り → f4 以降は無音。
+        assert!(buf[8].abs() < 1e-6, "f4 L (読み切り後)={}", buf[8]);
+        assert_eq!(s.active_count(), 0);
+    }
+
+    #[test]
+    fn varispeed_half_rate_doubles_output_with_interpolation() {
+        // rate=0.5: source を 0.5 フレーム歩幅で読む → 出力尺が倍、L 出力 = 0,0.5,1,1.5,...
+        // （線形補間値）。pitch が 1 オクターブ下がる varispeed の直接検証。
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(
+            ScheduledSample::new(0.0, mk_sample_mono_ramp(4))
+                .with_pan(-1.0)
+                .with_region(0, 4)
+                .with_rate(0.5),
+        );
+        let mut buf = vec![0.0f32; 40]; // 20 frames
+        s.render(&mut buf);
+        assert!((buf[0] - 0.0).abs() < 1e-4, "f0 L={}", buf[0]);
+        assert!((buf[2] - 0.5).abs() < 1e-4, "f1 L={}", buf[2]); // 補間
+        assert!((buf[4] - 1.0).abs() < 1e-4, "f2 L={}", buf[4]);
+        assert!((buf[6] - 1.5).abs() < 1e-4, "f3 L={}", buf[6]); // 補間
+        assert!((buf[8] - 2.0).abs() < 1e-4, "f4 L={}", buf[8]);
+        // 出力 8 フレーム（4/0.5）で読み切り → f8 以降は無音。
+        assert!(buf[16].abs() < 1e-6, "f8 L (読み切り後)={}", buf[16]);
+        assert_eq!(s.active_count(), 0);
+    }
+
+    #[test]
+    fn varispeed_invalid_rate_falls_back_to_one() {
+        // rate<=0 / 非有限は with_rate が 1.0 に丸める（無音化や逆走を誤って起こさない）。
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(
+            ScheduledSample::new(0.0, mk_sample_mono_ramp(6))
+                .with_pan(-1.0)
+                .with_region(0, 6)
+                .with_rate(0.0),
+        );
+        let mut buf = vec![0.0f32; 40];
+        s.render(&mut buf);
+        // rate=1.0 として 0,1,2,3,4,5 が出る。
+        assert!((buf[0] - 0.0).abs() < 1e-4, "f0 L={}", buf[0]);
+        assert!((buf[2] - 1.0).abs() < 1e-4, "f1 L={}", buf[2]);
+        assert_eq!(s.active_count(), 0);
+    }
+
+    #[test]
     fn set_global_gain_ramps_linearly_to_target() {
         let mut s = Scheduler::new(48_000, 2);
         // 直流 1.0 のモノラルサンプルを想定して 1ch 出力にすると計算が容易。
@@ -615,6 +750,21 @@ mod tests {
         s.schedule(ScheduledSample::new(0.0, mk_sample_stereo(100)));
         assert!(!s.stop("does-not-exist"));
         assert_eq!(s.active_count(), 1);
+    }
+
+    #[test]
+    fn stop_all_clears_every_event() {
+        // play_id 有無に依らず、発音中も開始待機中も全消去する（hard-stop-all）。
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(ScheduledSample::new(0.0, mk_sample_stereo(100))); // play_id 無し
+        s.schedule(
+            ScheduledSample::new(5.0, mk_sample_stereo(100)).with_play_id("p-a".to_string()),
+        );
+        assert_eq!(s.active_count(), 2);
+        assert_eq!(s.stop_all(), 2);
+        assert_eq!(s.active_count(), 0);
+        // 空に対しては 0 を返す（冪等）。
+        assert_eq!(s.stop_all(), 0);
     }
 
     #[test]

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -44,10 +44,10 @@ impl ScheduledSample {
         self
     }
 
-    /// 再生レート（varispeed）を設定する。`<= 0` は無効なので 1.0 に丸める（無音化や逆再生を
+    /// 再生レート（varispeed）を設定する。`<= 0` / 非有限は 1.0 に丸める（無音化や逆再生を
     /// 誤って起こさない）。逆再生は別 modifier（`reverse()`・#213 系）の領分。
     pub fn with_rate(mut self, rate: f64) -> Self {
-        self.rate = if rate.is_finite() && rate > 0.0 { rate } else { 1.0 };
+        self.rate = sanitize_rate(rate);
         self
     }
 
@@ -79,6 +79,17 @@ fn equal_power_pan(pan: f32) -> (f32, f32) {
     let pan01 = (pan.clamp(-1.0, 1.0) + 1.0) * 0.5; // [-1,1] -> [0,1]
     let angle = pan01 * std::f32::consts::FRAC_PI_2;
     (angle.cos(), angle.sin())
+}
+
+/// varispeed レートを正規化する（`<=0` / 非有限は 1.0 = 自然尺へ丸める）。誤った無音化や
+/// 逆走を起こさない。`with_rate` / `schedule` / daemon の出力尺計算 / 検証ハーネスが、
+/// `pub` field 直書きや JSON 由来の生値を含む全経路で同一規約を共有するための単一定義。
+pub fn sanitize_rate(rate: f64) -> f64 {
+    if rate.is_finite() && rate > 0.0 {
+        rate
+    } else {
+        1.0
+    }
 }
 
 /// 再生領域（slice）をサンプル端で clamp し `(clamped_start, effective_len)` を返す。
@@ -195,13 +206,9 @@ impl Scheduler {
             event.slice_len_frames,
         );
 
-        // varispeed レート（<=0/非有限は 1.0 に丸め済み・with_rate 保証だが直接 schedule
-        // 経路でも安全側に倒す）。
-        let rate = if event.rate.is_finite() && event.rate > 0.0 {
-            event.rate
-        } else {
-            1.0
-        };
+        // varispeed レート。with_rate が正規化済みだが、`rate` は pub field なので直書き経路
+        // でも安全側に倒す（sanitize_rate で単一規約を共有）。
+        let rate = sanitize_rate(event.rate);
 
         // 末尾フェードアウト（線形 release）。SC `orbitPlayBuf` の
         // `fadeOut = min(0.008, actualDuration * 0.04)` に一致させクリックを防ぐ。
@@ -295,33 +302,39 @@ impl Scheduler {
             let (pan_l, pan_r) = (active.pan_l, active.pan_r);
 
             let slice_len = active.slice_len;
+            let slice_len_f = slice_len as f64;
             let rate = active.rate;
             // 補間の上端 clamp（slice 末尾フレーム）。floor+1 が slice をはみ出さないようにする。
             let last_src = slice_len.saturating_sub(1);
+            // 末尾フェード（線形 release・SC `linen` の fadeOut 部）を **出力時間**で数える。
+            // 出力 fade_frames 分を source 空間の幅 `fade_span_src = fade_frames*rate` に写し、
+            // fade 開始 source 位置 `fade_start_src` を loop 前に 1 回求める（per-frame の
+            // division を no-fade の common path から排除する）。
+            let fading = active.fade_frames > 0;
+            let fade_span_src = active.fade_frames as f64 * rate;
+            let fade_start_src = slice_len_f - fade_span_src;
 
             // 出力フレームを 1 つずつ生成し、source を rate 倍の歩幅で分数走査する（varispeed）。
             // rate=1.0 のときは read_pos が整数列を辿り frac=0 で補間が元サンプルに一致するため、
             // 既存 rate=1.0 経路とビット同一になる（厳密な一般化）。出力尺 = slice_len/rate。
             for i in 0..writable_frames {
                 let pos = active.read_pos; // slice 相対の分数読み位置
-                if pos >= slice_len as f64 {
+                if pos >= slice_len_f {
                     break; // source 読み切り（残り出力枠は無音にせず発音終了）
                 }
-                // 線形補間: floor と floor+1 を frac で混合。上端は slice 末尾で clamp。
-                let i0 = pos.floor();
-                let frac = (pos - i0) as f32;
-                let s0 = i0 as usize; // slice 相対の整数フレーム
+                // 線形補間: floor と floor+1 を frac で混合。pos>=0 なので `as usize` = floor。
+                let s0 = pos as usize; // slice 相対の整数フレーム
+                let frac = (pos - s0 as f64) as f32;
                 let s1 = (s0 + 1).min(last_src);
                 let src_frame0 = active.slice_start + s0; // サンプル内の絶対フレーム
                 let src_frame1 = active.slice_start + s1;
                 let dst_frame = dst_offset_frames + i;
 
-                // 末尾フェードアウト（線形 release・SC `linen` の fadeOut 部）。**出力時間**で
-                // 数える: 残り出力フレーム数が fade_frames 以下で 1.0→0.0 へ線形減衰。
-                // rate=1.0 では remaining = slice_len-pos となり従来条件と一致する。
-                let out_frames_remaining = ((slice_len as f64 - pos) / rate).ceil() as usize;
-                let env = if active.fade_frames > 0 && out_frames_remaining <= active.fade_frames {
-                    out_frames_remaining as f32 / active.fade_frames as f32
+                // fade 開始 source 位置に達したら 1.0→0.0 へ線形減衰（残り出力幅 / fade 幅）。
+                // common path（fade 前 / fade 無し）は比較1つで division しない。rate=1.0 では
+                // env = (slice_len-pos)/fade_frames となり従来の fade とビット一致する。
+                let env = if fading && pos >= fade_start_src {
+                    (((slice_len_f - pos) / fade_span_src) as f32).clamp(0.0, 1.0)
                 } else {
                     1.0
                 };

--- a/rust/crates/orbit-audio-daemon/examples/export_verify_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/examples/export_verify_pcm.rs
@@ -49,9 +49,16 @@ struct GoldenEvent {
     pan: f32,
     offset_sec: f64,
     duration_sec: f64,
+    /// varispeed レート（1.0 = 自然尺）。rate を持たない既存 golden は 1.0 として parse する。
+    #[serde(default = "default_rate")]
+    rate: f64,
     gain_db: f64,
     // panRaw は JSON に存在するが未使用。serde は未知フィールドを無視するため宣言しない。
     sequence_name: String,
+}
+
+fn default_rate() -> f64 {
+    1.0
 }
 
 // ─── 出力 JSON（artifact 契約 ②）────────────────────────────────────────────
@@ -99,12 +106,15 @@ fn frame_at(sec: f64, sr: f64) -> usize {
 }
 
 /// イベントの再生尺フレーム。whole（durationSec=0）= サンプル全尺 / slice = durationSec フレーム。
+/// varispeed では出力尺 = source 尺 / rate。
 fn play_span(ev: &GoldenEvent, sample_frames: &HashMap<String, usize>, sr: f64) -> usize {
-    if ev.duration_sec > 0.0 {
+    let source_frames = if ev.duration_sec > 0.0 {
         frame_at(ev.duration_sec, sr)
     } else {
         sample_frames[&ev.sample]
-    }
+    };
+    let rate = if ev.rate.is_finite() && ev.rate > 0.0 { ev.rate } else { 1.0 };
+    (source_frames as f64 / rate).ceil() as usize
 }
 
 /// body 窓 `[onset+BODY_HEAD_OFFSET, onset+span-tail_trim)`。
@@ -172,6 +182,7 @@ fn render_golden(golden: &GoldenSchedule) -> (CapturedAudio, HashMap<String, usi
             ev.pan,
             ev.offset_sec,
             ev.duration_sec,
+            ev.rate,
         )
         .expect("play_at");
         let end = frame_at(ev.onset_sec, sr) + play_span(ev, &sample_frames, sr);

--- a/rust/crates/orbit-audio-daemon/examples/export_verify_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/examples/export_verify_pcm.rs
@@ -18,6 +18,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use orbit_audio_core::sanitize_rate;
 use orbit_audio_daemon::backend::StubBackend;
 use orbit_audio_daemon::engine_wrap::EngineWrap;
 use orbit_audio_verify::{
@@ -113,8 +114,7 @@ fn play_span(ev: &GoldenEvent, sample_frames: &HashMap<String, usize>, sr: f64) 
     } else {
         sample_frames[&ev.sample]
     };
-    let rate = if ev.rate.is_finite() && ev.rate > 0.0 { ev.rate } else { 1.0 };
-    (source_frames as f64 / rate).ceil() as usize
+    (source_frames as f64 / sanitize_rate(ev.rate)).ceil() as usize
 }
 
 /// body 窓 `[onset+BODY_HEAD_OFFSET, onset+span-tail_trim)`。

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-use orbit_audio_core::{resolve_slice_region, Engine, Sample};
+use orbit_audio_core::{resolve_slice_region, sanitize_rate, Engine, Sample};
 use orbit_audio_native::{
     load_sample_resampled, LoaderError, OutputError, OutputStream, ResampleError, StreamStats,
     StreamStatsSnapshot,
@@ -188,9 +188,8 @@ impl EngineWrap {
         let (slice_start_frame, effective_len_frames) =
             resolve_slice_region(total_frames, offset_frames, requested_len_frames);
         // PlayEnded 用の **出力**尺は varispeed で source 尺 / rate になる（render の出力尺と一致）。
-        // <=0/非有限な rate は core が 1.0 に丸めるので、ここも同じ規約で出力尺を計算する。
-        let effective_rate = if rate.is_finite() && rate > 0.0 { rate } else { 1.0 };
-        let out_duration_sec = effective_len_frames as f64 / sr / effective_rate;
+        // core と同じ sanitize_rate で正規化し、出力尺の規約を一致させる。
+        let out_duration_sec = effective_len_frames as f64 / sr / sanitize_rate(rate);
         let play_id = format!("p-{}", short_uuid());
         self.engine
             .schedule_with_play_id(

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -153,9 +153,10 @@ impl EngineWrap {
     /// `pan` は [-1.0, 1.0]（0.0 = 中央、範囲外は core で clamp）。
     /// `offset_sec` / `duration_sec` は再生領域（`chop` の slice）。`duration_sec <= 0` で
     /// 「offset 以降すべて」。いずれもサンプル端で clamp。
-    /// 戻り値の `duration_sec` は **実際に再生される区間の尺**（slice 指定時は slice 長、
-    /// whole-file 時はサンプル全尺）なので、呼び出し側は PlayEnded を再生終端に合わせて
-    /// 遅延送信できる。
+    /// `rate` は varispeed（1.0 = 自然尺、>1 = 速く短く高ピッチ、<1 = 遅く長く低ピッチ。
+    /// `<=0`/非有限は core で 1.0 に丸め）。
+    /// 戻り値の `duration_sec` は **実際に再生される区間の出力尺**（slice 実尺 / rate）なので、
+    /// 呼び出し側は PlayEnded を再生終端（varispeed 後の出力終端）に合わせて遅延送信できる。
     #[allow(clippy::too_many_arguments)]
     pub fn play_at(
         &self,
@@ -165,6 +166,7 @@ impl EngineWrap {
         pan: f32,
         offset_sec: f64,
         duration_sec: f64,
+        rate: f64,
     ) -> Result<PlayHandle, WrapError> {
         let sample = self
             .lock_samples()?
@@ -181,11 +183,14 @@ impl EngineWrap {
         } else {
             0
         };
-        // 再生領域を clamp。PlayEnded 用の出力尺（slice 実尺・rate=1.0）と、scheduler が
-        // render に使う尺が必ず一致するよう、両者が同一式（resolve_slice_region）を共有する。
+        // 再生領域を clamp。render が読む source 尺（effective_len_frames）は rate に依らず
+        // 不変で、scheduler の render と同一式（resolve_slice_region）を共有する。
         let (slice_start_frame, effective_len_frames) =
             resolve_slice_region(total_frames, offset_frames, requested_len_frames);
-        let out_duration_sec = effective_len_frames as f64 / sr;
+        // PlayEnded 用の **出力**尺は varispeed で source 尺 / rate になる（render の出力尺と一致）。
+        // <=0/非有限な rate は core が 1.0 に丸めるので、ここも同じ規約で出力尺を計算する。
+        let effective_rate = if rate.is_finite() && rate > 0.0 { rate } else { 1.0 };
+        let out_duration_sec = effective_len_frames as f64 / sr / effective_rate;
         let play_id = format!("p-{}", short_uuid());
         self.engine
             .schedule_with_play_id(
@@ -196,6 +201,7 @@ impl EngineWrap {
                 // clamp 済みの実尺を渡す。生の requested_len_frames を渡すと、render 尺と
                 // PlayEnded 尺の一致が scheduler 内の再 clamp に依存してしまう（latent な desync）。
                 effective_len_frames,
+                rate,
                 play_id.clone(),
                 sample,
             )
@@ -205,6 +211,16 @@ impl EngineWrap {
             start_sec: time_sec,
             duration_sec: out_duration_sec,
         })
+    }
+
+    /// 全アクティブ再生を即時停止する hard-stop-all。停止件数を返す。
+    /// daemon が保持する disposable な voice（in-flight one-shot / varispeed の長尺 slice）を
+    /// respawn / stopAll で一括 drop する。PlayEnded 抑制集合は触らない（停止された voice の
+    /// PlayEnded 遅延タスクはそのまま発火しうるが、consumer 側が play_id 不在で無害に無視する）。
+    pub fn stop_all(&self) -> Result<usize, WrapError> {
+        self.engine
+            .stop_all()
+            .map_err(|e| WrapError::Scheduler(e.to_string()))
     }
 
     /// `play_id` に一致するアクティブ再生を停止する。true = 停止、false = 見つからず。

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -287,8 +287,11 @@ async fn handle_command(
                     ProtocolError::new("PARAM_OUT_OF_RANGE", "duration_sec must be >= 0"),
                 );
             }
+            // rate は varispeed（省略時 1.0 = 自然尺）。pan と同じく非致命的 param なので reject
+            // せず core 側で 1.0 に丸める（<=0/非有限。誤った無音化や逆走を起こさない）。
+            let rate = param_f64(&params, "rate", 1.0);
             match params.get("sample_id").and_then(|v| v.as_str()) {
-                Some(sid) => match engine.play_at(sid, time_sec, gain, pan, offset_sec, duration_sec) {
+                Some(sid) => match engine.play_at(sid, time_sec, gain, pan, offset_sec, duration_sec, rate) {
                     Ok(handle) => {
                         // 遅延タスクを先に spawn して await コストを避ける
                         schedule_play_ended(
@@ -334,6 +337,12 @@ async fn handle_command(
                 &id,
                 ProtocolError::new("MALFORMED_REQUEST", "missing 'play_id' param"),
             ),
+        },
+        // 全アクティブ再生の即時停止（hard-stop-all）。respawn / stopAll で in-flight voice
+        // （varispeed の長尺 slice 含む）を断つ。停止件数を返す（冪等・空でも ok）。
+        "StopAll" => match engine.stop_all() {
+            Ok(n) => ok(&id, json!({"stopped": n})),
+            Err(e) => err(&id, wrap_err_to_protocol(&e)),
         },
         "SetGlobalGain" => {
             let value = params.get("value").and_then(|v| v.as_f64()).unwrap_or(1.0);

--- a/rust/crates/orbit-audio-daemon/tests/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/tests/protocol.rs
@@ -209,6 +209,53 @@ async fn stop_unknown_id_returns_not_found() {
     );
 }
 
+/// StopAll は全アクティブ再生（発音中 + 開始待機中）を停止し件数を返す（hard-stop-all・#319）。
+/// 冪等: 空に対しては 0 を返す。
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn stop_all_clears_scheduled_plays() {
+    let daemon = TestDaemon::start().await;
+    let mut ws = daemon.connect().await;
+    let _hs = TestDaemon::recv_handshake(&mut ws).await;
+
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let wav_path = format!("{manifest_dir}/../../../test-assets/audio/kick.wav");
+    send_cmd(&mut ws, "l", "LoadSample", json!({ "path": wav_path })).await;
+    let load_resp = recv_reply_for_id(&mut ws, "l").await;
+    let sample_id = load_resp["result"]["sample_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("LoadSample resp missing sample_id: {load_resp}"))
+        .to_string();
+
+    // 未来時刻に 2 voice をスケジュール（transport 未到達でも scheduler に開始待機で居る）。
+    for (id, t) in [("p1", 10.0), ("p2", 11.0)] {
+        send_cmd(
+            &mut ws,
+            id,
+            "PlayAt",
+            json!({ "sample_id": sample_id, "time_sec": t, "gain": 1.0 }),
+        )
+        .await;
+        let _ = recv_reply_for_id(&mut ws, id).await;
+    }
+
+    send_cmd(&mut ws, "sa", "StopAll", json!({})).await;
+    let resp = recv_reply_for_id(&mut ws, "sa").await;
+    assert_eq!(
+        resp["result"]["stopped"].as_u64(),
+        Some(2),
+        "StopAll should clear both scheduled voices: {resp}"
+    );
+
+    // 冪等: 2 回目は 0。
+    send_cmd(&mut ws, "sa2", "StopAll", json!({})).await;
+    let resp2 = recv_reply_for_id(&mut ws, "sa2").await;
+    assert_eq!(
+        resp2["result"]["stopped"].as_u64(),
+        Some(0),
+        "second StopAll should be idempotent (0): {resp2}"
+    );
+}
+
 /// SetGlobalGain は正の値を受け入れる。
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn set_global_gain_accepts() {

--- a/rust/crates/orbit-audio-daemon/tests/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/tests/protocol.rs
@@ -256,6 +256,71 @@ async fn stop_all_clears_scheduled_plays() {
     );
 }
 
+/// PlayAt の `rate` が **wire 経由**（`session.rs` の `param_f64("rate")` → `engine.play_at`）で
+/// 出力尺に効くことを、PlayEnded の `ended_at_sec`（= start_sec + 出力尺）で検証する（#319）。
+/// オフライン harness は `wrap.play_at` を直接呼んで session 層を bypass するため、`"rate"` キーの
+/// typo / forward 漏れは全 golden が rate=1.0（既定値）で silent に通る。本テストが唯一その経路を
+/// 通す。サンプルを rate=2.0 で発音し、出力尺が自然尺の半分（= LoadSample の frames/sample_rate / 2）
+/// になることを確認する（rate が wire を通らず default=1.0 に落ちると自然尺のままで fail）。
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn play_at_rate_halves_play_ended_time() {
+    let daemon = TestDaemon::start().await;
+    let mut ws = daemon.connect().await;
+    let _hs = TestDaemon::recv_handshake(&mut ws).await;
+
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let wav_path = format!("{manifest_dir}/../../../test-assets/audio/kick.wav");
+    send_cmd(&mut ws, "l", "LoadSample", json!({ "path": wav_path })).await;
+    let load_resp = recv_reply_for_id(&mut ws, "l").await;
+    let sample_id = load_resp["result"]["sample_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("LoadSample resp missing sample_id: {load_resp}"))
+        .to_string();
+    // 自然尺 D = frames / sample_rate（出力 SR に変換済みのロード値）。
+    let frames = load_resp["result"]["frames"].as_f64().expect("frames");
+    let sr = load_resp["result"]["sample_rate"].as_f64().expect("sample_rate");
+    let natural_sec = frames / sr;
+
+    // rate=2.0 で発音 → 出力尺は natural_sec / 2、ended_at_sec = start(0) + natural_sec/2。
+    send_cmd(
+        &mut ws,
+        "p",
+        "PlayAt",
+        json!({ "sample_id": sample_id, "time_sec": 0.0, "gain": 1.0, "rate": 2.0 }),
+    )
+    .await;
+    let pid = recv_reply_for_id(&mut ws, "p").await["result"]["play_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("PlayAt resp missing play_id"))
+        .to_string();
+
+    // kick.wav は 1 秒未満。PlayEnded が発火するまで虚時間を進める（単一イベント収集は
+    // stop_suppresses_play_ended と同型で並列実行でも安定）。
+    advance_and_yield(Duration::from_secs(3)).await;
+
+    let mut ended_at = None;
+    for _ in 0..40 {
+        match tokio::time::timeout(Duration::from_millis(100), next_json(&mut ws)).await {
+            Ok(msg) if msg["event"] == "PlayEnded" && msg["data"]["play_id"] == pid.as_str() => {
+                ended_at = msg["data"]["ended_at_sec"].as_f64();
+                break;
+            }
+            Ok(_) => {}
+            Err(_) => break,
+        }
+    }
+
+    let ended_at = ended_at.unwrap_or_else(|| panic!("PlayEnded not received for rate=2.0 voice"));
+    let expected = natural_sec / 2.0;
+    // rate=2.0 の出力尺は自然尺の半分。rate が wire を通らず 1.0 に落ちると natural_sec のままで
+    // fail する（expected の 2 倍 = 明確に許容外）。
+    assert!(
+        (ended_at - expected).abs() < 0.02,
+        "rate=2.0 ended_at should be natural/2: ended_at={ended_at}, expected={expected} \
+         (natural={natural_sec}); rate が wire を通っていない可能性"
+    );
+}
+
 /// SetGlobalGain は正の値を受け入れる。
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn set_global_gain_accepts() {

--- a/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
@@ -14,6 +14,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use orbit_audio_core::sanitize_rate;
 use orbit_audio_daemon::engine_wrap::EngineWrap;
 use orbit_audio_daemon::backend::StubBackend;
 use orbit_audio_verify::{
@@ -114,8 +115,7 @@ fn render_golden(golden: &GoldenSchedule) -> (CapturedAudio, HashMap<String, usi
         } else {
             sample_frames[&ev.sample]
         };
-        let rate = if ev.rate.is_finite() && ev.rate > 0.0 { ev.rate } else { 1.0 };
-        let play_frames = (source_frames as f64 / rate).ceil() as usize;
+        let play_frames = (source_frames as f64 / sanitize_rate(ev.rate)).ceil() as usize;
         let end = frame_at(ev.onset_sec, sr) + play_frames;
         last_end_frame = last_end_frame.max(end);
     }

--- a/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
@@ -42,12 +42,19 @@ struct GoldenEvent {
     pan: f32,
     offset_sec: f64,
     duration_sec: f64,
+    /// varispeed レート（1.0 = 自然尺）。rate を持たない既存 golden は 1.0 として parse する。
+    #[serde(default = "default_rate")]
+    rate: f64,
     #[allow(dead_code)]
     gain_db: f64,
     #[allow(dead_code)]
     pan_raw: f64,
     #[allow(dead_code)]
     sequence_name: String,
+}
+
+fn default_rate() -> f64 {
+    1.0
 }
 
 fn repo_path(rel: &str) -> PathBuf {
@@ -96,15 +103,19 @@ fn render_golden(golden: &GoldenSchedule) -> (CapturedAudio, HashMap<String, usi
             ev.pan,
             ev.offset_sec,
             ev.duration_sec,
+            ev.rate,
         )
         .expect("play_at");
-        // 出力尺の見積もり（whole=サンプル尺 / slice=duration_sec）。
+        // 出力尺の見積もり（whole=サンプル尺 / slice=duration_sec）。varispeed では出力尺が
+        // source 尺 / rate になるので、render 余白の確保にも rate を反映する。
         let sr = golden.sample_rate as f64;
-        let play_frames = if ev.duration_sec > 0.0 {
+        let source_frames = if ev.duration_sec > 0.0 {
             frame_at(ev.duration_sec, sr)
         } else {
             sample_frames[&ev.sample]
         };
+        let rate = if ev.rate.is_finite() && ev.rate > 0.0 { ev.rate } else { 1.0 };
+        let play_frames = (source_frames as f64 / rate).ceil() as usize;
         let end = frame_at(ev.onset_sec, sr) + play_frames;
         last_end_frame = last_end_frame.max(end);
     }
@@ -317,4 +328,69 @@ fn examples22_parity_render_matches_schedule() {
             "examples22 イベント間 {gap_start}-{gap_end}s は無音のはず（RMS={gap:.6}）"
         );
     }
+}
+
+const VARISPEED_SR: u32 = 48_000;
+
+/// arpeggio_c.wav の `[0, 0.5s]` slice を指定 `rate` で offline render し PCM を返す。
+/// `engine_wrap` の出力尺 `effective_len_frames / sr / rate` と `play_at`→scheduler の
+/// varispeed seam を rate≠1.0 で実際に通す（#319 統合検証）。
+fn render_varispeed_slice(rate: f64) -> Vec<f32> {
+    let (wrap, _guard) = EngineWrap::start_with(StubBackend {
+        sample_rate: VARISPEED_SR,
+        channels: 2,
+    })
+    .expect("EngineWrap start_with StubBackend");
+    let wav = repo_path("test-assets/audio/arpeggio_c.wav");
+    let info = wrap
+        .load_sample(wav.clone())
+        .unwrap_or_else(|e| panic!("load_sample {}: {e}", wav.display()));
+    assert!(
+        info.frames as f64 / VARISPEED_SR as f64 >= 0.5,
+        "arpeggio_c.wav は >=0.5s 必要（frames={}）",
+        info.frames
+    );
+    // slice [0, 0.5s]（offset=0, duration=0.5）を指定 rate で発音。
+    wrap.play_at(&info.sample_id, 0.0, 1.0, 0.0, 0.0, 0.5, rate)
+        .expect("play_at");
+    // rate=1.0 の出力尺 0.5s + 0.25s 余白。rate=2.0 はこれより短く収まる。
+    let total = (0.75 * VARISPEED_SR as f64) as usize;
+    wrap.render_offline(total, BLOCK_FRAMES)
+}
+
+/// interleaved stereo PCM の、|sample| が閾値を超える最後のフレーム index（信号終端）。
+/// 無信号なら 0。GRM 独立: core の領域解決を import せず peak で直接測る。
+fn last_signal_frame(pcm: &[f32]) -> usize {
+    let channels = 2usize;
+    let frames = pcm.len() / channels;
+    let threshold = 0.01f32;
+    for f in (0..frames).rev() {
+        let l = pcm[f * channels].abs();
+        let r = pcm[f * channels + 1].abs();
+        if l.max(r) > threshold {
+            return f;
+        }
+    }
+    0
+}
+
+#[test]
+fn varispeed_rate2_renders_half_duration_of_rate1() {
+    //! #319 — varispeed の統合検証。同一 slice [0,0.5s] を rate=1.0 と rate=2.0 で実 `play_at`→
+    //! offline render し、rate=2.0 の信号終端が rate=1.0 の **約半分**の時刻に来ることを PCM 上で
+    //! 確認する（slice 尺をスロット尺へ詰める varispeed の「尺合わせ再生」の直接証拠）。
+    //! 信号終端比 ≈ rate 比なので source の中身に依らず成立する（端の沈黙にも頑健）。
+    let rate1_end = last_signal_frame(&render_varispeed_slice(1.0));
+    let rate2_end = last_signal_frame(&render_varispeed_slice(2.0));
+
+    assert!(
+        rate1_end > 0 && rate2_end > 0,
+        "両 rate とも信号が必要（無音回帰検出）: rate1_end={rate1_end}, rate2_end={rate2_end}"
+    );
+    // rate=2.0 は半分の尺で読み切る。比は理論上 2.0、fade tail / 閾値交差の余裕で ±8%。
+    let ratio = rate1_end as f64 / rate2_end as f64;
+    assert!(
+        (ratio - 2.0).abs() < 0.16,
+        "rate=2.0 は rate=1.0 の約半尺のはず: rate1_end={rate1_end}, rate2_end={rate2_end}, ratio={ratio:.3}"
+    );
 }

--- a/test-assets/verify-fixtures/chop_region.schedule.json
+++ b/test-assets/verify-fixtures/chop_region.schedule.json
@@ -9,6 +9,7 @@
       "pan": 0,
       "offsetSec": 0,
       "durationSec": 0.5,
+      "rate": 1,
       "gainDb": -3,
       "panRaw": 0,
       "sequenceName": "chop"
@@ -20,6 +21,7 @@
       "pan": 0,
       "offsetSec": 0.5,
       "durationSec": 0.5,
+      "rate": 1,
       "gainDb": -3,
       "panRaw": 0,
       "sequenceName": "chop"

--- a/test-assets/verify-fixtures/examples22_parity.schedule.json
+++ b/test-assets/verify-fixtures/examples22_parity.schedule.json
@@ -9,6 +9,7 @@
       "pan": -0.6,
       "offsetSec": 0,
       "durationSec": 0,
+      "rate": 1,
       "gainDb": -3,
       "panRaw": -60,
       "sequenceName": "kick"
@@ -20,6 +21,7 @@
       "pan": 0.6,
       "offsetSec": 0,
       "durationSec": 0,
+      "rate": 1,
       "gainDb": -6,
       "panRaw": 60,
       "sequenceName": "snare"
@@ -31,6 +33,7 @@
       "pan": 0,
       "offsetSec": 0,
       "durationSec": 0,
+      "rate": 1,
       "gainDb": -9,
       "panRaw": 0,
       "sequenceName": "hat"
@@ -42,6 +45,7 @@
       "pan": 0.2,
       "offsetSec": 0,
       "durationSec": 0.5,
+      "rate": 1,
       "gainDb": -4,
       "panRaw": 20,
       "sequenceName": "chopd"
@@ -53,6 +57,7 @@
       "pan": 0.2,
       "offsetSec": 0.5,
       "durationSec": 0.5,
+      "rate": 1,
       "gainDb": -4,
       "panRaw": 20,
       "sequenceName": "chopd"

--- a/test-assets/verify-fixtures/pan_three_voices.schedule.json
+++ b/test-assets/verify-fixtures/pan_three_voices.schedule.json
@@ -9,6 +9,7 @@
       "pan": -1,
       "offsetSec": 0,
       "durationSec": 0,
+      "rate": 1,
       "gainDb": -3,
       "panRaw": -100,
       "sequenceName": "left"
@@ -20,6 +21,7 @@
       "pan": -0.5,
       "offsetSec": 0,
       "durationSec": 0,
+      "rate": 1,
       "gainDb": -3,
       "panRaw": -50,
       "sequenceName": "mid"
@@ -31,6 +33,7 @@
       "pan": 1,
       "offsetSec": 0,
       "durationSec": 0,
+      "rate": 1,
       "gainDb": -3,
       "panRaw": 100,
       "sequenceName": "right"

--- a/test-assets/verify-fixtures/per_event_gain.schedule.json
+++ b/test-assets/verify-fixtures/per_event_gain.schedule.json
@@ -9,6 +9,7 @@
       "pan": 0,
       "offsetSec": 0,
       "durationSec": 0,
+      "rate": 1,
       "gainDb": -3,
       "panRaw": 0,
       "sequenceName": "loud"
@@ -20,6 +21,7 @@
       "pan": 0,
       "offsetSec": 0,
       "durationSec": 0,
+      "rate": 1,
       "gainDb": -9,
       "panRaw": 0,
       "sequenceName": "quiet"

--- a/tests/audio/rust-engine/mock-daemon-server.ts
+++ b/tests/audio/rust-engine/mock-daemon-server.ts
@@ -26,6 +26,7 @@ export interface MockDaemonHandlers {
   LoadSample?: MockHandler
   PlayAt?: MockHandler
   Stop?: MockHandler
+  StopAll?: MockHandler
   SetGlobalGain?: MockHandler
   GetStatus?: MockHandler
 }

--- a/tests/audio/rust-engine/rust-engine-player.spec.ts
+++ b/tests/audio/rust-engine/rust-engine-player.spec.ts
@@ -34,7 +34,7 @@ async function waitFor(
   throw new Error(`waitFor: condition not met within ${timeoutMs}ms`)
 }
 
-/** GetStatus + LoadSample + PlayAt の既定ハンドラ（uptime=10 で anchor を固定的に）。 */
+/** GetStatus + LoadSample + PlayAt + StopAll の既定ハンドラ（uptime=10 で anchor を固定的に）。 */
 function defaultHandlers(overrides: MockDaemonHandlers = {}): MockDaemonHandlers {
   let playSeq = 0
   return {
@@ -54,6 +54,7 @@ function defaultHandlers(overrides: MockDaemonHandlers = {}): MockDaemonHandlers
       sample_rate: 48000,
     }),
     PlayAt: () => ({ play_id: `p-${playSeq++}` }),
+    StopAll: () => ({ stopped: 0 }),
     ...overrides,
   }
 }
@@ -182,6 +183,8 @@ describe('RustEnginePlayer with mock daemon', () => {
     expect(rec.sample_id).toBe('s-/audio/loop.wav')
     expect(rec.offset_sec as number).toBeCloseTo(0.5, 5)
     expect(rec.duration_sec as number).toBeCloseTo(0.25, 5)
+    // eventDurationMs=250=sliceDuration → rate=1.0（自然尺・varispeed なし）。
+    expect(rec.rate as number).toBeCloseTo(1.0, 5)
     // rate=1.0 なので time-stretch warn は出ない。
     const rateWarns = warn.mock.calls.filter((c) => String(c[0]).includes('rate='))
     expect(rateWarns.length).toBe(0)
@@ -198,18 +201,21 @@ describe('RustEnginePlayer with mock daemon', () => {
     expect(playAtRecords()[1].gain as number).toBeCloseTo(gainDbToAmplitude(-6), 4)
   })
 
-  it('slice の rate≠1.0（time-stretch）は 1 回 warn し、自然尺で鳴らす', async () => {
+  it('slice の rate≠1.0 は varispeed レートを PlayAt で送る（warn しない・#319）', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const p = await boot()
-    // chop(8) → sliceDuration=0.125。eventDurationMs=500 → rate=0.25 ≠ 1.0。
+    // chop(8) → sliceDuration=0.125。eventDurationMs=500 → rate=0.125/0.5=0.25（<1 = 遅く低ピッチ）。
     p.scheduleSliceEvent('/audio/loop.wav', 0, 1, 8, 500, 0, 0, 'seqA')
-    p.scheduleSliceEvent('/audio/loop.wav', 10, 2, 8, 500, 0, 0, 'seqA')
     p.start()
-    await waitFor(() => playAtRecords().length >= 2)
-    // rate≠1.0 でも slice は自然尺（duration=sliceDuration=0.125）で鳴る。
-    expect(playAtRecords()[0].duration_sec as number).toBeCloseTo(0.125, 5)
+    await waitFor(() => playAtRecords().length >= 1)
+    const rec = playAtRecords()[0]
+    // slice 領域は source 自然尺（duration=sliceDuration=0.125）、varispeed は rate=0.25 で
+    // daemon の render に委ねる（出力尺 = 0.125/0.25 = 0.5s = スロット尺）。
+    expect(rec.duration_sec as number).toBeCloseTo(0.125, 5)
+    expect(rec.rate as number).toBeCloseTo(0.25, 5)
+    // varispeed は実装済みなので time-stretch 未対応 warn は出ない。
     const rateWarns = warn.mock.calls.filter((c) => String(c[0]).includes('rate='))
-    expect(rateWarns.length).toBe(1) // warn-once
+    expect(rateWarns.length).toBe(0)
     warn.mockRestore()
   })
 
@@ -542,6 +548,50 @@ describe('RustEnginePlayer with mock daemon', () => {
     const statusAfter = server.received.filter((r) => r.method === 'GetStatus').length
     expect(statusAfter).toBe(statusBefore)
     expect(p.isRunning).toBe(false)
+  })
+
+  it('stopAll() は daemon に StopAll を送る（hard-stop-all・#319）', async () => {
+    const p = await boot()
+    p.scheduleEvent('/audio/kick.wav', 0, 0, 0, 'seqA')
+    p.start()
+    // 少なくとも 1 回 PlayAt が dispatch されてから stopAll を呼ぶ。
+    await waitFor(() => playAtRecords().length >= 1)
+    p.stopAll()
+    // stopAll は fire-and-forget（同期）。loopback WebSocket の往復を待つため waitFor を使う。
+    await waitFor(() => server.received.some((r) => r.method === 'StopAll'))
+    expect(server.received.some((r) => r.method === 'StopAll')).toBe(true)
+  })
+
+  it('respawn backoff 中に quit() しても clean に終わる（quit-during-respawn）', async () => {
+    // Gap5: daemon 死 → respawn が RESPAWN_BACKOFF_MS(150ms) の待機に入った直後に
+    // quit() を呼んでも unhandled rejection が出ず、respawn が完了せず clean に終わること。
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const p = await boot()
+    p.scheduleEvent('/audio/a.wav', 0, 0, 0, 'seqA')
+    p.start()
+    await waitFor(() => server.received.some((r) => r.method === 'PlayAt'))
+    const statusBefore = server.received.filter((r) => r.method === 'GetStatus').length
+    // dropConnections: server は listen 継続（再接続可能）で daemon 死を模す。
+    // respawn が完全に通ると GetStatus が追加される — それを逆に「通らなかった」確認に使う。
+    server.dropConnections()
+    // onDaemonDied が respawning=true をセットし warn を出すまで待つ。
+    // この時点で respawnLoop は setTimeout(150) の中で backoff 待機中。
+    await waitFor(() => warnSpy.mock.calls.some((c) => String(c[0]).includes('respawning')), {
+      timeoutMs: 1000,
+    })
+    // backoff の 150ms が切れる前に quit() を発行する（disposed=true → backoff 後の
+    // disposed チェックで respawnLoop が早期 return する経路を踏む）。
+    await p.quit() // resolve するはずで、throw しない
+    player = null // afterEach の二重 quit を避ける
+    // quit 後に settle 猶予を置く。もし respawn が完了していれば GetStatus が増える。
+    await new Promise((r) => setTimeout(r, 300))
+    const statusAfter = server.received.filter((r) => r.method === 'GetStatus').length
+    // respawn は完了していない（disposed guard で早期 return）→ GetStatus は増えていない。
+    expect(statusAfter).toBe(statusBefore)
+    expect(p.isRunning).toBe(false)
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
   })
 })
 

--- a/tests/audio/verify/schedule-golden.ts
+++ b/tests/audio/verify/schedule-golden.ts
@@ -59,6 +59,8 @@ export interface GoldenEvent {
   offsetSec: number
   /** slice 領域長（秒）。0 = offset 以降すべて。 */
   durationSec: number
+  /** varispeed レート（1.0 = 自然尺）。slice 尺をスロット尺へ詰める rate。 */
+  rate: number
   /** トレーサビリティ用の生値。 */
   gainDb: number
   panRaw: number
@@ -107,7 +109,7 @@ export function resolveGolden(
     player.seedDuration(abs, sec)
   }
   const events: GoldenEvent[] = recorded.map((play) => {
-    const { gain, pan, offsetSec, durationSec } = player.toDaemonParams(play)
+    const { gain, pan, offsetSec, durationSec, rate } = player.toDaemonParams(play)
     return {
       onsetSec: play.time / 1000,
       sample: basename(play.filepath),
@@ -115,6 +117,7 @@ export function resolveGolden(
       pan,
       offsetSec,
       durationSec,
+      rate,
       gainDb: play.gainDb,
       panRaw: play.pan,
       sequenceName: play.sequenceName,


### PR DESCRIPTION
## 概要

post-2.0 engine-first の次フェーズ **A3**（cutover #108 までの parity gap 充填の1つ目）。#304（PR #305）が「見かけの parity を作らない」ために rate≠1.0 を 1回 warn + 自然尺に倒した箇所を、実機で**尺合わせ再生**する varispeed で埋める。`ORBITSCORE_ENGINE=rust` opt-in の裏。SC 既定経路は無改変。

正本: `docs/development/POST_2.0_NEXT_STEPS.html §4 A3`。Closes #319。

## owner 決定（Step0 = 2 spike + advisor）

- **Q1 = varispeed-only**: slice rate≠1.0 の SC parity は SC `PlayBuf.ar(rate: sliceDur/slotDur)` = **純 varispeed（ピッチも動く）**で、pitch-preserving stretch は SC 経路に存在しない → **parity を埋めるのに Signalsmith は不要**。`fixpitch()`/`time()` は SC 未実装の **net-new #213 機能**（Signalsmith FFI + license gate 新設 = 高リスク）として分離。決め手は blast radius（varispeed は Rust 内部完結・共有 DSL 表面/SC 経路に非接触・新依存ゼロ）。
- **Q2 = time()=varispeed + 将来 `stretch()` 予約**（spec で確定）。

## 主な変更

### varispeed core（`scheduler.rs`）
`ScheduledSample.rate` + 分数読み位置 `read_pos: f64`。source を `rate` 倍歩幅で分数走査 + 線形補間。**rate=1.0 で frac=0 → 元サンプルにビット同一**（既存 slice/pan/fade テストが無改変で通る厳密な一般化）。fade は出力時間（`slice_len/rate`）で数える。

### seam（TS→daemon→core 一貫）
`rust-engine-player.ts`（warn→rate 算出・`toDaemonParams`/`executePlayback` が rate を渡す）→ `daemon-client.ts`/`protocol-types.ts`（PlayAt rate）→ `session.rs`（rate 解析）→ `engine_wrap.rs`（出力尺 `/rate`）→ `engine.rs`/`scheduler.rs`。**spec-first**（DSL spec + protocol doc を先に更新）。

### 織り込みフォローアップ3件
- **daemon hard-stop-all（global）**: core `stop_all` + daemon `StopAll` + TS `stopAll()` 配線。varispeed の長尺 voice が global stop を跨いで鳴り続けるのを断つ。**per-sequence selective stop は明示 defer**（#319 コメント記録）。
- **Gap5**: quit-during-respawn の CI テスト。
- **bot Finding 2**: connect 時 error の二重ログ修正。

## 検証（Done 基準 = offline 決定論 PCM）
- core 単体（rate=2.0 倍勾配 / rate=0.5 補間 / rate=1.0 ビット同一 / invalid 丸め）
- **統合**: `verify_schedule_pcm.rs` で同一 slice を rate=1.0/2.0 で実 `play_at`→render し、rate=2.0 が**半尺**で終わることを PCM 信号終端比で確認
- StopAll protocol + TS（rate 送信 / stopAll / Gap5）
- **npm 1168 passed / 27 skipped・cargo workspace 全緑**
- capture seam は含めない（offline で足りる・#300 Step0 の決定を維持）

## 明示 defer
fixpitch()/time()/Signalsmith/cargo-deny → #213 / capture seam / A4 LinkAudio / γ / cutover #108 / per-sequence hard-stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)