### PR TITLE
test(engine): A4-PR4 active-loops across-respawn e2e (full DSL, interpreter-driven)

### DIFF
--- a/docs/development/POST_2.0_NEXT_STEPS.html
+++ b/docs/development/POST_2.0_NEXT_STEPS.html
@@ -202,7 +202,7 @@
     <li><strong>core</strong>: Rust LinkAudio 隔離 GPL モジュール + lock-free / outputChannel parity / Link tempo lead（#283）。</li>
     <li><strong>織り込みフォローアップ</strong>:
       <ul>
-        <li><strong>active-loops の実 <code>loop()</code> across-respawn e2e</strong> — A4 完了時に pan/slice/stretch/LinkAudio 全部入りで full DSL を respawn 跨ぎ検証（recovery consolidation）。<strong>capture 非依存の state-level e2e</strong>（<code>createAudioEngine</code> 経由・onDispatch / daemon 状態クエリで検証）として軽く作る。</li>
+        <li><strong>active-loops の実 <code>loop()</code> across-respawn e2e</strong>（#335）— A4 完了時に pan/slice/<strong>varispeed</strong>/LinkAudio 全部入りで full DSL を respawn 跨ぎ検証（recovery consolidation）。<strong>capture 非依存の state-level e2e</strong>＝「<code>createAudioEngine</code> 経由」は実 interpreter＋実 <code>RustEnginePlayer</code> 経路の意（booted player を <code>InterpreterV2</code> に注入して <code>onDispatch</code> を取得・<strong>production 変更ゼロ</strong>）。onDispatch / daemon 状態クエリで検証。pan/varispeed/output_channel は payload として <strong>exercise</strong>（DispatchInfo/GetStatus に出ないので state-assert 不可・per-param 正しさは PR1-3 offline + 非gated rate guard が担保）。</li>
       </ul>
     </li>
   </ul>
@@ -249,7 +249,7 @@
     <tr>
       <td>active loops の real <code>loop()</code> across-respawn e2e テスト</td><td>#300</td>
       <td>player-level の continuous-stream プロキシ + 構造論（loop timer は <code>loop-sequence.ts</code> の setTimeout = 純 TS・daemon 非依存）で足りる。full interpreter 駆動は重い</td>
