### PR TITLE
ci(rust): wire Rust workspace into CI (fmt / clippy / test / cargo-deny)

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -60,9 +60,26 @@ jobs:
     defaults:
       run:
         working-directory: rust
+    env:
+      # cargo-deny は `cargo metadata` 経由で crates.io sparse-index を更新する。
+      # runner では index 取得が HTTP2/SSL の transient blip で失敗することがある
+      # （観測例: "Error in the HTTP2 framing layer" / "unexpected eof while reading"）。
+      # 既定 retry=3 では落ちたため引き上げる。registry は下の rust-cache でも温める。
+      CARGO_NET_RETRY: "10"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      # cargo-deny 自体は cargo を要するが、この job は build しないため registry が
+      # 毎回 cold になり network に依存する。toolchain + cache で registry index を
+      # 温め、cold fetch（= flake 源）への露出を減らす。
+      - name: Setup Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
 
       - name: Install cargo-deny
         uses: taiki-e/install-action@v2

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,76 @@
+name: Rust CI
+
+# Rust workspace (rust/) の検証。既存 code-review.yml は npm/TS のみを回しており
+# Rust は CI で一切検証されていなかった（Issue #326）。本 job が fmt / clippy /
+# test / license-gate を PR ごとに回す。
+#
+# スコープ（Issue #326）:
+# - ubuntu-latest で permissive + cross-platform な default グラフを検証する。
+# - `link-audio` feature(GPL・Ableton Link・build.rs が macOS 専用)は ubuntu で
+#   ビルド不可かつ GPL 隔離方針のため CI では有効化しない。`clap-host`(permissive)は検証する。
+# - 実機 output device / multicast を要する gated テストは全て `#[ignore]` なので
+#   `cargo test` で自動的に skip される（CI に audio device は無い）。
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  rust:
+    name: fmt / clippy / test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install ALSA dev headers (cpal backend)
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+
+      - name: Setup Rust toolchain (stable + rustfmt + clippy)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: Format check
+        run: cargo fmt --all --check
+
+      - name: Clippy (default features)
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+
+      - name: Clippy (clap-host feature)
+        run: cargo clippy -p orbit-audio-daemon --features clap-host --all-targets --locked -- -D warnings
+
+      - name: Test (default features, gated tests auto-skipped)
+        run: cargo test --workspace --locked
+
+      - name: Test (clap-host feature, gated tests auto-skipped)
+        run: cargo test -p orbit-audio-daemon --features clap-host --locked
+
+  cargo-deny:
+    name: license / dependency gate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+
+      # default グラフ(link-audio off)が GPL-free であることを assert する。
+      # GPL 隔離 crate orbit-link-audio は [workspace] exclude かつ default-off feature
+      # 経由でしか graph に入らないため、ここに GPL が現れたら隔離が壊れている。
+      - name: cargo-deny check
+        run: cargo deny check

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -64,7 +64,7 @@ jobs:
       # cargo-deny は `cargo metadata` 経由で crates.io sparse-index を更新する。
       # runner では index 取得が HTTP2/SSL の transient blip で失敗することがある
       # （観測例: "Error in the HTTP2 framing layer" / "unexpected eof while reading"）。
-      # 既定 retry=3 では落ちたため引き上げる。registry は下の rust-cache でも温める。
+      # 既定の retry 回数では落ちたため引き上げる。registry は下の rust-cache でも温める。
       CARGO_NET_RETRY: "10"
     steps:
       - name: Checkout code

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -63,7 +63,21 @@ ubuntu の scheduling 差で reply 到達前に 64 を超過。修正 = **`Strea
 HTTP2 framing / SSL unexpected eof）。`rust` job は rust-cache で registry が温まり network 依存が低い一方、
 **cargo-deny job は toolchain/cache 無しで毎回 cold fetch** していた。対策: cargo-deny job に
 `dtolnay/rust-toolchain@stable` + `Swatinem/rust-cache@v2` + `CARGO_NET_RETRY=10` を追加（registry を温め
-cold fetch への露出を減らす）。
+cold fetch への露出を減らす）。修正後 CI で両 rust job + code-review すべて green（cold cache でも cargo-deny 通過）。
+
+**レビュー（/simplify + /code:pr-review-team）**:
+- `/simplify`（reuse/simplification/efficiency/altitude 4 agent）: reuse 1件適用（harness の `"StreamStats"` リテラル →
+  既存 const `protocol::EVENT_STREAM_STATS`）。他は意図的な複雑さ（診断 state・二重 cap・YAML job 重複）として clean 判定。
+- `/code:pr-review-team`（code-reviewer / silent-failure-hunter / pr-test-analyzer / comment-analyzer）: **Critical=0**。
+  Important 3件を修正:
+  1. (silent-failure) harness 診断: 別 ID reply で budget 枯渇時、reply は `event` を持たず `"<reply-or-other>"` の
+     羅列になる → `event=<名>` / `reply(id=<id>)` を区別記録。budget/backstop も const 化（panic メッセージと同期）。
+  2. (comment) `analysis.rs` / 3. `pan_real_wav.rs`: rustfmt 整列で設計根拠コメントが直前 `let` 行の trailing comment
+     列に帰属して見える問題 → 空行挿入で独立コメント化（fmt 安定確認済）。
+  - Minor: `protocol.rs` の `"StreamStats"` も const 化 / `config.rs` の不正確なソートコメント訂正
+    （存在しない sample-rate ソートの記述を削除）/ workflow の retry コメントを具体値非依存に修正。
+  - 見送り（理由付き）: teardown timeout backstop（現 count backstop で十分）/ `deny.toml` の `unknown-git`
+    （#326 スコープ外・clack git dep に warning が出る恐れ）/ `workflow_dispatch`（GitHub UI の Re-run で代替可能・前提誤り）。
 
 ---
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -55,7 +55,15 @@ verify テストの WAV fixture は git-tracked（CI で `cargo test` 可）。
 「budget 圧迫回避」を主張していたが events vec から外すだけで loop counter には効いていなかった）。
 ubuntu の scheduling 差で reply 到達前に 64 を超過。修正 = **`StreamStats` を budget に数えない**
 （非 StreamStats を 64 で cap・anti-hang の絶対上限 backstop 併設・reply 未達時は何を見たかを panic に出力）。
-挙動は behavior-preserving（macOS 19/19・ubuntu は push で検証）。
+挙動は behavior-preserving（macOS 19/19・ubuntu は push で検証）。修正後 CI で `fmt / clippy / test` 1m43s green
+（7 テスト含む全 19 が ubuntu でも pass）= 仮説確定。
+
+**cargo-deny job の network 堅牢化**: 同 CI で `license / dependency gate`（cargo-deny）が 10s で fail。原因は
+依存・config ではなく **crates.io sparse-index 取得の transient flake**（`cargo metadata` の index 更新が
+HTTP2 framing / SSL unexpected eof）。`rust` job は rust-cache で registry が温まり network 依存が低い一方、
+**cargo-deny job は toolchain/cache 無しで毎回 cold fetch** していた。対策: cargo-deny job に
+`dtolnay/rust-toolchain@stable` + `Swatinem/rust-cache@v2` + `CARGO_NET_RETRY=10` を追加（registry を温め
+cold fetch への露出を減らす）。
 
 ---
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,38 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.170 ci(rust): wire Rust workspace into CI — fmt / clippy / test / cargo-deny (#326) (Jun 26, 2026)
+
+**Date**: 2026-06-26
+**Status**: ✅ 実装完了（PR レビュー前）
+**Branch**: `326-ci-rust-job`
+**Issue**: #326（post-2.0 engine track / γ・cutover #108 前の hardening + CI 負債解消）
+
+これまで CI は `code-review.yml`（npm/TS のみ）で **Rust を一切検証していなかった**。#340 で「CI green ≠ Rust 検証」が
+繰り返し問題になった（gated 実機 RUN とローカル cargo が唯一の根拠）。本 PR で Rust workspace を PR ごとに CI 検証する。
+
+**前提クリーンアップ（CI ゲートを green にするため必須）**:
+- **fmt drift 19 ファイル**を `cargo fmt --all` で解消（Rust CI 不在で fmt が変更ファイルにしか当たっていなかった。
+  `cargo fmt --all` は workspace-exclude の `orbit-link-audio` も整形＝CI の `--check` と一貫）。純整形コミットに分離。
+- **clippy 警告**を解消（auto-fix: redundant closure / div_ceil / collapsible if 等 + 手動 3 件: orbit-clap-spike の
+  `sort_by`→`sort_by_key(Reverse)` / `if x>0 {a/x}`→`checked_div().unwrap_or(0)` ×2）。挙動不変。
+
+**workflow（`.github/workflows/rust-ci.yml`・2 job）**:
+- `rust`（ubuntu）: libasound2-dev（cpal/ALSA）→ dtolnay/rust-toolchain@stable + Swatinem/rust-cache@v2 →
+  `cargo fmt --all --check` / `clippy`（default & clap-host）`--all-targets --locked -- -D warnings` /
+  `cargo test`（default & clap-host）`--locked`（gated は `#[ignore]` で自動 skip・CI に device 無し）。
+- `cargo-deny`（ubuntu）: taiki-e/install-action → `cargo deny check`。default グラフ(link-audio off)が GPL-free を assert。
+
+**スコープ判断**: GPL feature `link-audio`（build.rs が `target_os != "macos"` で error）は ubuntu でビルド不可かつ
+GPL 隔離方針のため **CI では有効化しない**（default グラフ = permissive + cross-platform に保つ）。実機 gated テストは
+CI で走らない（audio device 無し）。
+
+**ローカル全 green 確認**: fmt clean / clippy `-D warnings` clean（default + clap-host）/ cargo test 全通過
+（default + clap-host・非gated）/ cargo-deny `advisories+bans+licenses+sources ok` / `--locked` OK /
+verify テストの WAV fixture は git-tracked（CI で `cargo test` 可）。
+
+---
+
 ### 6.169 feat(engine): daemon CLAP integration — in-process plugin hosting (#340) (Jun 26, 2026)
 
 **Date**: 2026-06-26

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -47,6 +47,16 @@ CI で走らない（audio device 無し）。
 （default + clap-host・非gated）/ cargo-deny `advisories+bans+licenses+sources ok` / `--locked` OK /
 verify テストの WAV fixture は git-tracked（CI で `cargo test` 可）。
 
