### PR TITLE
feat(engine): A4-1 named-channel routing + sum-by-name on rust mixer (post-2.0 A4)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -41,7 +41,9 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **運用**: GPL/Ableton Link を一切導入しない permissive 増分。SC 既定経路 無改変・audio `play()` 意味論 無改変。Rust workspace は CI fmt/clippy 非 gate（追加コードは周囲スタイルに整合）。
 
-**/simplify 適用（4観点並列）**: ① `render_offline`/`render_offline_channel` を `render_offline_inner(closure)` に共通化 ② `Engine::render`/`render_channel` を `with_scheduler` ヘルパに集約 ③ altitude 指摘で `Engine::render_channel` に `#[doc(hidden)]`・`Scheduler::render_channel` を `pub(crate)` に絞り「混在呼び出し禁止」の prose-only 不変条件を crate 外へ露出しない（本番 RT caller は A4-2 で追加）④ テスト `body` クロージャを `rms_avg` ヘルパに hoist。efficiency = クリーン。test 構造重複（reuse minor）は test 閾値で skip。
+**/simplify 適用（4観点並列）**: ① `render_offline`/`render_offline_channel` を `render_offline_inner(closure)` に共通化 ② `Engine::render`/`render_channel` を `with_scheduler` ヘルパに集約 ③ altitude 指摘で `Scheduler::render_channel` を `pub(crate)` に絞り直接の外部アクセスを閉じる（`Engine::render_channel` は pub + `#[doc(hidden)]` で daemon の `render_offline_channel` から呼ぶため cross-crate 可能）。「混在呼び出し禁止」は呼び出し元責任の prose 規約でアクセス制御では強制されない（A4-2 で RT 配線後に再評価）④ テスト `body` クロージャを `rms_avg` ヘルパに hoist。efficiency = クリーン。test 構造重複（reuse minor）は test 閾値で skip。
+
+**/code:pr-review-team 適用（4専門レビュアー並列）**: code-reviewer = Critical/Important 0。silent-failure / comment-analyzer 指摘 = `Scheduler::render_channel` doc + 本 WORK_LOG ③ の「crate 外へ露出しない」が過大主張（Engine::render_channel は pub・daemon が使用）→ 修正済。pr-test-analyzer 指摘 = sum-by-name が同一 onset のみ → `render_channel_sums_same_name_at_staggered_onsets`（非ゼロ `dst_offset_frames` の `+=` を pin）を追加。latent: transport 二重進行 invariant は prose のみ（production caller 無し）→ A4-2 の single-pass multi-buffer で恒久解消。空文字列 channel `""` vs `None` の wire 意味論は A4-2 で確定。
 
 ### 6.159 feat(engine): slice varispeed parity — chop rate≠1.0 on rust engine (post-2.0 A3 / #319) (Jun 22, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -41,6 +41,8 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **運用**: GPL/Ableton Link を一切導入しない permissive 増分。SC 既定経路 無改変・audio `play()` 意味論 無改変。Rust workspace は CI fmt/clippy 非 gate（追加コードは周囲スタイルに整合）。
 
