### PR TITLE
chore(engine): rescan warn-only + teardown busy-wait verdict (#342)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -38,6 +38,8 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **ローカル検証**: fmt（`--all --check`）clean / clippy（clap-host + daemon clap-host・`-D warnings`）clean / test（clap-host 11 + daemon protocol 19 ほか・0 failed。protocol の loopback bind は sandbox 制限で要 sandbox-off 実行）。
 
+**レビュー（/simplify）**: 4 agent（reuse/simplification/efficiency/altitude）。reuse+efficiency+altitude が一致して **warn-once latch** を指摘（unthrottled warn は misbehaving plugin の繰り返し rescan でログ flood）。`OrbitHostMainThread` に `bool` フィールド `warned_rescan_unsupported` を追加し warn-once 化（main-thread 専用なので atomic 不要・`session.rs` の `device_lost_reported` 慣習を再利用）。host.rs コメントは warn メッセージとの重複を削り latch の根拠に絞った。clap_host.rs の #342-#3 verdict コメントは altitude が「load-bearing な anti-footgun・clean」と判定し維持（simplification の「1行圧縮」より altitude を採用）。
+
 ### 6.171 fix(engine): drain install ring on teardown to prevent plugin-instance leak (#342-#1) (Jun 26, 2026)
 
 **Date**: 2026-06-26

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,27 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.172 chore(engine): rescan warn-only + teardown busy-wait verdict (#342-#2 / #342-#3) (Jun 27, 2026)
+
+**Date**: 2026-06-27
+**Status**: ✅ 実装完了（PR レビュー前）
+**Branch**: `342-rescan-warn-teardown-verdict`
+**Issue**: #342（項目2・項目3）
+**スプリント**: Pre-γ hardening スプリント PR A（#342-2 + #342-3 を1 PR に束ね・owner 承認）。B = #295 は独立。
+
+軽量 2 項目を1 PR に束ねた（owner 判断・§2 の「#342 を1 PR に束ねる」override）。リスクのある #295 とは切り離す。
+
+**#342-#2: audio-port rescan warn-only（`orbit-clap-host/src/host.rs`）**
+- `HostAudioPortsImpl::rescan`（AudioPortRescanFlags）は S1 で no-op（`is_rescan_flag_supported=false` 広告済）。
+- plugin が動的にポートを変えると構築時固定の `is_effect`（`has_audio_input`）が陳腐化しうる。サイレントを避け **warn ログ1文**を追加して可視化（`flags` を Debug 出力）。
+- **動的ポート対応そのものは作らない**（#342 項目2 の将来作業）。note/param rescan は対象外（is_effect 陳腐化は audio ports 固有）。
+
+**#342-#3: teardown busy-wait は据え置き（verdict・`orbit-audio-daemon/src/clap_host.rs`）**
+- `ClapTeardownGuard::drop` の `sleep(2ms)` poll は **変更推奨なし**（現結論）。guard は非 RT スレッド（`main()` 非 async）で走り、RT audio thread は `done` を atomic store するだけ。Condvar 置換は notify 時に RT thread へ mutex を強いて **RT を悪化**させる。
+- 将来 async context から `StreamGuard` を drop する場合のみ async yield / atomic-wait に変える旨を**コードコメントで明記**（将来の誤った "fix" を防ぐ）。コード logic 変更なし。
+
+**ローカル検証**: fmt（`--all --check`）clean / clippy（clap-host + daemon clap-host・`-D warnings`）clean / test（clap-host 11 + daemon protocol 19 ほか・0 failed。protocol の loopback bind は sandbox 制限で要 sandbox-off 実行）。
+
 ### 6.171 fix(engine): drain install ring on teardown to prevent plugin-instance leak (#342-#1) (Jun 26, 2026)
 
 **Date**: 2026-06-26

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -40,6 +40,13 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 **レビュー（/simplify）**: 4 agent（reuse/simplification/efficiency/altitude）。reuse+efficiency+altitude が一致して **warn-once latch** を指摘（unthrottled warn は misbehaving plugin の繰り返し rescan でログ flood）。`OrbitHostMainThread` に `bool` フィールド `warned_rescan_unsupported` を追加し warn-once 化（main-thread 専用なので atomic 不要・`session.rs` の `device_lost_reported` 慣習を再利用）。host.rs コメントは warn メッセージとの重複を削り latch の根拠に絞った。clap_host.rs の #342-#3 verdict コメントは altitude が「load-bearing な anti-footgun・clean」と判定し維持（simplification の「1行圧縮」より altitude を採用）。
 
+**レビュー（/code:pr-review-team）**: code-reviewer / silent-failure-hunter / pr-test-analyzer = **Critical/Important=0**。comment-analyzer のみ **Critical 1 + Important 2**（#342-#3 verdict コメントの事実誤り）を指摘し、一次情報で裏取りして全て採用・修正:
+- **C-1**: 「`main()` の非 async スコープで drop」は誤り。`_stream_guard` は `async fn run()`（`#[tokio::main]` multi_thread・worker 2）末尾・`server::serve().await` 返却後に drop = **tokio worker の async context**。teardown 中 worker を最大 TEARDOWN_TIMEOUT(500ms) ブロックしうるが、通常は RT thread が即 `done` を立て数 ms で抜け・shutdown フェーズなので許容（`done` を立てる cpal callback は worker と独立で deadlock しない）→ コメント訂正。
+- **I-1**: 「RT thread は `done` を atomic store するだけ」は過小。実際は stop_processing(CLAP 仕様=RT 必須)+buffers 解放+install ring drain も行う（processor.rs で確認）→ コメント訂正。
+- **I-2**: 「Condvar は notify 時に RT thread へ mutex を強いる」は技術的に誤り（`Condvar::notify_one` は `&self`・mutex 保持不要）。真の RT 不適理由は notify の syscall(futex/psynch_cvsignal) レイテンシ → コメント訂正（code-reviewer は mutex 説を是としたが comment-analyzer が正しい・一次情報で裁定）。
+- Minor 対応: pr-test-analyzer の「real plugin 不要で latch を単体テスト可」を採用し `rescan_warn_latches_after_first_request`（`AudioPortRescanFlags` を trivially 構築・UFCS 呼び）追加。silent-failure の「再要求 flags の観測性」を `else { tracing::debug!(...) }` で対応（warn flood 回避・debug は既定抑制）。
+- 再検証: fmt/clippy clean・clap-host 12 + daemon protocol 19 ほか 0 failed。
+
 ### 6.171 fix(engine): drain install ring on teardown to prevent plugin-instance leak (#342-#1) (Jun 26, 2026)
 
 **Date**: 2026-06-26

--- a/rust/crates/orbit-audio-daemon/src/clap_host.rs
+++ b/rust/crates/orbit-audio-daemon/src/clap_host.rs
@@ -166,6 +166,11 @@ impl Drop for ClapTeardownGuard {
                 );
                 break;
             }
+            // #342-#3 verdict: この poll-sleep は意図的で変更推奨なし。guard は非 RT スレッド
+            // （`main()` の非 async スコープ）で走り、RT audio thread は `done` を atomic store する
+            // だけ。Condvar 置換は notify 時に RT thread へ mutex を強いて RT を悪化させるため不可。
+            // 将来 async context から `StreamGuard` を drop する場合のみ、Condvar でなく async yield /
+            // atomic-wait に変えること。
             std::thread::sleep(Duration::from_millis(2));
         }
     }

