### PR TITLE
docs(engine): mixer/routing/effects/automation/module DSL design note

### DIFF
--- a/docs/development/POST_2.0_MIXER_DSL_DESIGN.html
+++ b/docs/development/POST_2.0_MIXER_DSL_DESIGN.html
@@ -127,7 +127,7 @@
 <table>
   <thead><tr><th>ドメイン</th><th>行き先</th><th>備考</th></tr></thead>
   <tbody>
-    <tr><td><strong>audio</strong></td><td>master / hardware ch（<code>"3,4"</code>）/ cue / <strong>LinkAudio channel</strong></td><td>LinkAudio egress = A4（実装済）。sum-by-name の加算は LinkAudio mixer 内で起きる egress の話で、汎用 sum とは別物。</td></tr>
+    <tr><td><strong>audio</strong></td><td>master / hardware ch（<code>"3,4"</code>）/ cue / <strong>LinkAudio channel（<code>link("drum")</code>）</strong></td><td>LinkAudio egress = A4（実装済）。<strong>per-output の destination に格下げ</strong>（現状の <code>global.linkAudio()</code> グローバルモード＝「ファイル全体が Link・hardware 混在不可」を廃し、任意の node の <code>output()</code> に <code>link(...)</code> を生やす）。現状グローバルなのは SC 時代の plugin lifecycle 制約（scsynth boot 紐付き）で、<strong>native engine では per-channel で解禁</strong>。sum-by-name の加算は LinkAudio mixer 内 egress の話で汎用 sum とは別物。<strong>Link セッション接続（discovery / tempo sync）の on/off は別レイヤのセッションスイッチ</strong>（どの node を egress するかの routing とは独立）。</td></tr>
     <tr><td><strong>data（MIDI）</strong></td><td><strong>IAC bus</strong>（macOS 仮想 MIDI）</td><td>音でなくデータの送り出し。<code>seq.midi()</code> は audio bus でなく MIDI bus へ（<code>output()</code> 免除・#282）。LinkAudio(音) と IAC(データ) は対称な egress。core spec L606 に「routing 予定・別 issue」。</td></tr>
   </tbody>
 </table>
@@ -137,7 +137,24 @@
   「常に行き先を指す」を採ると <code>output()</code> の引数は {master / hardware ch / LinkAudio ch / cue / sum / aux} を取りうる
   ＝<strong>多態</strong>。<code>"drum"</code> が sum か LinkAudio channel か cue かの<strong>名前解決ルール</strong>を決める必要がある。
   案A: <code>output()</code> を「次のノード」として一本化（graph edge・要名前解決）/ 案B: 終端 <code>output()</code> と
-  bus 投入を別動詞にして多態を避ける。<strong>未決</strong>。
+  bus 投入を別動詞にして多態を避ける。<strong>有力な解決（2026-06-24 レビュー）= 型付き destination コンストラクタ</strong>:
+  <code>link("drum")</code> / <code>cue()</code> / <code>sum("drum")</code> / <code>out("3,4")</code> のように destination を型で明示すれば、
+  bare string（"drum" が sum か Link か cue か）の曖昧さが消える。残るは記法の細部。
+</div>
+
+<h3>2.2 master ノード（一級・既定の終端 + master chain）</h3>
+<p>
+  <strong>master を一級ノードにする</strong>（.vsix 期に作っていた master トラックの再定義）。master は
+  <strong>既定の終端</strong>（<code>output()</code> 省略時の行き先）であり、<strong>自前の master chain を持つ</strong>。
+  この master chain こそ §10 の<strong>マスタリング chain</strong>（EQ / comp / limiter / normalizer）で、
+  #304 の master effects もここに載る。概念的には「全 source/sum/aux が合流する root sum bus + master FX」。
+</p>
+<div class="callout c-inv">
+  <span class="lbl">master-only → LinkAudio（2-track）も同じ仕組み</span>
+  「master だけを LinkAudio に 2ch で送る」は特別モードではなく、<strong>master ノードの出力を <code>link()</code> に向けるだけ</strong>
+  （<code>master.output(link("main"))</code>）。<strong>per-channel egress</strong>（各 seq/sum を別 Link channel へ）と
+  <strong>master-only egress</strong>（master 1本を Link へ）は「<strong>どのノードに Link 出力を生やすか</strong>」の違いだけ。
+  egress 先・mastering・通常再生がすべて同一の routing 機構に乗る。
 </div>
 
 <h2>3. 信号パス / チェーン意味論</h2>
@@ -276,11 +293,14 @@ LOOP(lead)</pre>
   <li><strong>SOLO(a,b,c)</strong> = 集合ベース予約キーワード（RUN/LOOP/MUTE の group-diff 再利用・multi-solo がタダ）。</li>
   <li>capture/render seam の用途 = ①検証 ②recovery ギャップ ③<strong>render/mastering</strong>。</li>
   <li>VST は <strong>format-agnostic な DSL</strong> 設計で δ で差し込む（DSL 改修ゼロ）。</li>
+  <li><strong>master = 一級ノード</strong>（既定の終端 + 自前の master chain = §10 マスタリング chain・#304 master effects の置き場）。〔2026-06-24 レビュー追加〕</li>
+  <li><strong>LinkAudio = per-output destination</strong>（<code>link(...)</code>・現 <code>global.linkAudio()</code> グローバルモードから格下げ・native で hardware+Link 混在解禁）。<strong>Link セッション接続の on/off は別スイッチ</strong>（egress routing と独立）。master-only→Link（2ch）も per-channel も「どの node に <code>link()</code> を生やすか」の違いだけ。〔2026-06-24 レビュー追加〕</li>
+  <li><strong>型付き destination コンストラクタ</strong>（<code>link()</code> / <code>cue()</code> / <code>sum()</code> / <code>out()</code>）で <code>output()</code> の名前解決（下記 open の有力解）。〔2026-06-24 レビュー〕</li>
 </ul>
 
 <h3>未決（記法・意味論の詰め） <span class="badge b-next">open</span></h3>
 <ul>
-  <li><code>output()</code> の<strong>多態と名前解決</strong>（master/hw/Link/cue/sum/aux の判別）。</li>
+  <li><code>output()</code> の<strong>多態と名前解決</strong>（master/hw/Link/cue/sum/aux の判別）→ <strong>有力解=型付き destination コンストラクタ</strong>（§2 callout）。残るは記法細部。</li>
   <li><strong>effect インスタンス・ハンドル</strong>の構文（重複対応 + param アドレス）。</li>
   <li><strong>mono / stereo / multi</strong> の channel-count モデル（推論 vs 明示）。</li>
   <li><strong>solo × mute 相互作用</strong>・group/aux の solo。</li>