+**/simplify 適用（4観点並列）**: ① `render_offline`/`render_offline_channel` を `render_offline_inner(closure)` に共通化 ② `Engine::render`/`render_channel` を `with_scheduler` ヘルパに集約 ③ altitude 指摘で `Engine::render_channel` に `#[doc(hidden)]`・`Scheduler::render_channel` を `pub(crate)` に絞り「混在呼び出し禁止」の prose-only 不変条件を crate 外へ露出しない（本番 RT caller は A4-2 で追加）④ テスト `body` クロージャを `rms_avg` ヘルパに hoist。efficiency = クリーン。test 構造重複（reuse minor）は test 閾値で skip。
+
 ### 6.159 feat(engine): slice varispeed parity — chop rate≠1.0 on rust engine (post-2.0 A3 / #319) (Jun 22, 2026)
 
 **Date**: 2026-06-22

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,30 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.160 feat(engine): A4-1 named-channel routing + sum-by-name on rust mixer (post-2.0 A4 / #322) (Jun 22, 2026)
+
+**Date**: 2026-06-22
+**Status**: ✅ 実装 + cargo workspace 全緑（core 単体 5〔routing 分離 / sum 2x / unknown 無音 / unrouted skip / unfiltered 全混合〕+ verify harness 2〔routing 分離・sum-by-name +6dB を実 WAV + region_rms/db_difference で〕。TS 変更ゼロ = npm 影響なし）
+**Branch**: `322-linkaudio-routing-sum`
+**Parent**: #321（A4 meta）
+
+**背景**: post-2.0 engine-first の parity gap 充填 #2（A3 = PR #320 マージ済の次）。`.orbs` の `outputChannel`（LinkAudio・#209）を Rust 経路で鳴らす A4 の **permissive-first 第1増分**。正本: `POST_2.0_NEXT_STEPS.html §3/§4`。
+
+**Step0（3 偵察 + web spike + advisor + owner 決定）**:
+- **parity か net-new か = net-new 確定**: 動く SC 音参照なし（#209 OPEN・`orbitPlayBufLink` SynthDef 未定義）+ scsynth UGen 経路は Rust 非適用 + Rust に tempo 概念皆無・`LinkAudioSink` 無し。Done は「SC 一致」にできず、層A 決定論受信が correct の定義。
+- **GPL 面**: 既存 `packages/sc-link-audio` の `link_audio_facade.hpp` は型エイリアスのみ・`channel_registry.cpp` は SC ガード依存でそのまま FFI 不可。`rusty_link` は GPLv2+ かつ標準 Link（tempo）のみで LinkAudio(audio) を wrap しない。→ A4-2 で薄い SC-free C++ shim を新規し sum-by-name は permissive Rust 側に残す（advisor 指摘で GPL 面最小化）。
+- **lock-free**: `PostMixSink`/`RingTapSink`/`rtrb` は `orbit-clap-spike`（S1 スパイク）に実証済だが本番未配線。A4-2 で本番へ移植（lock-free 化 + permissive↔GPL 境界を兼ねる）。
+- **受信検証**: `LinkAudioSource`（in-process 受信 API）存在だが Link discovery は UDP multicast 依存で同一プロセス/CI 不安定（Ableton/link #50）・SC 側も headless 受信未検証。
+
+**owner 決定（2026-06-22）**: ①検証境界 = 層A headless + **層B も headless 試行**（discovery 不成立なら手動 fallback を報告・stop&report）②GPL 隔離 = feature-gated 薄 crate in-process（default off）③staging = permissive-first 4 分割（PR1 routing+sum → PR2 GPL crate+shim+cargo-deny → PR3 tempo leader → PR4 across-respawn e2e）。
+
+**本 PR（A4-1）の実装**:
+- `orbit-audio-core`: event に `channel: Option<String>` タグ追加（`ScheduledSample`/`ActiveSample` + `with_channel`）。`render` を `render_filtered(out, channel_filter)` に refactor（filter=None で従来の hardware sum とビット同一）+ `render_channel(out, name)`（同名 channel は自然加算 = sum-by-name・DSL §8.1.2）。`Engine::render_channel` / `schedule_with_play_id` に channel を thread。
+- `orbit-audio-daemon`: `EngineWrap::play_at` に `channel` 引数 + `render_offline_channel`（層A 決定論受信側・cpal 非依存）。wire（protocol channel_name 解析）は A4-2 へ（session.rs は `None` 固定）。
+- 「耳」活用: 既存 verify ハーネス（#307/#311 の `region_rms`/`db_difference`）に per-channel PCM を通し routing 分離 + sum-by-name +6dB を実 WAV で検証。
+
+**運用**: GPL/Ableton Link を一切導入しない permissive 増分。SC 既定経路 無改変・audio `play()` 意味論 無改変。Rust workspace は CI fmt/clippy 非 gate（追加コードは周囲スタイルに整合）。
+
 ### 6.159 feat(engine): slice varispeed parity — chop rate≠1.0 on rust engine (post-2.0 A3 / #319) (Jun 22, 2026)
 
 **Date**: 2026-06-22

--- a/rust/crates/orbit-audio-core/src/engine.rs
+++ b/rust/crates/orbit-audio-core/src/engine.rs
@@ -52,6 +52,8 @@ impl Engine {
     /// `slice_start_frame` / `slice_len_frames` は再生領域（`chop` の slice）。
     /// `slice_len_frames == 0` で「offset 以降すべて」。サンプル端で clamp される。
     /// `rate` は varispeed（1.0 = 自然尺・`<=0`/非有限は 1.0 に丸め）。
+    /// `channel` は出力先 channel 名（LinkAudio outputChannel・#209）。`None` = 既定
+    /// （unrouted / hardware sum）。同名 channel は `render_channel` で加算合成される。
     #[allow(clippy::too_many_arguments)]
     pub fn schedule_with_play_id(
         &self,
@@ -61,6 +63,7 @@ impl Engine {
         slice_start_frame: usize,
         slice_len_frames: usize,
         rate: f64,
+        channel: Option<String>,
         play_id: String,
         sample: Sample,
     ) -> Result<(), EngineError> {
@@ -71,6 +74,7 @@ impl Engine {
                 .with_pan(pan)
                 .with_region(slice_start_frame, slice_len_frames)
                 .with_rate(rate)
+                .with_channel(channel)
                 .with_play_id(play_id),
         );
         Ok(())
@@ -118,6 +122,20 @@ impl Engine {
     pub fn render(&self, out: &mut [f32]) {
         match self.inner.try_lock() {
             Ok(mut s) => s.render(out),
+            Err(_) => {
+                for x in out.iter_mut() {
+                    *x = 0.0;
+                }
+            }
+        }
+    }
+
+    /// `render` の channel filter 版。指定 channel 名に属する event だけを `out` に加算する
+    /// （LinkAudio per-channel tap・#209）。RT 競合時は無音（silent drop）。
+    /// 本番 hardware `render` と同一 tick で混在させないこと（[`Scheduler::render_channel`] 参照）。
+    pub fn render_channel(&self, out: &mut [f32], channel: &str) {
+        match self.inner.try_lock() {
+            Ok(mut s) => s.render_channel(out, channel),
             Err(_) => {
                 for x in out.iter_mut() {
                     *x = 0.0;

--- a/rust/crates/orbit-audio-core/src/engine.rs
+++ b/rust/crates/orbit-audio-core/src/engine.rs
@@ -114,14 +114,13 @@ impl Engine {
         Ok(())
     }
 
-    /// オーディオコールバックから呼び出される。`out` は interleaved f32。
-    ///
-    /// リアルタイムスレッドで呼ばれるため `try_lock` を用い、ロック競合時は
-    /// 無音（silent drop）を返してコールバックを即時完了させる。将来的には
-    /// lock-free ringbuffer に置き換える余地あり（Phase 2）。
-    pub fn render(&self, out: &mut [f32]) {
+    /// `try_lock` で Scheduler を借りて `f` を実行する。RT スレッドから呼ばれるため、ロック
+    /// 競合時は無音（silent drop）で即時 return する（将来 lock-free ringbuffer 化の余地あり・
+    /// Phase 2）。`render` / `render_channel` がこの try-lock + silent-drop 規約を共有する。
+    fn with_scheduler(&self, out: &mut [f32], f: impl FnOnce(&mut Scheduler, &mut [f32])) {
         match self.inner.try_lock() {
-            Ok(mut s) => s.render(out),
+            // MutexGuard を DerefMut で &mut Scheduler に再借用して closure に渡す。
+            Ok(mut s) => f(&mut s, out),
             Err(_) => {
                 for x in out.iter_mut() {
                     *x = 0.0;
@@ -130,18 +129,17 @@ impl Engine {
         }
     }
 
+    /// オーディオコールバックから呼び出される。`out` は interleaved f32。RT 競合時は無音。
+    pub fn render(&self, out: &mut [f32]) {
+        self.with_scheduler(out, |s, b| s.render(b));
+    }
+
     /// `render` の channel filter 版。指定 channel 名に属する event だけを `out` に加算する
-    /// （LinkAudio per-channel tap・#209）。RT 競合時は無音（silent drop）。
+    /// （LinkAudio per-channel tap・#209）。test/scaffolding 用（本番 RT caller は A4-2 で追加）。
     /// 本番 hardware `render` と同一 tick で混在させないこと（[`Scheduler::render_channel`] 参照）。
+    #[doc(hidden)]
     pub fn render_channel(&self, out: &mut [f32], channel: &str) {
-        match self.inner.try_lock() {
-            Ok(mut s) => s.render_channel(out, channel),
-            Err(_) => {
-                for x in out.iter_mut() {
-                    *x = 0.0;
-                }
-            }
-        }
+        self.with_scheduler(out, |s, b| s.render_channel(b, channel));
     }
 
     /// 現在の出力ストリーム時刻（秒）を返す。

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -283,11 +283,15 @@ impl Scheduler {
     /// 指定 channel 名に属する event だけを `out` に加算する（LinkAudio per-channel tap・#209）。
     /// 同名 channel の複数 event は自然に加算され sum-by-name（DSL §8.1.2）になる。
     /// transport（cursor / master gain ramp / 完了 event の掃除）は filter 有無に依らず 1 回
-    /// 進むため、本番 hardware `render`（filter=None）と同一 tick での混在呼び出しはしない
-    /// こと（per-channel 同時 render の multi-buffer 化は後続 PR）。
+    /// 進む。したがって同一 tick で「`render`（filter=None）と混在」または「複数 channel を
+    /// 続けて `render_channel`」すると transport が二重に進む（どちらも禁止）。invariant 自体を
+    /// 消す per-channel 同時 render（multi-buffer・1 パスで N channel を埋め transport を 1 回進める）
+    /// は後続 PR（A4-2）で実装する。
     ///
-    /// 本番 RT caller はまだ無い（A4-2 で追加）ので `pub(crate)` に絞り、crate 境界の外へ
-    /// 「混在呼び出し禁止」の prose-only 不変条件を露出しない（Engine 経由でのみ到達可能）。
+    /// 本番 RT caller はまだ無い（A4-2 で追加）。`Scheduler::render_channel` を `pub(crate)` に
+    /// 絞り直接の外部アクセスは閉じるが、`Engine::render_channel`（pub + `#[doc(hidden)]`）経由では
+    /// crate 外からも呼べる（orbit-audio-daemon の `render_offline_channel` が使用）。よって上記
+    /// 「混在呼び出し禁止」は呼び出し元責任の prose 規約であり、アクセス制御では強制されない。
     pub(crate) fn render_channel(&mut self, out: &mut [f32], channel: &str) {
         self.render_filtered(out, Some(channel));
     }
@@ -905,6 +909,36 @@ mod tests {
         assert!((buf[0] - 0.0).abs() < 1e-4, "f0 L={}", buf[0]);
         assert!((buf[2] - 2.0).abs() < 1e-4, "f1 L={}", buf[2]);
         assert!((buf[8] - 8.0).abs() < 1e-4, "f4 L={}", buf[8]);
+    }
+
+    #[test]
+    fn render_channel_sums_same_name_at_staggered_onsets() {
+        // 同名 channel に onset をずらした 2 つの定数 event。重なり部 = 加算（2.0）、非重なり部 =
+        // 後発のみ（1.0）。同一 onset テスト（offset=0）が通らない `dst_offset_frames != 0` の
+        // `+=` 経路を pin する（`+=` を `=` に変える regression は重なり部が 1.0 になり落ちる）。
+        let sr = 48_000u32;
+        let mut s = Scheduler::new(sr, 2);
+        let onset1 = 5.0 / sr as f64; // 出力 frame 5 から
+        s.schedule(
+            ScheduledSample::new(0.0, Sample::new(vec![1.0f32; 10], sr, 1))
+                .with_pan(-1.0)
+                .with_region(0, 10)
+                .with_channel(Some("mix".to_string())),
+        );
+        s.schedule(
+            ScheduledSample::new(onset1, Sample::new(vec![1.0f32; 10], sr, 1))
+                .with_pan(-1.0)
+                .with_region(0, 10)
+                .with_channel(Some("mix".to_string())),
+        );
+        let mut buf = vec![0.0f32; 60]; // 30 frames stereo
+        s.render_channel(&mut buf, "mix");
+        // frame 0..4: ev0 のみ（hard-left → L = 値）= 1.0
+        assert!((buf[2 * 2] - 1.0).abs() < 1e-4, "f2 (ev0 only) L={}", buf[2 * 2]);
+        // frame 5..9: ev0 + ev1 の重なり = 2.0（dst_offset_frames=5 の += を pin）
+        assert!((buf[2 * 7] - 2.0).abs() < 1e-4, "f7 (overlap) L={}", buf[2 * 7]);
+        // frame 10..14: ev1 のみ = 1.0
+        assert!((buf[2 * 12] - 1.0).abs() < 1e-4, "f12 (ev1 only) L={}", buf[2 * 12]);
     }
 
     #[test]

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -285,7 +285,10 @@ impl Scheduler {
     /// transport（cursor / master gain ramp / 完了 event の掃除）は filter 有無に依らず 1 回
     /// 進むため、本番 hardware `render`（filter=None）と同一 tick での混在呼び出しはしない
     /// こと（per-channel 同時 render の multi-buffer 化は後続 PR）。
-    pub fn render_channel(&mut self, out: &mut [f32], channel: &str) {
+    ///
+    /// 本番 RT caller はまだ無い（A4-2 で追加）ので `pub(crate)` に絞り、crate 境界の外へ
+    /// 「混在呼び出し禁止」の prose-only 不変条件を露出しない（Engine 経由でのみ到達可能）。
+    pub(crate) fn render_channel(&mut self, out: &mut [f32], channel: &str) {
         self.render_filtered(out, Some(channel));
     }
 

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -23,6 +23,10 @@ pub struct ScheduledSample {
     pub sample: Sample,
     /// Stop 命令での個別停止用識別子。`None` なら停止不可（fire-and-forget）。
     pub play_id: Option<String>,
+    /// 出力先 channel 名（LinkAudio outputChannel・#209）。`None` = 既定（unrouted / hardware
+    /// sum）。同名 channel の event は `Scheduler::render_channel` で加算合成される
+    /// （sum-by-name・DSL §8.1.2）。
+    pub channel: Option<String>,
 }
 
 impl ScheduledSample {
@@ -36,6 +40,7 @@ impl ScheduledSample {
             rate: 1.0,
             sample,
             play_id: None,
+            channel: None,
         }
     }
 
@@ -68,6 +73,12 @@ impl ScheduledSample {
 
     pub fn with_play_id(mut self, play_id: String) -> Self {
         self.play_id = Some(play_id);
+        self
+    }
+
+    /// 出力先 channel 名（LinkAudio outputChannel・#209）を設定する。`None` で既定（unrouted）。
+    pub fn with_channel(mut self, channel: Option<String>) -> Self {
+        self.channel = channel;
         self
     }
 }
@@ -157,6 +168,8 @@ struct ActiveSample {
     read_pos: f64,
     /// 個別停止用識別子
     play_id: Option<String>,
+    /// 出力先 channel 名（LinkAudio・#209）。`render_channel` の filter キー。`None` = unrouted。
+    channel: Option<String>,
 }
 
 impl Scheduler {
@@ -239,6 +252,7 @@ impl Scheduler {
             sample: event.sample,
             read_pos: 0.0,
             play_id: event.play_id,
+            channel: event.channel,
         });
     }
 
@@ -259,10 +273,25 @@ impl Scheduler {
         n
     }
 
-    /// 出力バッファにアクティブなサンプル群を加算する。
+    /// 出力バッファにアクティブなサンプル群を加算する（全 channel = hardware sum 経路）。
     ///
     /// `out` は interleaved（`output_channels` フレーム単位）であることを想定。
     pub fn render(&mut self, out: &mut [f32]) {
+        self.render_filtered(out, None);
+    }
+
+    /// 指定 channel 名に属する event だけを `out` に加算する（LinkAudio per-channel tap・#209）。
+    /// 同名 channel の複数 event は自然に加算され sum-by-name（DSL §8.1.2）になる。
+    /// transport（cursor / master gain ramp / 完了 event の掃除）は filter 有無に依らず 1 回
+    /// 進むため、本番 hardware `render`（filter=None）と同一 tick での混在呼び出しはしない
+    /// こと（per-channel 同時 render の multi-buffer 化は後続 PR）。
+    pub fn render_channel(&mut self, out: &mut [f32], channel: &str) {
+        self.render_filtered(out, Some(channel));
+    }
+
+    /// `render` / `render_channel` の実体。`channel_filter == None` で全 event（従来の
+    /// hardware sum とビット同一）、`Some(name)` で当該 channel の event のみ加算する。
+    fn render_filtered(&mut self, out: &mut [f32], channel_filter: Option<&str>) {
         for s in out.iter_mut() {
             *s = 0.0;
         }
@@ -271,6 +300,13 @@ impl Scheduler {
         let output_channels = self.output_channels as usize;
 
         for active in self.events.iter_mut() {
+            // channel filter: Some の時は一致する channel の event のみ。None は全通過
+            // （従来の hardware sum とビット同一）。
+            if let Some(want) = channel_filter {
+                if active.channel.as_deref() != Some(want) {
+                    continue;
+                }
+            }
             // このバッファ区間にこのサンプルが重なるか？
             let buf_start = self.cursor_frames;
             let buf_end = self.cursor_frames + frames_to_render as u64;
@@ -819,5 +855,97 @@ mod tests {
         let mut s = Scheduler::new(48_000, 2);
         s.set_global_gain(-0.5, 0);
         assert_eq!(s.global_gain(), 0.0);
+    }
+
+    // === LinkAudio named-channel routing + sum-by-name（A4-1・#322） ===
+
+    #[test]
+    fn render_channel_routes_only_matching_events() {
+        // "a" に ramp（hard-left = L が源値）、"b" に定数 100 を同時刻に出力。
+        // render_channel("a") は "a" の値（0,1,2,...）のみで、"b" の 100 は混じらない。
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(
+            ScheduledSample::new(0.0, mk_sample_mono_ramp(10))
+                .with_pan(-1.0)
+                .with_region(0, 10)
+                .with_channel(Some("a".to_string())),
+        );
+        s.schedule(
+            ScheduledSample::new(0.0, Sample::new(vec![100.0f32; 10], 48_000, 1))
+                .with_pan(-1.0)
+                .with_region(0, 10)
+                .with_channel(Some("b".to_string())),
+        );
+        let mut buf = vec![0.0f32; 40]; // 20 frames stereo
+        s.render_channel(&mut buf, "a");
+        // フィルタが "b" を取り込む regression なら 100 が加算され落ちる。
+        assert!((buf[0] - 0.0).abs() < 1e-4, "f0 L={}", buf[0]);
+        assert!((buf[2] - 1.0).abs() < 1e-4, "f1 L={}", buf[2]);
+        assert!((buf[8] - 4.0).abs() < 1e-4, "f4 L={}", buf[8]);
+    }
+
+    #[test]
+    fn render_channel_sums_same_name() {
+        // 同名 channel "mix" に 2 つの同一 ramp → 加算合成（sum-by-name）で各フレーム 2 倍。
+        // last-writer-wins の regression なら 1 倍のまま。
+        let mut s = Scheduler::new(48_000, 2);
+        for _ in 0..2 {
+            s.schedule(
+                ScheduledSample::new(0.0, mk_sample_mono_ramp(10))
+                    .with_pan(-1.0)
+                    .with_region(0, 10)
+                    .with_channel(Some("mix".to_string())),
+            );
+        }
+        let mut buf = vec![0.0f32; 40];
+        s.render_channel(&mut buf, "mix");
+        assert!((buf[0] - 0.0).abs() < 1e-4, "f0 L={}", buf[0]);
+        assert!((buf[2] - 2.0).abs() < 1e-4, "f1 L={}", buf[2]);
+        assert!((buf[8] - 8.0).abs() < 1e-4, "f4 L={}", buf[8]);
+    }
+
+    #[test]
+    fn render_unfiltered_includes_all_channels() {
+        // render（filter なし = hardware sum）は channel に依らず全 event を混合する。
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(
+            ScheduledSample::new(0.0, mk_sample_mono_ramp(10))
+                .with_pan(-1.0)
+                .with_region(0, 10)
+                .with_channel(Some("a".to_string())),
+        );
+        s.schedule(
+            ScheduledSample::new(0.0, mk_sample_mono_ramp(10))
+                .with_pan(-1.0)
+                .with_region(0, 10)
+                .with_channel(Some("b".to_string())),
+        );
+        let mut buf = vec![0.0f32; 40];
+        s.render(&mut buf);
+        // a + b 両方が混ざる → 0,2,4,...
+        assert!((buf[2] - 2.0).abs() < 1e-4, "f1 L={}", buf[2]);
+    }
+
+    #[test]
+    fn render_channel_unknown_is_silent() {
+        // 未使用 channel 名を tap すると完全無音（どの event にもマッチしない）。
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(
+            ScheduledSample::new(0.0, mk_sample_stereo(100))
+                .with_channel(Some("a".to_string())),
+        );
+        let mut buf = vec![0.0f32; 200];
+        s.render_channel(&mut buf, "nonexistent");
+        assert!(buf.iter().all(|&x| x == 0.0), "未使用 channel は無音のはず");
+    }
+
+    #[test]
+    fn unrouted_event_is_skipped_by_channel_render() {
+        // channel=None（unrouted）の event は render_channel では出ない（hardware 専用）。
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(ScheduledSample::new(0.0, mk_sample_stereo(100))); // channel None
+        let mut buf = vec![0.0f32; 200];
+        s.render_channel(&mut buf, "a");
+        assert!(buf.iter().all(|&x| x == 0.0), "unrouted event は channel tap に出ない");
     }
 }

--- a/rust/crates/orbit-audio-daemon/examples/export_verify_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/examples/export_verify_pcm.rs
@@ -183,6 +183,7 @@ fn render_golden(golden: &GoldenSchedule) -> (CapturedAudio, HashMap<String, usi
             ev.offset_sec,
             ev.duration_sec,
             ev.rate,
+            None,
         )
         .expect("play_at");
         let end = frame_at(ev.onset_sec, sr) + play_span(ev, &sample_frames, sr);

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -283,18 +283,17 @@ impl EngineWrap {
         self.engine.now_sec().unwrap_or_else(|| self.uptime_sec())
     }
 
-    /// 検証ハーネス（#311 phase 2）用: スケジュール済みイベントを cpal を介さず
-    /// オフラインで `total_frames` 分 render し、interleaved f32 PCM を返す。
-    ///
-    /// 本番経路（cpal callback）とは独立した test-only API。`Engine::render` は内部で
-    /// `try_lock` するが、オフライン単スレッド駆動では競合がなく常に成功する。`block_frames`
-    /// 単位で回すことで、実 callback と同様にイベントが block 境界をまたぐ経路も通す。
-    /// `play_at` 由来の sec→frame 変換 / `resolve_slice_region` を経た出力を捕捉できる
-    /// （phase 1 の Scheduler 直接駆動が飛ばした層）。
+    /// `render_offline` / `render_offline_channel` の共通本体。`render_fn` で 1 block 分の
+    /// 描画（全 channel / channel filter）を切り替える。`block_frames` 単位で回すことで、
+    /// 実 callback と同様にイベントが block 境界をまたぐ経路も通す。
     ///
     /// `block_frames == 0` は panic（テストハーネス用途なので不正設定は早期に落とす）。
-    #[doc(hidden)]
-    pub fn render_offline(&self, total_frames: usize, block_frames: usize) -> Vec<f32> {
+    fn render_offline_inner(
+        &self,
+        total_frames: usize,
+        block_frames: usize,
+        mut render_fn: impl FnMut(&mut [f32]),
+    ) -> Vec<f32> {
         assert!(block_frames > 0, "render_offline: block_frames must be > 0");
         let channels = self.channels as usize;
         let mut data = Vec::with_capacity(total_frames * channels);
@@ -303,20 +302,30 @@ impl EngineWrap {
         while rendered < total_frames {
             let this_frames = block_frames.min(total_frames - rendered);
             let buf = &mut block[..this_frames * channels];
-            self.engine.render(buf);
+            render_fn(buf);
             data.extend_from_slice(buf);
             rendered += this_frames;
         }
         data
     }
 
-    /// `render_offline` の channel filter 版（LinkAudio per-channel 受信側の決定論検証・層A）。
-    /// 指定 channel 名に属する event だけをオフラインで決定論レンダする。`render_offline` 同様
-    /// test-only（cpal 非依存・実時間非依存）。同名 channel は加算合成される（sum-by-name）。
-    /// 1 つの wrap で複数 channel を続けて tap すると transport が二重に進むため、検証は
-    /// channel ごとに fresh な wrap を使うこと。
+    /// 検証ハーネス（#311 phase 2）用: スケジュール済みイベントを cpal を介さず
+    /// オフラインで `total_frames` 分 render し、interleaved f32 PCM を返す。
     ///
-    /// `block_frames == 0` は panic（テストハーネス用途なので不正設定は早期に落とす）。
+    /// 本番経路（cpal callback）とは独立した test-only API。`Engine::render` は内部で
+    /// `try_lock` するが、オフライン単スレッド駆動では競合がなく常に成功する。
+    /// `play_at` 由来の sec→frame 変換 / `resolve_slice_region` を経た出力を捕捉できる
+    /// （phase 1 の Scheduler 直接駆動が飛ばした層）。
+    #[doc(hidden)]
+    pub fn render_offline(&self, total_frames: usize, block_frames: usize) -> Vec<f32> {
+        self.render_offline_inner(total_frames, block_frames, |buf| self.engine.render(buf))
+    }
+
+    /// `render_offline` の channel filter 版（LinkAudio per-channel 受信側の決定論検証・層A）。
+    /// 指定 channel 名に属する event だけをオフラインで決定論レンダする。同名 channel は
+    /// 加算合成される（sum-by-name）。1 つの wrap で複数 channel を続けて tap すると transport が
+    /// 二重に進むため（[`orbit_audio_core::Scheduler::render_channel`] 参照）、検証は channel
+    /// ごとに fresh な wrap を使うこと。
     #[doc(hidden)]
     pub fn render_offline_channel(
         &self,
@@ -324,22 +333,9 @@ impl EngineWrap {
         total_frames: usize,
         block_frames: usize,
     ) -> Vec<f32> {
-        assert!(
-            block_frames > 0,
-            "render_offline_channel: block_frames must be > 0"
-        );
-        let channels = self.channels as usize;
-        let mut data = Vec::with_capacity(total_frames * channels);
-        let mut block = vec![0.0f32; block_frames * channels];
-        let mut rendered = 0usize;
-        while rendered < total_frames {
-            let this_frames = block_frames.min(total_frames - rendered);
-            let buf = &mut block[..this_frames * channels];
-            self.engine.render_channel(buf, channel);
-            data.extend_from_slice(buf);
-            rendered += this_frames;
-        }
-        data
+        self.render_offline_inner(total_frames, block_frames, |buf| {
+            self.engine.render_channel(buf, channel)
+        })
     }
 
     /// マスターゲインを設定する。`ramp_sec` が 0 以下なら即時。

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -155,6 +155,8 @@ impl EngineWrap {
     /// 「offset 以降すべて」。いずれもサンプル端で clamp。
     /// `rate` は varispeed（1.0 = 自然尺、>1 = 速く短く高ピッチ、<1 = 遅く長く低ピッチ。
     /// `<=0`/非有限は core で 1.0 に丸め）。
+    /// `channel` は出力先 channel 名（LinkAudio outputChannel・#209）。`None` = 既定
+    /// （unrouted / hardware sum）。同名 channel の event は per-channel render で加算合成される。
     /// 戻り値の `duration_sec` は **実際に再生される区間の出力尺**（slice 実尺 / rate）なので、
     /// 呼び出し側は PlayEnded を再生終端（varispeed 後の出力終端）に合わせて遅延送信できる。
     #[allow(clippy::too_many_arguments)]
@@ -167,6 +169,7 @@ impl EngineWrap {
         offset_sec: f64,
         duration_sec: f64,
         rate: f64,
+        channel: Option<String>,
     ) -> Result<PlayHandle, WrapError> {
         let sample = self
             .lock_samples()?
@@ -201,6 +204,7 @@ impl EngineWrap {
                 // PlayEnded 尺の一致が scheduler 内の再 clamp に依存してしまう（latent な desync）。
                 effective_len_frames,
                 rate,
+                channel,
                 play_id.clone(),
                 sample,
             )
@@ -300,6 +304,38 @@ impl EngineWrap {
             let this_frames = block_frames.min(total_frames - rendered);
             let buf = &mut block[..this_frames * channels];
             self.engine.render(buf);
+            data.extend_from_slice(buf);
+            rendered += this_frames;
+        }
+        data
+    }
+
+    /// `render_offline` の channel filter 版（LinkAudio per-channel 受信側の決定論検証・層A）。
+    /// 指定 channel 名に属する event だけをオフラインで決定論レンダする。`render_offline` 同様
+    /// test-only（cpal 非依存・実時間非依存）。同名 channel は加算合成される（sum-by-name）。
+    /// 1 つの wrap で複数 channel を続けて tap すると transport が二重に進むため、検証は
+    /// channel ごとに fresh な wrap を使うこと。
+    ///
+    /// `block_frames == 0` は panic（テストハーネス用途なので不正設定は早期に落とす）。
+    #[doc(hidden)]
+    pub fn render_offline_channel(
+        &self,
+        channel: &str,
+        total_frames: usize,
+        block_frames: usize,
+    ) -> Vec<f32> {
+        assert!(
+            block_frames > 0,
+            "render_offline_channel: block_frames must be > 0"
+        );
+        let channels = self.channels as usize;
+        let mut data = Vec::with_capacity(total_frames * channels);
+        let mut block = vec![0.0f32; block_frames * channels];
+        let mut rendered = 0usize;
+        while rendered < total_frames {
+            let this_frames = block_frames.min(total_frames - rendered);
+            let buf = &mut block[..this_frames * channels];
+            self.engine.render_channel(buf, channel);
             data.extend_from_slice(buf);
             rendered += this_frames;
         }

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -290,8 +290,10 @@ async fn handle_command(
             // rate は varispeed（省略時 1.0 = 自然尺）。pan と同じく非致命的 param なので reject
             // せず core 側で 1.0 に丸める（<=0/非有限。誤った無音化や逆走を起こさない）。
             let rate = param_f64(&params, "rate", 1.0);
+            // channel（LinkAudio outputChannel・#209）の wire 解析は A4-2（GPL 隔離 + 実 commit）
+            // で追加する。A4-1 では None 固定で hardware sum 経路（既存挙動・regression なし）。
             match params.get("sample_id").and_then(|v| v.as_str()) {
-                Some(sid) => match engine.play_at(sid, time_sec, gain, pan, offset_sec, duration_sec, rate) {
+                Some(sid) => match engine.play_at(sid, time_sec, gain, pan, offset_sec, duration_sec, rate, None) {
                     Ok(handle) => {
                         // 遅延タスクを先に spawn して await コストを避ける
                         schedule_play_ended(

--- a/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
@@ -442,6 +442,13 @@ fn rms_window(c: &CapturedAudio, a: f64, b: f64) -> f32 {
     region_rms(c, 0, s, e).max(region_rms(c, 1, s, e))
 }
 
+/// 窓 [a, b) 秒の L/R 平均 RMS（average power）。sum-by-name の dB 比較に使う。
+fn rms_avg(c: &CapturedAudio, a: f64, b: f64) -> f32 {
+    let sr = LINKAUDIO_SR as f64;
+    let (s, e) = ((a * sr) as usize, (b * sr) as usize);
+    (region_rms(c, 0, s, e) + region_rms(c, 1, s, e)) / 2.0
+}
+
 #[test]
 fn linkaudio_routing_separates_channels() {
     //! A4-1 層A — outputChannel routing。kickA→"drums"(0.1s)、kickB→"bass"(2.1s)。
@@ -474,17 +481,12 @@ fn linkaudio_routing_separates_channels() {
 fn linkaudio_sum_by_name_accumulates() {
     //! A4-1 層A — sum-by-name。同名 channel "drums" に kick を 2 つ同時 onset すると加算され、
     //! 単一 kick より約 +6dB（2x 振幅）。last-writer-wins の regression なら 0dB。
-    let body = |c: &CapturedAudio| -> f32 {
-        let sr = LINKAUDIO_SR as f64;
-        let (s, e) = ((0.12 * sr) as usize, (0.4 * sr) as usize);
-        (region_rms(c, 0, s, e) + region_rms(c, 1, s, e)) / 2.0
-    };
-    let single = body(&render_kick_channel(&[(0.1, "drums")], "drums", 0.7));
-    let summed = body(&render_kick_channel(
-        &[(0.1, "drums"), (0.1, "drums")],
-        "drums",
-        0.7,
-    ));
+    let single = rms_avg(&render_kick_channel(&[(0.1, "drums")], "drums", 0.7), 0.12, 0.4);
+    let summed = rms_avg(
+        &render_kick_channel(&[(0.1, "drums"), (0.1, "drums")], "drums", 0.7),
+        0.12,
+        0.4,
+    );
     assert!(
         single > 1e-4 && summed > 1e-4,
         "両方に信号が必要（single={single:.5}, summed={summed:.5}）"

--- a/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
@@ -105,6 +105,7 @@ fn render_golden(golden: &GoldenSchedule) -> (CapturedAudio, HashMap<String, usi
             ev.offset_sec,
             ev.duration_sec,
             ev.rate,
+            None,
         )
         .expect("play_at");
         // 出力尺の見積もり（whole=サンプル尺 / slice=duration_sec）。varispeed では出力尺が
@@ -351,7 +352,7 @@ fn render_varispeed_slice(rate: f64) -> Vec<f32> {
         info.frames
     );
     // slice [0, 0.5s]（offset=0, duration=0.5）を指定 rate で発音。
-    wrap.play_at(&info.sample_id, 0.0, 1.0, 0.0, 0.0, 0.5, rate)
+    wrap.play_at(&info.sample_id, 0.0, 1.0, 0.0, 0.0, 0.5, rate, None)
         .expect("play_at");
     // rate=1.0 の出力尺 0.5s + 0.25s 余白。rate=2.0 はこれより短く収まる。
     let total = (0.75 * VARISPEED_SR as f64) as usize;
@@ -392,5 +393,105 @@ fn varispeed_rate2_renders_half_duration_of_rate1() {
     assert!(
         (ratio - 2.0).abs() < 0.16,
         "rate=2.0 は rate=1.0 の約半尺のはず: rate1_end={rate1_end}, rate2_end={rate2_end}, ratio={ratio:.3}"
+    );
+}
+
+// === LinkAudio named-channel routing + sum-by-name（A4-1・#322・層A 決定論検証） ===
+//
+// 「耳」ハーネス（#307/#311 の region_rms / db_difference）で、Rust mixer の per-channel
+// routing（outputChannel が正しい channel に届く）と sum-by-name（同名 channel が加算）を
+// 実 WAV + 実 play_at + render_offline_channel で検証する。GPL / Ableton Link 非依存（層A）。
+
+const LINKAUDIO_SR: u32 = 48_000;
+
+/// kick.wav を `plays`（(onset_sec, channel_name)）でスケジュールし、`tap` channel を
+/// offline render して CapturedAudio を返す。1 wrap で複数 channel を tap すると transport が
+/// 二重進行するため、呼び出しごとに fresh な wrap を使う（multi-buffer 同時 render は後続 PR）。
+fn render_kick_channel(plays: &[(f64, &str)], tap: &str, total_sec: f64) -> CapturedAudio {
+    let (wrap, _guard) = EngineWrap::start_with(StubBackend {
+        sample_rate: LINKAUDIO_SR,
+        channels: 2,
+    })
+    .expect("EngineWrap start_with StubBackend");
+    let wav = repo_path("test-assets/audio/kick.wav");
+    let info = wrap
+        .load_sample(wav.clone())
+        .unwrap_or_else(|e| panic!("load_sample {}: {e}", wav.display()));
+    for (onset, ch) in plays {
+        wrap.play_at(
+            &info.sample_id,
+            *onset,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            Some((*ch).to_string()),
+        )
+        .expect("play_at");
+    }
+    let total = (total_sec * LINKAUDIO_SR as f64) as usize;
+    let data = wrap.render_offline_channel(tap, total, BLOCK_FRAMES);
+    CapturedAudio::new(data, 2, LINKAUDIO_SR)
+}
+
+/// 窓 [a, b) 秒の L/R 最大 RMS。
+fn rms_window(c: &CapturedAudio, a: f64, b: f64) -> f32 {
+    let sr = LINKAUDIO_SR as f64;
+    let (s, e) = ((a * sr) as usize, (b * sr) as usize);
+    region_rms(c, 0, s, e).max(region_rms(c, 1, s, e))
+}
+
+#[test]
+fn linkaudio_routing_separates_channels() {
+    //! A4-1 層A — outputChannel routing。kickA→"drums"(0.1s)、kickB→"bass"(2.1s)。
+    //! "drums" tap は 0.1s に信号・2.1s は無音（kickB は別 channel）。"bass" tap は逆。
+    //! filter が channel を取り違える / 全部通す regression を捕まえる。
+    let plays = [(0.1, "drums"), (2.1, "bass")];
+
+    let drums = render_kick_channel(&plays, "drums", 2.8);
+    assert!(rms_window(&drums, 0.12, 0.4) > 1e-3, "drums tap に kickA 信号が必要");
+    assert!(
+        rms_window(&drums, 2.12, 2.4) < 1e-5,
+        "drums tap に kickB(bass) が漏れてはいけない（RMS={}）",
+        rms_window(&drums, 2.12, 2.4)
+    );
+
+    let bass = render_kick_channel(&plays, "bass", 2.8);
+    assert!(
+        rms_window(&bass, 0.12, 0.4) < 1e-5,
+        "bass tap に kickA(drums) が漏れてはいけない（RMS={}）",
+        rms_window(&bass, 0.12, 0.4)
+    );
+    assert!(rms_window(&bass, 2.12, 2.4) > 1e-3, "bass tap に kickB 信号が必要");
+
+    // 未使用 channel は完全無音。
+    let ghost = render_kick_channel(&plays, "ghost", 2.8);
+    assert!(rms_window(&ghost, 0.0, 2.8) < 1e-6, "未使用 channel は無音のはず");
+}
+
+#[test]
+fn linkaudio_sum_by_name_accumulates() {
+    //! A4-1 層A — sum-by-name。同名 channel "drums" に kick を 2 つ同時 onset すると加算され、
+    //! 単一 kick より約 +6dB（2x 振幅）。last-writer-wins の regression なら 0dB。
+    let body = |c: &CapturedAudio| -> f32 {
+        let sr = LINKAUDIO_SR as f64;
+        let (s, e) = ((0.12 * sr) as usize, (0.4 * sr) as usize);
+        (region_rms(c, 0, s, e) + region_rms(c, 1, s, e)) / 2.0
+    };
+    let single = body(&render_kick_channel(&[(0.1, "drums")], "drums", 0.7));
+    let summed = body(&render_kick_channel(
+        &[(0.1, "drums"), (0.1, "drums")],
+        "drums",
+        0.7,
+    ));
+    assert!(
+        single > 1e-4 && summed > 1e-4,
+        "両方に信号が必要（single={single:.5}, summed={summed:.5}）"
+    );
+    let diff = db_difference(summed, single); // 20*log10(2) ≈ +6.02 dB
+    assert!(
+        (diff - 6.02).abs() <= GAIN_DB_TOLERANCE,
+        "sum-by-name は約 +6dB のはず: 計測 {diff:.2} dB (single={single:.5}, summed={summed:.5})"
     );
 }


### PR DESCRIPTION
## 概要

post-2.0 engine-first の parity gap 充填 #2（A4 = LinkAudio）の **permissive-first 第1増分**。
`.orbs` の `outputChannel`（LinkAudio・#209）を Rust 経路（`ORBITSCORE_ENGINE=rust`）で鳴らす基盤として、
named-channel routing と同名サミング（sum-by-name）を mixer に入れ、既存の offline PCM 検証ハーネス
（#307/#311 の「耳」）で決定論検証する。**GPL / Ableton Link は一切導入しない**（permissive 維持）。

正本: `docs/development/POST_2.0_NEXT_STEPS.html §3/§4`。Step0 調査・owner 判断は #321（A4 meta）に記録。

## 変更内容

- **orbit-audio-core**: event に `channel: Option<String>` タグ追加（`ScheduledSample`/`ActiveSample` + `with_channel`）。`render` を `render_filtered(out, channel_filter)` に refactor（**filter=None で従来の hardware sum とビット同一**）+ `render_channel(out, name)`。同名 channel は自然加算 = sum-by-name（DSL §8.1.2）。`Engine::render_channel` / `schedule_with_play_id` に channel を thread。
- **orbit-audio-daemon**: `EngineWrap::play_at` に `channel` 引数 + `render_offline_channel`（層A 決定論受信側・cpal 非依存・実時間非依存）。**wire（protocol `channel_name` 解析）は A4-2 へ分離**（`session.rs` は `None` 固定 = 既存挙動・regression なし）。

## テスト（耳なし決定論）

- **core 単体 5**: routing 分離 / sum 2x / unknown channel 無音 / unrouted skip / unfiltered 全混合
- **verify harness 2**: routing 分離・sum-by-name +6dB を**実 WAV + `region_rms`/`db_difference`** で検証

cargo workspace 全緑。pre-commit hook の npm フルスイート全緑（TS 変更ゼロ・wire schema 不変）。
SC 既定経路 無改変・audio `play()` 意味論 無改変。

## スコープ外（後続 PR）

- A4-2: GPL 隔離 crate `orbit-link-audio` + 薄 SC-free C++ shim + FFI + `cargo-deny`/`deny.toml` + feature flag（default off）+ 実 LinkAudio commit + wire
- A4-3: Link tempo leader（#283 Rust 版）+ 層B headless 試行
- A4-4: active-loops across-respawn e2e

Refs #321
Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)