### PR TITLE
feat(engine): wire setLinkTempo to Rust daemon (A4-PR3 / #333)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -88,6 +88,25 @@ integration 18 passed / `cargo test --workspace` 緑。
   稀で benign・audio-side disjoint は無傷）。
 - 適用後: orbit-link-audio 9 passed + daemon lib 6 passed + clippy clean（diff 内）。
 
+**レビュー（/code:pr-review-team・4 agent 並列 + CI）**: CI green（Build / code-review）。Critical 0。
+Important 6 件を fixer で解消（advisor 確認後）:
+- **SF-1（silent-failure）**: shim `orbit_link_set_tempo` が void で **false-positive success** → `int` 返り値化し
+  `LinkAudioOutput::set_tempo -> bool`・`false` を `WrapError::LinkAudio`(runtime) に昇格。push が silent fail
+  すると MIDI（`global.tempo()` free-run）と Link-audio egress（古い session tempo を poll）が別 tempo に乖離
+  するのを防ぐ。既存 `LINK_AUDIO_RUNTIME` taxonomy に乗る・**新規 GPL 面ゼロ**。
+- **CR-1（code-review）**: `commit_channel`/`capture_beat` を `pub(crate)`（egress.rs のみ）。`session_tempo`/
+  `register_channel`/`set_enabled` は cross-crate で daemon が呼ぶため `pub` 維持。SAFETY コメントを
+  「型で締まる分（pub(crate)）」と「呼び出し規律で守る分（pub・consumer/control thread）」に正直に書き分け。
+- **CR-2**: bpm に sanity 上限 `MAX_LINK_BPM=999`（`+Inf` 伝播 / `beat_per_frame` overflow 防止・下限なし）。
+- **CM-1（comment）**: /simplify の hoist で stale 化した struct doc（「tempo poll は pump_once」）を修正。
+- **PT-1（pr-test）**: re-anchor trigger を pure `reanchor_beat_on_change` に抽出し device-free に sequence
+  テスト（anchor→steady→change→epsilon→capture 例外。trait/mock は over-engineering として回避・advisor）。
+- **PT-2**: `validate_bpm` を pure 抽出 + 単体テスト。
+- comment 改善 3 件（SAFETY に `session_tempo` Thread-safe:no 追記 / teardown コメントを「最後の Arc」/
+  engine_wrap の `as_ref` を interior mutability 説明に）。
+- 検証: orbit-link-audio 10 + daemon lib 7 + integration 18 passed・clippy clean（diff 内）。署名変更を含むため
+  **再レビュー（silent-failure + pr-test 再実行 + 全 suite）で closure を裏取り**（advisor 指示・自己宣言しない）。
+
 ### 6.164 feat(engine): A4-2b-2b dynamic N-channel LinkAudio registration (pool + readiness race / #331) (Jun 23, 2026)
 
 **Date**: 2026-06-23

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,28 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.165 feat(engine): A4-PR3 setLinkTempo TS-side wire (#333) (Jun 23, 2026)
+
+**Date**: 2026-06-23
+**Status**: ✅ 完了
+**Branch**: `333-linkaudio-tempo-leader`
+**Issue**: #333（A4 PR3 Link tempo leader の TS 側実装）
+
+**実装内容**:
+- `protocol-types.ts`: `CommandMethod` union に `'SetLinkTempo'` を追加（Rust daemon 名と一致）
+- `daemon-client.ts`: `setLinkTempo(bpm: number)` メソッドを追加 — `this.request('SetLinkTempo', { bpm })` パターン
+- `rust-engine-player.ts`: `GapKind` に `'linkTempo'` 追加・`freshWarned()` に `linkTempo: false` 追加・`setLinkTempo` no-op を実装に差し替え（`LINK_AUDIO_UNAVAILABLE` = warn-once 握り潰し、`LINK_AUDIO_RUNTIME` = rethrow）
+- `mock-daemon-server.ts`: `MockDaemonHandlers` に `SetLinkTempo?: MockHandler` 追加
+- `daemon-client.spec.ts`: 2 テスト追加（bpm params 送信・UNAVAILABLE 変換）
+- `rust-engine-player.spec.ts`: 3 テスト追加 + defaultHandlers に SetLinkTempo デフォルト追加（registerLinkAudioChannel と対称）
+
+**技術的決定**:
+- GapKind を `'linkTempo'` で分離（`outputChannel` と共用しない）— channel 登録と tempo push は独立した warn サイレンス単位
+- defaultHandlers() の SetLinkTempo デフォルトが LINK_AUDIO_UNAVAILABLE を投げる — boot() 単体で warn-once パスを自動カバー
+- Rust 側依存点: method 文字列 `'SetLinkTempo'`・params `{ bpm: number }` が確定済みインタフェース
+
+**テスト結果**: 全 1187 テスト green（27 skipped は既存）
+
 ### 6.164 feat(engine): A4-2b-2b dynamic N-channel LinkAudio registration (pool + readiness race / #331) (Jun 23, 2026)
 
 **Date**: 2026-06-23

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -104,8 +104,15 @@ Important 6 件を fixer で解消（advisor 確認後）:
 - **PT-2**: `validate_bpm` を pure 抽出 + 単体テスト。
 - comment 改善 3 件（SAFETY に `session_tempo` Thread-safe:no 追記 / teardown コメントを「最後の Arc」/
   engine_wrap の `as_ref` を interior mutability 説明に）。
-- 検証: orbit-link-audio 10 + daemon lib 7 + integration 18 passed・clippy clean（diff 内）。署名変更を含むため
-  **再レビュー（silent-failure + pr-test 再実行 + 全 suite）で closure を裏取り**（advisor 指示・自己宣言しない）。
+- 検証: orbit-link-audio 10 + daemon lib 7 + integration 18 passed・clippy clean（diff 内）。
+- **再レビュー（silent-failure + pr-test 再実行・advisor 指示の one-time closure check）**: SF-1 / PT-1 / PT-2 すべて
+  **resolved** を再確認。新規 SF-2（global.ts:265 の `.catch` が opaque log）は **defer**: `DaemonProtocolError` が
+  `super(`[${code}] ${message}`)`（errors.ts:45）で code+message をレンダーするため既に有用＝opaque でない。warn-once
+  再設計は never-path（set_tempo は no-peer でも success・Link 例外でのみ false）への過剰設計 + global.ts は SC/Rust
+  共有のため **reject**（advisor）。SF-3（pre-existing・Minor）= shim `orbit_link_session_tempo` の catch に fprintf を
+  追加し set_tempo と observability を対称化（1行）。SF-4 benign（None は production unreachable）。**内部レビュー
+  closed**（毎修正後の再レビューは LLM が必ず新指摘を出す非終了ループ＝substance 収束で閉じる・advisor）→ 外部
+  closure は @claude bot（load-bearing seam: unsafe Sync の call-discipline / FFI bool contract / poll re-anchor）。
 
 ### 6.164 feat(engine): A4-2b-2b dynamic N-channel LinkAudio registration (pool + readiness race / #331) (Jun 23, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -76,6 +76,18 @@ integration 18 passed / `cargo test --workspace` 緑。
 
 **テスト結果**: 全 1187 テスト green（27 skipped は既存）
 
+**レビュー（/simplify・4 観点並列）**: reuse / altitude = clean（altitude は poll-based re-anchor を
+「the strongest altitude win」と評価）。適用 2 件:
+- **simplification**: egress.rs の anchor / re-anchor が同じ 4 フィールド更新を重複 →
+  `start_segment(anchor_beat, produced, bpm)` ヘルパに集約（segment invariant を 1 箇所に）。
+- **efficiency**: `session_tempo()` を per-channel `pump_once` で N 回読んでいた → consumer_loop の
+  round ごと 1 回に hoist し `pump_once(&output, session_tempo)` へ snapshot を渡す（session-global な
+  値の N FFI reads/round → 1・correctness は各 channel が自分の `last_bpm` と比較で保持）。
+- skip: F-1（commit 内の二重 `captureAudioSessionState`・ABI 変更が要る design-level・informational）/
+  エラー文字列重複の const 化（never-parsed の cosmetic）/ `set_link_tempo` の mutex lock（tempo 変更は
+  稀で benign・audio-side disjoint は無傷）。
+- 適用後: orbit-link-audio 9 passed + daemon lib 6 passed + clippy clean（diff 内）。
+
 ### 6.164 feat(engine): A4-2b-2b dynamic N-channel LinkAudio registration (pool + readiness race / #331) (Jun 23, 2026)
 
 **Date**: 2026-06-23

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -113,6 +113,12 @@ Important 6 件を fixer で解消（advisor 確認後）:
   追加し set_tempo と observability を対称化（1行）。SF-4 benign（None は production unreachable）。**内部レビュー
   closed**（毎修正後の再レビューは LLM が必ず新指摘を出す非終了ループ＝substance 収束で閉じる・advisor）→ 外部
   closure は @claude bot（load-bearing seam: unsafe Sync の call-discipline / FFI bool contract / poll re-anchor）。
+- **外部レビュー（@claude bot・load-bearing seam スコープ・3m57s）**: 3 点すべて ✅ 問題なし — ① `unsafe impl Sync`
+  健全（型レベル + 抽象層で cross-thread 誤呼びが閉じている）② FFI bool contract end-to-end（false-positive success
+  なし・false は全段 rethrow・ピン留めテスト付き）③ poll re-anchor continuity（tempo 変化点で `new_anchor` が旧 slope の
+  beat と同値＝数学的に連続・`capture_beat()` 非再呼びで ring-latency 誤差を再導入しない）。実質的 blocking なし。唯一の
+  minor = SAFETY コメントに `num_peers`（test-only・Thread-safe:yes）が未言及 → 1 行追記で対応。**Critical/Important=0・
+  bot 承認**。owner マージ待ち（self-merge しない）。
 
 ### 6.164 feat(engine): A4-2b-2b dynamic N-channel LinkAudio registration (pool + readiness race / #331) (Jun 23, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,14 +17,51 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
-### 6.165 feat(engine): A4-PR3 setLinkTempo TS-side wire (#333) (Jun 23, 2026)
+### 6.165 feat(engine): A4-PR3 Link tempo leader — Rust daemon + TS wire (#333) (Jun 23, 2026)
 
 **Date**: 2026-06-23
-**Status**: ✅ 完了
+**Status**: ✅ 実装完了（レビュー前）
 **Branch**: `333-linkaudio-tempo-leader`
-**Issue**: #333（A4 PR3 Link tempo leader の TS 側実装）
+**Issue**: #333（A4 PR3 Link tempo leader）
+**PR**: #334
 
-**実装内容**:
+`global.tempo()` を Ableton Link セッションに push し OrbitScore を Rust 経路
+（`ORBITSCORE_ENGINE=rust`）の Link tempo leader にする。SC 経路は既に動作中（#283）で、
+本 PR は Rust 経路の no-op を実装して parity を埋める（net-new・新規 GPL 面ゼロ）。
+tempo FFI（`set_tempo`/`session_tempo`）は A4-2b で GPL 隔離 crate に既存だったため、
+残作業は wire + handle-ownership/threading + tempo-change re-anchor に絞られた。
+
+**Rust 実装（threading seam・Opus 直列・advisor 設計確認済）**:
+- **論点1 handle 共有 = 案A + newtype**: `orbit-link-audio/src/lib.rs` で `LinkAudioOutput` を
+  `Arc` 共有可能化（`unsafe impl Sync` 追加・SAFETY を「app-state path=control / audio-state
+  path=consumer の disjoint thread role を Link が内部同期」で根拠付け）。control 側は
+  `LinkTempoControl(Arc<LinkAudioOutput>)` newtype で `set_tempo` のみ公開し audio-state
+  メソッド（commit/capture_beat/session_tempo）を型レベルで隠蔽（`set_tempo` は `pub(crate)`）。
+- **論点3 re-anchor = poll-based**（advisor が当初の explicit 推奨を撤回）: `egress.rs` で consumer が
+  毎 pump `session_tempo()` を poll し、変化検出で segment baseline（`seg_anchor_beat`/
+  `seg_anchor_produced`/`beat_per_frame`）を切り替える。Link は last-setter-wins なので自分の push も
+  他ピア（Ableton 等）の変更も追従する（explicit を包含・control→consumer 同期配線不要）。**`capture_beat()`
+  を再呼びしない**連続 carry（ring latency 位相誤差の再導入を回避・advisor の load-bearing detail）。
+  境界での beat 連続 + slope 変化を単体テストで固定（`reanchor_is_beat_continuous_and_changes_slope`・
+  `reanchor_slowdown_reduces_slope_but_keeps_continuity`）。
+- **論点2 blocking = spawn_blocking**: `session.rs` の `SetLinkTempo` arm が `set_tempo`（内部
+  `captureAppSessionState`・非RT・block しうる）を LoadSample と同様 spawn_blocking で隔離する
+  （tokio worker を塞がない・app-state path を audio スレッド外で実行する Link 制約も満たす）。
+- daemon `link_audio.rs`: `LinkAudioControl` が `LinkTempoControl` を保持、`consumer_loop` は
+  `Arc<LinkAudioOutput>` を所有（teardown = `orbit_link_destroy` は app-side cleanup〔enable(false)+
+  delete〕で audio-thread 非依存＝shim 確認済のため、last-Arc-drop が consumer 外でも安全）。
+  `engine_wrap.rs`: `set_link_tempo(&self)`（feature 有 = `as_ref` で `set_tempo` / 無 =
+  `LINK_AUDIO_UNAVAILABLE` stub）。
+- **lifecycle 決定（MVP）**: tempo-lead は Link subsystem up（feature `link-audio` 起動・
+  `LinkAudioControl` spawn 済）を要する。active channel 0 でも可。channel 完全非依存の単独 leader への
+  decouple は defer。
+- **license**: tempo API は既に `orbit-link-audio` 内＝**新規 GPL 面ゼロ**。`cargo deny check licenses`
+  ok（default graph GPL-free 維持）。
+
+**Rust テスト**: `orbit-link-audio` 9 passed（re-anchor 連続性 2 件含む）/ daemon lib 6 passed +
+integration 18 passed / `cargo test --workspace` 緑。
+
+**TS 実装内容**:
 - `protocol-types.ts`: `CommandMethod` union に `'SetLinkTempo'` を追加（Rust daemon 名と一致）
 - `daemon-client.ts`: `setLinkTempo(bpm: number)` メソッドを追加 — `this.request('SetLinkTempo', { bpm })` パターン
 - `rust-engine-player.ts`: `GapKind` に `'linkTempo'` 追加・`freshWarned()` に `linkTempo: false` 追加・`setLinkTempo` no-op を実装に差し替え（`LINK_AUDIO_UNAVAILABLE` = warn-once 握り潰し、`LINK_AUDIO_RUNTIME` = rethrow）

--- a/packages/engine/src/audio/rust-engine/daemon-client.ts
+++ b/packages/engine/src/audio/rust-engine/daemon-client.ts
@@ -266,6 +266,14 @@ export class DaemonClient extends EventEmitter {
     await this.request('RegisterLinkAudioChannel', { channel })
   }
 
+  /**
+   * OrbitScore の global.tempo を Link に push してテンポリーダーになる（#283・A4-PR3）。
+   * daemon が feature `link-audio` 無効ビルドなら LINK_AUDIO_UNAVAILABLE、runtime 失敗なら LINK_AUDIO_RUNTIME で reject。
+   */
+  async setLinkTempo(bpm: number): Promise<void> {
+    await this.request('SetLinkTempo', { bpm })
+  }
+
   async getStatus(): Promise<Record<string, unknown>> {
     return this.request('GetStatus', {})
   }

--- a/packages/engine/src/audio/rust-engine/protocol-types.ts
+++ b/packages/engine/src/audio/rust-engine/protocol-types.ts
@@ -26,6 +26,9 @@ export type CommandMethod =
   // LinkAudio outputChannel を daemon に登録する（#209・A4-2b-2）。daemon が
   // feature `link-audio` 無効なら LINK_AUDIO_UNAVAILABLE、runtime 失敗なら LINK_AUDIO_RUNTIME を返す。
   | 'RegisterLinkAudioChannel'
+  // OrbitScore の global.tempo を Link に push してテンポリーダーになる（#283・A4-PR3）。
+  // daemon が feature `link-audio` 無効なら LINK_AUDIO_UNAVAILABLE、runtime 失敗なら LINK_AUDIO_RUNTIME を返す。
+  | 'SetLinkTempo'
   | 'GetStatus'
   | 'Ping'
   // gated な fault 注入（recovery floor の kill-test 専用）。daemon 側で

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -47,9 +47,10 @@ import { DaemonConnectionError, DaemonProtocolError, DaemonQuitError } from './e
 /**
  * boundary で明示する未対応 feature gap の種別（A4 era）。
  * - `outputChannel`(LinkAudio) / `masterEffect`: 未対応 feature gap。
+ * - `linkTempo`: Link テンポリード（#283・A4-PR3）。daemon が feature 無効ビルドなら warn-once。
  * pan / slice 領域 / slice varispeed（rate≠1.0）は実装済みのため gap ではない。
  */
-type GapKind = 'outputChannel' | 'masterEffect'
+type GapKind = 'outputChannel' | 'masterEffect' | 'linkTempo'
 
 /** chop slice 情報。`scheduleSliceEvent` 由来。発火時に領域（offset/duration）へ解決する。 */
 export interface SliceSpec {
@@ -163,6 +164,7 @@ const RESPAWN_BACKOFF_MS = 150
 const freshWarned = (): Record<GapKind, boolean> => ({
   outputChannel: false,
   masterEffect: false,
+  linkTempo: false,
 })
 
 export class RustEnginePlayer implements AudioEngineBackend {
@@ -455,8 +457,19 @@ export class RustEnginePlayer implements AudioEngineBackend {
     }
   }
 
-  async setLinkTempo(_bpm: number): Promise<void> {
-    // Link テンポリード（#283）は LinkAudio 同様 A4 era。S2 では no-op。
+  async setLinkTempo(bpm: number): Promise<void> {
+    try {
+      await this.daemon.setLinkTempo(bpm)
+    } catch (err) {
+      if (err instanceof DaemonProtocolError && err.code === 'LINK_AUDIO_UNAVAILABLE') {
+        this.warnOnce(
+          'linkTempo',
+          `⚠️  [rust-engine] setLinkTempo(${bpm}): Link テンポリードは daemon がビルドされていないため無効（feature link-audio 未ビルド）— tempo push はスキップされます。`,
+        )
+        return
+      }
+      throw err
+    }
   }
 
   /**

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -193,6 +193,37 @@ impl EngineWrap {
         ))
     }
 
+    /// Link セッションに tempo(BPM)を push し OrbitScore を tempo leader にする（PR3・#333）。
+    /// `LinkAudioControl::set_tempo` は内部で `captureAppSessionState`（非RT・block しうる）を呼ぶので、
+    /// daemon WS handler は **spawn_blocking** で audio スレッド以外に隔離すること（session.rs）。tempo は
+    /// `LinkTempoControl`（`Arc<LinkAudioOutput>`）経由なので `&self` で足りる（register と違い `as_ref`）。
+    #[cfg(feature = "link-audio")]
+    pub fn set_link_tempo(&self, bpm: f64) -> Result<(), WrapError> {
+        // mutex poison は egress 利用可能だが runtime で壊れた状態 → runtime error。
+        let guard = self
+            .link
+            .lock()
+            .map_err(|_| WrapError::LinkAudio("link mutex poisoned".into()))?;
+        match guard.as_ref() {
+            Some(ctl) => {
+                ctl.set_tempo(bpm);
+                Ok(())
+            }
+            // egress 経路が無い（test backend）= unavailable（TS は warn-once で握り潰す）。
+            None => Err(WrapError::LinkAudioUnavailable(
+                "link audio not initialized (test backend has no egress path)".into(),
+            )),
+        }
+    }
+
+    /// feature `link-audio` 無効ビルド用の stub。TS は UNAVAILABLE を warn-once で握り潰す。
+    #[cfg(not(feature = "link-audio"))]
+    pub fn set_link_tempo(&self, _bpm: f64) -> Result<(), WrapError> {
+        Err(WrapError::LinkAudioUnavailable(
+            "engine built without 'link-audio' feature".into(),
+        ))
+    }
+
     /// 全 LinkAudio channel の ring overflow drop（interleaved サンプル数）の累積合計（A4-2b-2b）。
     /// daemon の 1 Hz ticker が polling して増加を WARNING event で surface する（非 RT observability）。
     /// link 未初期化（test backend）時は control 分が 0。test 注入分（本番 0）を必ず加える。

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -195,8 +195,11 @@ impl EngineWrap {
 
     /// Link セッションに tempo(BPM)を push し OrbitScore を tempo leader にする（PR3・#333）。
     /// `LinkAudioControl::set_tempo` は内部で `captureAppSessionState`（非RT・block しうる）を呼ぶので、
-    /// daemon WS handler は **spawn_blocking** で audio スレッド以外に隔離すること（session.rs）。tempo は
-    /// `LinkTempoControl`（`Arc<LinkAudioOutput>`）経由なので `&self` で足りる（register と違い `as_ref`）。
+    /// daemon WS handler は **spawn_blocking** で audio スレッド以外に隔離すること（session.rs）。
+    /// `&self` で足りる: `set_link_tempo` は Rust 可視の可変状態を持たない（`LinkTempoControl` は `Arc`
+    /// 共有で、tempo 反映は shim の interior mutability＝captureAppSessionState→commit）。
+    /// `register_link_audio_channel` が `registered` HashMap を変更し `as_mut` を要するのと違い、ここは
+    /// `guard.as_ref()` で足りる。
     #[cfg(feature = "link-audio")]
     pub fn set_link_tempo(&self, bpm: f64) -> Result<(), WrapError> {
         // mutex poison は egress 利用可能だが runtime で壊れた状態 → runtime error。
@@ -205,9 +208,16 @@ impl EngineWrap {
             .lock()
             .map_err(|_| WrapError::LinkAudio("link mutex poisoned".into()))?;
         match guard.as_ref() {
+            // set_tempo は成功 true / 失敗 false。false（shim 内 Link 例外・実質起きない）は
+            // false-positive success を返さず runtime error に昇格する（silent-failure 対策）。
             Some(ctl) => {
-                ctl.set_tempo(bpm);
-                Ok(())
+                if ctl.set_tempo(bpm) {
+                    Ok(())
+                } else {
+                    Err(WrapError::LinkAudio(
+                        "link set_tempo failed (Link rejected commit)".into(),
+                    ))
+                }
             }
             // egress 経路が無い（test backend）= unavailable（TS は warn-once で握り潰す）。
             None => Err(WrapError::LinkAudioUnavailable(

--- a/rust/crates/orbit-audio-daemon/src/link_audio.rs
+++ b/rust/crates/orbit-audio-daemon/src/link_audio.rs
@@ -156,9 +156,17 @@ fn consumer_loop(
         }
 
         // 2. 全 channel を pump（共有 output を & で渡す）。1 つでも commit したら sleep しない。
+        // session tempo は session-global なので per-channel に N 回読まず round ごとに 1 回 capture し、
+        // 各 channel の re-anchor 判定へ snapshot を渡す（efficiency: N FFI reads/round → 1）。channels 空
+        // （tempo lead のみ・egress 無し）の round では読まない。
+        let session_tempo = if channels.is_empty() {
+            0.0
+        } else {
+            output.session_tempo()
+        };
         let mut pumped = false;
         for ch in channels.iter_mut() {
-            while let Some(rc) = ch.egress.pump_once(&output) {
+            while let Some(rc) = ch.egress.pump_once(&output, session_tempo) {
                 pumped = true;
                 match rc {
                     // NoSubscriber は Live 未参加の通常状態（silent）。回復で streak をリセット。

--- a/rust/crates/orbit-audio-daemon/src/link_audio.rs
+++ b/rust/crates/orbit-audio-daemon/src/link_audio.rs
@@ -195,8 +195,10 @@ fn consumer_loop(
         }
     }
     // ループ脱出 → channels + この thread の output Arc が drop。control 側(LinkTempoControl)も同一 Arc を
-    // 保持するため、Link teardown は最後の Arc が落ちる時(EngineWrap drop)に走る。LinkAudioGuard の join が
-    // この thread の終了を保証するので、teardown 時に audio スレッドは動いていない(destroy は app-side)。
+    // 保持するため、Link teardown(orbit_link_destroy)は **最後の Arc**(consumer thread 側 or
+    // EngineWrap.link 側のどちらか後の drop)が落ちた時に 1 回走る。LinkAudioGuard の join がこの thread の
+    // 終了を保証してから後段が drop されるので、teardown 時に audio スレッドは動いていない(destroy は
+    // app-side cleanup・PR3)。
 }
 
 /// GPL consumer thread を明示 teardown する RAII guard。**drop で shutdown フラグを立てて join**。
@@ -296,11 +298,13 @@ impl LinkAudioControl {
             .sum()
     }
 
-    /// Link セッションに tempo(BPM)を push し OrbitScore を tempo leader にする(PR3)。`set_tempo` は
-    /// 内部で `captureAppSessionState`(非RT・block しうる)を呼ぶので、呼び出し側(daemon WS handler)は
-    /// spawn_blocking で audio スレッド以外に隔離すること。`&self`(tempo は Arc・内部可変性不要)。
-    pub fn set_tempo(&self, bpm: f64) {
-        self.tempo.set_tempo(bpm);
+    /// Link セッションに tempo(BPM)を push し OrbitScore を tempo leader にする(PR3)。成功 `true` /
+    /// 失敗 `false`(shim 内で Link 例外を catch・実質起きない)。呼び出し側は `false` を runtime error に
+    /// 昇格する(false-positive success を返さない)。`set_tempo` は内部で `captureAppSessionState`
+    /// (非RT・block しうる)を呼ぶので、呼び出し側(daemon WS handler)は spawn_blocking で audio スレッド
+    /// 以外に隔離すること。`&self`(tempo は Arc・内部可変性不要)。
+    pub fn set_tempo(&self, bpm: f64) -> bool {
+        self.tempo.set_tempo(bpm)
     }
 
     /// 名前付き channel を登録する。`RingTapSink` と readiness flag を生成し、**sink+ready を callback

--- a/rust/crates/orbit-audio-daemon/src/link_audio.rs
+++ b/rust/crates/orbit-audio-daemon/src/link_audio.rs
@@ -27,7 +27,9 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use orbit_audio_native::{LinkChannelActivate, RingTapSink, MAX_LINK_CHANNELS};
-use orbit_link_audio::{CommitResult, LinkAudioError, LinkAudioOutput, LinkChannelEgress};
+use orbit_link_audio::{
+    CommitResult, LinkAudioError, LinkAudioOutput, LinkChannelEgress, LinkTempoControl,
+};
 
 /// ring 容量（秒）。callback の push と consumer の drain を decouple する緩衝。
 const RING_SECONDS: usize = 2;
@@ -106,9 +108,11 @@ struct ActiveChannel {
 
 /// GPL consumer thread の本体。`shutdown` が立つまでループし、registration を処理しつつ全 channel の
 /// egress を pump する。**teardown は drop 順ではなく明示 signal+join**（A0 §13 教訓）: 戻ると
-/// `channels` と `output` がこの thread 上で drop され `LinkAudioOutput::drop`→Link teardown が走る。
+/// `channels` とこの thread の `output` Arc が drop される。`output` は control 側(LinkTempoControl)と
+/// 共有する `Arc<LinkAudioOutput>` なので、Link teardown(`orbit_link_destroy`)は最後の Arc が落ちる時に
+/// 1 回走る(PR3・案A)。
 fn consumer_loop(
-    output: LinkAudioOutput,
+    output: Arc<LinkAudioOutput>,
     cmd_rx: mpsc::Receiver<RegisterCmd>,
     shutdown: Arc<AtomicBool>,
 ) {
@@ -182,7 +186,9 @@ fn consumer_loop(
             std::thread::sleep(Duration::from_millis(2));
         }
     }
-    // ループ脱出 → channels + output がこの thread 上で drop → Link teardown。
+    // ループ脱出 → channels + この thread の output Arc が drop。control 側(LinkTempoControl)も同一 Arc を
+    // 保持するため、Link teardown は最後の Arc が落ちる時(EngineWrap drop)に走る。LinkAudioGuard の join が
+    // この thread の終了を保証するので、teardown 時に audio スレッドは動いていない(destroy は app-side)。
 }
 
 /// GPL consumer thread を明示 teardown する RAII guard。**drop で shutdown フラグを立てて join**。
@@ -222,6 +228,9 @@ pub struct LinkAudioControl {
     /// counter clone（producer=callback / consumer thread が別 clone を持つ・同一 Arc）。冪等判定と
     /// observability（[`Self::total_ring_drops`]）を 1 map に集約し channel↔counter の対応を保つ。
     registered: HashMap<String, Arc<AtomicU64>>,
+    /// Link tempo leader の control ハンドル(set_tempo のみ・audio-state path には到達不能)。
+    /// consumer thread が持つ `Arc<LinkAudioOutput>` と同一 session を共有する(PR3)。
+    tempo: LinkTempoControl,
 }
 
 impl LinkAudioControl {
@@ -236,11 +245,14 @@ impl LinkAudioControl {
         sample_rate: u32,
         num_channels: usize,
     ) -> Result<(Self, LinkAudioGuard), LinkAudioError> {
-        let output = LinkAudioOutput::new(120.0, "orbit-engine")?;
+        let output = Arc::new(LinkAudioOutput::new(120.0, "orbit-engine")?);
         // discovery を有効化（Live/peer が channel を購読できるように）。enable は単なる FFI で
         // "audio thread" 制約の対象外なので control thread で呼んでよい（capture_beat のみ
         // consumer thread = audio thread から呼ぶ・egress.rs 参照）。
         output.set_enabled(true);
+        // control 側 tempo ハンドル。consumer thread が持つ Arc と同一 Link session を共有し、
+        // set_tempo(app-state path)だけを公開する(PR3・案A + newtype)。
+        let tempo = LinkTempoControl::new(output.clone());
 
         let (cmd_tx, cmd_rx) = mpsc::channel::<RegisterCmd>();
         let shutdown = Arc::new(AtomicBool::new(false));
@@ -258,6 +270,7 @@ impl LinkAudioControl {
                 sample_rate,
                 num_channels,
                 registered: HashMap::new(),
+                tempo,
             },
             LinkAudioGuard {
                 shutdown,
@@ -273,6 +286,13 @@ impl LinkAudioControl {
             .values()
             .map(|d| d.load(Ordering::Relaxed))
             .sum()
+    }
+
+    /// Link セッションに tempo(BPM)を push し OrbitScore を tempo leader にする(PR3)。`set_tempo` は
+    /// 内部で `captureAppSessionState`(非RT・block しうる)を呼ぶので、呼び出し側(daemon WS handler)は
+    /// spawn_blocking で audio スレッド以外に隔離すること。`&self`(tempo は Arc・内部可変性不要)。
+    pub fn set_tempo(&self, bpm: f64) {
+        self.tempo.set_tempo(bpm);
     }
 
     /// 名前付き channel を登録する。`RingTapSink` と readiness flag を生成し、**sink+ready を callback
@@ -391,17 +411,24 @@ mod unit_tests {
     fn total_ring_drops_sums_registered_channel_counters() {
         use super::{LinkAudioControl, RegisterCmd};
         use orbit_audio_native::LinkChannelActivate;
+        use orbit_link_audio::{LinkAudioOutput, LinkTempoControl};
         use std::sync::atomic::Ordering;
         use std::sync::mpsc;
+        use std::sync::Arc;
 
         let (reg_tx, _reg_rx) = rtrb::RingBuffer::<LinkChannelActivate>::new(MAX_LINK_CHANNELS);
         let (cmd_tx, cmd_rx) = mpsc::channel::<RegisterCmd>();
+        // tempo は device-free に構築できる(LinkAudioOutput::new は network discovery を起こさない)。
+        let tempo = LinkTempoControl::new(Arc::new(
+            LinkAudioOutput::new(120.0, "orbit-test").expect("create link session"),
+        ));
         let mut control = LinkAudioControl {
             reg_tx,
             cmd_tx,
             sample_rate: 48_000,
             num_channels: 2,
             registered: HashMap::new(),
+            tempo,
         };
 
         // 空集合は 0。

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -226,6 +226,16 @@ fn to_json_or_fallback<T: serde::Serialize>(v: &T) -> String {
     }
 }
 
+/// SetLinkTempo の bpm 上限（sanity bound）。Ableton Link の実用上限近辺。musical な厳密ゲートではなく、
+/// `f64::MAX` 等が `beat_per_frame` を `+Inf` に飛ばして beat 計算を壊すのを防ぐ防御的キャップ。
+const MAX_LINK_BPM: f64 = 999.0;
+
+/// SetLinkTempo の bpm を検証する（pure）。NaN / ±Inf / 非正値を弾き、`MAX_LINK_BPM` で上限を課す。
+/// 下限は付けない（遅い tempo を弾かない）。
+fn validate_bpm(bpm: f64) -> bool {
+    bpm.is_finite() && bpm > 0.0 && bpm <= MAX_LINK_BPM
+}
+
 /// Command を dispatch し、Response JSON を組み立てる。
 ///
 /// `tx` は event 送信用チャンネル（PlayEnded 等の遅延通知に使う）。
@@ -306,7 +316,7 @@ async fn handle_command(
         // 実行する Link 制約も満たす）。feature 無効ビルドは engine stub が LINK_AUDIO_UNAVAILABLE を返し
         // TS は warn-once で握り潰す。
         "SetLinkTempo" => match params.get("bpm").and_then(|p| p.as_f64()) {
-            Some(bpm) if bpm.is_finite() && bpm > 0.0 => {
+            Some(bpm) if validate_bpm(bpm) => {
                 let engine = engine.clone();
                 let res = tokio::task::spawn_blocking(move || engine.set_link_tempo(bpm)).await;
                 match res {
@@ -320,7 +330,10 @@ async fn handle_command(
             }
             _ => err(
                 &id,
-                ProtocolError::new("MALFORMED_REQUEST", "missing or non-positive 'bpm' param"),
+                ProtocolError::new(
+                    "MALFORMED_REQUEST",
+                    "missing or out-of-range 'bpm' param (0 < bpm <= 999)",
+                ),
             ),
         },
         "PlayAt" => {
@@ -573,5 +586,22 @@ mod tests {
     fn link_audio_runtime_maps_to_runtime_code() {
         let e = WrapError::LinkAudio("channel limit reached".into());
         assert_eq!(wrap_err_to_protocol(&e).code, "LINK_AUDIO_RUNTIME");
+    }
+
+    // SetLinkTempo の bpm 検証（PT-2 / CR-2）: musical な値は受理、garbage は弾く。
+    #[test]
+    fn validate_bpm_accepts_musical_range_rejects_garbage() {
+        // 受理: 一般的な範囲 + 遅い tempo（下限を付けないので 20 も valid）+ 上限ちょうど。
+        assert!(validate_bpm(120.0));
+        assert!(validate_bpm(20.0));
+        assert!(validate_bpm(MAX_LINK_BPM));
+        // 棄却: 非正値・NaN・±Inf・上限超過（Inf 伝播 / beat_per_frame overflow を防ぐ）。
+        assert!(!validate_bpm(0.0));
+        assert!(!validate_bpm(-1.0));
+        assert!(!validate_bpm(f64::NAN));
+        assert!(!validate_bpm(f64::INFINITY));
+        assert!(!validate_bpm(f64::NEG_INFINITY));
+        assert!(!validate_bpm(MAX_LINK_BPM + 1.0));
+        assert!(!validate_bpm(f64::MAX));
     }
 }

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -300,6 +300,29 @@ async fn handle_command(
                 ProtocolError::new("MALFORMED_REQUEST", "missing or empty 'channel' param"),
             ),
         },
+        // LinkAudio tempo leader: global.tempo() を Link セッションに push する（PR3・#333）。
+        // set_link_tempo は内部で captureAppSessionState（非RT・block しうる）を呼ぶので、LoadSample と
+        // 同様 spawn_blocking で tokio ワーカーを塞がない（set_tempo=app-state path は audio スレッド以外で
+        // 実行する Link 制約も満たす）。feature 無効ビルドは engine stub が LINK_AUDIO_UNAVAILABLE を返し
+        // TS は warn-once で握り潰す。
+        "SetLinkTempo" => match params.get("bpm").and_then(|p| p.as_f64()) {
+            Some(bpm) if bpm.is_finite() && bpm > 0.0 => {
+                let engine = engine.clone();
+                let res = tokio::task::spawn_blocking(move || engine.set_link_tempo(bpm)).await;
+                match res {
+                    Ok(Ok(())) => ok(&id, json!({"status": "tempo_set", "bpm": bpm})),
+                    Ok(Err(e)) => err(&id, wrap_err_to_protocol(&e)),
+                    Err(join_err) => err(
+                        &id,
+                        ProtocolError::new("INTERNAL_ERROR", join_err.to_string()),
+                    ),
+                }
+            }
+            _ => err(
+                &id,
+                ProtocolError::new("MALFORMED_REQUEST", "missing or non-positive 'bpm' param"),
+            ),
+        },
         "PlayAt" => {
             let time_sec = param_f64(&params, "time_sec", 0.0);
             let gain = param_f64(&params, "gain", 1.0) as f32;

--- a/rust/crates/orbit-link-audio/shim/orbit_link_shim.cpp
+++ b/rust/crates/orbit-link-audio/shim/orbit_link_shim.cpp
@@ -201,6 +201,8 @@ double orbit_link_session_tempo(OrbitLink* link) {
   try {
     return link->link.captureAudioSessionState().tempo();
   } catch (...) {
+    // set_tempo と対称に observability を残す(0.0 は Rust 側で 120 fallback / re-anchor skip・SF-3)。
+    std::fprintf(stderr, "[orbit-link] session_tempo failed: unknown exception\n");
     return 0.0;
   }
 }

--- a/rust/crates/orbit-link-audio/shim/orbit_link_shim.cpp
+++ b/rust/crates/orbit-link-audio/shim/orbit_link_shim.cpp
@@ -165,16 +165,21 @@ int orbit_link_commit_channel(OrbitLink* link, int32_t channel_id,
   }
 }
 
-void orbit_link_set_tempo(OrbitLink* link, double bpm) {
-  if (!link) return;
+// Link tempo を push する。戻り値 1=成功 / 0=失敗(link null or Link 例外を catch)。呼び出し側
+// (Rust)は false を runtime error に昇格し、false-positive success を返さない(silent-failure 対策)。
+int orbit_link_set_tempo(OrbitLink* link, double bpm) {
+  if (!link) return 0;
   try {
     auto state = link->link.captureAppSessionState();
     state.setTempo(bpm, link->link.clock().micros());
     link->link.commitAppSessionState(state);
+    return 1;
   } catch (const std::exception& e) {
     std::fprintf(stderr, "[orbit-link] set_tempo failed: %s\n", e.what());
+    return 0;
   } catch (...) {
     std::fprintf(stderr, "[orbit-link] set_tempo failed: unknown exception\n");
+    return 0;
   }
 }
 

--- a/rust/crates/orbit-link-audio/shim/orbit_link_shim.hpp
+++ b/rust/crates/orbit-link-audio/shim/orbit_link_shim.hpp
@@ -53,7 +53,8 @@ int orbit_link_commit_channel(OrbitLink* link, int32_t channel_id,
                               double quantum);
 
 // Link テンポリーダーとして BPM を push する(app-thread 経路・PR3 で配線)。
-void orbit_link_set_tempo(OrbitLink* link, double bpm);
+// 戻り値 1=成功 / 0=失敗(link null or Link 例外)。
+int orbit_link_set_tempo(OrbitLink* link, double bpm);
 
 // egress 開始時の beat anchor を取得する(GPL consumer thread = "audio thread" から 1 回)。
 double orbit_link_capture_beat(OrbitLink* link, double quantum);

--- a/rust/crates/orbit-link-audio/src/egress.rs
+++ b/rust/crates/orbit-link-audio/src/egress.rs
@@ -50,10 +50,36 @@ fn reconstruct_beat(
     seg_anchor_beat + produced.saturating_sub(seg_anchor_produced) as f64 * beat_per_frame
 }
 
+/// anchored 後の re-anchor 判定(pure)。`session_tempo` が `last_bpm` から有意(> [`TEMPO_EPSILON_BPM`])に
+/// 変化していれば、新 segment の起点 beat(= 今の再構成 beat・連続 carry)を `Some` で返す。変化なし /
+/// `session_tempo <= 0`(capture 例外 or 初期化前)は `None`。`capture_beat()` を呼ばず output 非依存なので、
+/// pump_once の trigger logic を device 不要で unit-test できる(PT-1)。
+#[inline]
+fn reanchor_beat_on_change(
+    seg_anchor_beat: f64,
+    seg_anchor_produced: u64,
+    beat_per_frame: f64,
+    last_bpm: f64,
+    session_tempo: f64,
+    produced: u64,
+) -> Option<f64> {
+    if session_tempo > 0.0 && (session_tempo - last_bpm).abs() > TEMPO_EPSILON_BPM {
+        Some(reconstruct_beat(
+            seg_anchor_beat,
+            seg_anchor_produced,
+            beat_per_frame,
+            produced,
+        ))
+    } else {
+        None
+    }
+}
+
 /// 1 つの channel への egress driver。**`LinkAudioOutput` は所有しない**（A4-2b-2b）: consumer
 /// thread が 1 つの `LinkAudioOutput`（Link session）を持ち、その上の複数 channel をそれぞれ本 driver
-/// で回す。`pump_once` に共有 output を `&` で渡す（commit / anchor capture / tempo poll はその output
-/// 経由）。**beat anchor は per-channel**（各 channel が自分の first-pump-with-data で capture・session
+/// で回す。`pump_once` に共有 output を `&` で渡す（commit / anchor capture はその output 経由。tempo
+/// snapshot は consumer_loop が round ごとに 1 回 `output.session_tempo()` で取得し引数で渡す）。
+/// **beat anchor は per-channel**（各 channel が自分の first-pump-with-data で capture・session
 /// 単位に hoist しない）。GPL consumer thread が所有する(`Send`)。
 pub struct LinkChannelEgress {
     consumer: rtrb::Consumer<f32>,
@@ -133,8 +159,9 @@ impl LinkChannelEgress {
     /// ring に 1 block 分溜まっていれば drain して `output` の当該 channel へ commit する。commit したら
     /// `Some(result)`、データ不足なら `None`。consumer thread が共有 `output` を `&` で渡してループで
     /// 呼ぶ(None の間は短い sleep)。`session_tempo` は consumer_loop が round ごとに 1 回読んだ snapshot
-    /// (session-global なので per-channel に読み直さない・efficiency)。<=0 は capture 失敗(shim catch)で、
-    /// 初回 anchor の fallback には使うが re-anchor の比較基準にはしない(過渡的な 0 で誤検出しない)。
+    /// (session-global なので per-channel に読み直さない・efficiency)。<=0 は capture 例外(shim が 0.0 を
+    /// 返す)または Link セッション初期化前の過渡状態で、初回 anchor の fallback には使うが re-anchor の
+    /// 比較基準にはしない(過渡的な 0 で誤検出しない)。
     pub fn pump_once(&mut self, output: &LinkAudioOutput, session_tempo: f64) -> Option<CommitResult> {
         let block_samples = self.block_frames * self.num_channels;
         if self.consumer.slots() < block_samples {
@@ -152,15 +179,16 @@ impl LinkChannelEgress {
             let bpm = if session_tempo > 0.0 { session_tempo } else { 120.0 };
             self.start_segment(output.capture_beat(self.quantum), produced, bpm);
             self.anchored = true;
-        } else if session_tempo > 0.0 && (session_tempo - self.last_bpm).abs() > TEMPO_EPSILON_BPM {
+        } else if let Some(new_anchor) = reanchor_beat_on_change(
+            self.seg_anchor_beat,
+            self.seg_anchor_produced,
+            self.beat_per_frame,
+            self.last_bpm,
+            session_tempo,
+            produced,
+        ) {
             // tempo 変更を検出 → segment を切り替える。新 segment の起点 beat は「今の再構成 beat」(連続)・
             // 起点 produced は今の produced・slope を新 tempo に。`capture_beat()` は呼ばない(連続 carry)。
-            let new_anchor = reconstruct_beat(
-                self.seg_anchor_beat,
-                self.seg_anchor_produced,
-                self.beat_per_frame,
-                produced,
-            );
             self.start_segment(new_anchor, produced, session_tempo);
         }
 
@@ -289,5 +317,39 @@ mod tests {
         // 境界後 produced=2000 → 2.0 + 1000*0.001 = 3.0(旧 slope なら 2.0+1000*0.002=4.0)。
         let after = reconstruct_beat(seg2_beat, seg2_prod, bpf2, 2000);
         assert!((after - 3.0).abs() < 1e-9, "after={after}");
+    }
+
+    #[test]
+    fn reanchor_decision_sequence_anchor_steady_change_drop() {
+        // pump_once の re-anchor trigger logic(else-if 分岐)を pure helper 経由で device 不要に検証(PT-1)。
+        // anchored 済み(seg=0, produced=0, last_bpm=120)を起点に steady → 変更 → 微小変化 → capture 例外。
+        let sr = 48_000u32;
+        let bpf120 = (120.0 / 60.0) / sr as f64;
+
+        // steady（同 tempo）→ re-anchor しない。
+        assert_eq!(
+            reanchor_beat_on_change(0.0, 0, bpf120, 120.0, 120.0, 4800),
+            None
+        );
+        // tempo 変更(120→140) → Some(今の再構成 beat = 連続点)。
+        let at_change = reconstruct_beat(0.0, 0, bpf120, 4800);
+        assert_eq!(
+            reanchor_beat_on_change(0.0, 0, bpf120, 120.0, 140.0, 4800),
+            Some(at_change)
+        );
+        // epsilon 未満の揺れ → None（浮動小数ノイズで誤検出しない）。
+        assert_eq!(
+            reanchor_beat_on_change(0.0, 0, bpf120, 120.0, 120.0 + 1e-9, 4800),
+            None
+        );
+        // session_tempo<=0（capture 例外 or 初期化前）→ None（誤検出しない）。
+        assert_eq!(
+            reanchor_beat_on_change(0.0, 0, bpf120, 120.0, 0.0, 4800),
+            None
+        );
+        assert_eq!(
+            reanchor_beat_on_change(0.0, 0, bpf120, 120.0, -1.0, 4800),
+            None
+        );
     }
 }

--- a/rust/crates/orbit-link-audio/src/egress.rs
+++ b/rust/crates/orbit-link-audio/src/egress.rs
@@ -13,8 +13,10 @@
 //! 🔴 tempo-change re-anchor(PR3 / advisor): `beats_at_begin` は **共有 Link セッションの時間軸**に
 //! 乗るので、session tempo が変わると beat/frame 換算(`beat_per_frame`)が古くなり drift する。Link は
 //! last-setter-wins で **自分の tempo push も他ピア(Ableton 等)の変更も** session tempo に現れるため、
-//! consumer が毎 pump で `session_tempo()` を poll し、変化を検出したら segment を切り替える(poll-based:
-//! 自分の push 時のみ re-anchor する explicit を包含し、control→consumer の同期配線も要らない)。
+//! consumer_loop が round ごとに `session_tempo()` を 1 回読み(session-global な値を per-channel に N 回
+//! 読まない・efficiency)、各 channel の `pump_once` がそれを `last_bpm` と比較して変化を検出したら segment
+//! を切り替える(poll-based: 自分の push 時のみ re-anchor する explicit を包含し、control→consumer の同期
+//! 配線も要らない)。
 //! 切り替えでは **`capture_beat()` を再呼びしない**(再 sample すると ring latency 位相誤差を再導入する)。
 //! 代わりに segment baseline(`seg_anchor_beat` / `seg_anchor_produced` / `beat_per_frame`)を「今の
 //! 再構成 beat」へ連続 carry し、slope(`beat_per_frame`)だけを新 tempo に更新する(piecewise-linear)。
@@ -118,10 +120,22 @@ impl LinkChannelEgress {
         (bpm / 60.0) / self.sample_rate as f64
     }
 
+    /// segment baseline(起点 beat / 起点 produced / slope / last_bpm)を一括設定する。初回 anchor と
+    /// tempo 変更時の re-anchor で共有し、「segment とは何か」を 1 箇所に集約する(simplification)。
+    #[inline]
+    fn start_segment(&mut self, anchor_beat: f64, produced: u64, bpm: f64) {
+        self.seg_anchor_beat = anchor_beat;
+        self.seg_anchor_produced = produced;
+        self.beat_per_frame = self.beat_per_frame_for(bpm);
+        self.last_bpm = bpm;
+    }
+
     /// ring に 1 block 分溜まっていれば drain して `output` の当該 channel へ commit する。commit したら
     /// `Some(result)`、データ不足なら `None`。consumer thread が共有 `output` を `&` で渡してループで
-    /// 呼ぶ(None の間は短い sleep)。
-    pub fn pump_once(&mut self, output: &LinkAudioOutput) -> Option<CommitResult> {
+    /// 呼ぶ(None の間は短い sleep)。`session_tempo` は consumer_loop が round ごとに 1 回読んだ snapshot
+    /// (session-global なので per-channel に読み直さない・efficiency)。<=0 は capture 失敗(shim catch)で、
+    /// 初回 anchor の fallback には使うが re-anchor の比較基準にはしない(過渡的な 0 で誤検出しない)。
+    pub fn pump_once(&mut self, output: &LinkAudioOutput, session_tempo: f64) -> Option<CommitResult> {
         let block_samples = self.block_frames * self.num_channels;
         if self.consumer.slots() < block_samples {
             return None;
@@ -132,32 +146,22 @@ impl LinkChannelEgress {
         let dropped = self.drops.load(Ordering::Relaxed);
         let produced = produced_frames(self.drained_frames, dropped, self.num_channels);
 
-        // 現在の session tempo(captureAudioSessionState・lock-free・audio スレッド)。last-setter-wins
-        // なので自分の push も他ピアの変更もここに現れる。<=0 は capture 失敗(shim catch)で、初回 anchor の
-        // fallback には使うが re-anchor の比較基準にはしない(過渡的な 0 で誤検出しない)。
-        let tempo = output.session_tempo();
-
         if !self.anchored {
             // egress 開始時に anchor(beat)を 1 回だけ capture。以後 `capture_beat()` は二度と呼ばない
-            // (ring latency 位相誤差の再導入を避ける・advisor)。
-            let bpm = if tempo > 0.0 { tempo } else { 120.0 };
-            self.seg_anchor_beat = output.capture_beat(self.quantum);
-            self.seg_anchor_produced = produced;
-            self.beat_per_frame = self.beat_per_frame_for(bpm);
-            self.last_bpm = bpm;
+            // (ring latency 位相誤差の再導入を避ける・advisor)。session_tempo<=0 は fallback 120。
+            let bpm = if session_tempo > 0.0 { session_tempo } else { 120.0 };
+            self.start_segment(output.capture_beat(self.quantum), produced, bpm);
             self.anchored = true;
-        } else if tempo > 0.0 && (tempo - self.last_bpm).abs() > TEMPO_EPSILON_BPM {
+        } else if session_tempo > 0.0 && (session_tempo - self.last_bpm).abs() > TEMPO_EPSILON_BPM {
             // tempo 変更を検出 → segment を切り替える。新 segment の起点 beat は「今の再構成 beat」(連続)・
             // 起点 produced は今の produced・slope を新 tempo に。`capture_beat()` は呼ばない(連続 carry)。
-            self.seg_anchor_beat = reconstruct_beat(
+            let new_anchor = reconstruct_beat(
                 self.seg_anchor_beat,
                 self.seg_anchor_produced,
                 self.beat_per_frame,
                 produced,
             );
-            self.seg_anchor_produced = produced;
-            self.beat_per_frame = self.beat_per_frame_for(tempo);
-            self.last_bpm = tempo;
+            self.start_segment(new_anchor, produced, session_tempo);
         }
 
         let beats_at_begin = reconstruct_beat(

--- a/rust/crates/orbit-link-audio/src/egress.rs
+++ b/rust/crates/orbit-link-audio/src/egress.rs
@@ -9,11 +9,24 @@
 //! とすることで、producer-side の ring drop が起きても後続 block の beat が producer の真の位置を追い、
 //! 永久 beat desync(drained-only だと drop 分だけ恒久的に遅れる)を防ぐ。drop は「音の gap」になるだけ。
 //! per-block の "now"(clock().micros())は使わない(ring latency 分の位相ずれを避ける)。
+//!
+//! 🔴 tempo-change re-anchor(PR3 / advisor): `beats_at_begin` は **共有 Link セッションの時間軸**に
+//! 乗るので、session tempo が変わると beat/frame 換算(`beat_per_frame`)が古くなり drift する。Link は
+//! last-setter-wins で **自分の tempo push も他ピア(Ableton 等)の変更も** session tempo に現れるため、
+//! consumer が毎 pump で `session_tempo()` を poll し、変化を検出したら segment を切り替える(poll-based:
+//! 自分の push 時のみ re-anchor する explicit を包含し、control→consumer の同期配線も要らない)。
+//! 切り替えでは **`capture_beat()` を再呼びしない**(再 sample すると ring latency 位相誤差を再導入する)。
+//! 代わりに segment baseline(`seg_anchor_beat` / `seg_anchor_produced` / `beat_per_frame`)を「今の
+//! 再構成 beat」へ連続 carry し、slope(`beat_per_frame`)だけを新 tempo に更新する(piecewise-linear)。
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use crate::{CommitResult, LinkAudioOutput};
+
+/// tempo 変化検出の閾値(BPM)。Link の tempo は set 間で安定なので小さな epsilon で十分。
+/// 浮動小数の往復誤差で毎 block re-anchor しないための下限。
+const TEMPO_EPSILON_BPM: f64 = 1e-6;
 
 /// produced frame 数 = drain した frame + producer-side で drop された frame。
 /// drop(`dropped_samples` = interleaved サンプル単位)を frame に直して算入する。
@@ -22,18 +35,24 @@ fn produced_frames(drained_frames: u64, dropped_samples: u64, num_channels: usiz
     drained_frames + dropped_samples / (num_channels as u64).max(1)
 }
 
-/// buffer-begin の beat を線形再構成する。per-block の "now" を使わず anchor + produced-frames で
-/// 決定論的に求める(ring latency 非依存)。
+/// segment baseline から buffer-begin の beat を線形再構成する。per-block の "now" を使わず
+/// `seg_anchor_beat + (produced - seg_anchor_produced) * beat_per_frame` で決定論的に求める
+/// (ring latency 非依存)。tempo 変更時は segment を更新して境界で beat 連続・slope だけ変える。
 #[inline]
-fn reconstruct_beat(anchor_beat: f64, beat_per_frame: f64, produced_frames: u64) -> f64 {
-    anchor_beat + produced_frames as f64 * beat_per_frame
+fn reconstruct_beat(
+    seg_anchor_beat: f64,
+    seg_anchor_produced: u64,
+    beat_per_frame: f64,
+    produced: u64,
+) -> f64 {
+    seg_anchor_beat + produced.saturating_sub(seg_anchor_produced) as f64 * beat_per_frame
 }
 
 /// 1 つの channel への egress driver。**`LinkAudioOutput` は所有しない**（A4-2b-2b）: consumer
 /// thread が 1 つの `LinkAudioOutput`（Link session）を持ち、その上の複数 channel をそれぞれ本 driver
-/// で回す。`pump_once` に共有 output を `&` で渡す（commit / anchor capture はその output 経由）。
-/// **beat anchor は per-channel**（各 channel が自分の first-pump-with-data で capture・session 単位に
-/// hoist しない）。GPL consumer thread が所有する(`Send`)。
+/// で回す。`pump_once` に共有 output を `&` で渡す（commit / anchor capture / tempo poll はその output
+/// 経由）。**beat anchor は per-channel**（各 channel が自分の first-pump-with-data で capture・session
+/// 単位に hoist しない）。GPL consumer thread が所有する(`Send`)。
 pub struct LinkChannelEgress {
     consumer: rtrb::Consumer<f32>,
     /// native の RingTapSink が producer-side で drop した **interleaved サンプル数**(累積)。
@@ -46,10 +65,18 @@ pub struct LinkChannelEgress {
     block_frames: usize,
     /// pre-alloc した block バッファ(block_frames * num_channels)。RT 外だが alloc を毎回避ける。
     scratch: Vec<f32>,
-    // --- beat anchor(この channel の最初の pump で 1 回 capture・per-channel)---
+    // --- beat anchor(segment baseline・poll-based re-anchor・PR3)---
+    // 初回 pump で 1 回だけ `capture_beat()`。以降の tempo 変更(自分の push / 他ピア・last-setter-wins)は
+    // `session_tempo()` の poll で検出し、`capture_beat()` を再呼びせず segment を連続 carry する。
     anchored: bool,
-    anchor_beat: f64,
+    /// 現 segment の起点 beat。
+    seg_anchor_beat: f64,
+    /// 現 segment 起点での produced-frames。`beat = seg_anchor_beat + (produced -
+    /// seg_anchor_produced) * beat_per_frame`。
+    seg_anchor_produced: u64,
     beat_per_frame: f64,
+    /// 直近に観測した有効 session BPM(変化検出用)。
+    last_bpm: f64,
     /// この consumer が drain した frame 数(累積)。
     drained_frames: u64,
 }
@@ -77,10 +104,18 @@ impl LinkChannelEgress {
             block_frames,
             scratch: vec![0.0; block_frames * num_channels],
             anchored: false,
-            anchor_beat: 0.0,
+            seg_anchor_beat: 0.0,
+            seg_anchor_produced: 0,
             beat_per_frame: 0.0,
+            last_bpm: 0.0,
             drained_frames: 0,
         }
+    }
+
+    /// 指定 BPM から beat/frame 換算(beat_per_frame = (bpm/60)/sr)を求める。
+    #[inline]
+    fn beat_per_frame_for(&self, bpm: f64) -> f64 {
+        (bpm / 60.0) / self.sample_rate as f64
     }
 
     /// ring に 1 block 分溜まっていれば drain して `output` の当該 channel へ commit する。commit したら
@@ -92,20 +127,45 @@ impl LinkChannelEgress {
             return None;
         }
 
-        // この channel の egress 開始時に anchor(beat + tempo)を 1 回だけ capture。以後は frame から
-        // 再構成する(per-channel: channel ごとに登録時刻が違うので anchor も channel 固有)。
-        if !self.anchored {
-            self.anchor_beat = output.capture_beat(self.quantum);
-            let tempo = output.session_tempo();
-            let bpm = if tempo > 0.0 { tempo } else { 120.0 };
-            self.beat_per_frame = (bpm / 60.0) / self.sample_rate as f64;
-            self.anchored = true;
-        }
-
-        // この block の先頭時点の produced-frames から beat を決定論再構成(drop 算入)。
+        // この block 先頭時点の produced-frames(drop 算入)。anchor / re-anchor / commit すべてで同一値を
+        // 使う(between-call の drop 増加で beat がずれないように 1 回だけ load する)。
         let dropped = self.drops.load(Ordering::Relaxed);
         let produced = produced_frames(self.drained_frames, dropped, self.num_channels);
-        let beats_at_begin = reconstruct_beat(self.anchor_beat, self.beat_per_frame, produced);
+
+        // 現在の session tempo(captureAudioSessionState・lock-free・audio スレッド)。last-setter-wins
+        // なので自分の push も他ピアの変更もここに現れる。<=0 は capture 失敗(shim catch)で、初回 anchor の
+        // fallback には使うが re-anchor の比較基準にはしない(過渡的な 0 で誤検出しない)。
+        let tempo = output.session_tempo();
+
+        if !self.anchored {
+            // egress 開始時に anchor(beat)を 1 回だけ capture。以後 `capture_beat()` は二度と呼ばない
+            // (ring latency 位相誤差の再導入を避ける・advisor)。
+            let bpm = if tempo > 0.0 { tempo } else { 120.0 };
+            self.seg_anchor_beat = output.capture_beat(self.quantum);
+            self.seg_anchor_produced = produced;
+            self.beat_per_frame = self.beat_per_frame_for(bpm);
+            self.last_bpm = bpm;
+            self.anchored = true;
+        } else if tempo > 0.0 && (tempo - self.last_bpm).abs() > TEMPO_EPSILON_BPM {
+            // tempo 変更を検出 → segment を切り替える。新 segment の起点 beat は「今の再構成 beat」(連続)・
+            // 起点 produced は今の produced・slope を新 tempo に。`capture_beat()` は呼ばない(連続 carry)。
+            self.seg_anchor_beat = reconstruct_beat(
+                self.seg_anchor_beat,
+                self.seg_anchor_produced,
+                self.beat_per_frame,
+                produced,
+            );
+            self.seg_anchor_produced = produced;
+            self.beat_per_frame = self.beat_per_frame_for(tempo);
+            self.last_bpm = tempo;
+        }
+
+        let beats_at_begin = reconstruct_beat(
+            self.seg_anchor_beat,
+            self.seg_anchor_produced,
+            self.beat_per_frame,
+            produced,
+        );
 
         // ring から 1 block 分を scratch へコピー(chunk は self.consumer のみ借用・scratch は別 field)。
         {
@@ -149,12 +209,12 @@ mod tests {
 
     #[test]
     fn reconstruct_beat_is_linear_and_monotonic() {
-        // anchor=4.0, bpf=0.001 → produced=1000 で +1.0 = 5.0。
-        assert!((reconstruct_beat(4.0, 0.001, 1000) - 5.0).abs() < 1e-9);
-        // produced=0 で anchor そのもの。
-        assert!((reconstruct_beat(4.0, 0.001, 0) - 4.0).abs() < 1e-9);
+        // seg_anchor_beat=4.0, seg_anchor_produced=0, bpf=0.001 → produced=1000 で +1.0 = 5.0。
+        assert!((reconstruct_beat(4.0, 0, 0.001, 1000) - 5.0).abs() < 1e-9);
+        // produced=seg_anchor_produced で anchor そのもの。
+        assert!((reconstruct_beat(4.0, 0, 0.001, 0) - 4.0).abs() < 1e-9);
         // 単調増加。
-        assert!(reconstruct_beat(0.0, 0.001, 2000) > reconstruct_beat(0.0, 0.001, 1000));
+        assert!(reconstruct_beat(0.0, 0, 0.001, 2000) > reconstruct_beat(0.0, 0, 0.001, 1000));
     }
 
     #[test]
@@ -165,10 +225,10 @@ mod tests {
         let anchor = 0.0;
         let nch = 2;
         // block1: drained=512(256f), drop=0 → produced=256 → beat=0.256。
-        let b1 = reconstruct_beat(anchor, bpf, produced_frames(256, 0, nch));
+        let b1 = reconstruct_beat(anchor, 0, bpf, produced_frames(256, 0, nch));
         // この後 producer が 512 sample(256f)drop。block2: drained=512(256f), drop=512 →
         // produced=256+256=512 → beat=0.512。drained-only だと 0.256 のままで desync する。
-        let b2 = reconstruct_beat(anchor, bpf, produced_frames(256, 512, nch));
+        let b2 = reconstruct_beat(anchor, 0, bpf, produced_frames(256, 512, nch));
         assert!((b1 - 0.256).abs() < 1e-9, "b1={b1}");
         assert!(
             (b2 - 0.512).abs() < 1e-9,
@@ -176,5 +236,54 @@ mod tests {
         );
         // drop 分だけ beat が前進している(gap を埋めるのでなく真の位置を追う)。
         assert!((b2 - b1 - 0.256).abs() < 1e-9);
+    }
+
+    #[test]
+    fn reanchor_is_beat_continuous_and_changes_slope() {
+        // advisor の load-bearing detail: tempo 変更時の re-anchor は境界で beat 連続・slope だけ変える
+        // (capture_beat() を再呼びしない連続 carry)。
+        // segment1: anchor_beat=0, anchor_produced=0, bpf=0.001。produced=1000 → beat=1.0。
+        let bpf1 = 0.001;
+        let (seg1_beat, seg1_prod) = (0.0_f64, 0_u64);
+        let at_change = reconstruct_beat(seg1_beat, seg1_prod, bpf1, 1000);
+        assert!((at_change - 1.0).abs() < 1e-9);
+
+        // tempo 2x → bpf2 = 0.002。re-anchor: seg2_beat = at_change(連続), seg2_prod=1000。
+        let bpf2 = 0.002;
+        let (seg2_beat, seg2_prod) = (at_change, 1000_u64);
+
+        // 境界(produced=1000)で連続: 新 segment でも同じ beat。
+        let at_boundary_new = reconstruct_beat(seg2_beat, seg2_prod, bpf2, 1000);
+        assert!(
+            (at_boundary_new - at_change).abs() < 1e-9,
+            "境界で beat が不連続: {at_boundary_new} != {at_change}"
+        );
+
+        // 境界後 produced=1500 → beat = 1.0 + 500*0.002 = 2.0(新 slope)。
+        let after = reconstruct_beat(seg2_beat, seg2_prod, bpf2, 1500);
+        assert!((after - 2.0).abs() < 1e-9, "after={after}");
+
+        // 旧 slope のままなら 1.0 + 500*0.001 = 1.5 だったはず → slope が変わっている。
+        let old_slope_would_be = reconstruct_beat(seg1_beat, seg1_prod, bpf1, 1500);
+        assert!((old_slope_would_be - 1.5).abs() < 1e-9);
+        assert!(
+            after > old_slope_would_be,
+            "tempo 増で slope が増えていない: after={after} old={old_slope_would_be}"
+        );
+    }
+
+    #[test]
+    fn reanchor_slowdown_reduces_slope_but_keeps_continuity() {
+        // 減速側(tempo 半分)。境界連続 + slope 減少を確認。
+        let bpf1 = 0.002;
+        let (seg1_beat, seg1_prod) = (0.0_f64, 0_u64);
+        let at_change = reconstruct_beat(seg1_beat, seg1_prod, bpf1, 1000); // 2.0
+        let bpf2 = 0.001;
+        let (seg2_beat, seg2_prod) = (at_change, 1000_u64);
+        // 連続。
+        assert!((reconstruct_beat(seg2_beat, seg2_prod, bpf2, 1000) - at_change).abs() < 1e-9);
+        // 境界後 produced=2000 → 2.0 + 1000*0.001 = 3.0(旧 slope なら 2.0+1000*0.002=4.0)。
+        let after = reconstruct_beat(seg2_beat, seg2_prod, bpf2, 2000);
+        assert!((after - 3.0).abs() < 1e-9, "after={after}");
     }
 }

--- a/rust/crates/orbit-link-audio/src/lib.rs
+++ b/rust/crates/orbit-link-audio/src/lib.rs
@@ -105,6 +105,8 @@ pub struct LinkAudioOutput {
 //     daemon 側の **呼び出し規律**で disjoint 性を守る: `session_tempo` は consumer(audio) thread の
 //     consumer_loop が round ごとに 1 回 / `register_channel` は consumer thread / `set_enabled` は
 //     consumer thread spawn 前の control から(いずれも audio session state と競合しない)。
+//   - `num_peers` (= numPeers・Thread-safe:yes) は session state path に属さず任意スレッドから安全
+//     (state を触らない standard Link API・現状 test のみが呼ぶ)。
 // よって app-state path と audio-state path は常に別スレッドから呼ばれ Link が内部で同期する。
 unsafe impl Send for LinkAudioOutput {}
 unsafe impl Sync for LinkAudioOutput {}

--- a/rust/crates/orbit-link-audio/src/lib.rs
+++ b/rust/crates/orbit-link-audio/src/lib.rs
@@ -50,7 +50,7 @@ extern "C" {
         beats_at_begin: f64,
         quantum: f64,
     ) -> c_int;
-    fn orbit_link_set_tempo(link: *mut OrbitLinkRaw, bpm: f64);
+    fn orbit_link_set_tempo(link: *mut OrbitLinkRaw, bpm: f64) -> c_int;
     fn orbit_link_capture_beat(link: *mut OrbitLinkRaw, quantum: f64) -> f64;
     fn orbit_link_session_tempo(link: *mut OrbitLinkRaw) -> f64;
 }
@@ -91,15 +91,21 @@ pub struct LinkAudioOutput {
 }
 
 // SAFETY (Send): 構築スレッドから GPL consumer thread へ move して使う。
-// SAFETY (Sync): PR3 で `Arc<LinkAudioOutput>` を control スレッドと consumer=audio
-// スレッドで共有する。アクセスは Ableton Link の thread モデルに従い disjoint:
-//   - app-state path (`set_tempo` = captureAppSessionState・内部 mutex) は control
-//     スレッド(spawn_blocking)から・[`LinkTempoControl`] 経由のみ。
-//   - audio-state path (`commit_channel` / `capture_beat` / `session_tempo` =
-//     captureAudioSessionState・単一 audio スレッド専用) は consumer スレッドから。
-// 両 path は別スレッドから呼ばれ Link が内部で同期する。control 側は
-// [`LinkTempoControl`] newtype で audio-state メソッドに型レベルで到達できない
-// (`set_tempo` は `pub(crate)`・newtype のみが委譲呼び出しする)。
+// SAFETY (Sync): PR3 で `Arc<LinkAudioOutput>` を control スレッドと consumer=audio スレッドで
+// 共有する。同時アクセスが起きないことが不変条件で、Ableton Link の thread モデルに従い path を
+// disjoint なスレッドへ分離して担保する:
+//   - app-state path (`set_tempo` = captureAppSessionState・内部 mutex で Thread-safe:yes) は
+//     control スレッド(spawn_blocking)から。`set_tempo` は `pub(crate)` で [`LinkTempoControl`]
+//     経由のみ到達でき、これは **型レベルで保証**される。
+//   - audio-state path のうち `commit_channel` / `capture_beat` (= captureAudioSessionState・
+//     Thread-safe:no・単一 audio スレッド専用) は `pub(crate)` で本 crate(egress.rs)内からのみ
+//     呼べる(型レベルで cross-crate を締める)。
+//   - `session_tempo` (= captureAudioSessionState・Thread-safe:no) と `register_channel` /
+//     `set_enabled` は **cross-crate で daemon が呼ぶため `pub`**。これらは型では締められず、
+//     daemon 側の **呼び出し規律**で disjoint 性を守る: `session_tempo` は consumer(audio) thread の
+//     consumer_loop が round ごとに 1 回 / `register_channel` は consumer thread / `set_enabled` は
+//     consumer thread spawn 前の control から(いずれも audio session state と競合しない)。
+// よって app-state path と audio-state path は常に別スレッドから呼ばれ Link が内部で同期する。
 unsafe impl Send for LinkAudioOutput {}
 unsafe impl Sync for LinkAudioOutput {}
 
@@ -146,8 +152,9 @@ impl LinkAudioOutput {
     /// interleaved f32 の 1 ブロックを channel に commit する。`beats_at_begin` は呼び出し側
     /// (GPL consumer thread)が cumulative-frames から決定論再構成した buffer-begin の beat 位置
     /// (ring latency 分の位相ずれを避けるため shim 内では "now" から計算しない・A4-2b-2)。
+    /// audio-state path(captureAudioSessionState)なので `pub(crate)`＝egress.rs からのみ呼ぶ。
     #[allow(clippy::too_many_arguments)]
-    pub fn commit_channel(
+    pub(crate) fn commit_channel(
         &self,
         channel_id: i32,
         interleaved: &[f32],
@@ -193,17 +200,20 @@ impl LinkAudioOutput {
         }
     }
 
-    /// Link テンポリーダーとして BPM を push する。内部で `captureAppSessionState`
+    /// Link テンポリーダーとして BPM を push する。成功 `true` / 失敗 `false`(shim 内で link null or
+    /// Link 例外を catch・実質起きない)。呼び出し側は `false` を runtime error に昇格して
+    /// false-positive success を避ける(silent-failure 対策)。内部で `captureAppSessionState`
     /// (非RT・block しうる)を呼ぶので audio スレッド以外から呼ぶこと。control 側は
     /// [`LinkTempoControl`] 経由でのみ到達する(`pub(crate)`)。
-    pub(crate) fn set_tempo(&self, bpm: f64) {
-        // SAFETY: raw は valid。
-        unsafe { orbit_link_set_tempo(self.raw, bpm) };
+    pub(crate) fn set_tempo(&self, bpm: f64) -> bool {
+        // SAFETY: raw は valid。shim は 1=成功 / 0=失敗。
+        unsafe { orbit_link_set_tempo(self.raw, bpm) == 1 }
     }
 
     /// egress 開始時の beat anchor を取得する(quantum 指定)。GPL consumer thread
     /// (= Link "audio thread")から 1 回だけ呼ぶ。以後は cumulative-frames から線形再構成する。
-    pub fn capture_beat(&self, quantum: f64) -> f64 {
+    /// audio-state path(captureAudioSessionState)なので `pub(crate)`＝egress.rs からのみ呼ぶ。
+    pub(crate) fn capture_beat(&self, quantum: f64) -> f64 {
         // SAFETY: raw は valid。
         unsafe { orbit_link_capture_beat(self.raw, quantum) }
     }
@@ -242,11 +252,11 @@ impl LinkTempoControl {
         Self { output }
     }
 
-    /// Link セッションに BPM を push し OrbitScore を tempo leader にする。
-    /// `captureAppSessionState`(非RT・block しうる)を内部で呼ぶので、呼び出し側は
-    /// audio スレッド以外(spawn_blocking 等)で実行すること。
-    pub fn set_tempo(&self, bpm: f64) {
-        self.output.set_tempo(bpm);
+    /// Link セッションに BPM を push し OrbitScore を tempo leader にする。成功 `true` / 失敗 `false`
+    /// (shim 内で Link 例外を catch・実質起きない)。`captureAppSessionState`(非RT・block しうる)を
+    /// 内部で呼ぶので、呼び出し側は audio スレッド以外(spawn_blocking 等)で実行すること。
+    pub fn set_tempo(&self, bpm: f64) -> bool {
+        self.output.set_tempo(bpm)
     }
 }
 
@@ -281,7 +291,7 @@ mod tests {
         let rc_bad = out.commit_channel(99, &silence, 256, 2, 48_000, 0.0, 4.0);
         assert_eq!(rc_bad, CommitResult::ChannelNotFound);
 
-        out.set_tempo(124.0);
+        assert!(out.set_tempo(124.0), "set_tempo は no-peer でも commit 成功する");
         // drop で teardown。
     }
 

--- a/rust/crates/orbit-link-audio/src/lib.rs
+++ b/rust/crates/orbit-link-audio/src/lib.rs
@@ -14,6 +14,7 @@
 
 use std::ffi::{CString, NulError};
 use std::os::raw::{c_char, c_int};
+use std::sync::Arc;
 
 mod egress;
 pub use egress::LinkChannelEgress;
@@ -82,15 +83,25 @@ pub enum CommitResult {
 
 /// 1 つの Ableton Link セッションと、その上の名前付き出力 channel 群。
 ///
-/// `Send`: 構築スレッドから GPL consumer thread へ move して使う想定。`!Sync`
-/// (内部の Link 状態は単一スレッドからのみ触る)。
+/// `Send + Sync`: PR3 以降 `Arc<LinkAudioOutput>` を control スレッド(tempo push)と
+/// consumer=audio スレッド(egress)で共有する。Link の thread モデルに従い app-state
+/// path と audio-state path を disjoint なスレッドから呼ぶ(下の `unsafe impl` 参照)。
 pub struct LinkAudioOutput {
     raw: *mut OrbitLinkRaw,
 }
 
-// SAFETY: `raw` は単一の所有者(本 struct)を通じてのみアクセスされ、構築後に
-// consumer thread へ move される。複数スレッドからの同時アクセスは行わない。
+// SAFETY (Send): 構築スレッドから GPL consumer thread へ move して使う。
+// SAFETY (Sync): PR3 で `Arc<LinkAudioOutput>` を control スレッドと consumer=audio
+// スレッドで共有する。アクセスは Ableton Link の thread モデルに従い disjoint:
+//   - app-state path (`set_tempo` = captureAppSessionState・内部 mutex) は control
+//     スレッド(spawn_blocking)から・[`LinkTempoControl`] 経由のみ。
+//   - audio-state path (`commit_channel` / `capture_beat` / `session_tempo` =
+//     captureAudioSessionState・単一 audio スレッド専用) は consumer スレッドから。
+// 両 path は別スレッドから呼ばれ Link が内部で同期する。control 側は
+// [`LinkTempoControl`] newtype で audio-state メソッドに型レベルで到達できない
+// (`set_tempo` は `pub(crate)`・newtype のみが委譲呼び出しする)。
 unsafe impl Send for LinkAudioOutput {}
+unsafe impl Sync for LinkAudioOutput {}
 
 impl LinkAudioOutput {
     /// 指定 BPM と peer 名で Link セッションを生成する。
@@ -182,8 +193,10 @@ impl LinkAudioOutput {
         }
     }
 
-    /// Link テンポリーダーとして BPM を push する(PR3 で配線)。
-    pub fn set_tempo(&self, bpm: f64) {
+    /// Link テンポリーダーとして BPM を push する。内部で `captureAppSessionState`
+    /// (非RT・block しうる)を呼ぶので audio スレッド以外から呼ぶこと。control 側は
+    /// [`LinkTempoControl`] 経由でのみ到達する(`pub(crate)`)。
+    pub(crate) fn set_tempo(&self, bpm: f64) {
         // SAFETY: raw は valid。
         unsafe { orbit_link_set_tempo(self.raw, bpm) };
     }
@@ -204,8 +217,36 @@ impl LinkAudioOutput {
 
 impl Drop for LinkAudioOutput {
     fn drop(&mut self) {
-        // SAFETY: raw は valid で、本 struct が唯一の所有者。二重解放はしない。
+        // SAFETY: raw は valid で、本 struct が唯一の所有者。`Arc<LinkAudioOutput>` で
+        // 共有しても drop は最後の Arc が落ちた時に 1 回だけ走る(二重解放はしない)。
+        // `orbit_link_destroy` は app-side cleanup(enable(false)+delete)で audio スレッド
+        // 要件が無いため、最後の Arc が consumer 以外のスレッドで落ちても安全(PR3・advisor)。
         unsafe { orbit_link_destroy(self.raw) };
+    }
+}
+
+/// Link tempo leader の control-side ハンドル(PR3・論点1 案A + newtype)。
+///
+/// `set_tempo` だけを公開し、audio-state メソッド(commit / capture_beat / session_tempo)を
+/// 型レベルで隠蔽する。daemon の control スレッド(WS handler を spawn_blocking で隔離)が
+/// 保持し、consumer=audio スレッドが持つ `Arc<LinkAudioOutput>` と同一 Link セッションを
+/// 共有する。これにより control から audio-state path を誤って呼べない(thread role の
+/// disjoint 性を型で担保する)。
+pub struct LinkTempoControl {
+    output: Arc<LinkAudioOutput>,
+}
+
+impl LinkTempoControl {
+    /// consumer と同一 session を指す `Arc` から control ハンドルを作る。
+    pub fn new(output: Arc<LinkAudioOutput>) -> Self {
+        Self { output }
+    }
+
+    /// Link セッションに BPM を push し OrbitScore を tempo leader にする。
+    /// `captureAppSessionState`(非RT・block しうる)を内部で呼ぶので、呼び出し側は
+    /// audio スレッド以外(spawn_blocking 等)で実行すること。
+    pub fn set_tempo(&self, bpm: f64) {
+        self.output.set_tempo(bpm);
     }
 }
 

--- a/rust/crates/orbit-link-audio/src/lib.rs
+++ b/rust/crates/orbit-link-audio/src/lib.rs
@@ -349,7 +349,7 @@ mod tests {
         for _ in 0..400 {
             let block = vec![0.2f32; 256 * 2];
             let _ = prod.push_partial_slice(&block);
-            let _ = egress.pump_once(&sender);
+            let _ = egress.pump_once(&sender, sender.session_tempo());
             got = recv.count();
             if got > 0 {
                 break;

--- a/tests/audio/rust-engine/daemon-client.spec.ts
+++ b/tests/audio/rust-engine/daemon-client.spec.ts
@@ -140,6 +140,32 @@ describe('DaemonClient with mock server', () => {
     })
   })
 
+  it('SetLinkTempo は bpm を params に送って resolve する', async () => {
+    const url = await server.start({
+      SetLinkTempo: () => ({ status: 'accepted' }),
+    })
+    await client.start({ wsUrlOverride: url })
+    await expect(client.setLinkTempo(120)).resolves.toBeUndefined()
+    const rec = server.received.find((r) => r.method === 'SetLinkTempo')
+    expect(rec?.params.bpm).toBe(120)
+  })
+
+  it('SetLinkTempo の LINK_AUDIO_UNAVAILABLE は DaemonProtocolError に変換される', async () => {
+    const url = await server.start({
+      SetLinkTempo: () => {
+        const e = new Error('engine built without link-audio feature') as Error & {
+          code?: string
+        }
+        e.code = 'LINK_AUDIO_UNAVAILABLE'
+        throw e
+      },
+    })
+    await client.start({ wsUrlOverride: url })
+    await expect(client.setLinkTempo(120)).rejects.toMatchObject({
+      code: 'LINK_AUDIO_UNAVAILABLE',
+    })
+  })
+
   it('error レスポンスは DaemonProtocolError に変換される', async () => {
     const url = await server.start({
       SetGlobalGain: () => {

--- a/tests/audio/rust-engine/mock-daemon-server.ts
+++ b/tests/audio/rust-engine/mock-daemon-server.ts
@@ -29,6 +29,7 @@ export interface MockDaemonHandlers {
   StopAll?: MockHandler
   SetGlobalGain?: MockHandler
   RegisterLinkAudioChannel?: MockHandler
+  SetLinkTempo?: MockHandler
   GetStatus?: MockHandler
 }
 

--- a/tests/audio/rust-engine/rust-engine-player.spec.ts
+++ b/tests/audio/rust-engine/rust-engine-player.spec.ts
@@ -62,6 +62,11 @@ function defaultHandlers(overrides: MockDaemonHandlers = {}): MockDaemonHandlers
         code: 'LINK_AUDIO_UNAVAILABLE',
       })
     },
+    SetLinkTempo: () => {
+      throw Object.assign(new Error('mock daemon built without link-audio feature'), {
+        code: 'LINK_AUDIO_UNAVAILABLE',
+      })
+    },
     ...overrides,
   }
 }
@@ -369,6 +374,45 @@ describe('RustEnginePlayer with mock daemon', () => {
     const gapWarns = warn.mock.calls.filter((c) =>
       String(c[0]).includes('without the link-audio feature'),
     )
+    expect(gapWarns.length).toBe(0)
+    warn.mockRestore()
+  })
+
+  it('setLinkTempo: daemon が SetLinkTempo を受理 → throw せず warn も出さない', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // Link テンポリードを持つ daemon（feature 有効）を模す: 受理して ok を返す。
+    const p = await boot(defaultHandlers({ SetLinkTempo: () => ({ status: 'accepted' }) }))
+    await expect(p.setLinkTempo(120)).resolves.toBeUndefined()
+    expect(server.received.some((r) => r.method === 'SetLinkTempo')).toBe(true)
+    const tempoWarns = warn.mock.calls.filter((c) => String(c[0]).includes('setLinkTempo'))
+    expect(tempoWarns.length).toBe(0)
+    warn.mockRestore()
+  })
+
+  it('setLinkTempo: LINK_AUDIO_UNAVAILABLE（feature 無効ビルド）は warn-once で握り潰す', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const p = await boot() // 既定 handler が LINK_AUDIO_UNAVAILABLE を投げる
+    await expect(p.setLinkTempo(120)).resolves.toBeUndefined()
+    await p.setLinkTempo(130) // 2 回目も warn は増えない（warn-once）
+    const gapWarns = warn.mock.calls.filter((c) => String(c[0]).includes('setLinkTempo'))
+    expect(gapWarns.length).toBe(1)
+    warn.mockRestore()
+  })
+
+  it('setLinkTempo: LINK_AUDIO_RUNTIME（runtime 失敗）は feature-gap と区別して rethrow する', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const p = await boot(
+      defaultHandlers({
+        SetLinkTempo: () => {
+          // runtime 失敗（Link peer 不在等）→ feature-gap と誤認せず rethrow されるべき。
+          throw Object.assign(new Error('link tempo push failed: no peers'), {
+            code: 'LINK_AUDIO_RUNTIME',
+          })
+        },
+      }),
+    )
+    await expect(p.setLinkTempo(120)).rejects.toThrow()
+    const gapWarns = warn.mock.calls.filter((c) => String(c[0]).includes('setLinkTempo'))
     expect(gapWarns.length).toBe(0)
     warn.mockRestore()
   })


### PR DESCRIPTION
## 概要

A4 PR3（Link tempo leader）の TypeScript 側 wire 実装。Rust daemon への `setLinkTempo` 配線を追加する。

- `setLinkTempo(bpm)` を `DaemonClient` → `RustEnginePlayer` に配線
- `LINK_AUDIO_UNAVAILABLE`（feature 無効ビルド）= warn-once で握り潰し
- `LINK_AUDIO_RUNTIME`（runtime 失敗）= rethrow
- `registerLinkAudioChannel` パターンに厳密に倣った実装

## Rust 側インタフェース（Opus 実装中の daemon 側との接合点）

| 項目 | 値 |
|------|-----|
| method 名 | `SetLinkTempo` |
| params | `{ bpm: number }` |

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `protocol-types.ts` | `CommandMethod` に `'SetLinkTempo'` 追加 |
| `daemon-client.ts` | `setLinkTempo(bpm)` メソッド追加 |
| `rust-engine-player.ts` | `GapKind`・`freshWarned`・`setLinkTempo` 実装 |
| `mock-daemon-server.ts` | `MockDaemonHandlers` に `SetLinkTempo?` 追加 |
| `daemon-client.spec.ts` | 2 テスト追加 |
| `rust-engine-player.spec.ts` | 3 テスト追加 + defaultHandlers デフォルト追加 |

## テスト計画

- [ ] `daemon-client.spec.ts`: bpm params 送信確認・UNAVAILABLE → DaemonProtocolError 変換
- [ ] `rust-engine-player.spec.ts`: 受理（warn なし）・UNAVAILABLE warn-once・RUNTIME rethrow
- [ ] 全テスト green（1187 passed / 27 skipped）✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)