+**CI が炙り出した harness bug の修正（#326 の価値そのもの）**: 初回 CI で `protocol.rs` の 7 テストが
+**ubuntu のみ** fail（macOS ローカルは green）。全て実 `LoadSample`(kick.wav) 後のコマンド reply 待ちで
+`common/mod.rs` の `recv_reply_with_events` が「64 messages 以内に reply 来ず」で panic。root cause は
+**scan budget の数え漏れ**: `for _ in 0..64` が全メッセージを数える一方、`StreamStats`（1 Hz ticker が
+`start_paused` の auto-advance で reply 前に積む noise）を budget から除外していなかった（コメントは
+「budget 圧迫回避」を主張していたが events vec から外すだけで loop counter には効いていなかった）。
+ubuntu の scheduling 差で reply 到達前に 64 を超過。修正 = **`StreamStats` を budget に数えない**
+（非 StreamStats を 64 で cap・anti-hang の絶対上限 backstop 併設・reply 未達時は何を見たかを panic に出力）。
+挙動は behavior-preserving（macOS 19/19・ubuntu は push で検証）。
+
 ---
 
 ### 6.169 feat(engine): daemon CLAP integration — in-process plugin hosting (#340) (Jun 26, 2026)

--- a/rust/crates/orbit-audio-daemon/examples/export_verify_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/examples/export_verify_pcm.rs
@@ -121,7 +121,10 @@ fn play_span(ev: &GoldenEvent, sample_frames: &HashMap<String, usize>, sr: f64) 
 /// verify_schedule_pcm.rs の `body_window` と同値（あちらは test binary の private 関数で
 /// `orbit-audio-verify` には無く import 不可。共通化は follow-up）。
 fn body_window(onset: usize, span: usize, tail_trim: usize) -> (usize, usize) {
-    (onset + BODY_HEAD_OFFSET, onset + span.saturating_sub(tail_trim))
+    (
+        onset + BODY_HEAD_OFFSET,
+        onset + span.saturating_sub(tail_trim),
+    )
 }
 
 /// stereo interleaved `cap.data` から mono mix `(L+R)/2` の `CapturedAudio` を生成。