--- a/rust/crates/orbit-audio-daemon/src/clap_host.rs
+++ b/rust/crates/orbit-audio-daemon/src/clap_host.rs
@@ -166,11 +166,18 @@ impl Drop for ClapTeardownGuard {
                 );
                 break;
             }
-            // #342-#3 verdict: この poll-sleep は意図的で変更推奨なし。guard は非 RT スレッド
-            // （`main()` の非 async スコープ）で走り、RT audio thread は `done` を atomic store する
-            // だけ。Condvar 置換は notify 時に RT thread へ mutex を強いて RT を悪化させるため不可。
-            // 将来 async context から `StreamGuard` を drop する場合のみ、Condvar でなく async yield /
-            // atomic-wait に変えること。
+            // #342-#3 verdict: この poll-sleep は意図的で変更推奨なし。guard は tokio worker 上の
+            // async フレーム（`run()` 末尾・`server::serve().await` 返却後）で drop され、teardown 中
+            // その worker を最大 TEARDOWN_TIMEOUT(500ms) ブロックしうる。ただし通常は RT thread が即
+            // `done` を立てるため数 ms 以内に抜け、500ms は audio thread 不在(device lost)時の安全弁。
+            // drop は serve 返却後の shutdown フェーズで起こるので worker ブロックは許容範囲（`done` を
+            // 立てる cpal callback は tokio worker と独立なので deadlock しない）。
+            // RT audio thread 側は teardown_requested 検知後 stop_processing(CLAP 仕様=RT 必須)・
+            // buffers 解放・install ring drain を行い、最後に `done` を atomic store する。
+            // Condvar 置換は不可: notify が syscall(futex / macOS psynch_cvsignal)を伴いカーネル遷移
+            // レイテンシが非決定論的で RT を損なう(notify_one は mutex 保持を要さないので mutex の有無
+            // とは無関係)。将来 serve 中の hot-reload 等で async teardown が要るなら spawn_blocking /
+            // tokio::sync::Notify / atomic-wait に移行すること。
             std::thread::sleep(Duration::from_millis(2));
         }
     }