-      <td><strong>A4 末</strong> — full DSL（pan/slice/stretch/LinkAudio）を respawn 跨ぎ。<strong>capture 非依存の state-level e2e</strong>（<code>createAudioEngine</code> 経由・onDispatch / daemon 状態クエリ）</td>
+      <td><strong>A4 末（#335）</strong> — full DSL（pan/slice/varispeed/LinkAudio）を respawn 跨ぎ。<strong>capture 非依存の state-level e2e</strong>（実 interpreter＋実 <code>RustEnginePlayer</code> を <code>InterpreterV2</code> に注入＝「createAudioEngine 経由」の意・production 変更ゼロ・onDispatch / daemon 状態クエリ）</td>
       <td>小〜中</td>
     </tr>
     <tr>

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,57 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.166 test(engine): A4-PR4 active-loops across-respawn e2e — full DSL / interpreter-driven (#335) (Jun 23, 2026)
+
+**Date**: 2026-06-23
+**Status**: ✅ 実装完了（レビュー前）
+**Branch**: `335-active-loops-across-respawn-e2e`
+**Issue**: #335（A4 PR4・#321 の 4-PR 計画の最終手）
+**正本**: `docs/development/POST_2.0_NEXT_STEPS.html` §4（A4 末）/ §5（active-loops follow-up 行）
+
+A4 の最後の1手。#300（recovery floor）が proxy + 構造論で足りるとして**意図的に defer** した
+「実 `loop()` を interpreter 駆動で動かし real daemon を respawn 跨いで継続する」検証を、
+A4 完了時点で full DSL 全部入りで consolidation する（recovery consolidation・defer backlog 一掃）。
+
+**スコープ（test-only・production 変更ゼロ）**:
+- 既存 `tests/audio/rust-engine/real-daemon-recovery.spec.ts`（#300 gated kill-test）を **scaffold に拡張**。
+- 実 `InterpreterV2` に、onDispatch を得るために直接構築した実 `RustEnginePlayer` を注入
+  （= `createAudioEngine(rust)` と同じ player・leg2 の RecordingScheduler 注入と同じ seam）。
+  spec の「createAudioEngine 経由」= 実 interpreter + 実 player 経路の意（§4/§5 を spec-first で明確化）。
+- fixture = full DSL（pan / chop 領域 / per-event gain / **varispeed rate≠1.0** / LinkAudio output
+  channel / tempo leader）の `LOOP()` を回す `.orbs`。
+
+**scout question の結論（observability seam）**:
+- `daemonPid` / `getDaemonStatus()` / `injectDaemonFault()` / `isRunning` は player に public 既存・
+  `onDispatch` も options に既存 → **観測 seam は既存**（§6 の production 追加例外は不成立）→ test-only。
+- 観測境界: `DispatchInfo` は timing + `gain` + sample のみ surface。**pan / rate / output_channel は
+  `daemon.playAt` へ渡り respawn 跨ぎで exercise されるが onDispatch/GetStatus に出ない**ため値は
+  state-assert しない（per-param 正しさは PR1-3 offline + 下記 rate guard が担保・capture は §6 で OUT）。
+
+**テスト構成（2 層）**:
+- 非gated（CI 常時・daemon 不要）= fixture-integrity guard: RecordingScheduler で interpreter の
+  スケジュールを取り、`toDaemonParams` で **chopd=varispeed rate 2.0 / kick・snare=rate 1.0 /
+  pan 3 値 / gain 3 値** を機械チェック（"full DSL" 主張が hollow にならない保証）。
+- gated（`ORBIT_REAL_DAEMON=1`・ローカル）= recovery e2e: LOOP() → 実 daemon SIGKILL（mid-loop）
+  → auto-respawn → **dispatch 継続を state-level に assert**（liveness/新 pid / transport 再 anchor /
+  onset clip なし / 複数 sample で loop 群復帰 / per-event gain 保持 / fresh daemon 状態）。
+- daemon は default build（feature `link-audio` OFF）。setLinkTempo / output channel は warn-once
+  no-op（hardware bus へ）で loop を stall させないことを実機で確認（LinkAudio 自体の recovery は
+  観測 seam 不在のため非検証）。
+
+**検証**:
+- gated kill-test を **ローカルで 3 回連続 PASS**（各 respawn attempt 1/5・~5.6s）。
+- 非gated guard PASS / npm 全緑（**1188 passed | 28 skipped**）/ cargo `--workspace` 全緑（rust 無変更）。
+- SC 既定経路 無改変 / audio `play()` 意味論 無改変 / production code 無変更。
+
+**主な変更ファイル**:
+- `tests/audio/rust-engine/real-daemon-recovery.spec.ts`（#335 拡張・非gated guard + gated e2e）
+- `docs/development/POST_2.0_NEXT_STEPS.html`（§4/§5 を「createAudioEngine 経由」= 実 player 注入と
+  spec-first で明確化・"stretch"→"varispeed"）
+
+A4 完結（PR4 マージ）で #300/#304 の defer backlog は一掃（残るは capture seam と bot Finding 4
+= quit backoff の 2 件のみ・いずれも trigger 待ち）。
+
 ### 6.165 feat(engine): A4-PR3 Link tempo leader — Rust daemon + TS wire (#333) (Jun 23, 2026)
 
 **Date**: 2026-06-23

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -74,6 +74,17 @@ recovery 不変式を `assertRecoveryInvariants` ヘルパに抽出（#300 runKi
 skip: 公開 `dispose()` 追加（§6 scope fence = 観測 seam でなく lifecycle・cast は shutdown.ts 前例で
 許容）/ `if(!preKillPid)throw`（dead でなく TS narrowing・コメント追記）。適用後 gated 4 テスト全緑。
 
+**レビュー（/code:pr-review-team）**: 4 専門 reviewer（code-reviewer/silent-failure-hunter/
+pr-test-analyzer/comment-analyzer）。Critical 0。Important 3 を解消 →
+① afterEach を try/finally 化（seq.stop() throw 時も実 daemon を quit・leak 防止）/
+② recovery wait を件数（killMark+N）から **sample 多様性（3 seq 全復帰）** に直結し `postSamples===3`
+（chopd が 8 ev/bar と密で件数 wait だと kick/snare 復帰前に満たされる decoupling を解消・flake 除去 +
+全 loop 復帰を検証）/ ③ chop(1) は slice 経路を bypass する旨へコメント修正（comment-analyzer）。
+併せて Minor: uptime 判定を wall-clock 経過基準へ（長い recovery 待ちでの margin 痩せ対策）/ teardown
+cast を不在 throw + `?.` 除去で silent-skip 防止 / pan を厳密値 set で固定 / "per-event"→"per-sequence"
+gain ラベル統一。skip: post[0] stale（SIGKILL 即時で sub-ms 窓・post[0] discriminator 維持）。
+適用後 gated 4 テスト全緑（#335 stricter `===3` を複数回安定 PASS）。
+
 ### 6.165 feat(engine): A4-PR3 Link tempo leader — Rust daemon + TS wire (#333) (Jun 23, 2026)
 
 **Date**: 2026-06-23

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -68,6 +68,12 @@ A4 完了時点で full DSL 全部入りで consolidation する（recovery cons
 A4 完結（PR4 マージ）で #300/#304 の defer backlog は一掃（残るは capture seam と bot Finding 4
 = quit backoff の 2 件のみ・いずれも trigger 待ち）。
 
+**レビュー（/simplify）**: 4 cleanup agent（reuse/simplification/efficiency/altitude）適用 —
+recovery 不変式を `assertRecoveryInvariants` ヘルパに抽出（#300 runKillTest と #335 で共有・
+~25 行重複を解消）/ 非gated guard の `toDaemonParams` を play ごと 1 回にキャッシュ。
+skip: 公開 `dispose()` 追加（§6 scope fence = 観測 seam でなく lifecycle・cast は shutdown.ts 前例で
+許容）/ `if(!preKillPid)throw`（dead でなく TS narrowing・コメント追記）。適用後 gated 4 テスト全緑。
+
 ### 6.165 feat(engine): A4-PR3 Link tempo leader — Rust daemon + TS wire (#333) (Jun 23, 2026)
 
 **Date**: 2026-06-23

--- a/tests/audio/rust-engine/real-daemon-recovery.spec.ts
+++ b/tests/audio/rust-engine/real-daemon-recovery.spec.ts
@@ -53,12 +53,14 @@ async function waitFor(
  * @param post kill mark 以降の dispatch（gap 中は guard が drop するので全て respawn 後）。
  * @param preKillPid kill 前の daemon pid（respawn で必ず変わる）。
  * @param preKillNowSec kill 直前の daemon transport now（再 anchor がこれを下回るべき基準）。
+ * @param killWallMs kill した瞬間の `Date.now()`（新 daemon の uptime 上界を実時間で測るため）。
  */
 async function assertRecoveryInvariants(
   p: RustEnginePlayer,
   post: DispatchInfo[],
   preKillPid: number | undefined,
   preKillNowSec: number,
+  killWallMs: number,
 ): Promise<void> {
   // (1) liveness: poll は止まらず、daemon は respawn（新 pid）し、loops が復帰している。
   expect(p.isRunning).toBe(true)
@@ -82,7 +84,11 @@ async function assertRecoveryInvariants(
 
   // (4) daemon-side 状態クエリ: 再 establish 済み（fresh transport / sample 再ロード / play_id 健全）。
   const status = await p.getDaemonStatus()
-  expect(Number(status.uptime_sec)).toBeLessThan(preKillNowSec) // fresh daemon（transport リセット）
+  // fresh daemon: 新 daemon の uptime は kill からの経過実時間を超えない（古い daemon の累積
+  //   uptime ≥ preKillNowSec を引き継いでいない）。preKillNowSec 基準だと #335 の長い recovery
+  //   待ちで margin が薄れるため、wall-clock の経過を上界にする（+2s は status RTT 等の余裕）。
+  const elapsedSinceKillSec = (Date.now() - killWallMs) / 1000
+  expect(Number(status.uptime_sec)).toBeLessThan(elapsedSinceKillSec + 2)
   expect(Number(status.loaded_samples)).toBeGreaterThanOrEqual(1) // sample 再ロード済み
   expect(Number(status.active_plays)).toBeGreaterThanOrEqual(0) // orphan なし（有限・健全）
 }
@@ -131,6 +137,7 @@ describe.runIf(RUN)('RustEnginePlayer recovery floor against real daemon (#300)'
 
     // --- fault 注入（daemon を殺す） ---
     await inject(p)
+    const killWallMs = Date.now()
 
     // 復旧を待つ。gap 中は executePlayback の guard が dispatch を drop し onDispatch を呼ばないので、
     // killMark を超える dispatch は全て respawn 後（= active loops の構造的復帰の観測）。
@@ -139,7 +146,7 @@ describe.runIf(RUN)('RustEnginePlayer recovery floor against real daemon (#300)'
     const post = dispatches.slice(killMark)
 
     // recovery 不変式（liveness/新 pid・transport 再 anchor・onset clip なし・daemon 状態）。
-    await assertRecoveryInvariants(p, post, preKillPid, preKillNowSec)
+    await assertRecoveryInvariants(p, post, preKillPid, preKillNowSec, killWallMs)
   }
 
   it('hard-death（SIGKILL・panic hook 素通り）から respawn しセッション生存', async () => {
@@ -170,11 +177,11 @@ describe.runIf(RUN)('RustEnginePlayer recovery floor against real daemon (#300)'
 // なので、onDispatch を得るために booted player を直接構築して InterpreterV2 に注入する
 // （production 変更ゼロ・leg2 の RecordingScheduler 注入と同じ seam）。
 //
-// full DSL surface（pan / chop 領域 / per-event gain / varispeed rate≠1.0 / LinkAudio output
+// full DSL surface（pan / chop 領域 / per-sequence gain / varispeed rate≠1.0 / LinkAudio output
 // channel / tempo leader）はすべて fixture に載る。ただし DispatchInfo は timing + gain + sample
 // しか surface しない（pan / rate / output_channel は daemon.playAt へ渡るが onDispatch にも
 // GetStatus にも出ない）ため、state-assert できるのは dispatch 継続 / 再 anchor / lead /
-// per-event gain / sample 再ロード / active_plays まで。pan / rate / output_channel は payload
+// per-sequence gain / sample 再ロード / active_plays まで。pan / rate / output_channel は payload
 // として respawn 跨ぎで exercise されるが値は assert しない（per-param 正しさは PR1-3 の offline
 // テスト + 下の非gated rate guard が担保・capture ベース検証は §6 で OUT）。
 // daemon は default build（feature `link-audio` OFF）なので LinkAudio egress / tempo push は
@@ -197,7 +204,8 @@ const DURATIONS: Record<string, number> = {
  *
  * chopd: arpeggio(1.0s) を chop(2)→sliceDur 0.5s。tempo120/4-4/length1 → barDur 2.0s、play 8
  * 要素 → eventDur 0.25s。rate = sliceDur/eventDur = 0.5/0.25 = 2.0（genuine varispeed・rate≠1.0）。
- * kick/snare は chop(1)=全体・rate=1.0。3 seq で pan / per-event gain / output channel が分かれる。
+ * kick/snare は chop(1)=plain event（slice 経路を通らず自然尺 rate=1.0）。3 seq で pan /
+ * per-sequence gain / output channel が分かれる。
  */
 function buildFullDslSource(trigger: 'RUN' | 'LOOP'): string {
   return [
@@ -265,14 +273,16 @@ describe('#335 fixture integrity — full DSL produces non-degenerate params (no
 
     // varispeed: chop(2) スロット詰めで rate=2.0（≠1.0 が genuine に起きる）。
     for (const p of arp) expect(p.rate).toBeCloseTo(2.0, 2)
-    // chop(1) 全体再生は rate=1.0。
+    // kick/snare は chop(1) = slice 経路を通らない plain event（event-scheduler は chopDivisions>1
+    //   のときだけ scheduleSliceEvent）。slice なし → toDaemonParams は自然尺 rate=1.0 を返す。
     for (const p of nonArp) expect(p.rate).toBeCloseTo(1.0, 2)
 
-    // pan が複数値（kick=-60 / snare=+60 / chopd=+20 → 正規化 [-1,1]）。
+    // pan が 3 seq で別々の正規化値（kick -60→-0.6 / snare +60→+0.6 / chopd +20→+0.2）。
+    //   件数でなく値を固定し sign/scale 回帰も捕まえる。
     const pans = new Set(params.map((p) => p.pan.toFixed(3)))
-    expect(pans.size).toBeGreaterThanOrEqual(3)
+    expect(pans).toEqual(new Set(['-0.600', '0.600', '0.200']))
 
-    // per-event gain が複数値（kick=-3 / snare=-6 / chopd=-4 dB → 線形 amp）。
+    // per-sequence gain（各 seq の defaultGain -3/-6/-4 dB が dispatch ごとに乗る）が別々の線形 amp。
     const gains = new Set(params.map((p) => p.gain.toFixed(4)))
     expect(gains.size).toBeGreaterThanOrEqual(3)
   })
@@ -286,17 +296,24 @@ describe.runIf(RUN)('RustEnginePlayer active-loops across respawn — full DSL (
   afterEach(async () => {
     // loop timer（loop-sequence.ts の setTimeout・daemon 非依存）を確実に止める。
     // 各 Sequence.stop() = clearTimeout(loopTimer) + setLooping(false)（= 空 LOOP() と同じ経路）。
-    // player.quit() だけだと timer が leak して event loop を生かし続ける。
-    if (interp) {
-      const seqs = (
-        interp as unknown as { state?: { sequences?: Map<string, { stop?: () => void }> } }
-      ).state?.sequences
-      if (seqs) for (const seq of seqs.values()) seq.stop?.()
-      interp = null
-    }
-    if (player) {
-      await player.quit()
-      player = null
+    // player.quit() だけだと timer が leak して event loop を生かし続ける。stop が throw しても
+    // 実 daemon プロセスを確実に終了させるため player.quit() は finally に置く。
+    try {
+      if (interp) {
+        const seqs = (
+          interp as unknown as { state?: { sequences?: Map<string, { stop: () => void }> } }
+        ).state?.sequences
+        // 構造 drift（state/sequences の rename）で cleanup を silent skip しないよう不在なら throw。
+        if (!seqs)
+          throw new Error('afterEach: interp.state.sequences 不在 — loop timer が leak する恐れ')
+        for (const seq of seqs.values()) seq.stop() // Sequence.stop() は必ず存在（?. で握り潰さない）
+        interp = null
+      }
+    } finally {
+      if (player) {
+        await player.quit()
+        player = null
+      }
     }
   })
 
@@ -329,23 +346,30 @@ describe.runIf(RUN)('RustEnginePlayer active-loops across respawn — full DSL (
     // expect は型を narrow しないので、process.kill(number) のために number|undefined を絞る。
     if (!preKillPid) throw new Error('no daemon pid to kill')
     process.kill(preKillPid, 'SIGKILL')
+    const killWallMs = Date.now()
 
-    // respawn + 複数 loop の復帰を待つ（gap 中の dispatch は guard が drop するので killMark
-    // 超えは全て respawn 後）。boot+sample 再ロードに時間がかかるので timeout は広め。
-    await waitFor(() => dispatches.length > killMark + 6, { timeoutMs: 25_000 })
+    // respawn + 全 loop の復帰を待つ。復帰判定を sample 多様性に直結させる: chopd は 8 ev/bar と
+    // 密なので単純な件数 wait（killMark+N）だと kick/snare が復帰する前に満たされ得る → 3 seq
+    // （kick/snare/chopd）すべてが respawn 後に再 dispatch するまで待つ。gap 中の dispatch は guard
+    // が drop するので killMark 超えは全て respawn 後。boot+sample 再ロードに時間がかかるので広め。
+    const uniquePostSamples = () =>
+      new Set(dispatches.slice(killMark).map((d) => path.basename(d.filepath))).size
+    await waitFor(() => uniquePostSamples() >= 3, { timeoutMs: 25_000 })
 
     const post = dispatches.slice(killMark)
 
     // #300 と共有する recovery 不変式（liveness/新 pid・再 anchor・onset clip なし・daemon 状態）。
-    await assertRecoveryInvariants(p, post, preKillPid, preKillNowSec)
+    await assertRecoveryInvariants(p, post, preKillPid, preKillNowSec, killWallMs)
 
     // 以下は interpreter 駆動 full DSL 固有の追加検証（#300 proxy では出せない観測）:
-    // (A) active loops（複数）の復帰: post dispatch が複数サンプルにまたがる（1 つの loop だけ
-    //     生き残ったのではなく、loop 群が再 establish された）。
+    // (A) active loops（全 3 seq）の漏れない復帰: post dispatch が 3 サンプル全てにまたがる。
+    //     上の wait と同条件だが tautology ではない — どれか 1 seq でも復帰しなければ wait が
+    //     timeout してテストは fail する（= 「loop 群が漏れなく再 establish」を強制）。
     const postSamples = new Set(post.map((d) => path.basename(d.filepath)))
-    expect(postSamples.size).toBeGreaterThanOrEqual(2)
+    expect(postSamples.size).toBe(3)
 
-    // (B) per-event gain が respawn を跨いで保持（複数の異なる gain が流れ続ける）。
+    // (B) per-sequence gain（各 seq の defaultGain）が respawn を跨いで保持（複数の異なる gain が
+    //     流れ続ける）。
     const postGains = new Set(post.map((d) => d.gain.toFixed(4)))
     expect(postGains.size).toBeGreaterThanOrEqual(2)
   }, 70_000)

--- a/tests/audio/rust-engine/real-daemon-recovery.spec.ts
+++ b/tests/audio/rust-engine/real-daemon-recovery.spec.ts
@@ -2,6 +2,10 @@
  * RustEnginePlayer の recovery floor（daemon supervision + auto-respawn / #300）を
  * 実 daemon に対して検証する gated kill-test。
  *
+ * （#335 拡張）ファイル末尾に A4-PR4 = interpreter 駆動の active-loops across-respawn e2e を
+ * 追加（full DSL を実 InterpreterV2 + 実 daemon で respawn 跨ぎ検証 + 非gated fixture-integrity
+ * guard）。詳細は末尾の #335 セクションコメント参照。
+ *
  * `ORBIT_REAL_DAEMON=1` のときだけ走る（実プロセス kill/panic は CI で flaky/危険なので
  * 既定 skip = ローカル実機 + 記録した手動 validation。librosa cross-check と同パターン）。
  * 事前に `cd rust && cargo build -p orbit-audio-daemon --release` 済みであること。
@@ -15,10 +19,13 @@
 
 import * as path from 'path'
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { InterpreterV2 } from '../../../packages/engine/src/interpreter/interpreter-v2'
+import { parseAudioDSL } from '../../../packages/engine/src/parser'
 import type { DispatchInfo } from '../../../packages/engine/src/audio/rust-engine/rust-engine-player'
 import { RustEnginePlayer } from '../../../packages/engine/src/audio/rust-engine/rust-engine-player'
+import { RecordingScheduler } from '../verify/recording-scheduler'
 
 const REPO_ROOT = path.resolve(__dirname, '../../../')
 const KICK = path.join(REPO_ROOT, 'test-assets/audio/kick.wav')
@@ -130,4 +137,214 @@ describe.runIf(RUN)('RustEnginePlayer recovery floor against real daemon (#300)'
       await p.injectDaemonFault()
     })
   }, 30_000)
+})
+
+// =============================================================================
+// #335 — A4-PR4: active-loops across-respawn e2e（full DSL・interpreter 駆動）
+//
+// #300 の recovery floor は player-level proxy（`p.scheduleEvent()` 直叩き）で active loops
+// の復帰を「構造論 + 連続供給の代理」で確認した（上の describe）。本ブロックはその意図的 defer
+// を A4 完了時点で consolidation する: 実 interpreter（InterpreterV2）が full DSL の `LOOP()` を
+// 駆動し、実 daemon を respawn 跨いで dispatch が継続することを state-level に観測する。
+//
+// 「createAudioEngine 経由」(spec §4/§5) の意 = 実 interpreter + 実 RustEnginePlayer 経路。
+// createAudioEngine(rust) は `new RustEnginePlayer()` を引数なしで構築するだけの薄い env factory
+// なので、onDispatch を得るために booted player を直接構築して InterpreterV2 に注入する
+// （production 変更ゼロ・leg2 の RecordingScheduler 注入と同じ seam）。
+//
+// full DSL surface（pan / chop 領域 / per-event gain / varispeed rate≠1.0 / LinkAudio output
+// channel / tempo leader）はすべて fixture に載る。ただし DispatchInfo は timing + gain + sample
+// しか surface しない（pan / rate / output_channel は daemon.playAt へ渡るが onDispatch にも
+// GetStatus にも出ない）ため、state-assert できるのは dispatch 継続 / 再 anchor / lead /
+// per-event gain / sample 再ロード / active_plays まで。pan / rate / output_channel は payload
+// として respawn 跨ぎで exercise されるが値は assert しない（per-param 正しさは PR1-3 の offline
+// テスト + 下の非gated rate guard が担保・capture ベース検証は §6 で OUT）。
+// daemon は default build（feature `link-audio` OFF）なので LinkAudio egress / tempo push は
+// warn-once no-op（hardware bus へ）= LinkAudio 自体の recovery は検証しない（観測 seam 不在）。
+// =============================================================================
+
+const SNARE = path.join(REPO_ROOT, 'test-assets/audio/snare.wav')
+const ARPEGGIO = path.join(REPO_ROOT, 'test-assets/audio/arpeggio_c.wav')
+
+/** fixture が参照する全サンプルの実尺（秒）。varispeed rate の決定論計算に使う。 */
+const DURATIONS: Record<string, number> = {
+  [KICK]: 0.5,
+  [SNARE]: 0.2,
+  [ARPEGGIO]: 1.0,
+}
+
+/**
+ * full DSL の `.orbs` ソース。`trigger` で RUN（one-shot・非gated guard 用）/ LOOP（継続・
+ * gated e2e 用）を切り替える。audio パスは documentDirectory=REPO_ROOT 相対。
+ *
+ * chopd: arpeggio(1.0s) を chop(2)→sliceDur 0.5s。tempo120/4-4/length1 → barDur 2.0s、play 8
+ * 要素 → eventDur 0.25s。rate = sliceDur/eventDur = 0.5/0.25 = 2.0（genuine varispeed・rate≠1.0）。
+ * kick/snare は chop(1)=全体・rate=1.0。3 seq で pan / per-event gain / output channel が分かれる。
+ */
+function buildFullDslSource(trigger: 'RUN' | 'LOOP'): string {
+  return [
+    'var global = init GLOBAL',
+    'global.tempo(120)',
+    'global.beat(4 by 4)',
+    'global.linkAudio()',
+    'global.start()',
+    '',
+    'var kick = init global.seq',
+    'kick.length(1)',
+    'kick.audio("test-assets/audio/kick.wav").chop(1)',
+    'kick.output("kick")',
+    'kick.defaultGain(-3).defaultPan(-60)',
+    'kick.play(1, 0, 1, 0)',
+    '',
+    'var snare = init global.seq',
+    'snare.length(1)',
+    'snare.audio("test-assets/audio/snare.wav").chop(1)',
+    'snare.output("snare")',
+    'snare.defaultGain(-6).defaultPan(60)',
+    'snare.play(0, 1, 0, 1)',
+    '',
+    'var chopd = init global.seq',
+    'chopd.beat(4 by 4).length(1)',
+    'chopd.audio("test-assets/audio/arpeggio_c.wav").chop(2)',
+    'chopd.output("drums")',
+    'chopd.defaultGain(-4).defaultPan(20)',
+    'chopd.play(1, 2, 1, 2, 1, 2, 1, 2)',
+    '',
+    `${trigger}(kick, snare, chopd)`,
+    '',
+  ].join('\n')
+}
+
+// --- 非gated: fixture が full DSL を genuine に exercise する証明（CI 常時・daemon 不要） ---
+// gated e2e の "full DSL" 主張が hollow（例: 取り違えで varispeed rate=1.0）にならないための
+// fixture-integrity guard。#300 recovery の焼き直しではなく、interpreter が出すスケジュールの
+// param（rate / pan / gain）を leg2 系（RecordingScheduler）で機械チェックする。
+describe('#335 fixture integrity — full DSL produces non-degenerate params (no daemon)', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('chopd は genuine varispeed(rate=2.0)・kick/snare は rate=1.0・pan/gain が分かれる', async () => {
+    vi.useFakeTimers()
+    const recording = new RecordingScheduler(DURATIONS)
+    const interp = new InterpreterV2({ audioEngine: recording })
+    await interp.execute(parseAudioDSL(buildFullDslSource('RUN')), {
+      documentDirectory: REPO_ROOT,
+    })
+    const recorded = recording.getRecorded()
+    expect(recorded.length).toBeGreaterThan(0)
+
+    // toDaemonParams（本番共有変換）で rate / pan / gain を解決する。
+    const resolver = new RustEnginePlayer()
+    for (const [abs, sec] of Object.entries(DURATIONS)) resolver.seedDuration(abs, sec)
+
+    const arp = recorded.filter((p) => p.filepath.includes('arpeggio'))
+    const nonArp = recorded.filter((p) => !p.filepath.includes('arpeggio'))
+    expect(arp.length).toBeGreaterThan(0)
+    expect(nonArp.length).toBeGreaterThan(0)
+
+    // varispeed: chop(2) スロット詰めで rate=2.0（≠1.0 が genuine に起きる）。
+    for (const p of arp) expect(resolver.toDaemonParams(p).rate).toBeCloseTo(2.0, 2)
+    // chop(1) 全体再生は rate=1.0。
+    for (const p of nonArp) expect(resolver.toDaemonParams(p).rate).toBeCloseTo(1.0, 2)
+
+    // pan が複数値（kick=-60 / snare=+60 / chopd=+20 → 正規化 [-1,1]）。
+    const pans = new Set(recorded.map((p) => resolver.toDaemonParams(p).pan.toFixed(3)))
+    expect(pans.size).toBeGreaterThanOrEqual(3)
+
+    // per-event gain が複数値（kick=-3 / snare=-6 / chopd=-4 dB → 線形 amp）。
+    const gains = new Set(recorded.map((p) => resolver.toDaemonParams(p).gain.toFixed(4)))
+    expect(gains.size).toBeGreaterThanOrEqual(3)
+  })
+})
+
+// --- gated: interpreter 駆動 loop() が daemon SIGKILL→respawn を跨いで dispatch 継続（Done） ---
+describe.runIf(RUN)('RustEnginePlayer active-loops across respawn — full DSL (#335)', () => {
+  let player: RustEnginePlayer | null = null
+  let interp: InterpreterV2 | null = null
+
+  afterEach(async () => {
+    // loop timer（loop-sequence.ts の setTimeout・daemon 非依存）を確実に止める。
+    // 各 Sequence.stop() = clearTimeout(loopTimer) + setLooping(false)（= 空 LOOP() と同じ経路）。
+    // player.quit() だけだと timer が leak して event loop を生かし続ける。
+    if (interp) {
+      const seqs = (
+        interp as unknown as { state?: { sequences?: Map<string, { stop?: () => void }> } }
+      ).state?.sequences
+      if (seqs) for (const seq of seqs.values()) seq.stop?.()
+      interp = null
+    }
+    if (player) {
+      await player.quit()
+      player = null
+    }
+  })
+
+  it('full DSL の LOOP() が SIGKILL→respawn 後も複数 loop で dispatch 継続', async () => {
+    const dispatches: DispatchInfo[] = []
+    const p = new RustEnginePlayer({
+      daemonPath: DAEMON_BIN,
+      lookaheadSec: LOOKAHEAD_SEC,
+      onDispatch: (info) => dispatches.push(info),
+    })
+    player = p
+    // 実 interpreter に実 player を注入（= createAudioEngine(rust) と同じ player を、onDispatch
+    // を得るために直接構築して inject）。execute() が audioEngine.boot() を駆動し、ソース内の
+    // global.start() が transportControl→globalScheduler.start()（= p.start()）を呼ぶ。
+    const i = new InterpreterV2({ audioEngine: p })
+    interp = i
+    await i.execute(parseAudioDSL(buildFullDslSource('LOOP')), { documentDirectory: REPO_ROOT })
+
+    // transport を十分進めてから kill（stale anchor ≠ fresh anchor の差を作る。loop は 2s バー
+    // 境界で発火するので ≥4s 待つと複数バー分の dispatch が貯まる）。
+    await waitFor(() => dispatches.some((d) => d.daemonNowSec >= 4.0), { timeoutMs: 20_000 })
+
+    const preKillPid = p.daemonPid
+    const preKillNowSec = dispatches[dispatches.length - 1].daemonNowSec
+    const killMark = dispatches.length
+    expect(preKillPid).toBeGreaterThan(0)
+    expect(preKillNowSec).toBeGreaterThan(4.0)
+
+    // --- SIGKILL（panic hook 素通り = C-ABI segfault 代理）---
+    if (!preKillPid) throw new Error('no daemon pid to kill')
+    process.kill(preKillPid, 'SIGKILL')
+
+    // respawn + 複数 loop の復帰を待つ（gap 中の dispatch は guard が drop するので killMark
+    // 超えは全て respawn 後）。boot+sample 再ロードに時間がかかるので timeout は広め。
+    await waitFor(() => dispatches.length > killMark + 6, { timeoutMs: 25_000 })
+
+    const post = dispatches.slice(killMark)
+
+    // (1) liveness + respawn（新 pid）。
+    expect(p.isRunning).toBe(true)
+    expect(post.length).toBeGreaterThan(0)
+    const postPid = p.daemonPid
+    expect(postPid).toBeGreaterThan(0)
+    expect(postPid).not.toBe(preKillPid)
+
+    // (2) transport 再 anchor（唯一 load-bearing な不変式）: fresh daemon は transport≈0 から
+    //     始まるので post の daemonNowSec は preKill（≥4s）より大きく下がる。
+    expect(post[0].daemonNowSec).toBeLessThan(preKillNowSec - 0.5)
+    expect(post[0].daemonNowSec).toBeGreaterThan(0)
+
+    // (3) onset clip しない: 全 post dispatch で lead = timeSec − daemonNowSec ≈ lookahead（正）。
+    for (const d of post) {
+      const lead = d.timeSec - d.daemonNowSec
+      expect(lead).toBeGreaterThan(0)
+      expect(lead).toBeLessThan(LOOKAHEAD_SEC + 0.1)
+    }
+
+    // (4) active loops（複数）の復帰: post dispatch が複数サンプルにまたがる（1 つの loop だけ
+    //     生き残ったのではなく、loop 群が再 establish された）。
+    const postSamples = new Set(post.map((d) => path.basename(d.filepath)))
+    expect(postSamples.size).toBeGreaterThanOrEqual(2)
+
+    // (5) per-event gain が respawn を跨いで保持（複数の異なる gain が流れ続ける）。
+    const postGains = new Set(post.map((d) => d.gain.toFixed(4)))
+    expect(postGains.size).toBeGreaterThanOrEqual(2)
+
+    // (6) daemon-side 状態: fresh transport / sample 再ロード / play_id 健全。
+    const status = await p.getDaemonStatus()
+    expect(Number(status.uptime_sec)).toBeLessThan(preKillNowSec)
+    expect(Number(status.loaded_samples)).toBeGreaterThanOrEqual(1)
+    expect(Number(status.active_plays)).toBeGreaterThanOrEqual(0)
+  }, 70_000)
 })

--- a/tests/audio/rust-engine/real-daemon-recovery.spec.ts
+++ b/tests/audio/rust-engine/real-daemon-recovery.spec.ts
@@ -46,6 +46,47 @@ async function waitFor(
   throw new Error(`waitFor: condition not met within ${timeoutMs}ms`)
 }
 
+/**
+ * respawn 後の recovery 不変式（#300 と #335 が共有）。実時間 kill は非決定的なので invariant
+ * ベースで検証する（exact-match / toEqual はしない）。
+ * @param p respawn 済み player（新 daemon に再接続済み）。
+ * @param post kill mark 以降の dispatch（gap 中は guard が drop するので全て respawn 後）。
+ * @param preKillPid kill 前の daemon pid（respawn で必ず変わる）。
+ * @param preKillNowSec kill 直前の daemon transport now（再 anchor がこれを下回るべき基準）。
+ */
+async function assertRecoveryInvariants(
+  p: RustEnginePlayer,
+  post: DispatchInfo[],
+  preKillPid: number | undefined,
+  preKillNowSec: number,
+): Promise<void> {
+  // (1) liveness: poll は止まらず、daemon は respawn（新 pid）し、loops が復帰している。
+  expect(p.isRunning).toBe(true)
+  expect(post.length).toBeGreaterThan(0)
+  const postPid = p.daemonPid
+  expect(postPid).toBeGreaterThan(0)
+  expect(postPid).not.toBe(preKillPid)
+
+  // (2) transport 再 anchor（desync 無し）: 新 daemon は transport≈0 から始まるので、復帰後の
+  //     daemonNowSec は kill 直前より大きく下がる（stale anchor の ~Ns を引きずらない）。
+  //     これが唯一 load-bearing な不変式（再 anchor が壊れると新 daemon に「数秒先」を送り desync）。
+  expect(post[0].daemonNowSec).toBeLessThan(preKillNowSec - 0.5)
+  expect(post[0].daemonNowSec).toBeGreaterThan(0)
+
+  // (3) onset clip しない: 復帰後の全 dispatch で lead = timeSec − daemonNowSec ≈ lookahead（正値）。
+  for (const d of post) {
+    const lead = d.timeSec - d.daemonNowSec
+    expect(lead).toBeGreaterThan(0)
+    expect(lead).toBeLessThan(LOOKAHEAD_SEC + 0.1)
+  }
+
+  // (4) daemon-side 状態クエリ: 再 establish 済み（fresh transport / sample 再ロード / play_id 健全）。
+  const status = await p.getDaemonStatus()
+  expect(Number(status.uptime_sec)).toBeLessThan(preKillNowSec) // fresh daemon（transport リセット）
+  expect(Number(status.loaded_samples)).toBeGreaterThanOrEqual(1) // sample 再ロード済み
+  expect(Number(status.active_plays)).toBeGreaterThanOrEqual(0) // orphan なし（有限・健全）
+}
+
 describe.runIf(RUN)('RustEnginePlayer recovery floor against real daemon (#300)', () => {
   let player: RustEnginePlayer | null = null
 
@@ -97,31 +138,8 @@ describe.runIf(RUN)('RustEnginePlayer recovery floor against real daemon (#300)'
 
     const post = dispatches.slice(killMark)
 
-    // (1) liveness: poll は止まらず、daemon は respawn（新 pid）し、loops が復帰している。
-    expect(p.isRunning).toBe(true)
-    expect(post.length).toBeGreaterThan(0)
-    const postPid = p.daemonPid
-    expect(postPid).toBeGreaterThan(0)
-    expect(postPid).not.toBe(preKillPid)
-
-    // (2) transport 再 anchor（desync 無し）: 新 daemon は transport≈0 から始まるので、復帰後の
-    //     daemonNowSec は kill 直前（≥2s）より大きく下がる（stale anchor の ~Ns を引きずらない）。
-    //     これが唯一 load-bearing な不変式（再 anchor が壊れると新 daemon に「数秒先」を送り desync）。
-    expect(post[0].daemonNowSec).toBeLessThan(preKillNowSec - 0.5)
-    expect(post[0].daemonNowSec).toBeGreaterThan(0)
-
-    // (3) onset clip しない: 復帰後の全 dispatch で lead = timeSec − daemonNowSec ≈ lookahead（正値）。
-    for (const d of post) {
-      const lead = d.timeSec - d.daemonNowSec
-      expect(lead).toBeGreaterThan(0)
-      expect(lead).toBeLessThan(LOOKAHEAD_SEC + 0.1)
-    }
-
-    // (4) daemon-side 状態クエリ: 再 establish 済み（fresh transport / sample 再ロード / play_id 健全）。
-    const status = await p.getDaemonStatus()
-    expect(Number(status.uptime_sec)).toBeLessThan(preKillNowSec) // fresh daemon（transport リセット）
-    expect(Number(status.loaded_samples)).toBeGreaterThanOrEqual(1) // sample 再ロード済み
-    expect(Number(status.active_plays)).toBeGreaterThanOrEqual(0) // orphan なし（有限・健全）
+    // recovery 不変式（liveness/新 pid・transport 再 anchor・onset clip なし・daemon 状態）。
+    await assertRecoveryInvariants(p, post, preKillPid, preKillNowSec)
   }
 
   it('hard-death（SIGKILL・panic hook 素通り）から respawn しセッション生存', async () => {
@@ -232,26 +250,30 @@ describe('#335 fixture integrity — full DSL produces non-degenerate params (no
     const recorded = recording.getRecorded()
     expect(recorded.length).toBeGreaterThan(0)
 
-    // toDaemonParams（本番共有変換）で rate / pan / gain を解決する。
+    // toDaemonParams（本番共有変換）で rate / pan / gain を解決する（1 play 1 回だけ）。
     const resolver = new RustEnginePlayer()
     for (const [abs, sec] of Object.entries(DURATIONS)) resolver.seedDuration(abs, sec)
+    const params = recorded.map((play) => ({
+      filepath: play.filepath,
+      ...resolver.toDaemonParams(play),
+    }))
 
-    const arp = recorded.filter((p) => p.filepath.includes('arpeggio'))
-    const nonArp = recorded.filter((p) => !p.filepath.includes('arpeggio'))
+    const arp = params.filter((p) => p.filepath.includes('arpeggio'))
+    const nonArp = params.filter((p) => !p.filepath.includes('arpeggio'))
     expect(arp.length).toBeGreaterThan(0)
     expect(nonArp.length).toBeGreaterThan(0)
 
     // varispeed: chop(2) スロット詰めで rate=2.0（≠1.0 が genuine に起きる）。
-    for (const p of arp) expect(resolver.toDaemonParams(p).rate).toBeCloseTo(2.0, 2)
+    for (const p of arp) expect(p.rate).toBeCloseTo(2.0, 2)
     // chop(1) 全体再生は rate=1.0。
-    for (const p of nonArp) expect(resolver.toDaemonParams(p).rate).toBeCloseTo(1.0, 2)
+    for (const p of nonArp) expect(p.rate).toBeCloseTo(1.0, 2)
 
     // pan が複数値（kick=-60 / snare=+60 / chopd=+20 → 正規化 [-1,1]）。
-    const pans = new Set(recorded.map((p) => resolver.toDaemonParams(p).pan.toFixed(3)))
+    const pans = new Set(params.map((p) => p.pan.toFixed(3)))
     expect(pans.size).toBeGreaterThanOrEqual(3)
 
     // per-event gain が複数値（kick=-3 / snare=-6 / chopd=-4 dB → 線形 amp）。
-    const gains = new Set(recorded.map((p) => resolver.toDaemonParams(p).gain.toFixed(4)))
+    const gains = new Set(params.map((p) => p.gain.toFixed(4)))
     expect(gains.size).toBeGreaterThanOrEqual(3)
   })
 })
@@ -304,6 +326,7 @@ describe.runIf(RUN)('RustEnginePlayer active-loops across respawn — full DSL (
     expect(preKillNowSec).toBeGreaterThan(4.0)
 
     // --- SIGKILL（panic hook 素通り = C-ABI segfault 代理）---
+    // expect は型を narrow しないので、process.kill(number) のために number|undefined を絞る。
     if (!preKillPid) throw new Error('no daemon pid to kill')
     process.kill(preKillPid, 'SIGKILL')
 
@@ -313,38 +336,17 @@ describe.runIf(RUN)('RustEnginePlayer active-loops across respawn — full DSL (
 
     const post = dispatches.slice(killMark)
 
-    // (1) liveness + respawn（新 pid）。
-    expect(p.isRunning).toBe(true)
-    expect(post.length).toBeGreaterThan(0)
-    const postPid = p.daemonPid
-    expect(postPid).toBeGreaterThan(0)
-    expect(postPid).not.toBe(preKillPid)
+    // #300 と共有する recovery 不変式（liveness/新 pid・再 anchor・onset clip なし・daemon 状態）。
+    await assertRecoveryInvariants(p, post, preKillPid, preKillNowSec)
 
-    // (2) transport 再 anchor（唯一 load-bearing な不変式）: fresh daemon は transport≈0 から
-    //     始まるので post の daemonNowSec は preKill（≥4s）より大きく下がる。
-    expect(post[0].daemonNowSec).toBeLessThan(preKillNowSec - 0.5)
-    expect(post[0].daemonNowSec).toBeGreaterThan(0)
-
-    // (3) onset clip しない: 全 post dispatch で lead = timeSec − daemonNowSec ≈ lookahead（正）。
-    for (const d of post) {
-      const lead = d.timeSec - d.daemonNowSec
-      expect(lead).toBeGreaterThan(0)
-      expect(lead).toBeLessThan(LOOKAHEAD_SEC + 0.1)
-    }
-
-    // (4) active loops（複数）の復帰: post dispatch が複数サンプルにまたがる（1 つの loop だけ
+    // 以下は interpreter 駆動 full DSL 固有の追加検証（#300 proxy では出せない観測）:
+    // (A) active loops（複数）の復帰: post dispatch が複数サンプルにまたがる（1 つの loop だけ
     //     生き残ったのではなく、loop 群が再 establish された）。
     const postSamples = new Set(post.map((d) => path.basename(d.filepath)))
     expect(postSamples.size).toBeGreaterThanOrEqual(2)
 
-    // (5) per-event gain が respawn を跨いで保持（複数の異なる gain が流れ続ける）。
+    // (B) per-event gain が respawn を跨いで保持（複数の異なる gain が流れ続ける）。
     const postGains = new Set(post.map((d) => d.gain.toFixed(4)))
     expect(postGains.size).toBeGreaterThanOrEqual(2)
-
-    // (6) daemon-side 状態: fresh transport / sample 再ロード / play_id 健全。
-    const status = await p.getDaemonStatus()
-    expect(Number(status.uptime_sec)).toBeLessThan(preKillNowSec)
-    expect(Number(status.loaded_samples)).toBeGreaterThanOrEqual(1)
-    expect(Number(status.active_plays)).toBeGreaterThanOrEqual(0)
   }, 70_000)
 })


### PR DESCRIPTION
## 概要

A4（LinkAudio）の最終手 = #321 の 4-PR 計画の **PR4**。#300（recovery floor）が proxy + 構造論で足りるとして
意図的に defer した「実 `loop()` を interpreter 駆動で動かし real daemon を respawn 跨いで継続する」検証を、
A4 完了時点で **full DSL 全部入り**で consolidation する（recovery consolidation・defer backlog 一掃）。

正本: `docs/development/POST_2.0_NEXT_STEPS.html` §4（A4 末）/ §5（active-loops follow-up 行）。

## 変更内容（test-only・production 変更ゼロ）

- 既存 `tests/audio/rust-engine/real-daemon-recovery.spec.ts`（#300 gated kill-test）を **scaffold に拡張**。
- 実 `InterpreterV2` に、`onDispatch` を得るため直接構築した実 `RustEnginePlayer` を注入
  （= `createAudioEngine(rust)` と同じ player・leg2 の `RecordingScheduler` 注入と同じ seam）。
  spec の「createAudioEngine 経由」= 実 interpreter + 実 player 経路の意（§4/§5 を spec-first で明確化）。
- fixture = full DSL（pan / chop 領域 / per-event gain / **varispeed rate≠1.0** / LinkAudio output
  channel / tempo leader）の `LOOP()` を回す `.orbs`。
- **2 層構成**:
  - 非gated fixture-integrity guard（CI 常時・daemon 不要）: `RecordingScheduler` で interpreter の
    スケジュールを取り `toDaemonParams` で **chopd=rate 2.0 / kick・snare=rate 1.0 / pan 3 値 / gain 3 値**
    を機械チェック（"full DSL" 主張が hollow にならない保証）。
  - gated recovery e2e（`ORBIT_REAL_DAEMON=1`・ローカル）: `LOOP()` → 実 daemon SIGKILL（mid-loop）
    → auto-respawn → dispatch 継続を **state-level** に assert（共有ヘルパ `assertRecoveryInvariants`
    = liveness/新 pid・transport 再 anchor・onset clip なし・daemon 状態 + 複数 sample で loop 群復帰 +
    per-event gain 保持）。

## 観測境界（honesty）

- `DispatchInfo` は timing + `gain` + sample のみ surface。**pan / rate / output_channel は
  `daemon.playAt` へ渡り respawn 跨ぎで exercise されるが onDispatch/GetStatus に出ない**ため値は
  state-assert しない（per-param 正しさは PR1-3 offline + 非gated rate guard が担保・capture は §6 で OUT）。
- daemon は default build（feature `link-audio` OFF）。`setLinkTempo` / output channel は warn-once no-op
  （hardware bus へ）で loop を stall させないことを実機確認（**LinkAudio 自体の recovery は観測 seam
  不在のため非検証**）。

## 検証

- gated kill-test を **ローカルで複数回 PASS**（#300 hard-death / #300 clean-exit / #335・各 respawn attempt 1/5）:
  ```
  ✓ #300 hard-death（SIGKILL）から respawn しセッション生存  3135ms
  ✓ #300 clean-exit（InjectFault panic→exit1）から respawn しセッション生存  3007ms
  ✓ #335 full DSL の LOOP() が SIGKILL→respawn 後も複数 loop で dispatch 継続  5839ms
  ```
- 非gated guard PASS / npm 全緑（**1188 passed | 28 skipped**）/ cargo `--workspace` 全緑（rust 無変更）。
- SC 既定経路 無改変 / audio `play()` 意味論 無改変 / production code 無変更。

## レビュー

- `/simplify`（reuse/simplification/efficiency/altitude）適用済: 共有ヘルパ抽出 + toDaemonParams キャッシュ。

Closes #335
Refs #321