--- a/docs/development/POST_2.0_MIXER_DSL_DESIGN.html
+++ b/docs/development/POST_2.0_MIXER_DSL_DESIGN.html
@@ -1,0 +1,332 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>OrbitScore Post-2.0 — Mixer / Routing / Effects / Automation / Module DSL 設計ノート</title>
+<style>
+  :root {
+    --ink: #1a1a1a;
+    --bg: #fdfdfd;
+    --muted: #5b6470;
+    --line: #e2e6ea;
+    --accent-a: #1f6feb;   /* engine track */
+    --accent-b: #8957e5;   /* app track (OrbitStudio-era) */
+    --accent-c: #1a7f5a;   /* DSL / pitch track */
+    --warn-bg: #fff8e6;
+    --warn-bd: #e6c34a;
+    --stop-bg: #fdecef;
+    --stop-bd: #e5736f;
+    --inv-bg: #eef4ff;
+    --inv-bd: #1f6feb;
+    --code-bg: #f4f6f8;
+  }
+  html { color: var(--ink); background: var(--bg); }
+  body {
+    margin: 0 auto; max-width: 54em;
+    padding: 48px 28px 96px;
+    font: 16px/1.65 -apple-system, "Hiragino Sans", "Yu Gothic", system-ui, sans-serif;
+    text-rendering: optimizeLegibility;
+  }
+  h1 { font-size: 1.9em; margin: 0 0 .2em; letter-spacing: .01em; }
+  h2 { font-size: 1.35em; margin: 2.2em 0 .6em; padding-bottom: .25em; border-bottom: 2px solid var(--line); }
+  h3 { font-size: 1.1em; margin: 1.6em 0 .4em; }
+  .sub { color: var(--muted); margin: 0 0 1.5em; font-size: .95em; }
+  p { margin: .8em 0; }
+  code { background: var(--code-bg); padding: .1em .35em; border-radius: 4px; font: 13.5px/1.5 ui-monospace, "SF Mono", Menlo, monospace; }
+  pre { background: var(--code-bg); padding: 12px 14px; border-radius: 6px; overflow-x: auto; font: 13px/1.55 ui-monospace, Menlo, monospace; }
+  ul, ol { padding-left: 1.5em; }
+  li { margin: .3em 0; }
+  a { color: var(--accent-a); }
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: .9em; }
+  th, td { border: 1px solid var(--line); padding: 7px 10px; text-align: left; vertical-align: top; }
+  th { background: #f6f8fa; }
+  .badge { display: inline-block; font-size: .72em; font-weight: 700; padding: .12em .6em; border-radius: 999px; vertical-align: middle; letter-spacing: .03em; white-space: nowrap; }
+  .b-done { background: #def7e6; color: #1a7f3c; }
+  .b-next { background: #e6efff; color: #1f5fc0; }
+  .b-defer{ background: #fff2cc; color: #8a6d12; }
+  .b-risk { background: #fde2e2; color: #b53a37; }
+  .callout { border-left: 4px solid; border-radius: 0 6px 6px 0; padding: 12px 16px; margin: 1.2em 0; }
+  .c-inv  { background: var(--inv-bg);  border-color: var(--inv-bd); }
+  .c-warn { background: var(--warn-bg); border-color: var(--warn-bd); }
+  .c-stop { background: var(--stop-bg); border-color: var(--stop-bd); }
+  .callout .lbl { font-weight: 700; display: block; margin-bottom: .2em; }
+  .track { border: 1px solid var(--line); border-radius: 8px; padding: 4px 20px 16px; margin: 1.2em 0; border-top: 4px solid var(--accent-c); }
+  .track h3 { margin-top: 1em; }
+  .small { color: var(--muted); font-size: .88em; }
+  hr { border: none; border-top: 1px solid var(--line); margin: 2.5em 0; }
+</style>
+</head>
+<body>
+
+<h1>Mixer / Routing / Effects / Automation / Module — DSL 設計ノート</h1>
+<p class="sub">
+  Post-2.0 engine track の <strong>DSL 側未設計領域</strong>の設計ディスカッション記録 ·
+  2026-06-24 · Issue #337
+</p>
+
+<div class="callout c-warn">
+  <span class="lbl">この文書の位置づけ（重要）</span>
+  これは owner とのブレストを固定した <strong>設計ディスカッション記録</strong>であり、<strong>正規仕様（normative spec）ではない</strong>。
+  記載の DSL 記法は<strong>すべて叩き台（未確定）</strong>。<strong>実装は一切していない</strong>。
+  確定事項と未決事項は §11「決定台帳」で仕分ける。正規仕様化は別 issue で行う。
+</div>
+
+<h2>0. なぜこのノートが要るか</h2>
+<p>
+  engine 側のプラグインホスティング（<strong>γ out-of-process sandbox / δ VST3·AU</strong>）は
+  <a href="POST_2.0_NEXT_STEPS.html">POST_2.0_NEXT_STEPS.html</a> §2・§3 にロードマップ済。
+  だが <strong>それを <code>.orbs</code> DSL からどう叩くか</strong> ── plugin 呼び出し / effect chain /
+  send-return / aux / 出力ルーティング / automation / ファイル分割 ── は<strong>未設計</strong>。
+  ルーティング研究 <a href="../research/DAW_AUDIO_ARCHITECTURE.md">DAW_AUDIO_ARCHITECTURE.md</a> も
+  「③ DSL 表現面」を将来として留保している。本ノートはその DSL 表現面（と、それが要求する engine 要件）の設計をまとめる。
+</p>
+<p class="small">
+  VST について: DSL から見れば <strong>CLAP も VST3·AU も「plugin」で同一</strong>。フォーマット差は engine ホスティング
+  （γ→δ）に閉じ、<strong>DSL は format-agnostic</strong> に設計する。VST3 は SDK 3.8 で MIT 単独化済（license 障壁なし）。
+  δ が「最後」なのは engine 成熟度（CLAP &gt; AU &gt; VST3）の話で、DSL 設計上の遅延理由ではない。
+</p>
+
+<h2>1. 統合軸 ── reconciliation key = 名前</h2>
+<div class="callout c-inv">
+  <span class="lbl">全体を貫く1本の原理</span>
+  DSL は<strong>「あるべきグラフ（desired graph）」を宣言</strong>する。再評価のたびに engine は
+  <strong>走っている実グラフと desired を差分（diff）し、最小の delta だけ適用</strong>する
+  （node 追加 / edge 張り替え / 削除）。<strong>変わっていない node はそのまま鳴り続ける</strong>＝音切れなし。
+  この差分照合（reconciliation）の <strong>key が「名前」</strong>（React の key と同じ）。
+  名前一致 = 同一 node →<strong>その場で再束縛（param 更新）</strong>、新規名 = 追加、消えた名 = 削除。
+</div>
+<p>
+  「mixer/aux/inst が live で増える」問題の答えがこれ。<strong>グラフが変わること自体は問題ではない</strong> ──
+  問題は「丸ごと teardown→rebuild すると音が切れる」こと。宣言的グラフ + 名前キー差分なら、aux を1本足すのは
+  「+1 node の delta」で済み、既存は無停止。<strong>「再構築でなく再束縛」</strong>がこれで成立する。
+</p>
+<p>
+  そして <code>sum("drum")</code> / <code>aux("rev")</code> / effect ハンドル / module の export 名 ──
+  本ノートで「名前で実体を掴む」発想が繰り返し出るのは、すべて<strong>同じ reconciliation key</strong> だから。
+  この1点が <strong>routing・effect ハンドル・module identity・recovery（<a href="POST_2.0_NEXT_STEPS.html">#300</a>）</strong>
+  を束ねる。effect の並び替えは edge の張り替えだけで <strong>node の state（plugin 内部状態）は保持</strong>される。
+</p>
+
+<h2>2. ルーティング・グラフ</h2>
+<p>
+  グラフは <strong>4 種のノード</strong>と、それを繋ぐ<strong>エッジ</strong>で表す。エッジの向きは
+  <strong>「常に source が行き先を指す」</strong>（決定）。束ねる側が集めるより直感的で、変更時に認識がズレない。
+</p>
+<table>
+  <thead><tr><th>ノード</th><th>DSL（叩き台）</th><th>トポロジー</th><th>DAW 対応</th></tr></thead>
+  <tbody>
+    <tr><td><strong>source</strong></td><td><code>seq.inst("synth")</code> / <code>seq.audio("x.wav")</code> / 録音入力</td><td>信号の発生源（チェーン先頭）</td><td>音源 / クリップ / 入力</td></tr>
+    <tr><td><strong>sum（group）</strong></td><td><code>sum("drum")</code></td><td>直列サブミックス（メンバの主出力がここへ）</td><td>Group / Bus track</td></tr>
+    <tr><td><strong>aux（send-return）</strong></td><td><code>send("rev")</code> → <code>aux("rev")</code></td><td>並列タップ（コピーを送る・原音は継続）</td><td>Return / Aux track</td></tr>
+    <tr><td><strong>output（終端）</strong></td><td><code>output("master")</code> / <code>"3,4"</code> / cue / LinkAudio ch</td><td>信号の最終行き先</td><td>Master / hardware out / egress</td></tr>
+  </tbody>
+</table>
+
+<h3>2.1 output は 2 ドメイン</h3>
+<table>
+  <thead><tr><th>ドメイン</th><th>行き先</th><th>備考</th></tr></thead>
+  <tbody>
+    <tr><td><strong>audio</strong></td><td>master / hardware ch（<code>"3,4"</code>）/ cue / <strong>LinkAudio channel</strong></td><td>LinkAudio egress = A4（実装済）。sum-by-name の加算は LinkAudio mixer 内で起きる egress の話で、汎用 sum とは別物。</td></tr>
+    <tr><td><strong>data（MIDI）</strong></td><td><strong>IAC bus</strong>（macOS 仮想 MIDI）</td><td>音でなくデータの送り出し。<code>seq.midi()</code> は audio bus でなく MIDI bus へ（<code>output()</code> 免除・#282）。LinkAudio(音) と IAC(データ) は対称な egress。core spec L606 に「routing 予定・別 issue」。</td></tr>
+  </tbody>
+</table>
+
+<div class="callout c-warn">
+  <span class="lbl">open: output の多態と名前解決</span>
+  「常に行き先を指す」を採ると <code>output()</code> の引数は {master / hardware ch / LinkAudio ch / cue / sum / aux} を取りうる
+  ＝<strong>多態</strong>。<code>"drum"</code> が sum か LinkAudio channel か cue かの<strong>名前解決ルール</strong>を決める必要がある。
+  案A: <code>output()</code> を「次のノード」として一本化（graph edge・要名前解決）/ 案B: 終端 <code>output()</code> と
+  bus 投入を別動詞にして多態を避ける。<strong>未決</strong>。
+</div>
+
+<h2>3. 信号パス / チェーン意味論</h2>
+<ul>
+  <li><strong>チェーン順 = 信号フロー</strong>。effect は順序で音が変わる（comp→eq ≠ eq→comp）ので、メソッドチェーンの並びを実行順にマップする（研究 §4「insert 順序が最重要」）。</li>
+  <li><strong>source は先頭</strong>。<code>seq</code> は既に音源を持つ（<code>audio()</code> のサンプル）。<code>inst()</code> は<strong>音源の置換</strong>（サンプルの代わりに synth/sampler plugin）。<strong>再生でも録音でも source 先頭は不変</strong>（録音時は録る入力信号が source）。</li>
+  <li><code>play()</code> は<strong>パターン（trigger/note）</strong>で、信号パスとは直交。</li>
+  <li><strong><code>send()</code> の位置 = tap 点</strong>。「effect2 の後に send を置く＝effect2 直後でタップ」と読む。DAW の固定 pre/post-fader より柔軟で、method-chain の強みを活かす。</li>
+  <li><strong>mono / stereo / multi</strong>: 基本は source から伝播（推論）・必要時だけ明示。記号で everywhere に書かせると煩雑。</li>
+</ul>
+<pre>// 叩き台（記法は未確定）
+seq.inst("synth").play(1, 0, 1, 0)   // 音源 + パターン
+   .effect("comp").effect("eq")      // insert chain（この順 = 実行順）
+   .send("revAux", pre)              // ← 置いた位置 = tap 点
+   .output("master")                 // 終端（書かなければ master）
+
+sum("drum").effect("glue").output("master")     // group bus 自身も chain を持つ
+aux("revAux").effect("reverb").output("master") // aux も chain + output を持つ</pre>
+
+<h2>4. エフェクトとパラメータ</h2>
+<ul>
+  <li><strong>インスタンス・ハンドルが要る</strong>。同じ effect を2回挿すと <code>&lt;effect名&gt;.&lt;param&gt;</code> では曖昧。<strong>ハンドルを返す</strong>形にする（叩き台: <code>var eq1 = seq.effect("eq")</code> → <code>eq1.freq(...)</code>）。これも「名前で実体を掴む」= reconciliation key。</li>
+  <li>effect を挿すと<strong>外に見えるパラメータが予約</strong>され、ハンドル経由で <code>eq1.freq(800).q(1.2)</code> のように指定 or automation 対象にできる。</li>
+  <li>mono/stereo は §3 の channel-count モデルに従う。</li>
+</ul>
+
+<h2>5. Automation ── 3 層</h2>
+<p>「プログラム的に param 変化を書きたい」欲は満たしつつ <strong>RT 安全</strong>（audio スレッドは毎サンプル JS を呼べない）を守るため、3 層に分ける。<strong>OrbitScore は TS 上の DSL なので automation も TS で書け、便利関数を資産化できる</strong>。</p>
+<table>
+  <thead><tr><th>層</th><th>例</th><th>RT/評価</th><th>便利関数で巻き取れるか</th></tr></thead>
+  <tbody>
+    <tr><td><strong>① 時間決定論</strong></td><td><code>ramp(0,1,4bars)</code> / <code>(t)=&gt;…</code> / for·if で書いた時間関数</td><td><strong>事前レンダ</strong>して control-rate レーン / breakpoint に。RT 安全。</td><td>Yes</td></tr>
+    <tr><td><strong>② control-rate signal modulation</strong></td><td>LFO / envelope follower / sidechain / macro / <strong>live 入力レベル·onset</strong></td><td>engine が <strong>mod source を primitive で持つ</strong>。DSL/TS は <strong>「mod source → param」の配線（mod graph）を書くだけ</strong>。評価は engine が control-rate で回す。</td><td>Yes（「演奏音レベルに追従」「sidechain で揺らす」はここ）</td></tr>
+    <tr><td><strong>③ semantic / score-following</strong></td><td>「フレーズを聴いて」追従 / LLM 演奏計画</td><td>解析 + 計画が要る。<strong>north-star（別トラック）・本スコープ外</strong>。</td><td>No</td></tr>
+  </tbody>
+</table>
+<p class="small">
+  線引きは「決定論 vs 反応」ではなく <strong>「signal-rate の modulation（engine primitive・DSL は配線）」 vs 「cognitive な解析+計画」</strong>。
+  ①② は <a href="../research/">groove-from-structure</a>（揺れは構造から・RNG を時間グリッドに入れない）と整合 ＝ <strong>決定論的・構造由来</strong>に倒す。
+</p>
+<pre>// 叩き台（記法は未確定）
+var sweep = ramp(0, 1, 4bars)        // ① 決定論カーブ（pre-render）
+filter.cutoff.automate(sweep)
+
+var lfoMod = lfo(0.5)                 // ② mod source
+synth.cutoff.mod(lfoMod, 0.3)        // mod を param に配線（control-rate 評価）
+comp.thresh.sidechain("kick")        // ② 演奏音に反応（engine が follower 計算）</pre>
+
+<h2>6. Mixer 機能の完全性</h2>
+<p>挙がった未カバー項目は<strong>全部スコープ in</strong>。</p>
+<table>
+  <thead><tr><th>項目</th><th>扱い</th></tr></thead>
+  <tbody>
+    <tr><td><strong>mute / solo</strong></td><td>§7 の集合キーワードで。solo は <strong>multi-solo がタダ</strong>（Ableton の「実質1つ」問題を解消）。</td></tr>
+    <tr><td><strong>sidechain = aux「入力」</strong></td><td>node は<strong>非メイン入力ポート</strong>を持てる。エッジは「出力先」だけでなく「入力源」も張れる（研究: sidechain = 非メイン入力への routing）。</td></tr>
+    <tr><td><strong>PDC（plugin delay compensation）</strong> <span class="badge b-risk">engine 必須</span></td><td>plugin 遅延があると send/group の並列経路で位相がズレる → engine が<strong>自動で遅延補償</strong>。<strong>DSL 不可視だが正しさに不可分</strong>（研究「PDC 不可分」）。</td></tr>
+    <tr><td><strong>metering</strong></td><td>level/peak メータ = <strong>#307 capture/verify ハーネスの RMS/peak プリミティブの再利用</strong>（新規実装でない）。</td></tr>
+    <tr><td><strong>bus の入れ子</strong></td><td>sum を sum に入れる等は reconciliation グラフなら<strong>只のネスト</strong>で自動的に効く（特別扱い不要）。</td></tr>
+  </tbody>
+</table>
+
+<h2>7. 予約キーワード = 集合 + 差分（統一イディオム）</h2>
+<p>
+  既存の <code>RUN(...)</code> / <code>LOOP(...)</code> / <code>MUTE(...)</code> は
+  <strong>「シーケンス集合を取る予約キーワード + group-diff」</strong>（<code>loopGroup</code>/<code>muteGroup</code> を
+  <code>calculateLoopDiff</code> で差分処理）。<strong><code>SOLO(...)</code> はそこに <code>soloGroup</code> を1個足すだけ</strong>
+  ＝同じ機構の再利用で <strong>multi-solo がタダ</strong>。
+</p>
+<pre>SOLO(kick, snare, hat)   // 3つ同時 solo（集合）
+SOLO()                   // 全解除</pre>
+<p>
+  これは §1 の reconciliation（名前キー差分）と同じ思想 ── 集合も「desired な集合」を宣言し差分適用。
+  <code>RUN/LOOP/MUTE/SOLO</code> が一貫したセット演算になり、将来 <code>BYPASS(fx...)</code>（effect 一括バイパス）等も同型で足せる。
+</p>
+<div class="callout c-warn">
+  <span class="lbl">open: solo 意味論</span>
+  soloGroup 非空 = その集合だけ可聴（solo-in-place）・他は暗黙 mute。<strong>MUTE との相互作用</strong>（solo が mute を上書きするか）と、
+  <strong>group/aux を solo した時</strong>（配下も鳴る）の扱いは未決。
+</div>
+
+<h2>8. Module system（ファイル分割 / import）</h2>
+<p>単一ファイルの肥大化が痛いので、<strong>トラック毎・楽器毎・play 毎に分割し、自由に import</strong> したい。reconciliation と相性が良い: 各ファイルが<strong>名前キーで node を desired graph に寄与</strong>するだけ。import = グラフの合成（名前一致で merge）。</p>
+
+<h3>8.1 project vs performance の分離</h3>
+<div class="callout c-inv">
+  <span class="lbl">Global は丸ごと閉じ込めず「2 分割」</span>
+  <strong>project 所有（永続・preset/variant で差し替え）</strong>: mixer / aux / instrument graph / routing / output 設定 / SR
+  ── <strong>再構築が音切れの元 ＝ これだけ守る</strong>。<br>
+  <strong>performance 駆動（live・頻繁に書き換え・再評価が安い&歓迎）</strong>: <strong>tempo</strong> / transport start-stop /
+  key·transpose / どの pattern を live にするか。<br>
+  → tempo は迷わず後者。「tempo を live で多用」と「project が Global を持つ」は両立する。<strong>守るのは mixer graph であって tempo ではない</strong>。
+</div>
+<pre>// instruments.orbs（project 側・永続）
+export var lead = global.seq.inst("synth").effect("comp").output("master")
+
+// performance.orbs（live-coding 側）
+import { lead } from "./instruments"
+global.tempo(128)    // live param（再評価で再適用＝歓迎）
+LOOP(lead)</pre>
+<p>
+  <strong>hot-reload identity</strong>: performance を再評価しても import した project graph は<strong>作り直さず再束縛</strong>（§1 reconciliation）。
+  identity を project ランタイムに置くことで「再評価＝再束縛、再構築でない」が成立し、import 時の音切れが大半消える。
+  これは DAW の「プロジェクト vs クリップ」分離そのもの。
+</p>
+
+<h2>9. プロジェクト階層</h2>
+<p><strong>clip/pattern → track → song → album</strong>。既存の deferred「song 層」（<a href="POST_2.0_PITCH_MODEL_NOTES.md">pitch model notes</a>）の上に album（複数 song を束ねる）を載せる。これは OrbitStudio-era の project 構造。</p>
+
+<h2>10. Capture / render seam ── 用途は 3 つ</h2>
+<p>
+  これまで「耳なし検証」のために deferred だった capture seam は、<strong>mixer/effects グラフと組み合わさると用途が広がる</strong>。
+</p>
+<ol>
+  <li><strong>耳なし実時間検証</strong>（回帰テスト・#307 系）</li>
+  <li><strong>recovery の可聴ギャップ実測</strong>（#300 系）</li>
+  <li><strong>render / bounce / mastering 書き出し</strong> ← 新規価値</li>
+</ol>
+<div class="callout c-inv">
+  <span class="lbl">マスタリングも同じグラフで届く</span>
+  2-track ステレオを source に → <strong>master chain（EQ / comp / limiter / normalizer）</strong> → <strong>render（capture seam）</strong>
+  ＝ そのままマスタリング。OrbitScore が <strong>live-coding + production + mastering</strong> を1つのグラフで扱える絵になる。
+  capture seam が production 級（stem 書き出し / freeze / master export）の価値を持つ。
+</div>
+
+<h2>11. 決定台帳</h2>
+
+<h3>確定（このブレストで） <span class="badge b-done">決定</span></h3>
+<ul>
+  <li><strong>reconciliation key = 名前</strong>（宣言的グラフ + 差分適用が全体の統合軸）。</li>
+  <li>ルーティングの向き = <strong>常に source が行き先を指す</strong>。</li>
+  <li>routing 4 ノード: <strong>source / sum(group) / aux(send-return) / output(終端)</strong>。output は 2 ドメイン（audio / data=IAC）。</li>
+  <li>チェーン順 = 信号フロー（source 先頭・<code>inst()</code>=音源置換・<code>play()</code>=パターン直交・<code>send()</code> 位置=tap 点）。</li>
+  <li>automation = <strong>3 層</strong>（①時間決定論 pre-render / ②control-rate signal modulation / ③semantic=north-star 対象外）。便利関数は ①② を巻き取る。</li>
+  <li>Global = <strong>2 分割</strong>（project 所有の永続グラフ / performance 駆動の live param）。</li>
+  <li>mixer 未挙げ項目を<strong>全部スコープ in</strong>（solo / sidechain入力 / PDC / metering / nesting）。</li>
+  <li><strong>SOLO(a,b,c)</strong> = 集合ベース予約キーワード（RUN/LOOP/MUTE の group-diff 再利用・multi-solo がタダ）。</li>
+  <li>capture/render seam の用途 = ①検証 ②recovery ギャップ ③<strong>render/mastering</strong>。</li>
+  <li>VST は <strong>format-agnostic な DSL</strong> 設計で δ で差し込む（DSL 改修ゼロ）。</li>
+</ul>
+
+<h3>未決（記法・意味論の詰め） <span class="badge b-next">open</span></h3>
+<ul>
+  <li><code>output()</code> の<strong>多態と名前解決</strong>（master/hw/Link/cue/sum/aux の判別）。</li>
+  <li><strong>effect インスタンス・ハンドル</strong>の構文（重複対応 + param アドレス）。</li>
+  <li><strong>mono / stereo / multi</strong> の channel-count モデル（推論 vs 明示）。</li>
+  <li><strong>solo × mute 相互作用</strong>・group/aux の solo。</li>
+  <li><strong>automation API surface</strong>（便利関数の語彙・mod 配線の記法）。</li>
+  <li><strong>module eval semantics</strong>（project=宣言的フルグラフ〔削除含む diff〕 vs performance=加算的 live op〔暗黙削除しない〕）。</li>
+</ul>
+
+<h3>OrbitStudio-era（今は「塞がない」だけ） <span class="badge b-defer">cutover 後</span></h3>
+<ul>
+  <li>Global / project の永続所有（ランタイムが identity を持つ）。</li>
+  <li>hot-reload identity の実機構。</li>
+  <li>cue / A-B モニタリング UI（hardware out 選択・preview→promote ワークフロー）。</li>
+  <li>project config の variant / scene（同じ project を別設定で）。</li>
+  <li>song → album の階層構造。</li>
+</ul>
+
+<h3>engine 必須（DSL 不可視だが正しさに不可分） <span class="badge b-risk">engine</span></h3>
+<ul>
+  <li><strong>RT 安全な incremental graph mutation</strong>（走行中の原子的 add/remove/rewire・next-frame swap / double-buffer / lock-free）。</li>
+  <li><strong>PDC</strong>（plugin delay compensation）。</li>
+  <li><strong>非同期 plugin instantiation</strong>（audio thread 外でロード→準備後に atomic 挿入）。</li>
+  <li><strong>control-rate mod 評価</strong>（②automation の mod source / follower）。</li>
+</ul>
+
+<h2>12. シーケンシングと関連</h2>
+<div class="callout c-warn">
+  <span class="lbl">DSL spec 先行 → γ を de-risk</span>
+  γ の engine core routing graph（①）が「何を実行すべきか」は、<strong>DSL（③）が何を表現するか</strong>で決まる
+  （チェーン topology・send/return・順序変更の意味論）。先に DSL を決めずに γ を作ると手戻りが起きる。
+  → <strong>本ノートの routing-graph モデルを最初に詰める</strong>のが最も解きやすい順序。effect chain も automation もその上に乗る。
+</div>
+<ul>
+  <li><strong>A4 named channel</strong>（LinkAudio egress）= output の audio ドメイン1行目。汎用 sum とは別物（egress 固有）。</li>
+  <li><strong>β audio DSL ⊇ pitch DSL</strong>: plugin/effects は audio DSL の一部。β（<a href="POST_2.0_NEXT_STEPS.html">§3</a>）の表現力軸と噛み合う。</li>
+  <li><strong>#300 recovery</strong>: respawn 後の再 establish = 空からの full reconcile。土台は地続き。</li>
+  <li><strong>#307 capture</strong>: metering / render / mastering の共有プリミティブ。</li>
+  <li><strong>DAW_AUDIO_ARCHITECTURE.md</strong>: ①engine graph / ②plugin / ③DSL の3層・insert→send/return→group→master→out の層構造・PDC。</li>
+  <li><strong>groove-from-structure</strong>: automation の決定論方針の根拠。</li>
+</ul>
+
+<hr>
+<p class="small">
+  正本（engine 側）: <a href="POST_2.0_NEXT_STEPS.html">POST_2.0_NEXT_STEPS.html</a> §2・§3 ·
+  研究: <a href="../research/DAW_AUDIO_ARCHITECTURE.md">DAW_AUDIO_ARCHITECTURE.md</a> ·
+  本ノートは設計ディスカッション記録（Issue #337）。正規仕様化・実装は別 issue。
+</p>
+
+</body>
+</html>

--- a/docs/development/POST_2.0_MIXER_DSL_DESIGN.html
+++ b/docs/development/POST_2.0_MIXER_DSL_DESIGN.html
@@ -162,17 +162,20 @@
   <li><strong>チェーン順 = 信号フロー</strong>。effect は順序で音が変わる（comp→eq ≠ eq→comp）ので、メソッドチェーンの並びを実行順にマップする（研究 §4「insert 順序が最重要」）。</li>
   <li><strong>source は先頭</strong>。<code>seq</code> は既に音源を持つ（<code>audio()</code> のサンプル）。<code>inst()</code> は<strong>音源の置換</strong>（サンプルの代わりに synth/sampler plugin）。<strong>再生でも録音でも source 先頭は不変</strong>（録音時は録る入力信号が source）。</li>
   <li><code>play()</code> は<strong>パターン（trigger/note）</strong>で、信号パスとは直交。</li>
-  <li><strong><code>send()</code> の位置 = tap 点</strong>。「effect2 の後に send を置く＝effect2 直後でタップ」と読む。DAW の固定 pre/post-fader より柔軟で、method-chain の強みを活かす。</li>
+  <li><strong><code>send()</code> の位置 = tap 点。<u>何個でも置ける</u></strong>（reverb と delay と cue へ同時に等、各位置が独立した tap）。<strong>pre/post フラグは不要</strong> ── 早く書けば生に近い信号、最後に書けば処理後で、<strong>位置が pre/post を兼ねる</strong>。「pre/post-<em>fader</em>」だけは fader（チャンネル gain）への前後を指すので、<strong>gain/fader もチェーン上の1ノード</strong>にしておけば send をその前/後に置くことで自然に決まる（フラグ廃止）。</li>
   <li><strong>mono / stereo / multi</strong>: 基本は source から伝播（推論）・必要時だけ明示。記号で everywhere に書かせると煩雑。</li>
+  <li><strong>sum/aux/master を終端に書く = そのノードへ流し込む</strong>。<code>seq….sum("drum")</code> は「この seq の主出力を drum sum へ」（seq が行き先を指す＝§2 の向き）。同じ名前 <code>sum("drum")</code> を主語に書けばバス自身の chain を定義する。<strong>名前 = identity が「流し込む側」と「定義する側」を結ぶ</strong>。terse な終端ノード参照は <code>output(sum("drum"))</code> の sugar。</li>
 </ul>
 <pre>// 叩き台（記法は未確定）
 seq.inst("synth").play(1, 0, 1, 0)   // 音源 + パターン
+   .send("cue")                      // ← 早い位置 = 生に近い tap（pre 相当）
    .effect("comp").effect("eq")      // insert chain（この順 = 実行順）
-   .send("revAux", pre)              // ← 置いた位置 = tap 点
-   .output("master")                 // 終端（書かなければ master）
+   .send("revAux")                   // ← effect 後の tap（post 相当）・send は複数可
+   .sum("drum")                      // 主出力を drum sum へ流し込む（= output の代わり）
 
 sum("drum").effect("glue").output("master")     // group bus 自身も chain を持つ
-aux("revAux").effect("reverb").output("master") // aux も chain + output を持つ</pre>
+aux("revAux").effect("reverb").output("master") // aux も chain + output を持つ
+master.effect("limiter").output("3,4")          // master = 一級ノード（§2.2）</pre>
 
 <h2>4. エフェクトとパラメータ</h2>
 <ul>
@@ -296,6 +299,8 @@ LOOP(lead)</pre>
   <li><strong>master = 一級ノード</strong>（既定の終端 + 自前の master chain = §10 マスタリング chain・#304 master effects の置き場）。〔2026-06-24 レビュー追加〕</li>
   <li><strong>LinkAudio = per-output destination</strong>（<code>link(...)</code>・現 <code>global.linkAudio()</code> グローバルモードから格下げ・native で hardware+Link 混在解禁）。<strong>Link セッション接続の on/off は別スイッチ</strong>（egress routing と独立）。master-only→Link（2ch）も per-channel も「どの node に <code>link()</code> を生やすか」の違いだけ。〔2026-06-24 レビュー追加〕</li>
   <li><strong>型付き destination コンストラクタ</strong>（<code>link()</code> / <code>cue()</code> / <code>sum()</code> / <code>out()</code>）で <code>output()</code> の名前解決（下記 open の有力解）。〔2026-06-24 レビュー〕</li>
+  <li><strong><code>send()</code> は複数可・pre/post フラグ廃止</strong>（位置が tap 点＝pre/post を兼ねる。pre/post-fader は gain/fader ノードに対する位置で決まる）。〔2026-06-24 レビュー追加〕</li>
+  <li><strong>sum/aux/master を終端に書く = そのノードへ流し込む</strong>（名前 = identity が「流し込み」と「定義」を結ぶ・<code>output(node)</code> の sugar）。〔2026-06-24 レビュー追加〕</li>
 </ul>
 
 <h3>未決（記法・意味論の詰め） <span class="badge b-next">open</span></h3>

--- a/docs/development/POST_2.0_NOTATION_DSL_DESIGN.html
+++ b/docs/development/POST_2.0_NOTATION_DSL_DESIGN.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>OrbitScore Post-2.0 — MLTS Notation（リアルタイム譜面表示）設計ノート</title>
+<style>
+  :root {
+    --ink: #1a1a1a; --bg: #fdfdfd; --muted: #5b6470; --line: #e2e6ea;
+    --accent-a: #1f6feb; --accent-b: #8957e5; --accent-c: #1a7f5a;
+    --warn-bg: #fff8e6; --warn-bd: #e6c34a; --stop-bg: #fdecef; --stop-bd: #e5736f;
+    --inv-bg: #eef4ff; --inv-bd: #1f6feb; --code-bg: #f4f6f8;
+  }
+  html { color: var(--ink); background: var(--bg); }
+  body { margin: 0 auto; max-width: 54em; padding: 48px 28px 96px;
+    font: 16px/1.65 -apple-system, "Hiragino Sans", "Yu Gothic", system-ui, sans-serif; text-rendering: optimizeLegibility; }
+  h1 { font-size: 1.9em; margin: 0 0 .2em; letter-spacing: .01em; }
+  h2 { font-size: 1.35em; margin: 2.2em 0 .6em; padding-bottom: .25em; border-bottom: 2px solid var(--line); }
+  h3 { font-size: 1.1em; margin: 1.6em 0 .4em; }
+  .sub { color: var(--muted); margin: 0 0 1.5em; font-size: .95em; }
+  p { margin: .8em 0; }
+  code { background: var(--code-bg); padding: .1em .35em; border-radius: 4px; font: 13.5px/1.5 ui-monospace, "SF Mono", Menlo, monospace; }
+  pre { background: var(--code-bg); padding: 12px 14px; border-radius: 6px; overflow-x: auto; font: 13px/1.55 ui-monospace, Menlo, monospace; }
+  ul, ol { padding-left: 1.5em; }
+  li { margin: .3em 0; }
+  a { color: var(--accent-a); }
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: .9em; }
+  th, td { border: 1px solid var(--line); padding: 7px 10px; text-align: left; vertical-align: top; }
+  th { background: #f6f8fa; }
+  .badge { display: inline-block; font-size: .72em; font-weight: 700; padding: .12em .6em; border-radius: 999px; vertical-align: middle; letter-spacing: .03em; white-space: nowrap; }
+  .b-done { background: #def7e6; color: #1a7f3c; } .b-next { background: #e6efff; color: #1f5fc0; }
+  .b-defer{ background: #fff2cc; color: #8a6d12; } .b-risk { background: #fde2e2; color: #b53a37; }
+  .callout { border-left: 4px solid; border-radius: 0 6px 6px 0; padding: 12px 16px; margin: 1.2em 0; }
+  .c-inv  { background: var(--inv-bg);  border-color: var(--inv-bd); }
+  .c-warn { background: var(--warn-bg); border-color: var(--warn-bd); }
+  .c-stop { background: var(--stop-bg); border-color: var(--stop-bd); }
+  .callout .lbl { font-weight: 700; display: block; margin-bottom: .2em; }
+  .small { color: var(--muted); font-size: .88em; }
+  hr { border: none; border-top: 1px solid var(--line); margin: 2.5em 0; }
+</style>
+</head>
+<body>
+
+<h1>MLTS Notation — リアルタイム譜面表示 設計ノート</h1>
+<p class="sub">post-2.0 · 設計ディスカッション記録（owner ブレスト 2026-06-26）· Issue #339</p>
+
+<div class="callout c-warn">
+  <span class="lbl">この文書の位置づけ</span>
+  <strong>設計ディスカッション記録</strong>であり正規仕様ではない。<strong>実装は未着手</strong>（build は engine cutover 後・home 確定後）。
+  記載の記法・API は叩き台。明日の demo 用の最小スクリプトは <strong>gauge-by-progress の脇 spike</strong>（本来の engine 開発を邪魔しない範囲）。
+</div>
+
+<h2>0. 背景</h2>
+<p>
+  三輪氏（音楽家）の「<strong>譜面表示できる？</strong>」が発端。相手が音楽家なので <strong>本物の五線譜</strong>が要る（grid/piano-roll では不可）。
+  対象は <strong>Pitch DSL のみ</strong>（audio sequence は対象外）。
+</p>
+
+<h2>1. 核心課題 = MLTS（Multi-Layered Temporal Structure）</h2>
+<div class="callout c-inv">
+  <span class="lbl">なぜ既製ツールで書けないか</span>
+  MLTS = 層（sequence）ごとに <code>beat</code>/<code>tempo</code> が独立し、<strong>小節線が非整列にずれ込む</strong>（polymeter／polytempo）。
+  現代西洋記譜は<strong>共有小節線</strong>（全段が同じ barline グリッド）を大前提とするため、<strong>VexFlow 素・Verovio・MusicXML・OSMD・さらに LilyPond でも native に書けない</strong>領域。
+  ＝ <strong>レンダラは自作が必須</strong>。問いは「何の上に作るか」だけ。
+</div>
+<p class="small">
+  正本: Pitch DSL Spec v1.1 §9.4「ポリメーター/ハーモニックリズムの干渉（MLTS 拡張）」/ <a href="BEAT_METER_SPECIFICATION.md">BEAT_METER_SPECIFICATION.md</a>
+  （1小節 = (60000/tempo)×(numerator/denominator×4) ms・per-seq 独立 → 小節線がドリフトし LCM で再同期）。
+</p>
+
+<h2>2. ライブラリ判断 — VexFlow</h2>
+<table>
+  <thead><tr><th></th><th>VexFlow <span class="badge b-done">採用</span></th><th>OSMD</th><th>Verovio</th><th>abcjs</th><th>LilyPond</th></tr></thead>
+  <tbody>
+    <tr><td>レベル/入力</td><td>低レベル・programmatic（コードで音符）</td><td>高レベル・MusicXML</td><td>MEI/MusicXML (WASM)</td><td>ABC テキスト</td><td>テキスト→PDF/SVG（offline）</td></tr>
+    <tr><td>基盤</td><td>—</td><td><strong>VexFlow の上</strong></td><td>独自</td><td>独自</td><td>独自</td></tr>
+    <tr><td>小節線の自前配置（MLTS）</td><td><strong>✅ 可</strong></td><td>❌ 整列小節前提</td><td>❌ 整列前提</td><td>❌ 整列前提</td><td>△ frontier（native 不可）</td></tr>
+    <tr><td>License</td><td><strong>MIT</strong></td><td>BSD-3</td><td>LGPLv3</td><td>MIT</td><td>GPL</td></tr>
+    <tr><td>engraving</td><td>標準・clean</td><td>標準（自動）</td><td><strong>最高</strong></td><td>良</td><td><strong>出版級</strong></td></tr>
+  </tbody>
+</table>
+
+<h3>2.1 なぜ VexFlow か（MLTS が決め手）</h3>
+<ul>
+  <li><strong>VexFlow は低レベル programmatic</strong> ＝ <strong>層ごとの小節線を自前 x 座標で置ける</strong>。これが MLTS（ずれる小節線）に必須。小節内の難所（音符グリフ・臨時記号・連桁・spacing）は VexFlow に任せ、自作するのは <strong>「MLTS レイアウト層（層ごと bar grid + 時間軸での層間整列）」だけ</strong>。MIT・active(v5)・SVG+CSS でアニメ可。</li>
+  <li><strong>OSMD は不採用</strong>: 価値 = MusicXML から標準記譜を自動レイアウト。だがその自動化は<strong>整列小節線を前提</strong>＝MLTS が破る部分そのもの。MusicXML は MLTS を表現できず、生成も冗長。<strong>OSMD は VexFlow の上</strong>なので MLTS には VexFlow の低レベル制御が結局必要で、OSMD 層はむしろ邪魔。</li>
+  <li><strong>Verovio 不採用</strong>: engraving は最高だが LGPLv3 + MEI/MusicXML（整列前提）+ WASM 重 → MLTS では優位消失。</li>
+  <li><strong>publication = LilyPond だが MLTS は LilyPond でも frontier</strong>（ずれる小節線は native 不可）。→ MLTS の出版答えは「<strong>拡張 VexFlow / 自作レンダラ</strong>」。LilyPond は標準還元できる部分の補助。</li>
+</ul>
+<div class="callout c-inv">
+  <span class="lbl">長期: 拡張 VexFlow が MLTS 記譜システムの正攻法</span>
+  MLTS はどの既製ツールも native に書けない ＝ どの道レンダラは自作する。<strong>VexFlow を MLTS-aware に拡張</strong>すれば <strong>live と publication を1レンダラに統一</strong>できる（live は今・出版品質へ後で磨く）。
+  notation-model（中間表現）→ 複数レンダラ（VexFlow / 将来 LilyPond）も将来余地。
+</div>
+
+<h2>3. real-time = 自前（live-coding 整合）</h2>
+<p>
+  <strong>engine が timing を駆動し、VexFlow は「描画 + カーソル overlay」だけ</strong>。カーソルは VexFlow/lib 自身の synth でなく
+  <strong>OrbitScore の transport（<code>getTransportPosition()</code> / now_sec）から x 座標を出して駆動</strong>する。
+  組込 playback/cursor の価値は下がり、lib は engraving + programmatic 動的描画 + license + メンテで選ぶ ＝ VexFlow が最クリーン。
+  VexFlow は SVG + CSS アニメ・要素グループ化・音符の動的追加に対応（参考: mrk21.hatenablog.com/entry/2018/06/04/103857）。
+</p>
+
+<h2>4. データブリッジ（engine 非依存・interpreter 層）</h2>
+<p>scout（#339 関連調査）で確認。<strong>すべて interpreter レベル ＝ engine 非依存（今の SC エンジンでも動く）</strong>:</p>
+<ul>
+  <li><strong>音符 + timing + pitch</strong>: <code>interpreter.getState()</code> の per-seq <code>timedEvents</code>（<code>TimedEvent.pitch</code> = degree/alteration/oct/detune・public）。</li>
+  <li><strong>staff 位置</strong>: <code>resolveDegree</code>（<code>packages/engine/src/midi/index.ts</code> public）で degree→MIDI note。</li>
+  <li><strong>per-layer MLTS grid</strong>: per-seq <code>beat / tempo / length</code>（<code>Sequence.getState()</code>）→ 1小節長。</li>
+  <li><strong>playhead / 次 swap</strong>: <code>global.getTransportPosition()</code> / <code>getQuantizedEffectPosition()</code>。</li>
+  <li><strong>pitched 判別</strong>: <code>isMidi()</code>。</li>
+  <li><strong>既存 headless 実行</strong>: <code>npm run midi-run -- &lt;file.orbs&gt;</code>（degree→MIDI 解決の既存パス・抽出に再利用可）。</li>
+  <li><strong>最小 tap</strong>: <code>getState()</code> polling + 小さな WS（core 改変ゼロ）。clean 版は <code>InterpreterV2.addObserver()</code> 追加（~10行）。WS サーバは net-new（~50行）。</li>
+</ul>
+<p class="small">→ <strong>譜面 view は engine 非依存の read-only consumer</strong>として成立。audio path / engine core / .vsix を触らない。</p>
+
+<h2>5. home（後決め・優先は engine cutover）</h2>
+<ul>
+  <li><strong>2.0.0 .vsix には載せない</strong>（owner 判断・筋が悪い）。</li>
+  <li>engine 完成 → <strong>2.1.0 .vsix で engine 切替（cutover）→ そこで OrbitStudio を待たず譜面をやれる可能性</strong> / または <strong>OrbitStudio（VSCodium）パネル</strong>。VSCodium は engine ほど重くないので <strong>その時に decide</strong>。</li>
+  <li>notation は engine 非依存なので home は柔軟。<strong>当面の優先 = engine cutover（Path A → γ → cutover #108）まで行くこと</strong>。</li>
+</ul>
+
+<h2>6. 研究新規性</h2>
+<p>MLTS 記譜には標準が無い → <strong>その視覚言語を設計すること自体が貢献</strong>（論文の芽。owner の研究志向と噛む）。</p>
+
+<h2>7. 明日の demo（最小・gauge-by-progress）</h2>
+<p>
+  締切は外した（間に合わなくて良い）。最小 = <strong>pitch DSL を VexFlow で描画するスクリプトを用意するだけ</strong>（static でも可・「なんらか見せれれば良い」）。
+  <strong>scratchpad で・本来の engine 開発を一切邪魔しない範囲で</strong>進め、進捗で判断。良ければ後で正規 spike へ昇格、ダメなら捨てる。
+  実装案: <code>midi-run</code> 経路 or <code>getState()</code> + <code>resolveDegree</code> で pitch .orbs → 音符抽出 → VexFlow で per-layer offset barline 付き静的描画（MLTS の見せ場）。
+</p>
+
+<h2>8. シーケンシング</h2>
+<div class="callout c-warn">
+  <span class="lbl">優先順</span>
+  <strong>(1) engine = Path A（daemon CLAP 統合）</strong> → γ → <strong>cutover #108</strong>（= 本来の開発・最優先）。
+  <strong>(2) notation build は cutover 後</strong>（home = 2.1.0 .vsix or OrbitStudio・後決め）。表示する pitch コンテンツは Pitch DSL v1.1（Epic #224）が供給。
+  今やるのは<strong>本ノート（設計記録）のみ</strong> + demo 用最小 spike（任意・脇）。
+</div>
+
+<hr>
+<p class="small">
+  関連: <a href="POST_2.0_NEXT_STEPS.html">POST_2.0_NEXT_STEPS.html</a>（engine roadmap）·
+  <a href="POST_2.0_MIXER_DSL_DESIGN.html">POST_2.0_MIXER_DSL_DESIGN.html</a>（mixer/routing 設計）·
+  Pitch DSL Spec v1.1（specs-v2）· 本ノートは設計ディスカッション記録（Issue #339）。実装・正規仕様化は別 issue。
+</p>
+
+</body>
+</html>

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,38 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.168 docs(notation): MLTS real-time score-display design note (#339) (Jun 26, 2026)
+
+**Date**: 2026-06-26
+**Status**: ✅ 設計記録（discussion record・実装なし）
+**Branch**: `337-mixer-dsl-design`（docs のみのため同ブランチに同梱・owner 指示）
+**Issue**: #339
+**成果物**: `docs/development/POST_2.0_NOTATION_DSL_DESIGN.html`
+
+post-2.0 のリアルタイム/静的 譜面表示（MLTS notation）の設計をブレストし記録。三輪氏（音楽家）の
+「譜面表示できる？」が発端 → 本物の五線譜が要る・Pitch DSL のみ対象。
+
+**核心 = MLTS（Multi-Layered Temporal Structure）**: 層ごと beat/tempo 独立で小節線が非整列にずれ込む
+（polymeter）。現代西洋記譜は共有小節線前提で、VexFlow 素・OSMD・Verovio・MusicXML・LilyPond でも
+native に書けない → レンダラ自作必須。
+
+**ライブラリ判断 = VexFlow**（MIT・programmatic で小節線を自前配置＝MLTS に必須・active v5・SVG+CSS アニメ）。
+OSMD 不採用（MusicXML/整列小節前提・VexFlow の上）/ Verovio 不採用（LGPL+整列前提+WASM 重）/ publication=
+LilyPond だが MLTS は LilyPond でも frontier → MLTS は拡張 VexFlow が正攻法（live+publish 統一）。
+
+**real-time = 自前**（engine が timing 駆動・VexFlow は描画+カーソル overlay・cursor は transport から駆動）。
+**データブリッジ = engine 非依存**（interpreter getState の timedEvents+pitch / resolveDegree / per-seq
+beat/tempo/length / transport / midi-run / isMidi・最小は polling+WS で core 改変ゼロ）。
+
+**home（後決め・優先は engine cutover）**: 2.0.0 .vsix には載せない / engine 完成後 2.1.0 .vsix で engine
+切替 → OrbitStudio を待たず可能性 or OrbitStudio パネル。notation は engine 非依存で home 柔軟。
+**当面の優先 = engine cutover（Path A→γ→#108）**。notation build は cutover 後。
+
+**研究新規性**: MLTS 記譜に標準なし → 視覚言語の設計自体が貢献（論文の芽）。
+
+**スコープ**: 本エントリ = 設計記録のみ・実装なし。明日 demo の最小スクリプト（pitch DSL→VexFlow 静的描画）は
+gauge-by-progress の脇 spike（engine 開発を邪魔しない範囲・scratchpad）。
+
 ### 6.167 docs(engine): mixer / routing / effects / automation / module DSL design note (#337) (Jun 24, 2026)
 
 **Date**: 2026-06-24

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,35 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.167 docs(engine): mixer / routing / effects / automation / module DSL design note (#337) (Jun 24, 2026)
+
+**Date**: 2026-06-24
+**Status**: ✅ 設計ノート作成（discussion record・実装なし）
+**Branch**: `337-mixer-dsl-design`
+**Issue**: #337
+**成果物**: `docs/development/POST_2.0_MIXER_DSL_DESIGN.html`（手書き HTML・既存 specs スタイル）
+
+post-2.0 engine track の **DSL 側未設計領域**（mixer / routing / effects / automation / module）を
+owner とブレストし、設計ディスカッション記録として HTML に固定した。engine 側ホスティング（γ/δ）は
+`POST_2.0_NEXT_STEPS.html` §3 にあるが、それを DSL からどう叩くか（plugin 呼び出し / effect chain /
+send-return / aux / automation / ファイル分割）は未設計だった。
+
+**統合軸**: **reconciliation key = 名前**（宣言的グラフ + 名前キー差分適用。routing / effect ハンドル /
+module identity / recovery を束ねる）。
+
+**確定**（このブレスト）: ルーティングの向き=常に source が行き先を指す / routing 4 ノード（source・
+sum(group)・aux(send-return)・output(終端)）+ output 2 ドメイン（audio / data=IAC）/ chain 順=信号フロー
+（source 先頭・inst=音源置換・play=パターン直交・send 位置=tap）/ automation 3 層（時間決定論 pre-render /
+control-rate signal modulation / semantic=north-star 対象外）/ Global 2 分割（project=永続グラフ /
+performance=live param tempo 等）/ SOLO(a,b,c)=集合キーワード（RUN/LOOP/MUTE の group-diff 再利用・
+multi-solo がタダ）/ mixer 未挙げ項目 全部 in（solo・sidechain入力・PDC・metering・nesting）/
+capture seam の用途 3 つ（検証・recovery ギャップ・render/mastering）/ VST は format-agnostic DSL で δ で差込。
+
+**未決 / OrbitStudio-era / engine 必須**は HTML §11 決定台帳に仕分け記録。
+
+**プロセス**: docs-only のため full PR レビュー（simplify + pr-review-team）はオーバーエンジニアリング
+（CLAUDE.md）→ スキップ。正規仕様化・実装は別 issue。HTML は well-formed 検証済。
+
 ### 6.166 test(engine): A4-PR4 active-loops across-respawn e2e — full DSL / interpreter-driven (#335) (Jun 23, 2026)
 
 **Date**: 2026-06-23


### PR DESCRIPTION
## 概要

post-2.0 engine track の **DSL 側未設計領域**（mixer / routing / effects / automation / module system）の
**設計ディスカッション記録**を手書き HTML で固定（owner と 2026-06-24 にブレストした内容）。

engine 側ホスティング（γ out-of-process sandbox / δ VST3·AU）は `POST_2.0_NEXT_STEPS.html` §3 にロードマップ済だが、
**それを DSL からどう叩くか**は未設計だった（routing 研究 `DAW_AUDIO_ARCHITECTURE.md` も DSL 表現面を「将来」と留保）。

## 成果物

- `docs/development/POST_2.0_MIXER_DSL_DESIGN.html`（既存 specs スタイル・well-formed 検証済）

## 統合軸

**reconciliation key = 名前** — DSL は「あるべきグラフ」を宣言、engine は実グラフと差分して最小 delta だけ適用
（unchanged は無停止）。名前が routing / effect ハンドル / module identity / recovery を束ねる key。

## 内容（§11 決定台帳に4仕分け）

- **確定**: ルーティングの向き=source が行き先を指す / 4 ノード（source・sum(group)・aux(send-return)・output(終端)）
  + output 2 ドメイン（audio / data=IAC）/ chain 順=信号フロー / automation 3 層 / Global 2 分割 / SOLO 集合キーワード /
  mixer 項目全部 in / capture seam 3 用途（検証・recovery・mastering）/ VST は format-agnostic DSL で δ で差込。
- **未決**: output 多態の名前解決 / effect ハンドル構文 / mono-stereo モデル / solo×mute / automation API / module eval semantics。
- **OrbitStudio-era**: Global 所有 / hot-reload identity / cue·A-B UI / config variant / song→album。
- **engine 必須**: RT 安全な incremental graph mutation / PDC / 非同期 plugin instantiation / control-rate mod 評価。

## スコープ / プロセス

- **設計ノートのみ・実装なし**。正規仕様化は別 issue。
- **docs-only** のため full PR レビュー（simplify + pr-review-team）はオーバーエンジニアリング（CLAUDE.md）→ スキップ。

Closes #337