--- a/rust/crates/orbit-clap-host/src/host.rs
+++ b/rust/crates/orbit-clap-host/src/host.rs
@@ -109,8 +109,15 @@ impl HostAudioPortsImpl for OrbitHostMainThread<'_> {
         false
     }
 
-    fn rescan(&mut self, _flags: AudioPortRescanFlags) {
-        // S1: 動的ポート変更非対応
+    fn rescan(&mut self, flags: AudioPortRescanFlags) {
+        // S1: 動的ポート変更非対応。is_rescan_flag_supported=false を広告済みだが、plugin が
+        // それでも rescan を要求した場合は no-op になる。構築時に固定した is_effect
+        // （has_audio_input）／ポート構成が陳腐化しうるため、サイレントにせず warn で可視化する
+        // （#342-#2。動的ポート対応そのものは #342 項目2 の将来作業）。
+        tracing::warn!(
+            "[clap] plugin が audio-port rescan を要求したが S1 は動的ポート非対応のため no-op — \
+             構築時の is_effect/ポート構成が陳腐化している可能性 (flags={flags:?})"
+        );
     }
 }
 

--- a/rust/crates/orbit-clap-host/src/host.rs
+++ b/rust/crates/orbit-clap-host/src/host.rs
@@ -69,6 +69,9 @@ impl<'a> SharedHandler<'a> for OrbitHostShared {
 pub struct OrbitHostMainThread<'a> {
     _shared: &'a OrbitHostShared,
     plugin: Option<InitializedPluginHandle<'a>>,
+    /// audio-port rescan 非対応 warn の warn-once latch（#342-#2）。main thread 専用呼び出しなので
+    /// `bool` で足りる（`AtomicBool` 不要）。`device_lost_reported` 慣習と同型。
+    warned_rescan_unsupported: bool,
 }
 
 impl<'a> OrbitHostMainThread<'a> {
@@ -76,6 +79,7 @@ impl<'a> OrbitHostMainThread<'a> {
         Self {
             _shared: shared,
             plugin: None,
+            warned_rescan_unsupported: false,
         }
     }
 }
@@ -110,14 +114,17 @@ impl HostAudioPortsImpl for OrbitHostMainThread<'_> {
     }
 
     fn rescan(&mut self, flags: AudioPortRescanFlags) {
-        // S1: 動的ポート変更非対応。is_rescan_flag_supported=false を広告済みだが、plugin が
-        // それでも rescan を要求した場合は no-op になる。構築時に固定した is_effect
-        // （has_audio_input）／ポート構成が陳腐化しうるため、サイレントにせず warn で可視化する
-        // （#342-#2。動的ポート対応そのものは #342 項目2 の将来作業）。
-        tracing::warn!(
-            "[clap] plugin が audio-port rescan を要求したが S1 は動的ポート非対応のため no-op — \
-             構築時の is_effect/ポート構成が陳腐化している可能性 (flags={flags:?})"
-        );
+        // S1: is_rescan_flag_supported=false を広告済みだが plugin が rescan を要求した場合は no-op。
+        // 構築時固定の is_effect（has_audio_input）/ポート構成が陳腐化しうるので可視化する（#342-#2。
+        // 動的ポート対応そのものは #342 項目2 の将来作業）。同一 plugin の繰り返し要求でログを flood
+        // させないため warn-once（2 回目以降は新情報ゼロ）。
+        if !self.warned_rescan_unsupported {
+            tracing::warn!(
+                "[clap] plugin が audio-port rescan を要求したが S1 は動的ポート非対応のため no-op — \
+                 構築時の is_effect/ポート構成が陳腐化している可能性 (flags={flags:?})"
+            );
+            self.warned_rescan_unsupported = true;
+        }
     }
 }
 