@@ -230,15 +233,10 @@ fn process_fixture(fixture_name: &str) {
 
     // ─── PCM ダンプ ────────────────────────────────────────────────────────
     let gen_dir = repo_path("test-assets/verify-fixtures/phase3/.gen");
-    std::fs::create_dir_all(&gen_dir)
-        .unwrap_or_else(|e| panic!(".gen/ ディレクトリ作成失敗: {e}"));
+    std::fs::create_dir_all(&gen_dir).unwrap_or_else(|e| panic!(".gen/ ディレクトリ作成失敗: {e}"));
     let pcm_path = gen_dir.join(format!("{fixture_name}.pcm"));
     // stereo interleaved data を little-endian f32 バイト列としてダンプ（ヘッダ無し）。
-    let bytes: Vec<u8> = cap
-        .data
-        .iter()
-        .flat_map(|&s| s.to_le_bytes())
-        .collect();
+    let bytes: Vec<u8> = cap.data.iter().flat_map(|&s| s.to_le_bytes()).collect();
     std::fs::write(&pcm_path, &bytes)
         .unwrap_or_else(|e| panic!("PCM 書き込み失敗 {}: {e}", pcm_path.display()));
     println!(
@@ -284,8 +282,8 @@ fn process_fixture(fixture_name: &str) {
         // body peak ≈ 探索区間 peak のため数値差は無視できる（README が校正の正本）。
         let body_peak = region_peak(&mono, 0, w_start, w_end);
         let threshold = ONSET_THRESHOLD_RATIO as f32 * body_peak;
-        let onset_frame_threshold = detect_onset_threshold(&sub, 0, threshold)
-            .map(|local_f| local_f + search_start);
+        let onset_frame_threshold =
+            detect_onset_threshold(&sub, 0, threshold).map(|local_f| local_f + search_start);
 
         // ─── onset 検出（matched filter 法）──────────────────────────
         // matched filter の demo は per_event_gain 第1イベントのみ（他 fixture は threshold で

--- a/rust/crates/orbit-audio-daemon/src/main.rs
+++ b/rust/crates/orbit-audio-daemon/src/main.rs
@@ -10,8 +10,8 @@
 
 use orbit_audio_daemon::engine_wrap::EngineWrap;
 use orbit_audio_daemon::protocol::{
-    Event, ProtocolError, StartupError, StartupReady, ERROR_CODE_FATAL_PANIC,
-    ERROR_SEVERITY_FATAL, EVENT_DAEMON_ERROR, PROTOCOL_VERSION,
+    Event, ProtocolError, StartupError, StartupReady, ERROR_CODE_FATAL_PANIC, ERROR_SEVERITY_FATAL,
+    EVENT_DAEMON_ERROR, PROTOCOL_VERSION,
 };
 use orbit_audio_daemon::server;
 use serde_json::json;

--- a/rust/crates/orbit-audio-daemon/tests/common/mod.rs
+++ b/rust/crates/orbit-audio-daemon/tests/common/mod.rs
@@ -126,11 +126,16 @@ pub async fn recv_reply_for_id(ws: &mut WsClient, id: &str) -> Value {
 /// 備え、絶対上限の backstop も置く。（純 `StreamStats` を検証するテストは本ヘルパーを
 /// 使わず直接 `next_json` でドレインする）。
 pub async fn recv_reply_with_events(ws: &mut WsClient, id: &str) -> (Value, Vec<Value>) {
+    // StreamStats 以外で許容するメッセージ数。panic メッセージとも同期させる。
+    const NON_STREAM_BUDGET: u32 = 64;
+    // StreamStats だけが流れ続けて reply が来ない場合の絶対 backstop。
+    const HARD_CAP: usize = 10_000;
+
     let mut events = Vec::new();
-    let mut budget: u32 = 64;
+    let mut budget = NON_STREAM_BUDGET;
     let mut stream_stats_drained: u32 = 0;
     let mut non_stream_seen: Vec<String> = Vec::new();
-    for _ in 0..10_000 {
+    for _ in 0..HARD_CAP {
         let msg = next_json(ws).await;
         if msg["id"] == id {
             return (msg, events);
@@ -142,22 +147,22 @@ pub async fn recv_reply_with_events(ws: &mut WsClient, id: &str) -> (Value, Vec<
         // StreamStats 以外（他コマンドの reply / 別 event 等）のみ budget を消費する。
         assert!(
             budget > 0,
-            "did not receive reply for id={id} within 64 non-StreamStats messages \
-             (StreamStats drained={stream_stats_drained}); saw: {non_stream_seen:?}"
+            "did not receive reply for id={id} within {NON_STREAM_BUDGET} non-StreamStats \
+             messages (StreamStats drained={stream_stats_drained}); saw: {non_stream_seen:?}"
         );
         budget -= 1;
-        non_stream_seen.push(
-            msg["event"]
-                .as_str()
-                .unwrap_or("<reply-or-other>")
-                .to_string(),
-        );
+        // reply は event フィールドを持たないため、event 名と wrong-id reply を区別して記録する
+        // （budget が別コマンドの reply で枯渇したケースも診断できるようにする）。
+        non_stream_seen.push(match msg["event"].as_str() {
+            Some(ev) => format!("event={ev}"),
+            None => format!("reply(id={})", msg["id"].as_str().unwrap_or("?")),
+        });
         if msg["type"] == "event" {
             events.push(msg);
         }
     }
     panic!(
-        "did not receive reply for id={id} within 10000 total messages \
+        "did not receive reply for id={id} within {HARD_CAP} total messages \
          (StreamStats drained={stream_stats_drained}, non-StreamStats={})",
         non_stream_seen.len()
     );

--- a/rust/crates/orbit-audio-daemon/tests/common/mod.rs
+++ b/rust/crates/orbit-audio-daemon/tests/common/mod.rs
@@ -117,21 +117,49 @@ pub async fn recv_reply_for_id(ws: &mut WsClient, id: &str) -> Value {
 /// PlayStarted が reply より先に来るケース（`PlayAt` の実装順序）で、
 /// event を discard せず保持したいテスト向け。
 ///
-/// `StreamStats` は 1 Hz ticker が連続で積むことがあるため、scan budget の
-/// 圧迫を避けて `events` には含めない（純 StreamStats を検証するテストは
-/// `recv_reply_for_id` を使わず直接 `next_json` でドレインする）。
+/// scan budget は **`StreamStats` 以外**のメッセージのみで数える。`StreamStats` は
+/// 1 Hz ticker が `start_paused` 下の auto-advance で reply 到達前に複数積む noise であり、
+/// budget に数えると runtime の scheduling 差で reply 到達前に枯渇する（ubuntu CI で
+/// 顕在化・macOS ローカルは運良く回避していた・Issue #326）。実 `LoadSample` 後の
+/// コマンドで特に flood しやすい。`StreamStats` だけが流れ続けて reply が来ない事態に
+/// 備え、絶対上限の backstop も置く。（純 `StreamStats` を検証するテストは本ヘルパーを
+/// 使わず直接 `next_json` でドレインする）。
 pub async fn recv_reply_with_events(ws: &mut WsClient, id: &str) -> (Value, Vec<Value>) {
     let mut events = Vec::new();
-    for _ in 0..64 {
+    let mut budget: u32 = 64;
+    let mut stream_stats_drained: u32 = 0;
+    let mut non_stream_seen: Vec<String> = Vec::new();
+    for _ in 0..10_000 {
         let msg = next_json(ws).await;
         if msg["id"] == id {
             return (msg, events);
         }
-        if msg["type"] == "event" && msg["event"] != "StreamStats" {
+        if msg["event"] == "StreamStats" {
+            stream_stats_drained += 1;
+            continue;
+        }
+        // StreamStats 以外（他コマンドの reply / 別 event 等）のみ budget を消費する。
+        assert!(
+            budget > 0,
+            "did not receive reply for id={id} within 64 non-StreamStats messages \
+             (StreamStats drained={stream_stats_drained}); saw: {non_stream_seen:?}"
+        );
+        budget -= 1;
+        non_stream_seen.push(
+            msg["event"]
+                .as_str()
+                .unwrap_or("<reply-or-other>")
+                .to_string(),
+        );
+        if msg["type"] == "event" {
             events.push(msg);
         }
     }
-    panic!("did not receive reply for id={id} within 64 messages");
+    panic!(
+        "did not receive reply for id={id} within 10000 total messages \
+         (StreamStats drained={stream_stats_drained}, non-StreamStats={})",
+        non_stream_seen.len()
+    );
 }
 
 /// Command を JSON 文字列で送る。

--- a/rust/crates/orbit-audio-daemon/tests/common/mod.rs
+++ b/rust/crates/orbit-audio-daemon/tests/common/mod.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use futures_util::{SinkExt, StreamExt};
 use orbit_audio_daemon::backend::StubBackend;
 use orbit_audio_daemon::engine_wrap::EngineWrap;
+use orbit_audio_daemon::protocol::EVENT_STREAM_STATS;
 use orbit_audio_daemon::server;
 use orbit_audio_native::StreamStats;
 use serde_json::Value;
@@ -134,7 +135,7 @@ pub async fn recv_reply_with_events(ws: &mut WsClient, id: &str) -> (Value, Vec<
         if msg["id"] == id {
             return (msg, events);
         }
-        if msg["event"] == "StreamStats" {
+        if msg["event"] == EVENT_STREAM_STATS {
             stream_stats_drained += 1;
             continue;
         }

--- a/rust/crates/orbit-audio-daemon/tests/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/tests/protocol.rs
@@ -511,7 +511,8 @@ async fn daemon_error_warning_on_link_egress_drop() {
                     && msg["data"]["severity"] == "warning"
                     && msg["data"]["code"] == "LINK_EGRESS_DROP"
                 {
-                    warning_message = Some(msg["data"]["message"].as_str().unwrap_or("").to_string());
+                    warning_message =
+                        Some(msg["data"]["message"].as_str().unwrap_or("").to_string());
                     break;
                 }
             }

--- a/rust/crates/orbit-audio-daemon/tests/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/tests/protocol.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 use common::{
     advance_and_yield, next_json, recv_reply_for_id, recv_reply_with_events, send_cmd, TestDaemon,
 };
+use orbit_audio_daemon::protocol::EVENT_STREAM_STATS;
 use serde_json::json;
 
 /// 接続直後に daemon が送る handshake フレームの検証。
@@ -436,7 +437,7 @@ async fn stream_stats_ticks_at_1hz() {
             let res = tokio::time::timeout(Duration::from_millis(100), next_json(&mut ws)).await;
             match res {
                 Ok(msg) => {
-                    if msg["event"] == "StreamStats" {
+                    if msg["event"] == EVENT_STREAM_STATS {
                         stats_count += 1;
                     }
                 }

--- a/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
@@ -327,7 +327,7 @@ fn examples22_parity_render_matches_schedule() {
         // 出力 pan を atan2 で独立逆算し schedule の pan と突き合わせる（GRM 独立）。
         let measured = pan_from_lr_rms(l, r);
         assert!(
-            (measured - ev.pan as f32).abs() <= PAN_TOLERANCE,
+            (measured - ev.pan).abs() <= PAN_TOLERANCE,
             "seq {}: schedule pan {} → measured {measured} (L={l:.5}, R={r:.5})",
             ev.sequence_name,
             ev.pan

--- a/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
+++ b/rust/crates/orbit-audio-daemon/tests/verify_schedule_pcm.rs
@@ -15,8 +15,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use orbit_audio_core::sanitize_rate;
-use orbit_audio_daemon::engine_wrap::EngineWrap;
 use orbit_audio_daemon::backend::StubBackend;
+use orbit_audio_daemon::engine_wrap::EngineWrap;
 use orbit_audio_verify::{
     channel_rms, db_difference, pan_from_lr_rms, region_rms, CapturedAudio, GAIN_DB_TOLERANCE,
     PAN_TOLERANCE,
@@ -63,7 +63,9 @@ fn repo_path(rel: &str) -> PathBuf {
 }
 
 fn load_golden(fixture: &str) -> GoldenSchedule {
-    let path = repo_path(&format!("test-assets/verify-fixtures/{fixture}.schedule.json"));
+    let path = repo_path(&format!(
+        "test-assets/verify-fixtures/{fixture}.schedule.json"
+    ));
     let raw = std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("golden JSON {} を読めない: {e}", path.display()));
     serde_json::from_str(&raw).expect("golden JSON parse")
@@ -153,7 +155,10 @@ fn pan_three_voices_render_matches_schedule() {
         // （fade ≤384 + 余裕を除外）。
         let play_frames = sample_frames[&ev.sample];
         let (w_start, w_end) = body_window(onset, play_frames, 600);
-        assert!(w_start < w_end, "pan body 窓が狭すぎる: [{w_start}, {w_end})");
+        assert!(
+            w_start < w_end,
+            "pan body 窓が狭すぎる: [{w_start}, {w_end})"
+        );
         let l = region_rms(&cap, 0, w_start, w_end);
         let r = region_rms(&cap, 1, w_start, w_end);
         assert!(
@@ -210,7 +215,7 @@ fn chop_region_render_matches_schedule() {
 
     // イベント間（slice1 終端 0.6s 〜 slice2 開始 1.1s の中央 0.85s）は無音。
     let gap_start = (0.65 * sr) as usize;
-    let gap_end   = (0.95 * sr) as usize;
+    let gap_end = (0.95 * sr) as usize;
     let gap = region_rms(&cap, 0, gap_start, gap_end);
     assert!(gap < 1e-5, "chop イベント間は無音のはず（RMS={gap:.6}）");
 }
@@ -236,18 +241,26 @@ fn per_event_gain_render_matches_schedule() {
         // kick 0.5s も fade は最大 384 frames（min(0.5*0.04, 0.008)*48000）なので pan と同じ
         // 600 で除外する。dB 差は fade 不変だが、窓に fade を混ぜないよう揃える。
         let (w_start, w_end) = body_window(onset, play_frames, 600);
-        assert!(w_start < w_end, "onset={:.3}s の body 窓が狭すぎる", ev.onset_sec);
+        assert!(
+            w_start < w_end,
+            "onset={:.3}s の body 窓が狭すぎる",
+            ev.onset_sec
+        );
         let l = region_rms(&cap, 0, w_start, w_end);
         let r = region_rms(&cap, 1, w_start, w_end);
         // pan=0 → L/R ほぼ等しい。平均 RMS を使う。
         let rms = (l + r) / 2.0;
-        assert!(rms > 1e-4, "onset={:.3}s に信号が必要（RMS={rms:.5}）", ev.onset_sec);
+        assert!(
+            rms > 1e-4,
+            "onset={:.3}s に信号が必要（RMS={rms:.5}）",
+            ev.onset_sec
+        );
         rms_by_gain.push((ev.gain_db, rms));
     }
 
     // gainDb で並べて loud(-3) / quiet(-9) を識別する。
     rms_by_gain.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap()); // 降順 = loud first
-    let rms_loud  = rms_by_gain[0].1;
+    let rms_loud = rms_by_gain[0].1;
     let rms_quiet = rms_by_gain[1].1;
 
     // db_difference(quiet, loud) = 20*log10(quiet/loud) ≈ -6.0 dB。
@@ -262,7 +275,10 @@ fn per_event_gain_render_matches_schedule() {
     // イベント間（loud 終端 0.6s 〜 quiet 開始 3.1s の 1.0〜2.5s）は無音。両イベントが
     // 誤って onset=0 にレンダされる回帰（加算 RMS になり dB 差が崩れる）を捕まえる。
     let gap = region_rms(&cap, 0, (1.0 * sr) as usize, (2.5 * sr) as usize);
-    assert!(gap < 1e-5, "per_event_gain イベント間は無音のはず（RMS={gap:.6}）");
+    assert!(
+        gap < 1e-5,
+        "per_event_gain イベント間は無音のはず（RMS={gap:.6}）"
+    );
 }
 
 #[test]
@@ -457,7 +473,10 @@ fn linkaudio_routing_separates_channels() {
     let plays = [(0.1, "drums"), (2.1, "bass")];
 
     let drums = render_kick_channel(&plays, "drums", 2.8);
-    assert!(rms_window(&drums, 0.12, 0.4) > 1e-3, "drums tap に kickA 信号が必要");
+    assert!(
+        rms_window(&drums, 0.12, 0.4) > 1e-3,
+        "drums tap に kickA 信号が必要"
+    );
     assert!(
         rms_window(&drums, 2.12, 2.4) < 1e-5,
         "drums tap に kickB(bass) が漏れてはいけない（RMS={}）",
@@ -470,18 +489,28 @@ fn linkaudio_routing_separates_channels() {
         "bass tap に kickA(drums) が漏れてはいけない（RMS={}）",
         rms_window(&bass, 0.12, 0.4)
     );
-    assert!(rms_window(&bass, 2.12, 2.4) > 1e-3, "bass tap に kickB 信号が必要");
+    assert!(
+        rms_window(&bass, 2.12, 2.4) > 1e-3,
+        "bass tap に kickB 信号が必要"
+    );
 
     // 未使用 channel は完全無音。
     let ghost = render_kick_channel(&plays, "ghost", 2.8);
-    assert!(rms_window(&ghost, 0.0, 2.8) < 1e-6, "未使用 channel は無音のはず");
+    assert!(
+        rms_window(&ghost, 0.0, 2.8) < 1e-6,
+        "未使用 channel は無音のはず"
+    );
 }
 
 #[test]
 fn linkaudio_sum_by_name_accumulates() {
     //! A4-1 層A — sum-by-name。同名 channel "drums" に kick を 2 つ同時 onset すると加算され、
     //! 単一 kick より約 +6dB（2x 振幅）。last-writer-wins の regression なら 0dB。
-    let single = rms_avg(&render_kick_channel(&[(0.1, "drums")], "drums", 0.7), 0.12, 0.4);
+    let single = rms_avg(
+        &render_kick_channel(&[(0.1, "drums")], "drums", 0.7),
+        0.12,
+        0.4,
+    );
     let summed = rms_avg(
         &render_kick_channel(&[(0.1, "drums"), (0.1, "drums")], "drums", 0.7),
         0.12,

--- a/rust/crates/orbit-audio-verify/src/analysis.rs
+++ b/rust/crates/orbit-audio-verify/src/analysis.rs
@@ -150,7 +150,7 @@ mod tests {
     #[test]
     fn pan_inversion_hits_known_anchors() {
         let k = std::f32::consts::FRAC_1_SQRT_2; // 中央の左右ゲイン
-        // hard-left: R=0 → pan -1。
+                                                 // hard-left: R=0 → pan -1。
         assert!((pan_from_lr_rms(1.0, 0.0) - (-1.0)).abs() < 1e-5);
         // hard-right: L=0 → pan +1。
         assert!((pan_from_lr_rms(0.0, 1.0) - 1.0).abs() < 1e-5);

--- a/rust/crates/orbit-audio-verify/src/analysis.rs
+++ b/rust/crates/orbit-audio-verify/src/analysis.rs
@@ -150,7 +150,8 @@ mod tests {
     #[test]
     fn pan_inversion_hits_known_anchors() {
         let k = std::f32::consts::FRAC_1_SQRT_2; // 中央の左右ゲイン
-                                                 // hard-left: R=0 → pan -1。
+
+        // hard-left: R=0 → pan -1。
         assert!((pan_from_lr_rms(1.0, 0.0) - (-1.0)).abs() < 1e-5);
         // hard-right: L=0 → pan +1。
         assert!((pan_from_lr_rms(0.0, 1.0) - 1.0).abs() < 1e-5);

--- a/rust/crates/orbit-audio-verify/src/capture.rs
+++ b/rust/crates/orbit-audio-verify/src/capture.rs
@@ -105,7 +105,10 @@ mod tests {
     #[test]
     fn capture_collects_full_timeline_across_blocks() {
         let mut s = Scheduler::new(48_000, 2);
-        s.schedule(ScheduledSample::new(0.0, Sample::new(vec![1.0f32; 1000], 48_000, 1)));
+        s.schedule(ScheduledSample::new(
+            0.0,
+            Sample::new(vec![1.0f32; 1000], 48_000, 1),
+        ));
 
         // total=1000 を 512 ブロックで割る（端数 488 が出る → block 端の処理を通す）。
         let cap = capture(&mut s, 2, 1000, 512);

--- a/rust/crates/orbit-audio-verify/tests/chop_region_real_wav.rs
+++ b/rust/crates/orbit-audio-verify/tests/chop_region_real_wav.rs
@@ -164,8 +164,5 @@ fn region_offset_is_correctly_applied_with_ramp_sample() {
     // total_frames を縮めたとき範囲外 0.0 fallback で誤 pass しうるため、窓 RMS で確認する
     // （窓は total_frames まで取り、構造的に非空）。
     let after_rms = region_rms(&cap, 0, schedule_start + region_len, total_frames);
-    assert!(
-        after_rms < 1e-5,
-        "領域外は無音のはず。RMS={after_rms:.6}"
-    );
+    assert!(after_rms < 1e-5, "領域外は無音のはず。RMS={after_rms:.6}");
 }

--- a/rust/crates/orbit-audio-verify/tests/onset_fade_capture.rs
+++ b/rust/crates/orbit-audio-verify/tests/onset_fade_capture.rs
@@ -97,11 +97,7 @@ fn fade_tail_captured_in_l_channel_is_linear() {
         .map(|f| cap.at(f, 0).abs())
         .collect();
 
-    assert_eq!(
-        envelope.len(),
-        fade_frames,
-        "fade 窓の長さが一致するはず"
-    );
+    assert_eq!(envelope.len(), fade_frames, "fade 窓の長さが一致するはず");
 
     // body（fade 前）は定常 1.0 であることを確認（body 窓の先頭を数点）。
     let body_check = cap.at(start_frame, 0).abs();

--- a/rust/crates/orbit-audio-verify/tests/pan_real_wav.rs
+++ b/rust/crates/orbit-audio-verify/tests/pan_real_wav.rs
@@ -33,17 +33,17 @@ fn pan_is_recoverable_from_real_wav_render() {
     assert!(sample.frames() >= 25_000, "fixture too short");
 
     let slice_len = 4_800usize; // 0.1s
-    // 開始フレームはいずれも BLOCK_FRAMES(512) の倍数ではない（境界またぎを通す）。
-    // 中間値（±0.5）を含めるのが要: ±1/0 だけだと片 ch=0 / L=R となり、等パワー則を
-    // 線形則など他の対称 pan 則から判別できない（どの則でも通ってしまう）。pan=-0.5 では
-    // 等パワー L=cos(π/8)≈0.924 / R=sin(π/8)≈0.383 → atan2 で -0.5、線形則なら ≈-0.59 と
-    // なり PAN_TOLERANCE を超えて落ちる。
+                                // 開始フレームはいずれも BLOCK_FRAMES(512) の倍数ではない（境界またぎを通す）。
+                                // 中間値（±0.5）を含めるのが要: ±1/0 だけだと片 ch=0 / L=R となり、等パワー則を
+                                // 線形則など他の対称 pan 則から判別できない（どの則でも通ってしまう）。pan=-0.5 では
+                                // 等パワー L=cos(π/8)≈0.924 / R=sin(π/8)≈0.383 → atan2 で -0.5、線形則なら ≈-0.59 と
+                                // なり PAN_TOLERANCE を超えて落ちる。
     let events = [
-        (1_000usize, -1.0f32, -1.0f32),  // (start, commanded pan, expected pan) hard-left
+        (1_000usize, -1.0f32, -1.0f32), // (start, commanded pan, expected pan) hard-left
         (10_000usize, -0.5f32, -0.5f32), // 中間左（判別の鍵）
-        (20_000usize, 0.0f32, 0.0f32),   // center
-        (30_000usize, 0.5f32, 0.5f32),   // 中間右（判別の鍵）
-        (40_000usize, 1.0f32, 1.0f32),   // hard-right
+        (20_000usize, 0.0f32, 0.0f32),  // center
+        (30_000usize, 0.5f32, 0.5f32),  // 中間右（判別の鍵）
+        (40_000usize, 1.0f32, 1.0f32),  // hard-right
     ];
 
     let mut s = Scheduler::new(SAMPLE_RATE, CHANNELS);

--- a/rust/crates/orbit-audio-verify/tests/pan_real_wav.rs
+++ b/rust/crates/orbit-audio-verify/tests/pan_real_wav.rs
@@ -33,11 +33,12 @@ fn pan_is_recoverable_from_real_wav_render() {
     assert!(sample.frames() >= 25_000, "fixture too short");
 
     let slice_len = 4_800usize; // 0.1s
-                                // 開始フレームはいずれも BLOCK_FRAMES(512) の倍数ではない（境界またぎを通す）。
-                                // 中間値（±0.5）を含めるのが要: ±1/0 だけだと片 ch=0 / L=R となり、等パワー則を
-                                // 線形則など他の対称 pan 則から判別できない（どの則でも通ってしまう）。pan=-0.5 では
-                                // 等パワー L=cos(π/8)≈0.924 / R=sin(π/8)≈0.383 → atan2 で -0.5、線形則なら ≈-0.59 と
-                                // なり PAN_TOLERANCE を超えて落ちる。
+
+    // 開始フレームはいずれも BLOCK_FRAMES(512) の倍数ではない（境界またぎを通す）。
+    // 中間値（±0.5）を含めるのが要: ±1/0 だけだと片 ch=0 / L=R となり、等パワー則を
+    // 線形則など他の対称 pan 則から判別できない（どの則でも通ってしまう）。pan=-0.5 では
+    // 等パワー L=cos(π/8)≈0.924 / R=sin(π/8)≈0.383 → atan2 で -0.5、線形則なら ≈-0.59 と
+    // なり PAN_TOLERANCE を超えて落ちる。
     let events = [
         (1_000usize, -1.0f32, -1.0f32), // (start, commanded pan, expected pan) hard-left
         (10_000usize, -0.5f32, -0.5f32), // 中間左（判別の鍵）

--- a/rust/crates/orbit-audio-verify/tests/per_slice_gain.rs
+++ b/rust/crates/orbit-audio-verify/tests/per_slice_gain.rs
@@ -93,14 +93,8 @@ fn per_slice_gain_ratio_is_reflected_in_rms_db_difference() {
     let rms_b = region_rms(&cap, 0, body_b_start, body_b_end);
 
     // 両イベントに信号がある（無音に db_difference を当てない）。
-    assert!(
-        rms_a > 1e-3,
-        "イベント A に信号が必要。rms_a={rms_a:.5}"
-    );
-    assert!(
-        rms_b > 1e-3,
-        "イベント B に信号が必要。rms_b={rms_b:.5}"
-    );
+    assert!(rms_a > 1e-3, "イベント A に信号が必要。rms_a={rms_a:.5}");
+    assert!(rms_b > 1e-3, "イベント B に信号が必要。rms_b={rms_b:.5}");
 
     // dB 差: db_difference(rms_b, rms_a) = 20·log10(rms_b / rms_a)
     // gain_b=0.5 なので rms_b < rms_a → 負の値になる（expected_db ≈ -6.02 dB）。
@@ -149,8 +143,18 @@ fn per_slice_gain_double_is_plus_6db() {
     let cap = capture(&mut s, CHANNELS, total_frames, BLOCK);
 
     let body_margin = 256usize;
-    let rms_a = region_rms(&cap, 0, start_a + body_margin, start_a + slice_len - body_margin);
-    let rms_b = region_rms(&cap, 0, start_b + body_margin, start_b + slice_len - body_margin);
+    let rms_a = region_rms(
+        &cap,
+        0,
+        start_a + body_margin,
+        start_a + slice_len - body_margin,
+    );
+    let rms_b = region_rms(
+        &cap,
+        0,
+        start_b + body_margin,
+        start_b + slice_len - body_margin,
+    );
 
     assert!(rms_a > 1e-3, "イベント A に信号が必要。rms_a={rms_a:.5}");
     assert!(rms_b > 1e-3, "イベント B に信号が必要。rms_b={rms_b:.5}");

--- a/rust/crates/orbit-clap-spike/src/audio.rs
+++ b/rust/crates/orbit-clap-spike/src/audio.rs
@@ -75,7 +75,7 @@ impl AudioThreadStats {
             return None;
         }
         // Smallest bucket b where cumulative count >= ceil(99% x total).
-        let target = (total * 99 + 99) / 100; // integer ceil
+        let target = (total * 99).div_ceil(100); // integer ceil
         let mut cumulative: u64 = 0;
         for (i, bucket) in self.hist_us.iter().enumerate() {
             cumulative += bucket.load(Ordering::Relaxed);

--- a/rust/crates/orbit-clap-spike/src/audio.rs
+++ b/rust/crates/orbit-clap-spike/src/audio.rs
@@ -1,7 +1,7 @@
 //! Audio-thread integration: Engine + CLAP plugin + rtrb seam + PostMixSink (A0 §4.1).
 
 use crate::buffers::HostAudioBuffers;
-use crate::events::{PluginEventConsumer, drain_to_event_buffer};
+use crate::events::{drain_to_event_buffer, PluginEventConsumer};
 use crate::host::OrbitClapHost;
 use crate::sink::PostMixSink;
 
@@ -185,7 +185,9 @@ impl OrbitAudioProcessor {
             if let Ok(msg) = self.install_rx.pop() {
                 self.install(msg); // same move as static install (no lock/alloc)
                 let at = self.stats.callback_count.load(Ordering::Relaxed);
-                self.stats.installed_at_callback.store(at, Ordering::Relaxed);
+                self.stats
+                    .installed_at_callback
+                    .store(at, Ordering::Relaxed);
             }
         }
 

--- a/rust/crates/orbit-clap-spike/src/buffers.rs
+++ b/rust/crates/orbit-clap-spike/src/buffers.rs
@@ -63,8 +63,14 @@ impl HostAudioBuffers {
         let total_out = config.plugin_output_port_config.total_channel_count();
 
         Self {
-            input_ports: AudioPorts::with_capacity(total_in, config.plugin_input_port_config.ports.len()),
-            output_ports: AudioPorts::with_capacity(total_out, config.plugin_output_port_config.ports.len()),
+            input_ports: AudioPorts::with_capacity(
+                total_in,
+                config.plugin_input_port_config.ports.len(),
+            ),
+            output_ports: AudioPorts::with_capacity(
+                total_out,
+                config.plugin_output_port_config.ports.len(),
+            ),
             input_port_channels,
             output_port_channels,
             muxed: vec![0.0f32; frame_count * config.output_channel_count],
@@ -85,7 +91,9 @@ impl HostAudioBuffers {
             // resize/eprintln below are themselves RT violations and fire ONLY if cpal
             // breaks the fixed-size contract. The atomic counter (RT-safe) always records
             // it; the eprintln is debug-only to keep the syscall out of release builds.
-            self.stats.buffer_resize_count.fetch_add(1, Ordering::Relaxed);
+            self.stats
+                .buffer_resize_count
+                .fetch_add(1, Ordering::Relaxed);
             #[cfg(debug_assertions)]
             eprintln!(
                 "[orbit-clap-spike] WARN: buffer resize ({} -> {} frames) -- indicates BufferSize::Fixed did not hold",

--- a/rust/crates/orbit-clap-spike/src/config.rs
+++ b/rust/crates/orbit-clap-spike/src/config.rs
@@ -53,7 +53,7 @@ impl FullAudioConfig {
         }
 
         // Prefer stereo; then sort by sample rate preference
-        configs.sort_by(|a, b| b.channels().cmp(&a.channels()));
+        configs.sort_by_key(|cfg| std::cmp::Reverse(cfg.channels()));
         let chosen = configs.into_iter().next().unwrap();
 
         let (min_buf, max_buf) = match chosen.buffer_size() {
@@ -222,10 +222,8 @@ pub fn get_config_from_ports(
             },
         };
 
-        if info.flags.contains(AudioPortFlags::IS_MAIN) {
-            if main_port_index.replace(i).is_some() {
-                eprintln!("Warning: plugin defines multiple main ports");
-            }
+        if info.flags.contains(AudioPortFlags::IS_MAIN) && main_port_index.replace(i).is_some() {
+            eprintln!("Warning: plugin defines multiple main ports");
         }
 
         discovered.push(PluginAudioPortInfo {

--- a/rust/crates/orbit-clap-spike/src/config.rs
+++ b/rust/crates/orbit-clap-spike/src/config.rs
@@ -7,7 +7,9 @@ use crate::host::OrbitClapHost;
 use clack_extensions::audio_ports::{
     AudioPortFlags, AudioPortInfoBuffer, AudioPortType, PluginAudioPorts,
 };
-use clack_host::prelude::{ClapId, PluginAudioConfiguration, PluginInstance, PluginMainThreadHandle};
+use clack_host::prelude::{
+    ClapId, PluginAudioConfiguration, PluginInstance, PluginMainThreadHandle,
+};
 use cpal::traits::DeviceTrait;
 use cpal::{BufferSize, Device, SampleRate, StreamConfig, SupportedBufferSize};
 use std::fmt::{Display, Formatter};
@@ -63,10 +65,7 @@ impl FullAudioConfig {
             output_channel_count: chosen.channels() as usize,
             min_buffer_size: min_buf.max(1),
             max_likely_buffer_size: max_buf,
-            sample_rate: 44_100u32.clamp(
-                chosen.min_sample_rate().0,
-                chosen.max_sample_rate().0,
-            ),
+            sample_rate: 44_100u32.clamp(chosen.min_sample_rate().0, chosen.max_sample_rate().0),
             plugin_output_port_config: output_ports,
             plugin_input_port_config: input_ports,
         })
@@ -180,11 +179,18 @@ impl PluginAudioPortsConfig {
 }
 
 /// Query a plugin's audio ports via the AudioPorts extension.
-pub fn get_config_from_ports(handle: &mut PluginMainThreadHandle, is_input: bool) -> PluginAudioPortsConfig {
+pub fn get_config_from_ports(
+    handle: &mut PluginMainThreadHandle,
+    is_input: bool,
+) -> PluginAudioPortsConfig {
     let Some(ports) = handle.get_extension::<PluginAudioPorts>() else {
         eprintln!(
             "[orbit-clap-spike] plugin has no AudioPorts extension; assuming {}",
-            if is_input { "no input" } else { "default stereo output" }
+            if is_input {
+                "no input"
+            } else {
+                "default stereo output"
+            }
         );
         // empty() for input (a synth has none), default stereo for output.
         return if is_input {

--- a/rust/crates/orbit-clap-spike/src/config.rs
+++ b/rust/crates/orbit-clap-spike/src/config.rs
@@ -52,7 +52,7 @@ impl FullAudioConfig {
             anyhow::bail!("No F32 output config available — A0 spike requires F32 (CoreAudio should always provide it)");
         }
 
-        // Prefer stereo; then sort by sample rate preference
+        // Prefer stereo (sort by channel count, descending).
         configs.sort_by_key(|cfg| std::cmp::Reverse(cfg.channels()));
         let chosen = configs.into_iter().next().unwrap();
 

--- a/rust/crates/orbit-clap-spike/src/discovery.rs
+++ b/rust/crates/orbit-clap-spike/src/discovery.rs
@@ -97,8 +97,8 @@ impl std::error::Error for DiscoveryError {}
 /// (The `PluginFactory` borrows from the `PluginEntry`, so the entry must outlive the
 /// factory in the caller's stack frame; that's why this returns the entry, not the factory.)
 fn open_bundle(path: &Path) -> Result<PluginEntry, DiscoveryError> {
-    let bundle_path =
-        CString::new(path.to_string_lossy().as_bytes()).map_err(|_| DiscoveryError::NullBundlePath)?;
+    let bundle_path = CString::new(path.to_string_lossy().as_bytes())
+        .map_err(|_| DiscoveryError::NullBundlePath)?;
     // SAFETY: loading a native library is inherently unsafe.
     let library = unsafe { LibraryEntry::load_from_path(path) }?;
     Ok(unsafe { PluginEntry::load_from(library, &bundle_path) }?)

--- a/rust/crates/orbit-clap-spike/src/discovery.rs
+++ b/rust/crates/orbit-clap-spike/src/discovery.rs
@@ -113,7 +113,7 @@ pub fn list_plugins_in_file(path: &Path) -> Result<Vec<FoundPlugin>, DiscoveryEr
 
     Ok(factory
         .plugin_descriptors()
-        .filter_map(|p| PluginDescriptor::try_from(p))
+        .filter_map(PluginDescriptor::try_from)
         .map(|plugin| FoundPlugin {
             entry: entry.clone(),
             path: path.to_path_buf(),
@@ -134,7 +134,7 @@ pub fn load_plugin_id_from_path(
 
     Ok(factory
         .plugin_descriptors()
-        .filter_map(|p| PluginDescriptor::try_from(p))
+        .filter_map(PluginDescriptor::try_from)
         .find(|p| p.id == id)
         .map(|plugin| FoundPlugin {
             entry,

--- a/rust/crates/orbit-clap-spike/src/events.rs
+++ b/rust/crates/orbit-clap-spike/src/events.rs
@@ -1,23 +1,15 @@
 //! Event seam: control → audio thread via lock-free SPSC ring (A0 §4.2).
 
 use clack_host::events::event_types::{NoteOffEvent, NoteOnEvent};
-use clack_host::events::{Event, EventFlags, Match};
 use clack_host::events::io::EventBuffer;
+use clack_host::events::{Event, EventFlags, Match};
 use clack_host::prelude::Pckn;
 
 /// Events that the control / driver thread can push into the audio thread.
 #[derive(Debug, Clone, Copy)]
 pub enum PluginEvent {
-    NoteOn {
-        key: u8,
-        channel: u8,
-        velocity: f64,
-    },
-    NoteOff {
-        key: u8,
-        channel: u8,
-        velocity: f64,
-    },
+    NoteOn { key: u8, channel: u8, velocity: f64 },
+    NoteOff { key: u8, channel: u8, velocity: f64 },
 }
 
 /// Type alias for the producer side (control thread).

--- a/rust/crates/orbit-clap-spike/src/host.rs
+++ b/rust/crates/orbit-clap-spike/src/host.rs
@@ -27,9 +27,7 @@ impl HostHandlers for OrbitClapHost {
     type AudioProcessor<'a> = ();
 
     fn declare_extensions(builder: &mut HostExtensions<Self>, _shared: &Self::Shared<'_>) {
-        builder
-            .register::<HostLog>()
-            .register::<HostParams>();
+        builder.register::<HostLog>().register::<HostParams>();
         // Note: audio-ports and note-ports extensions are queried from the plugin,
         // they don't need to be registered as host-provided extensions here.
     }

--- a/rust/crates/orbit-clap-spike/src/main.rs
+++ b/rust/crates/orbit-clap-spike/src/main.rs
@@ -23,8 +23,8 @@ mod sink;
 use crate::audio::{AudioThreadStats, InstallMsg, OrbitAudioProcessor};
 use crate::buffers::HostAudioBuffers;
 use crate::config::FullAudioConfig;
-use crate::discovery::{FoundPlugin, list_plugins_in_file, load_plugin_id_from_path};
-use crate::events::{PluginEvent, make_event_ring};
+use crate::discovery::{list_plugins_in_file, load_plugin_id_from_path, FoundPlugin};
+use crate::events::{make_event_ring, PluginEvent};
 use crate::host::{MainThreadMessage, OrbitClapHost, OrbitHostMainThread, OrbitHostShared};
 use crate::sink::{CountingSink, PostMixSink, RingTapSink};
 
@@ -35,7 +35,7 @@ use orbit_audio_core::Engine;
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, mpsc};
+use std::sync::{mpsc, Arc};
 use std::time::{Duration, Instant};
 
 // ---- CLI ----------------------------------------------------------------
@@ -107,8 +107,7 @@ fn parse_args() -> anyhow::Result<Cli> {
     }
 
     Ok(Cli {
-        file_path: file_path
-            .ok_or_else(|| anyhow::anyhow!("--file-path is required"))?,
+        file_path: file_path.ok_or_else(|| anyhow::anyhow!("--file-path is required"))?,
         plugin_id,
         measure_secs,
         bpm,
@@ -145,9 +144,8 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
     // --- Instantiate (main thread) ----------------------------------------
     let (sender, receiver) = mpsc::channel::<MainThreadMessage>();
 
-    let plugin_id =
-        std::ffi::CString::new(found.plugin.id.as_str())
-            .map_err(|_| anyhow::anyhow!("plugin id contains null byte"))?;
+    let plugin_id = std::ffi::CString::new(found.plugin.id.as_str())
+        .map_err(|_| anyhow::anyhow!("plugin id contains null byte"))?;
 
     let host_info = HostInfo::new(
         "OrbitScore CLAP spike",
@@ -216,13 +214,8 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
     let stats = AudioThreadStats::new();
 
     // --- Audio processor (engine-only; plugin installed below) -----------
-    let mut processor = OrbitAudioProcessor::new(
-        engine,
-        event_consumer,
-        sink,
-        stats.clone(),
-        install_rx,
-    );
+    let mut processor =
+        OrbitAudioProcessor::new(engine, event_consumer, sink, stats.clone(), install_rx);
 
     let hot_secs = cli.hot_install_after_secs;
     if hot_secs == 0 {
@@ -401,8 +394,8 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
 fn select_plugin(path: &Path, id: Option<&str>) -> anyhow::Result<FoundPlugin> {
     match id {
         None => {
-            let plugins = list_plugins_in_file(path)
-                .map_err(|e| anyhow::anyhow!("Discovery error: {e}"))?;
+            let plugins =
+                list_plugins_in_file(path).map_err(|e| anyhow::anyhow!("Discovery error: {e}"))?;
             if plugins.is_empty() {
                 anyhow::bail!("No plugins found in {}", path.display());
             }

--- a/rust/crates/orbit-clap-spike/src/main.rs
+++ b/rust/crates/orbit-clap-spike/src/main.rs
@@ -352,15 +352,14 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
     // (callbacks running != audible output).
     let post_mix_peak = f32::from_bits(counting_peak.load(Ordering::Relaxed));
 
-    let mean_ns = if callbacks > 0 { sum_ns / callbacks } else { 0 };
+    let mean_ns = sum_ns.checked_div(callbacks).unwrap_or(0);
     let p99_ns = stats.p99_ns().unwrap_or(0);
 
     // Approximate block budget from actual sink frames.
-    let avg_frames_per_cb = if callbacks > 0 {
-        sink_frames / callbacks / output_channel_count as u64
-    } else {
-        0
-    };
+    let avg_frames_per_cb = sink_frames
+        .checked_div(callbacks)
+        .map(|f| f / output_channel_count as u64)
+        .unwrap_or(0);
     let block_budget_ns = avg_frames_per_cb * 1_000_000_000 / sample_rate as u64;
 
     println!();

--- a/rust/crates/orbit-link-audio/src/egress.rs
+++ b/rust/crates/orbit-link-audio/src/egress.rs
@@ -162,7 +162,11 @@ impl LinkChannelEgress {
     /// (session-global なので per-channel に読み直さない・efficiency)。<=0 は capture 例外(shim が 0.0 を
     /// 返す)または Link セッション初期化前の過渡状態で、初回 anchor の fallback には使うが re-anchor の
     /// 比較基準にはしない(過渡的な 0 で誤検出しない)。
-    pub fn pump_once(&mut self, output: &LinkAudioOutput, session_tempo: f64) -> Option<CommitResult> {
+    pub fn pump_once(
+        &mut self,
+        output: &LinkAudioOutput,
+        session_tempo: f64,
+    ) -> Option<CommitResult> {
         let block_samples = self.block_frames * self.num_channels;
         if self.consumer.slots() < block_samples {
             return None;
@@ -176,7 +180,11 @@ impl LinkChannelEgress {
         if !self.anchored {
             // egress 開始時に anchor(beat)を 1 回だけ capture。以後 `capture_beat()` は二度と呼ばない
             // (ring latency 位相誤差の再導入を避ける・advisor)。session_tempo<=0 は fallback 120。
-            let bpm = if session_tempo > 0.0 { session_tempo } else { 120.0 };
+            let bpm = if session_tempo > 0.0 {
+                session_tempo
+            } else {
+                120.0
+            };
             self.start_segment(output.capture_beat(self.quantum), produced, bpm);
             self.anchored = true;
         } else if let Some(new_anchor) = reanchor_beat_on_change(

--- a/rust/crates/orbit-link-audio/src/lib.rs
+++ b/rust/crates/orbit-link-audio/src/lib.rs
@@ -293,7 +293,10 @@ mod tests {
         let rc_bad = out.commit_channel(99, &silence, 256, 2, 48_000, 0.0, 4.0);
         assert_eq!(rc_bad, CommitResult::ChannelNotFound);
 
-        assert!(out.set_tempo(124.0), "set_tempo は no-peer でも commit 成功する");
+        assert!(
+            out.set_tempo(124.0),
+            "set_tempo は no-peer でも commit 成功する"
+        );
         // drop で teardown。
     }
 


### PR DESCRIPTION
## 背景

これまで CI（`code-review.yml`）は **npm/TS のみ**で Rust workspace を一切検証していなかった。#340（daemon CLAP 統合）では「CI green ≠ Rust 検証」が繰り返し問題になり、検証根拠はローカル cargo + gated 実機 RUN だけだった。本 PR で Rust を PR ごとに CI 検証し、後続の engine 系 PR（#342 / #295 / cutover #108）が初めて CI で守られるようにする。

Closes #326

## 変更

### 前提クリーンアップ（CI ゲートを green にするため必須）
- **`style(rust)`: fmt drift 19 ファイルを `cargo fmt --all` で解消**。Rust CI が無く fmt が変更ファイルにしか当たっていなかった。`cargo fmt --all` は workspace-exclude の `orbit-link-audio` も整形する（CI の `--check` と一貫）。純整形のみ・意味的変更なし。
- **`refactor(rust)`: clippy 警告を解消**。auto-fix（redundant closure / div_ceil / collapsible if 等）+ 手動 3 件（orbit-clap-spike: `sort_by`→`sort_by_key(Reverse)` / `if x>0 {a/x}`→`checked_div().unwrap_or(0)` ×2）。挙動不変。

### `.github/workflows/rust-ci.yml`（2 job・ubuntu-latest）
- **job `rust`**: libasound2-dev（cpal/ALSA）→ `dtolnay/rust-toolchain@stable` + `Swatinem/rust-cache@v2` → `cargo fmt --all --check` / `cargo clippy`（default & clap-host）`--all-targets --locked -- -D warnings` / `cargo test`（default & clap-host）`--locked`。
- **job `cargo-deny`**: `taiki-e/install-action` → `cargo deny check`。default グラフ(link-audio off)が GPL-free であることを assert（GPL 隔離 crate `orbit-link-audio` の混入検知）。

## スコープ判断
- GPL feature `link-audio`（build.rs が `target_os != "macos"` で error）は **ubuntu でビルド不可**かつ GPL 隔離方針のため **CI では有効化しない**（default グラフ = permissive + cross-platform に保つ）。`clap-host`(permissive) は検証する。
- 実機 output device / multicast を要する gated テストは全て `#[ignore]` なので `cargo test` で自動 skip（CI に audio device は無い）。
- security: untrusted input（`github.event.*`）を `run:` に渡していない。

## 検証
ローカルで全ステップを実行し green を確認:
- `cargo fmt --all --check` clean
- `cargo clippy -- -D warnings` clean（default + clap-host）
- `cargo test` 全通過（default + clap-host・非gated）
- `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok`
- `--locked` OK（Cargo.lock current）/ verify テストの WAV fixture は git-tracked

**本 PR 自体が新 Rust CI を初めて実行する**ので、CI の結果が workflow の実証になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)