### PR TITLE
fix(engine): drain install ring on teardown to prevent instance leak (#342-#1)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -46,6 +46,15 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **ローカル全 green**: fmt clean / clippy `-D warnings`（clap-host + daemon clap-host）/ cargo test workspace 0 failed（新規 drain test 含む）/ gated synth+effect GREEN。
 
+**CI（#326 で入れた Rust CI が #342-#1 を検証）**: `fmt / clippy / test`・`license / dependency gate`・`code-review` 3 チェックすべて SUCCESS。
+
+**レビュー（/simplify + /code:pr-review-team）**:
+- `/simplify`（4 agent）: drain_install_ring の戻り値 `u64`→`()` 簡素化（production で破棄・テストは DROPS+空で等価）/ Drop に install ring 非空検知ログ追加（altitude: 既存 plugin 検知と対称化）。reuse/efficiency は clean。
+- `/code:pr-review-team`（code-reviewer / silent-failure-hunter / pr-test-analyzer / comment-analyzer）: **Critical=0 / コード Important=0**。code-reviewer は 4 観点（drain ordering・RT 安全・Drop スレッド・doc 正確性）すべて clack/rtrb ソースで検証。
+  - 「Important」ラベル 2 件はいずれも doc/test-comment レベル: ① doc「Arc 減算のみ」が ordering-contingent（silent-failure I-1 + comment-analyzer）→ StreamGuard field 順 + host が Arc 保持の不変条件を doc に明記。② 実 leak シナリオは real plugin + 非決定 race で自動テスト不可（pr-test-analyzer・accepted structural gap）→ 単体テスト + gated テストに非カバー注記。
+  - Minor 対応: Drop ログの因果文言是正 + `slots()` 占有数追加（code-reviewer + silent-failure M-2）/ 単体テストに empty-ring ケース追加。
+  - 見送り: 正常経路 drain の silent 性への RT-path tracing（agent 自身の atomic 推奨と矛盾・benign event・Drop backstop で異常系は可視化済み）。
+
 ---
 
 ### 6.170 ci(rust): wire Rust workspace into CI — fmt / clippy / test / cargo-deny (#326) (Jun 26, 2026)

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -55,6 +55,12 @@ A design and implementation project for a new music DSL (Domain Specific Languag
   - Minor 対応: Drop ログの因果文言是正 + `slots()` 占有数追加（code-reviewer + silent-failure M-2）/ 単体テストに empty-ring ケース追加。
   - 見送り: 正常経路 drain の silent 性への RT-path tracing（agent 自身の atomic 推奨と矛盾・benign event・Drop backstop で異常系は可視化済み）。
 
+**advisor 収束相談（2026-06-26）**: 収束**確立**（第2フル ラウンド不要・provenance は transcript の skill 起動 + CI green on ccaa240・#326 と同論理）。**@claude bot = ordering 不変条件 + clack Drop/Arc 相互作用に絞った scoped review が妥当**との助言。
+
+**@claude bot scoped review（2026-06-27・owner GO 後に起動）**: load-bearing な正当性（正常 teardown 経路）を一次情報まで降りて検証し **Critical/Important=0 で確認**。リーク解析（wrong-thread UB → leak 再フレーム）正しい / drain が `host.shutdown()` 前に走る（field drop 順 + `teardown_done` 後書きスピン）/ drain 時点で `PluginInstance` Arc 生存（refcount 0 非到達）/ drain は RT benign、すべて ✅。
+- **bot の non-blocking 観察を post-bot advisor consult で精査 → bot の framing は誤りと判定**: bot は「panic-during-load corner はいずれの経路でも deactivate 未呼出 / 本 PR が新規導入したものでない」としたが、これは false。正しくは（advisor + 当方分析）**clap スレッドが load 中に panic した場合に wrong-thread deactivate の質が main（drain なし版 = `install_rx` drop）→ RT（drain 版 = audio thread）に変わる新挙動**。極稀（load 中 panic 要）+ 既存 panic-時 leak 病理に乗る + 正常経路では非発生 → #342-#1 スコープ外。**#342 項目4 として追跡**（コードで guard する場合は code change で再レビュー要）+ `drain_install_ring` doc に corner note 追記。
+- **再レビュー不要（advisor）**: コード変更は doc コメント追記のみで load-bearing logic 不変。8-agent ループの再走は不均衡。マージは owner の明示指示待ち（self-merge 禁止）。
+
 ---
 
 ### 6.170 ci(rust): wire Rust workspace into CI — fmt / clippy / test / cargo-deny (#326) (Jun 26, 2026)

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,37 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.171 fix(engine): drain install ring on teardown to prevent plugin-instance leak (#342-#1) (Jun 26, 2026)
+
+**Date**: 2026-06-26
+**Status**: ✅ 実装完了（PR レビュー前）
+**Branch**: `342-install-ring-drain`
+**Issue**: #342（#340 follow-on hardening・①install-ring teardown drain）
+
+#340 review が「install-ring teardown drain / wrong-thread stop_processing 残余」を #342 に分離していた。
+本 PR で一次情報（clack `f874e858` + rtrb 0.3.4）を精読し、**リスクの実体を確定**したうえで最小修正した。
+
+**確定した実体 = wrong-thread UB ではなく「リーク」**:
+- `StartedPluginAudioProcessor` は `Arc<PluginInstanceInner>` で `Drop` impl を持たない（process.rs:401）。drop は Arc 減算のみで plugin code を呼ばない。
+- `PluginInstance::Drop`（plugin.rs:399-410）は **sole Arc owner のときだけ** teardown し、processor handle が残存すれば意図的に **leak** する（wrong-thread teardown を避ける clack の設計）。
+- `PluginInstanceInner::Drop`（instance.rs:232-254）→ active なら `deactivate_with`（is_started なら stop_processing → deactivate → destroy）を **その drop が走るスレッド**で実行。
+- rtrb `RingBuffer::Drop`（lib.rs:233-242）は未消費スロットを drop するが、Producer/Consumer 共有 Arc の **最後の drop 時のみ**発火。
+- 帰結: Consumer（cpal `_stream`）が先に drop（refcount 2→1・未 drop）、Producer（clap・`host.shutdown()` の**後**）drop で初めて InstallMsg が drop される。よって `host.shutdown()`（= PluginInstance drop）時点で processor Arc が ring 越しに残存 → sole owner でない → **instance leak（deactivate/destroy 永久未呼出）**。
+- 発生条件: plugin load → install 着地前に teardown（teardown 分岐が hot-install pop より前で early-return する窓）。狭いエッジだが実在のリーク。
+
+**採用 A: drain-and-drop（owner 承認）**:
+- cpal teardown 分岐で `drain_install_ring`（install ring を pop 全消費 → InstallMsg を cpal スレッドで drop = Arc 解放・benign）。
+- これで `host.shutdown()` より前に processor Arc が解放され、`PluginInstance::Drop` が sole owner となって stop_processing+deactivate+destroy を **clap スレッド（= start_processing と同一）**で正常実行する。
+- spec 記述「専用スレッドへ handoff」は Arc 解放による暗黙 handoff で達成（実 teardown は clap スレッド）。新規 channel 不要・最小差分。spec deviation は §1 rule に従い owner 承認 + 本ログで記録。
+
+**テスト**:
+- drain を generic 関数 `drain_install_ring<T>(&mut Consumer<T>)` に切り出し、`DropCounter` で「全 pop + 全 drop + ring 空」を決定論検証（real plugin 不要）。
+- gated 実機 RUN（CoreAudio + test-synth/effect dylib）で正常 teardown 経路の非回帰を裏取り: synth peak 0.25 / effect ratio 0.50000・teardown panic/UB なし完了。
+
+**ローカル全 green**: fmt clean / clippy `-D warnings`（clap-host + daemon clap-host）/ cargo test workspace 0 failed（新規 drain test 含む）/ gated synth+effect GREEN。
+
+---
+
 ### 6.170 ci(rust): wire Rust workspace into CI — fmt / clippy / test / cargo-deny (#326) (Jun 26, 2026)
 
 **Date**: 2026-06-26

--- a/rust/crates/orbit-audio-daemon/tests/clap_host_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/clap_host_gated.rs
@@ -11,6 +11,11 @@
 //! - teardown（carry-forward #1）: guard drop で audio thread の stop_processing → stream 停止 →
 //!   instance deactivate の順を通す（panic / UB なく完了する）。
 //!
+//! 注意（#342-#1）: 本テストは plugin が hot-install 済みの **正常 teardown 経路** のみを通す
+//! （teardown 時に install ring は空 → drain は no-op）。#342-#1 が直す leak シナリオ
+//! （load → install 着地前に teardown する race）は real plugin + 非決定的 race を要するため
+//! ここでは再現・検証しない。drain 関数の契約は orbit-clap-host の単体テストで検証する。
+//!
 //! 実 output device を要するため `#[ignore]`。事前に test-synth dylib をビルドすること:
 //!   cargo build --manifest-path ../../../rust-spike/clap-test-synth/Cargo.toml
 //! 実行:

--- a/rust/crates/orbit-clap-host/src/processor.rs
+++ b/rust/crates/orbit-clap-host/src/processor.rs
@@ -73,6 +73,26 @@ pub struct InstallMsg {
 /// install ring の consumer 側（audio thread が保持）。
 pub type InstallConsumer = rtrb::Consumer<InstallMsg>;
 
+/// install ring に残った全アイテムを pop して drop し、drain 件数を返す（#342-#1）。
+///
+/// teardown 時に未ドレインの [`InstallMsg`]（= [`StartedPluginAudioProcessor`] を内包）が ring に
+/// 残ると、それが保持する `Arc<PluginInstanceInner>` のために host 側の `PluginInstance::Drop` が
+/// sole owner になれず、clack が wrong-thread teardown を避けて instance を **leak** する
+/// （deactivate/destroy が永久に呼ばれない）。ここで drop して Arc を解放すれば、`host.shutdown()` 時に
+/// `PluginInstance::Drop` が sole owner となり stop_processing+deactivate+destroy を clap スレッド
+/// （= start_processing と同一スレッド）で正常実行できる。
+///
+/// `InstallMsg` は `Drop` impl を持たない Arc + buffer なので、drop 自体は plugin code を呼ばない
+/// （Arc 減算のみ）。buffer の free が走るが、これは teardown 経路なので許容する（既存の
+/// `buffers = None` と同性質）。`Consumer<T>` で generic にして real plugin 無しで単体テストできる。
+fn drain_install_ring<T>(rx: &mut rtrb::Consumer<T>) -> u64 {
+    let mut drained = 0;
+    while rx.pop().is_ok() {
+        drained += 1;
+    }
+    drained
+}
+
 /// `orbit_audio_native::PostProcessor` を実装する CLAP audio-thread オーナー。
 ///
 /// cpal closure（`move |data, _| proc.process(data)`）が所有し、audio thread 上で排他的に動く。
@@ -183,6 +203,11 @@ impl PostProcessor for ClapPostProcessor {
                 let _ = p.stop_processing();
             }
             self.buffers = None;
+            // #342-#1: install ring に未ドレインの InstallMsg が残っていると、その
+            // StartedPluginAudioProcessor の Arc が ring 越しに生き続け、host.shutdown() で
+            // PluginInstance::Drop が sole owner になれず instance を leak する。ここで drain して
+            // Arc を解放し、clap スレッドでの正常 teardown を可能にする（drain_install_ring の doc 参照）。
+            drain_install_ring(&mut self.install_rx);
             self.teardown_done.store(true, Ordering::Release);
             return;
         }
@@ -312,5 +337,32 @@ mod tests {
         record(0.2);
         let peak2 = f32::from_bits(stats.post_peak_bits.load(Ordering::Relaxed));
         assert!((peak2 - 0.2).abs() < 1e-6, "reset 後は 0.2, got {peak2}");
+    }
+
+    #[test]
+    fn drain_install_ring_drops_all_pending_and_empties() {
+        // #342-#1: drain は ring 内の全アイテムを pop して **drop** し（= Arc 解放）、ring を空にする。
+        // InstallMsg は real plugin 無しでは作れないので、Drop を数える generic な代用型で検証する。
+        static DROPS: AtomicU64 = AtomicU64::new(0);
+        struct DropCounter;
+        impl Drop for DropCounter {
+            fn drop(&mut self) {
+                DROPS.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let (mut tx, mut rx) = rtrb::RingBuffer::<DropCounter>::new(4);
+        tx.push(DropCounter).expect("push 1");
+        tx.push(DropCounter).expect("push 2");
+
+        let drained = drain_install_ring(&mut rx);
+
+        assert_eq!(drained, 2, "2 件 drain したはず");
+        assert_eq!(
+            DROPS.load(Ordering::Relaxed),
+            2,
+            "drain したアイテムは drop されて Arc が解放されるはず"
+        );
+        assert!(rx.pop().is_err(), "drain 後の ring は空のはず");
     }
 }

--- a/rust/crates/orbit-clap-host/src/processor.rs
+++ b/rust/crates/orbit-clap-host/src/processor.rs
@@ -73,7 +73,7 @@ pub struct InstallMsg {
 /// install ring の consumer 側（audio thread が保持）。
 pub type InstallConsumer = rtrb::Consumer<InstallMsg>;
 
-/// install ring に残った全アイテムを pop して drop し、drain 件数を返す（#342-#1）。
+/// install ring に残った全アイテムを pop して drop する（#342-#1）。
 ///
 /// teardown 時に未ドレインの [`InstallMsg`]（= [`StartedPluginAudioProcessor`] を内包）が ring に
 /// 残ると、それが保持する `Arc<PluginInstanceInner>` のために host 側の `PluginInstance::Drop` が
@@ -85,12 +85,8 @@ pub type InstallConsumer = rtrb::Consumer<InstallMsg>;
 /// `InstallMsg` は `Drop` impl を持たない Arc + buffer なので、drop 自体は plugin code を呼ばない
 /// （Arc 減算のみ）。buffer の free が走るが、これは teardown 経路なので許容する（既存の
 /// `buffers = None` と同性質）。`Consumer<T>` で generic にして real plugin 無しで単体テストできる。
-fn drain_install_ring<T>(rx: &mut rtrb::Consumer<T>) -> u64 {
-    let mut drained = 0;
-    while rx.pop().is_ok() {
-        drained += 1;
-    }
-    drained
+fn drain_install_ring<T>(rx: &mut rtrb::Consumer<T>) {
+    while rx.pop().is_ok() {}
 }
 
 /// `orbit_audio_native::PostProcessor` を実装する CLAP audio-thread オーナー。
@@ -177,6 +173,15 @@ impl Drop for ClapPostProcessor {
             tracing::error!(
                 "ClapPostProcessor が plugin 保持のまま drop された — teardown 未完了で \
                  wrong-thread stop_processing の可能性（device 喪失で callback 停止 → teardown timeout か）"
+            );
+        }
+        // 同じ leak クラスの非対称な見落としを塞ぐ（#342-#1）。teardown 分岐が走れば install ring は
+        // drain 済みのはず。非空なら、device 喪失で teardown 分岐が走らず未 install の plugin instance が
+        // leak した可能性（drain せず検知のみ＝ここでの drain 可否は clack の Drop 挙動検証後に判断・defer）。
+        if !self.install_rx.is_empty() {
+            tracing::error!(
+                "ClapPostProcessor が非空の install ring を保持したまま drop された — \
+                 teardown 分岐が走らず未 install の plugin instance が leak した可能性（device 喪失か）"
             );
         }
     }
@@ -355,9 +360,9 @@ mod tests {
         tx.push(DropCounter).expect("push 1");
         tx.push(DropCounter).expect("push 2");
 
-        let drained = drain_install_ring(&mut rx);
+        drain_install_ring(&mut rx);
 
-        assert_eq!(drained, 2, "2 件 drain したはず");
+        // DROPS==2（2 件とも drop = Arc 解放）+ ring 空 で「2 件すべて drain した」を等価に保証する。
         assert_eq!(
             DROPS.load(Ordering::Relaxed),
             2,

--- a/rust/crates/orbit-clap-host/src/processor.rs
+++ b/rust/crates/orbit-clap-host/src/processor.rs
@@ -90,6 +90,14 @@ pub type InstallConsumer = rtrb::Consumer<InstallMsg>;
 /// よって audio スレッドの drop で refcount が 0 に達することはなく、`PluginInstanceInner::Drop`
 /// （= 実 deactivate/destroy）はここでは走らない。buffer free は teardown 経路なので許容する（既存の
 /// `buffers = None` と同性質）。`Consumer<T>` で generic にして real plugin 無しで単体テストできる。
+///
+/// **スコープ外の corner（#342 項目4 で追跡）**: clap スレッドが plugin load 中に panic した場合は
+/// 上の不変条件が崩れる。host.instance が unwind で drop された後（refcount は ring 残存分で 0 非到達）に
+/// 本 drain が Arc を 0 まで減算すると、`PluginInstanceInner::Drop`（実 deactivate/destroy）が audio(RT)
+/// スレッドで走りうる。drain なし版でも同 corner で deactivate は wrong-thread（install_rx drop = 非 RT の
+/// daemon スレッド）で走るので「deactivate が呼ばれない」のではなく、**drain 導入で wrong-thread の質が
+/// main→RT に変わる**新挙動である。正常 teardown 経路では発生せず、既存の panic-時 leak 病理に乗る極稀
+/// ケースのため #342-#1 のスコープ外とし、#342 項目4 として追跡する。
 fn drain_install_ring<T>(rx: &mut rtrb::Consumer<T>) {
     while rx.pop().is_ok() {}
 }

--- a/rust/crates/orbit-clap-host/src/processor.rs
+++ b/rust/crates/orbit-clap-host/src/processor.rs
@@ -82,8 +82,13 @@ pub type InstallConsumer = rtrb::Consumer<InstallMsg>;
 /// `PluginInstance::Drop` が sole owner となり stop_processing+deactivate+destroy を clap スレッド
 /// （= start_processing と同一スレッド）で正常実行できる。
 ///
-/// `InstallMsg` は `Drop` impl を持たない Arc + buffer なので、drop 自体は plugin code を呼ばない
-/// （Arc 減算のみ）。buffer の free が走るが、これは teardown 経路なので許容する（既存の
+/// `InstallMsg`（内包する `StartedPluginAudioProcessor` も）は custom `Drop` を持たないため、drop は
+/// `Arc<PluginInstanceInner>` の refcount 減算と `HostAudioBuffers` の free だけで plugin code を呼ばない。
+/// この「Arc 減算のみ」は **ordering 依存の不変条件**である: StreamGuard の field drop 順
+/// （`_clap_teardown` → `_stream` → `_clap_thread`）と teardown_requested/teardown_done フラグにより本 drain は
+/// 必ず `host.shutdown()` より前に走り、その時点で host 側 `PluginInstance` が同じ Arc を保持し続けている。
+/// よって audio スレッドの drop で refcount が 0 に達することはなく、`PluginInstanceInner::Drop`
+/// （= 実 deactivate/destroy）はここでは走らない。buffer free は teardown 経路なので許容する（既存の
 /// `buffers = None` と同性質）。`Consumer<T>` で generic にして real plugin 無しで単体テストできる。
 fn drain_install_ring<T>(rx: &mut rtrb::Consumer<T>) {
     while rx.pop().is_ok() {}
@@ -175,13 +180,15 @@ impl Drop for ClapPostProcessor {
                  wrong-thread stop_processing の可能性（device 喪失で callback 停止 → teardown timeout か）"
             );
         }
-        // 同じ leak クラスの非対称な見落としを塞ぐ（#342-#1）。teardown 分岐が走れば install ring は
-        // drain 済みのはず。非空なら、device 喪失で teardown 分岐が走らず未 install の plugin instance が
-        // leak した可能性（drain せず検知のみ＝ここでの drain 可否は clack の Drop 挙動検証後に判断・defer）。
-        if !self.install_rx.is_empty() {
+        // 同じ leak クラスの非対称な見落としを塞ぐ（#342-#1）。正常 teardown では install ring は
+        // drain 済みのはず。非空で drop される = teardown 分岐後に install が届いたか、device 喪失で
+        // 分岐自体が走らなかった可能性（drain せず検知のみ＝ここでの drain 可否は clack の Drop 挙動
+        // 検証後に判断・defer）。slots() で残数を出して transient な 1 件か飽和かを見分けられるようにする。
+        let pending = self.install_rx.slots();
+        if pending > 0 {
             tracing::error!(
-                "ClapPostProcessor が非空の install ring を保持したまま drop された — \
-                 teardown 分岐が走らず未 install の plugin instance が leak した可能性（device 喪失か）"
+                "ClapPostProcessor が非空 (slots={pending}) の install ring を保持したまま drop された — \
+                 teardown 分岐後の install 到着か device 喪失で、未 install の plugin instance が leak した可能性"
             );
         }
     }
@@ -348,6 +355,9 @@ mod tests {
     fn drain_install_ring_drops_all_pending_and_empties() {
         // #342-#1: drain は ring 内の全アイテムを pop して **drop** し（= Arc 解放）、ring を空にする。
         // InstallMsg は real plugin 無しでは作れないので、Drop を数える generic な代用型で検証する。
+        // 注意: これは drain 関数の契約（drop-all + empty）の検証であって、実 leak シナリオ
+        // （teardown-before-install で real plugin の deactivate が正しいスレッドに乗る）は real plugin +
+        // 非決定的 race を要するため自動テスト不可。後者は gated 実機テスト（正常経路）とソース根拠でカバーする。
         static DROPS: AtomicU64 = AtomicU64::new(0);
         struct DropCounter;
         impl Drop for DropCounter {
@@ -369,5 +379,10 @@ mod tests {
             "drain したアイテムは drop されて Arc が解放されるはず"
         );
         assert!(rx.pop().is_err(), "drain 後の ring は空のはず");
+
+        // empty-ring（最頻パス: install 済みで teardown 時に ring は既に空）も no-op で空のまま。
+        let (_tx2, mut empty_rx) = rtrb::RingBuffer::<DropCounter>::new(4);
+        drain_install_ring(&mut empty_rx);
+        assert!(empty_rx.pop().is_err(), "空 ring を drain しても空のまま");
     }
 }


### PR DESCRIPTION
## 概要

#340 follow-on hardening（#342）の **①install-ring teardown drain**。post-2.0 engine track の Pre-γ hardening スプリント 2 項目目（1 項目目 = #326 CI 配線・PR #344 マージ済み）。

一次情報（clack `f874e858` + rtrb 0.3.4）を精読し、未ドレイン `InstallMsg` のリスクの**実体を確定したうえで**最小修正した。

## 確定した実体: wrong-thread UB ではなく「リーク」

carry-forward note は「wrong-thread stop_processing 残余」を懸念していたが、ソース精読の結果これは誤りで、実体は**プラグインインスタンスのリーク**だった。

- `StartedPluginAudioProcessor` は `Arc<PluginInstanceInner>` で `Drop` impl を持たない（process.rs:401）。drop は Arc 減算のみで plugin code を呼ばない。
- `PluginInstance::Drop`（plugin.rs:399-410）は **sole Arc owner のときだけ** teardown し、processor handle が残存すれば意図的に **leak** する（wrong-thread teardown を避ける clack の設計）。
- rtrb `RingBuffer::Drop`（lib.rs:233-242）は未消費スロットを drop するが、Producer/Consumer 共有 `Arc` の**最後の drop 時のみ**発火する。
- 帰結: Consumer（cpal `_stream`）が先に drop（refcount 2→1・未 drop）、Producer（clap・`host.shutdown()` の**後**）drop で初めて `InstallMsg` が drop される。よって `host.shutdown()`（= PluginInstance drop）時点で processor Arc が ring 越しに残存 → sole owner でない → **instance leak（deactivate/destroy 永久未呼出）**。
- 発生条件: plugin load → install 着地前に teardown（teardown 分岐が hot-install pop より前で early-return する窓）。狭いエッジだが実在のリーク。

## 修正（採用 A: drain-and-drop）

- cpal teardown 分岐で `drain_install_ring` を呼び、install ring を pop 全消費して `InstallMsg` を drop（Arc 解放・benign）。
- これで `host.shutdown()` より前に processor Arc が解放され、`PluginInstance::Drop` が sole owner となって stop_processing+deactivate+destroy を **clap スレッド（= start_processing と同一スレッド）**で正常実行する。
- spec 記述「専用スレッドへ handoff」は **Arc 解放による暗黙 handoff** で達成（実 teardown は clap スレッド）。新規 channel 不要・最小差分。spec deviation は owner 承認済み。

## テスト

- drain を generic 関数 `drain_install_ring<T>(&mut Consumer<T>)` に切り出し、`DropCounter` で「全 pop + 全 drop + ring 空」を決定論検証（real plugin 不要）。
- **gated 実機 RUN**（CoreAudio + test-synth/effect dylib）で正常 teardown 経路の非回帰を裏取り: synth peak 0.25 / effect ratio 0.50000・teardown panic/UB なし完了。
- ローカル全 green: fmt clean / clippy `-D warnings`（clap-host + daemon clap-host）/ cargo test workspace 0 failed / gated synth+effect GREEN。

Refs #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)