--- a/rust/crates/orbit-clap-host/src/host.rs
+++ b/rust/crates/orbit-clap-host/src/host.rs
@@ -124,6 +124,10 @@ impl HostAudioPortsImpl for OrbitHostMainThread<'_> {
                  構築時の is_effect/ポート構成が陳腐化している可能性 (flags={flags:?})"
             );
             self.warned_rescan_unsupported = true;
+        } else {
+            // 初回 warn 済み。再要求の flags は warn を flood させず debug で残す（後続要求が別 flag を
+            // 立てても診断できるように・debug は既定で抑制される）。
+            tracing::debug!("[clap] audio-port rescan 再要求 (flags={flags:?}) — no-op 継続");
         }
     }
 }
@@ -153,3 +157,31 @@ impl HostParamsImplShared for OrbitHostShared {
 // pump は ClapHost::pump() として main thread で実行する — PluginInstance<OrbitClapHost>
 // は !Send なのでそのスレッド以外に移動できない。carry-forward #2: callback_requested
 // flag を AcqRel swap で読み出し、true なら call_on_main_thread_callback() を呼ぶ。
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // #342-#2: audio-port rescan 非対応 warn の warn-once latch が、初回で立ち、再要求では
+    // リセットされない（= 2 回目以降は warn を flood しない）ことを検証する。real plugin 不要 —
+    // rescan は `&mut OrbitHostMainThread` のメソッドで `AudioPortRescanFlags` は trivially 構築できる。
+    // regression 対象: 誰かが `if !self.warned_rescan_unsupported` ガードを外すと毎回 warn する。
+    #[test]
+    fn rescan_warn_latches_after_first_request() {
+        let shared = OrbitHostShared::new(Arc::new(AtomicBool::new(false)));
+        let mut mt = OrbitHostMainThread::new(&shared);
+        assert!(!mt.warned_rescan_unsupported, "初期状態は未 warn");
+
+        // UFCS で呼ぶ: OrbitHostMainThread は audio/note/params の 3 トレイトで rescan を実装するため
+        // メソッド構文は曖昧（E0034）。
+        HostAudioPortsImpl::rescan(&mut mt, AudioPortRescanFlags::CHANNEL_COUNT);
+        assert!(mt.warned_rescan_unsupported, "初回 rescan で latch が立つ");
+
+        // 別 flag で再要求しても latch は true のまま（warn flood せず panic もしない）。
+        HostAudioPortsImpl::rescan(&mut mt, AudioPortRescanFlags::LIST);
+        assert!(
+            mt.warned_rescan_unsupported,
+            "再要求でも latch は true のまま"
+        );
+    }
+}


### PR DESCRIPTION
## 概要

Pre-γ hardening スプリント **PR A**（#342-#2 + #342-#3 を1 PR に束ね・owner 承認）。リスクのある #295（low-latency 32/64）は独立 PR B として後続。

## #342-#2 audio-port rescan warn-only（`orbit-clap-host/src/host.rs`）

- `HostAudioPortsImpl::rescan`（AudioPortRescanFlags）は S1 で no-op（`is_rescan_flag_supported=false` 広告済）。
- plugin が動的にポートを変えると構築時固定の `is_effect`（`has_audio_input`）が陳腐化しうる。サイレントを避け **warn ログ1文**で可視化（`flags` を Debug 出力）。
- **動的ポート対応そのものは作らない**（#342 項目2 の将来作業）。note/param rescan は対象外。

## #342-#3 teardown busy-wait は据え置き（verdict・`orbit-audio-daemon/src/clap_host.rs`）

- `ClapTeardownGuard::drop` の `sleep(2ms)` poll は **変更推奨なし**。guard は非 RT スレッド（`main()` 非 async）で走り、RT audio thread は `done` を atomic store するだけ。Condvar 置換は notify 時に RT thread へ mutex を強いて **RT を悪化**させる。
- 将来 async context から `StreamGuard` を drop する場合のみ async yield / atomic-wait に変える旨を**コードコメントで明記**（誤った "fix" 防止）。logic 変更なし。

## テスト（ローカル）

- fmt（`--all --check`）clean / clippy（clap-host + daemon clap-host・`-D warnings`）clean。
- test: clap-host 11 + daemon protocol 19 ほか 0 failed（protocol の loopback bind は sandbox 制限のため sandbox-off で実行）。

## issue 状態

`Refs #342`（**Closes ではない**）。本 PR は項目2 の warn-only stopgap + 項目3 verdict を解消するが、**項目2 の動的ポート対応**と**項目4 の panic corner** は将来作業として open のまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)