### PR TITLE
spike(engine): gamma latency fork — pipelined solves 64f small buffer (#350)

### DIFF
--- a/docs/development/POST_2.0_GAMMA_LATENCY_FORK_SPIKE.md
+++ b/docs/development/POST_2.0_GAMMA_LATENCY_FORK_SPIKE.md
@@ -1,0 +1,108 @@
+# γ latency policy fork — spike verdict（候補 A / in-process 対照 / 候補 B）
+
+- **Issue**: #350（親 Epic #292 Post-2.0 Native Engine & OrbitStudio）
+- **前段**: #348 / PR #349（γ Step0 feasibility spike・FEASIBLE・[`POST_2.0_GAMMA_SANDBOX_SPIKE.md`](POST_2.0_GAMMA_SANDBOX_SPIKE.md)）
+- **正本（親）**: [`POST_2.0_NEXT_STEPS.html`](POST_2.0_NEXT_STEPS.html) γ セクション L181（段階分け: daemon CLAP 統合 → sandbox spike → **本フェーズ** → γ 本実装 → cutover #108）
+- **実装**: `rust/crates/orbit-sandbox-spike`（`sandbox-host` に `--child-rt-priority` / `--in-process` / `--pipelined` を追加）
+- **計測機**: MacBook Pro（Apple Silicon / arm64）, macOS, CoreAudio default output, 44100 Hz, stereo, release build
+- **日付**: 2026-06-27
+
+## 1. 目的とスコープ
+
+Step0 spike は同期（synchronous）round-trip 設計のみを計測し、worst-case callback tail（~2〜4ms・
+buffer 非依存・scheduling 由来）が同期設計に **≥256 frame の buffer 下限**を強制すると判定した。
+本フェーズは Step0 verdict §6 の **latency policy fork を計測して決める**（"run before you plan"）。
+**実装ではなく feasibility spike**（stop&report）。
+
+owner 方針（[memory: DAW 並み小バッファ性能が目標]）により、64f / 32f の小バッファ viability は
+edge case ではなく**性能ゴール**として扱う。「≥256f で妥協」を終着点にしない。
+
+### 計測した 3 モード
+
+1. **候補 A — synchronous + child RT 優先度**（`--child-rt-priority`）: child の spin スレッドを
+   mach `THREAD_TIME_CONSTRAINT_POLICY`（RT）に上げ、tail が child プリエンプト由来なら縮むはず。
+2. **in-process 対照**（`--in-process`）: child を使わず callback 内で直接トーンを合成する。
+   sandbox round-trip を通さない経路（= **ネイティブ楽器が走る経路**）の floor を測り、候補 B の
+   callback_max「tiny」基準を較正し、「この機材が 64f を in-process でクリーンに出せるか」を独立検証。
+3. **候補 B — one-block-pipelined**（`--pipelined`）: host は spin せず block N を渡して N-1 を読む。
+   tail を構造的に消す代わり 1 block の遅延 + child 遅延時の stale。判定軸は **stale 率**。
+
+## 2. 判定軸（モード別）
+
+- 候補 A / sync: **worst-case callback_max ÷ block budget**（Step0 と同じ。overruns ではない。
+  CoreAudio は budget 超過で xrun を発火しない = #295 fence）。
+- 候補 B（pipelined）: **stale 率**（host が出力すべき block を child が未完了だった割合）が主軸。
+  callback_max は副軸（spin しないので本来 tiny。spike すれば host プリエンプトの証拠）。
+- in-process: callback_max（floor の較正）。
+
+## 3. 結果
+
+### 3.1 候補 A — RT 優先度は tail を縮めず、むしろ不安定化（棄却）
+
+64f（budget 1.45ms）・同一セッション比較:
+
+| モード | worst callback_max | overruns | 備考 |
+|--------|-------------------:|---------:|------|
+| sync（RT 無し）| 2.21〜2.23ms（timeout 1 回で 5.0ms）| 0〜1 | Step0 と整合 |
+| sync + RT-prio | 1.99〜2.75ms | 0〜**154** | run2 で 154 overruns（≈223ms 無音）に不安定化 |
+
+RT は実際に有効化された（child が `RT thread enabled (period=1451us)` を出力）。それでも
+**~2ms tail は縮まず**、ある run では大量 overruns で悪化した。連続 spin スレッドに time-constraint を
+付けると macOS が computation 予算超過で demote しうる（既知）。
+→ tail は **child プリエンプト由来ではない**（= host 側）。候補 A は棄却。
+
+### 3.2 in-process 対照 — この機材は 64f を in-process でクリーンに出せる
+
+64f（budget 1.45ms）・4 run: worst callback_max = **6µs = 0.41%**（典型 0.7〜1µs）。
+
+- **~2ms tail は OS/driver の floor ではない**。in-process（round-trip 無し）では消える。
+  → tail は **sandbox の round-trip 待ち固有**（host が child を spin で待つ時間 + その間の host
+  スレッドプリエンプト）。
+- **owner 向け主張「ネイティブ楽器 = in-process は小バッファ OK」を実機で裏付け**。ネイティブ音源の
+  リアルタイム演奏は 64f でもクリーン（音源自体の DSP コストのみで決まる、DAW 内蔵音源と同等）。
+
+### 3.3 候補 B — pipelined が 64f（32f まで）を解く（採用）
+
+stale 率が判定軸。callback_max は副軸。
+
+| buffer | block budget | callback_max（worst）| **stale 率** | stall | 判定 |
+|-------:|-------------:|--------------------:|-------------:|------:|:-----|
+| 256 f  | 5.80 ms | 4.1µs（0.07%）| **0%** | 0 | クリーン |
+| 128 f  | 2.90 ms | 7.8µs（0.27%）| **0%** | 0 | クリーン |
+| 64 f   | 1.45 ms | 6.8µs（0.47%・15s run）| **≈0.11%**（11/10330）| 0 | **feasible** |
+| 32 f   | 0.73 ms | 3.5µs（0.48%）| **≈0.45%**（31/6861）| 9〜13 | feasible（要観察） |
+
+- **callback_max は全 buffer で <0.5% budget** = ~2.7〜3.1ms の同期 tail が**完全に消えた**
+  （host が spin しないため）。Step0 の「≥256f 下限」制約は pipelined では外れる。
+- **stale 率は 64f で ≈0.1%・32f で ≈0.45%**。buffer が小さいほど child の 1 block 当たり時間が
+  減るので増えるが、32f でも 0.5% 未満。stall（slot 再利用不可）は 64f 以上で 0、32f で数件。
+- post-mix peak = 0.25（gain 0.5 × tone 0.5）= 音は正しく流れている。
+
+## 4. Verdict — **候補 B（one-block-pipelined）を採用**
+
+- 候補 A（RT 優先度）は tail を縮めず棄却。tail は host 側（in-process 対照で確証）。
+- 候補 B は host の spin 待ちを無くし tail を構造的に消す。**32f まで小バッファで out-of-process
+  sandbox を feasible にする**（callback_max <0.5% budget・stale <0.5%）。owner の DAW 並み小バッファ
+  性能ゴールを、サンドボックス経路でも満たせる見込み。
+
+### B の代償（γ 本実装で織り込む）
+
+1. **1 block の出力遅延**（pipeline 固有）。64f で +1.45ms、32f で +0.73ms。「サンドボックス化した
+   3rd-party を通した低レイテンシ演奏」の total latency = in-process 経路 + 1 sandbox block。
+2. **stale（child が間に合わない）が <0.5% @32-64f**。本 spike は stale policy = silence。production は
+   **直前 block の repeat**（クリック回避）を採るべき。
+3. **stall（slot 2-outstanding 再利用圧）が 32f で数件** → 必要なら slot 数を 3 に増やす検討。
+
+## 5. defer（本フェーズでやらない）
+
+- event / param IPC のリッチさ（CLAP event を境界越しに RT 安全に渡す設計）。
+- 複数同時 plugin、境界越え automation。
+- 本番 daemon への pipelined sandbox host 統合（cutover #108 前の別フェーズ = γ 本実装）。
+- plugin 内部状態の crash 復帰。
+- stale policy（repeat-previous）/ slot 数調整 / RT 優先度を block/wake child に付ける案の本実装。
+
+## 6. 次ステップ
+
+1. γ 本実装で **pipelined（候補 B）を採用**し、stale policy = repeat-previous、slot 数の最終決定を行う。
+2. event/param IPC 設計（CLAP event を境界越しに RT 安全に渡す）。
+3. 本番 daemon への sandbox host 統合 → γ 本実装 → cutover #108。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,22 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.175 spike(engine): γ latency policy fork — pipelined solves 64f (#350) (Jun 27, 2026)
+
+γ staging の次段（Step0 #348 の後）。Step0 verdict §6 の **latency policy fork を計測して決める**（"run before you plan"）feasibility spike。owner 方針（DAW 並み小バッファ性能が目標）により 64f/32f を edge case ではなく性能ゴールとして扱う。
+
+`orbit-sandbox-spike` の `sandbox-host` に 3 モードを追加して計測:
+- **候補 A**（`--child-rt-priority`）: child の spin スレッドを mach `THREAD_TIME_CONSTRAINT_POLICY`（RT）へ（mach2・macOS 限定 target 依存）。
+- **in-process 対照**（`--in-process`）: child を使わず callback 内で直接合成し floor を測る。
+- **候補 B**（`--pipelined`）: host は spin せず block N を渡し N-1 を読む。ping-pong バッファ（input/output 各 2 slot・`seq&1` で uniform index・child も変更）+ 2-outstanding guard（`seq_done >= new_seq-2`）。判定軸 = **stale 率**（callback_max ではない・advisor 指摘）。
+
+**計測（MacBook Pro arm64・44100Hz・release・同一機材）**:
+- **候補 A は棄却**: 64f で worst callback_max ~2〜2.75ms（縮まず）、ある run で 154 overruns（≈223ms 無音）に不安定化。連続 spin スレッドへの time-constraint は macOS demote を招く。→ tail は child プリエンプト由来ではない。
+- **in-process 対照**: 64f worst callback_max = **6µs（0.41%）**。→ ~2ms tail は OS/driver floor ではなく **sandbox round-trip 待ち固有**。owner 主張「ネイティブ楽器=in-process は小バッファ OK」を実機で裏付け。
+- **候補 B が解く**: callback_max は 32〜256f すべてで ~3.5〜8µs（**<0.5% budget**）= tail 消滅。stale 率 = 256/128f 0% / 64f ≈0.11%（15s・11/10330）/ 32f ≈0.45%（31/6861）。stall は 64f+ で 0・32f で数件。
+
+**Verdict = 候補 B（one-block-pipelined）採用**。out-of-process sandbox を 32f まで小バッファで feasible にする。代償 = 1 block 遅延 + stale <0.5%（@32-64f・production は repeat-previous）+ 32f で slot 再利用圧（slot 3 化を検討）。同期設計の「≥256f 下限」制約は pipelined では外れる。verdict = `docs/development/POST_2.0_GAMMA_LATENCY_FORK_SPIKE.md`。次 = γ 本実装で pipelined 採用 → event/param IPC → daemon 統合 → cutover #108。
+
 ### 6.174 spike(engine): γ out-of-process sandbox feasibility — Gate1/Gate2 verdict (#348) (Jun 27, 2026)
 
 post-2.0 native engine の **γ（out-of-process sandbox）** フェーズ Step0。正本 `POST_2.0_NEXT_STEPS.html` の staging 指示「γ は単一 /goal にせず『daemon CLAP 統合（#340/#341 完了）→ sandbox スパイク』と段階化」に従い、feasibility spike（実装ではなく stop&report ゲート付き）を実施。

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -991,6 +991,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "cpal",
+ "mach2",
  "memmap2",
 ]
 

--- a/rust/crates/orbit-sandbox-spike/Cargo.toml
+++ b/rust/crates/orbit-sandbox-spike/Cargo.toml
@@ -27,3 +27,10 @@ cpal.workspace = true
 # atomic + bounded spin（macOS に futex は無いが atomic + spin で足りる）。
 memmap2 = "0.9"
 anyhow = "1"
+
+# candidate A (sync + child RT 優先度) の計測用。child の spin スレッドを mach
+# THREAD_TIME_CONSTRAINT_POLICY に上げ、プリエンプト由来の tail が縮むか測る（#350）。
+# macOS 専用 API なので target-gated。CI(ubuntu) の default グラフには現れない。
+# MIT/Apache-2.0（cargo-deny allow）。
+[target.'cfg(target_os = "macos")'.dependencies]
+mach2 = "0.4"

--- a/rust/crates/orbit-sandbox-spike/src/bin/sandbox-child.rs
+++ b/rust/crates/orbit-sandbox-spike/src/bin/sandbox-child.rs
@@ -12,18 +12,24 @@
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 
-use orbit_sandbox_spike::{open_shared, region_ptr, CHANNELS, MAX_FRAMES};
+use orbit_sandbox_spike::{open_shared, region_ptr, set_realtime_thread, CHANNELS, MAX_FRAMES};
 
 struct Cli {
     shm: PathBuf,
     /// > 0 なら N ブロック処理後に自発 segfault（Gate2 用）。0 = crash しない。
     crash_after_blocks: u64,
+    /// true なら spin スレッドを RT(time-constraint)優先度に上げる（candidate A・#350）。
+    rt_priority: bool,
+    /// RT の period（µs）= block period。computation/constraint をここから導く。0 = host 未指定。
+    rt_period_us: u64,
 }
 
 fn parse_args() -> anyhow::Result<Cli> {
     let mut args = std::env::args().skip(1);
     let mut shm: Option<PathBuf> = None;
     let mut crash_after_blocks: u64 = 0;
+    let mut rt_priority = false;
+    let mut rt_period_us: u64 = 0;
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--shm" => {
@@ -39,12 +45,21 @@ fn parse_args() -> anyhow::Result<Cli> {
                     .ok_or_else(|| anyhow::anyhow!("--crash-after-blocks requires a value"))?
                     .parse()?
             }
+            "--rt-priority" => rt_priority = true,
+            "--rt-period-us" => {
+                rt_period_us = args
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("--rt-period-us requires a value"))?
+                    .parse()?
+            }
             other => anyhow::bail!("Unknown argument: {other}"),
         }
     }
     Ok(Cli {
         shm: shm.ok_or_else(|| anyhow::anyhow!("--shm is required"))?,
         crash_after_blocks,
+        rt_priority,
+        rt_period_us,
     })
 }
 
@@ -58,6 +73,24 @@ fn main() -> anyhow::Result<()> {
         cli.shm.display(),
         cli.crash_after_blocks
     );
+
+    // candidate A: spin スレッド（このスレッド = 唯一の処理スレッド）を RT に上げる。
+    // computation = period/2・constraint = period*3/4（>= computation）。失敗しても通常優先度で
+    // 継続し、計測は RT 無効として読める（host は child_rt_priority を結果に出すので区別可能）。
+    if cli.rt_priority {
+        let period_ns = cli.rt_period_us.saturating_mul(1_000);
+        match set_realtime_thread(period_ns, period_ns / 2, period_ns * 3 / 4) {
+            Ok(()) => eprintln!(
+                "[sandbox-child pid={}] RT thread enabled (period={}us)",
+                std::process::id(),
+                cli.rt_period_us
+            ),
+            Err(e) => eprintln!(
+                "[sandbox-child pid={}] WARNING: RT thread NOT enabled: {e} (running at normal priority)",
+                std::process::id()
+            ),
+        }
+    }
 
     // gain は host 起動時に一度だけ設定され計測中は不変 → ループ外で 1 回だけ読む
     // （毎ブロックの shared control-line への atomic load + bit-cast を省く）。

--- a/rust/crates/orbit-sandbox-spike/src/bin/sandbox-child.rs
+++ b/rust/crates/orbit-sandbox-spike/src/bin/sandbox-child.rs
@@ -12,7 +12,9 @@
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 
-use orbit_sandbox_spike::{open_shared, region_ptr, set_realtime_thread, CHANNELS, MAX_FRAMES};
+use orbit_sandbox_spike::{
+    open_shared, region_ptr, set_realtime_thread, slot_offset, CHANNELS, MAX_FRAMES,
+};
 
 struct Cli {
     shm: PathBuf,
@@ -104,12 +106,14 @@ fn main() -> anyhow::Result<()> {
         if cur > last {
             let n = unsafe { (*r).n_frames.load(Ordering::Relaxed) as usize }.min(MAX_FRAMES);
             let count = n * CHANNELS;
-            // SAFETY: host の 1-outstanding 不変条件により、host は前 req 完了後のみ次の input を
-            // 上書きする = この req を処理している間 host は input/output に触れない。よって input を
-            // 読み gain を掛けて output に書くこの window で host との競合は無い。
+            // ping-pong: この seq の slot を read/write する（host も同じ seq&1 で index する）。
+            let off = slot_offset(cur);
+            // SAFETY: slot 不変条件（モジュール doc）により、host はこの seq の slot を処理中に触れない
+            // （sync は 1-outstanding、pipelined は 2-outstanding guard）。よって input[off..] を読み
+            // gain を掛けて output[off..] に書くこの window で host との競合は無い。
             unsafe {
-                let inp = (*r).input.as_ptr();
-                let out = (*r).output.as_mut_ptr();
+                let inp = (*r).input.as_ptr().add(off);
+                let out = (*r).output.as_mut_ptr().add(off);
                 for i in 0..count {
                     *out.add(i) = *inp.add(i) * gain;
                 }

--- a/rust/crates/orbit-sandbox-spike/src/bin/sandbox-child.rs
+++ b/rust/crates/orbit-sandbox-spike/src/bin/sandbox-child.rs
@@ -5,7 +5,7 @@
 //! 自発 segfault し、Gate2（親が子の crash を封じ込めて watchdog 復帰できるか）を駆動する。
 //!
 //! 使い方:
-//!   sandbox-child --shm <path> [--crash-after-blocks <N>]
+//!   sandbox-child --shm <path> [--crash-after-blocks <N>] [--rt-priority] [--rt-period-us <US>]
 
 #![allow(unsafe_code)]
 
@@ -78,19 +78,30 @@ fn main() -> anyhow::Result<()> {
 
     // candidate A: spin スレッド（このスレッド = 唯一の処理スレッド）を RT に上げる。
     // computation = period/2・constraint = period*3/4（>= computation）。失敗しても通常優先度で
-    // 継続し、計測は RT 無効として読める（host は child_rt_priority を結果に出すので区別可能）。
+    // 継続するが、適用可否を共有メモリ `rt_active` に書き、host が `child_rt_applied` として stdout に
+    // 出力する（stderr だけだと redirect で失われ「効果なし」と誤読されるため・silent-failure review）。
     if cli.rt_priority {
         let period_ns = cli.rt_period_us.saturating_mul(1_000);
-        match set_realtime_thread(period_ns, period_ns / 2, period_ns * 3 / 4) {
-            Ok(()) => eprintln!(
-                "[sandbox-child pid={}] RT thread enabled (period={}us)",
-                std::process::id(),
-                cli.rt_period_us
-            ),
-            Err(e) => eprintln!(
-                "[sandbox-child pid={}] WARNING: RT thread NOT enabled: {e} (running at normal priority)",
-                std::process::id()
-            ),
+        let applied = match set_realtime_thread(period_ns, period_ns / 2, period_ns * 3 / 4) {
+            Ok(()) => {
+                eprintln!(
+                    "[sandbox-child pid={}] RT thread enabled (period={}us)",
+                    std::process::id(),
+                    cli.rt_period_us
+                );
+                true
+            }
+            Err(e) => {
+                eprintln!(
+                    "[sandbox-child pid={}] WARNING: RT thread NOT enabled: {e} (running at normal priority)",
+                    std::process::id()
+                );
+                false
+            }
+        };
+        // SAFETY: r は host が確保した共有領域。rt_active は cross-process 可視（MAP_SHARED）。
+        unsafe {
+            (*r).rt_active.store(applied, Ordering::Relaxed);
         }
     }
 

--- a/rust/crates/orbit-sandbox-spike/src/bin/sandbox-host.rs
+++ b/rust/crates/orbit-sandbox-spike/src/bin/sandbox-host.rs
@@ -38,6 +38,10 @@ struct Cli {
     /// true なら spawn する子に --rt-priority を渡し RT(time-constraint)スケジュールにする
     /// （candidate A・#350）。period は buffer_frames + sample_rate から導く。
     child_rt_priority: bool,
+    /// true なら child を使わず callback 内で直接トーンを合成する in-process 対照（#350）。
+    /// sandbox round-trip を通さない経路（= ネイティブ楽器が走る経路）の callback_max floor を測り、
+    /// 「この機材/CoreAudio が 64f を in-process でクリーンに出せるか」を独立に検証する。
+    in_process: bool,
 }
 
 fn parse_args() -> anyhow::Result<Cli> {
@@ -49,6 +53,7 @@ fn parse_args() -> anyhow::Result<Cli> {
         child_crash_after_blocks: 0,
         gain: 0.5,
         child_rt_priority: false,
+        in_process: false,
     };
     while let Some(arg) = args.next() {
         let mut next = || {
@@ -62,6 +67,7 @@ fn parse_args() -> anyhow::Result<Cli> {
             "--child-crash-after-blocks" => cli.child_crash_after_blocks = next()?.parse()?,
             "--gain" => cli.gain = next()?.parse()?,
             "--child-rt-priority" => cli.child_rt_priority = true,
+            "--in-process" => cli.in_process = true,
             other => anyhow::bail!("Unknown argument: {other}"),
         }
     }
@@ -200,7 +206,105 @@ fn spawn_child(
 
 fn main() -> anyhow::Result<()> {
     let cli = parse_args()?;
-    run(&cli)
+    if cli.in_process {
+        run_in_process(&cli)
+    } else {
+        run(&cli)
+    }
+}
+
+/// in-process 対照（#350）: child を使わず callback 内で直接トーンを合成する。sandbox round-trip を
+/// 通さない経路（= ネイティブ楽器が走る経路）の callback_max floor を測り、candidate B の
+/// callback_max の「tiny」基準を較正する。また「この機材/CoreAudio が 64f を in-process でクリーンに
+/// 出せるか」を独立に検証する（host 側 tail が CoreAudio/OS 由来なら in-process でも spike する）。
+fn run_in_process(cli: &Cli) -> anyhow::Result<()> {
+    let cpal_host = cpal::default_host();
+    let device = cpal_host
+        .default_output_device()
+        .ok_or_else(|| anyhow::anyhow!("no default output device"))?;
+    let default_cfg = device.default_output_config()?;
+    let sample_rate = default_cfg.sample_rate().0;
+    let cpal_config = cpal::StreamConfig {
+        channels: CHANNELS as u16,
+        sample_rate: cpal::SampleRate(sample_rate),
+        buffer_size: match cli.buffer_frames {
+            Some(f) => cpal::BufferSize::Fixed(f),
+            None => cpal::BufferSize::Default,
+        },
+    };
+    println!(
+        "audio: {} Hz, {} ch, buffer={:?} (IN-PROCESS control)",
+        sample_rate, CHANNELS, cpal_config.buffer_size
+    );
+
+    let stats = RtStats::new();
+    let cb_stats = stats.clone();
+    let phase_inc = 2.0 * std::f64::consts::PI * 220.0 / sample_rate as f64;
+    let mut phase: f64 = 0.0;
+    // cpal の fatal error（device 切断等）で callback 配送が止まると無音のまま teardown され
+    // measurement_valid:true の誤データになりうる。error callback でも sentinel を立てる。
+    let measurement_invalid = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let err_flag = measurement_invalid.clone();
+
+    let stream = device.build_output_stream(
+        &cpal_config,
+        move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+            let cb_start = Instant::now();
+            let frames = data.len() / CHANNELS;
+            let mut peak: f32 = 0.0;
+            for f in 0..frames {
+                phase += phase_inc;
+                if phase >= std::f64::consts::TAU {
+                    phase -= std::f64::consts::TAU;
+                }
+                let s = (phase.sin() as f32) * 0.5;
+                data[f * CHANNELS] = s;
+                data[f * CHANNELS + 1] = s;
+                peak = peak.max(s.abs());
+            }
+            cb_stats
+                .post_peak_bits
+                .fetch_max(peak.to_bits(), Ordering::Relaxed);
+            cb_stats
+                .callback_max_ns
+                .fetch_max(cb_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+            cb_stats
+                .frames_total
+                .fetch_add(frames as u64, Ordering::Relaxed);
+            cb_stats.success_count.fetch_add(1, Ordering::Relaxed);
+        },
+        move |err| {
+            eprintln!("[cpal err] {err}");
+            err_flag.store(true, Ordering::Relaxed);
+        },
+        None,
+    )?;
+    stream.play()?;
+    std::thread::sleep(Duration::from_secs(cli.measure_secs));
+    drop(stream);
+
+    let invalid = measurement_invalid.load(Ordering::Relaxed);
+    let callbacks = stats.success_count.load(Ordering::Relaxed);
+    let frames_total = stats.frames_total.load(Ordering::Relaxed);
+    let cb_max = stats.callback_max_ns.load(Ordering::Relaxed);
+    let post_peak = f32::from_bits(stats.post_peak_bits.load(Ordering::Relaxed));
+    let avg_frames = frames_total.checked_div(callbacks).unwrap_or(0);
+    let block_budget_ns = avg_frames * 1_000_000_000 / sample_rate as u64;
+
+    println!();
+    println!("=== orbit-sandbox-spike (in-process control) ===");
+    if invalid {
+        println!("MEASUREMENT INVALID — cpal error during run (see stderr); 数値は信頼できない。");
+    }
+    println!("measurement_valid:     {}", !invalid);
+    println!("sample_rate:           {sample_rate}");
+    println!("total_callbacks:       {callbacks}");
+    println!("avg_frames_per_cb:     {avg_frames}");
+    println!("block_budget_ns:       ~{block_budget_ns}");
+    println!("callback_max_ns:       {cb_max}");
+    println!("post_mix_peak:         {post_peak:.5}");
+    println!("================================================");
+    Ok(())
 }
 
 fn run(cli: &Cli) -> anyhow::Result<()> {

--- a/rust/crates/orbit-sandbox-spike/src/bin/sandbox-host.rs
+++ b/rust/crates/orbit-sandbox-spike/src/bin/sandbox-host.rs
@@ -6,13 +6,16 @@
 //!
 //! 使い方:
 //!   sandbox-host [--measure-secs N] [--buffer-frames F] [--round-trip-timeout-us US]
-//!                [--child-crash-after-blocks N] [--gain G] [--child-rt-priority]
+//!                [--child-crash-after-blocks N] [--gain G]
+//!                [--child-rt-priority] [--in-process] [--pipelined]
 //!
 //! Gate1（RT round-trip が block budget に収まるか）: crash 無しで実行しレイテンシ分布を見る。
 //! Gate2（子の crash 封じ込め + watchdog 復帰）: --child-crash-after-blocks N で実行し、
 //!   respawn 後に round-trip が再開し audio が復帰することを確認する。
 //! candidate A（#350）: --child-rt-priority で子を RT(time-constraint)優先度にし、worst-case
 //!   tail が同期ベースライン（Step0）より縮むかを比較する。
+//! candidate B（#350）: --pipelined で host が spin せず block N を渡して N-1 を読む。判定軸は stale 率。
+//! in-process 対照（#350）: --in-process で child を使わず callback 内で直接合成し floor を測る。
 
 #![allow(unsafe_code)]
 
@@ -23,7 +26,9 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use orbit_sandbox_spike::{create_shared, region_ptr, SharedRegion, CHANNELS, MAX_FRAMES};
+use orbit_sandbox_spike::{
+    create_shared, region_ptr, slot_offset, SharedRegion, CHANNELS, MAX_FRAMES,
+};
 
 // ---- CLI ----------------------------------------------------------------
 
@@ -42,6 +47,9 @@ struct Cli {
     /// sandbox round-trip を通さない経路（= ネイティブ楽器が走る経路）の callback_max floor を測り、
     /// 「この機材/CoreAudio が 64f を in-process でクリーンに出せるか」を独立に検証する。
     in_process: bool,
+    /// true なら candidate B（one-block-pipelined）: host は spin せず block N を渡して N-1 を読む。
+    /// tail を構造的に消す代わり 1 block の遅延 + child 遅延時の stale。判定軸は stale 率（#350）。
+    pipelined: bool,
 }
 
 fn parse_args() -> anyhow::Result<Cli> {
@@ -54,6 +62,7 @@ fn parse_args() -> anyhow::Result<Cli> {
         gain: 0.5,
         child_rt_priority: false,
         in_process: false,
+        pipelined: false,
     };
     while let Some(arg) = args.next() {
         let mut next = || {
@@ -68,6 +77,7 @@ fn parse_args() -> anyhow::Result<Cli> {
             "--gain" => cli.gain = next()?.parse()?,
             "--child-rt-priority" => cli.child_rt_priority = true,
             "--in-process" => cli.in_process = true,
+            "--pipelined" => cli.pipelined = true,
             other => anyhow::bail!("Unknown argument: {other}"),
         }
     }
@@ -103,6 +113,10 @@ struct RtStats {
     post_peak_bits: AtomicU32,
     /// 最後に round-trip が成功した時刻（t_start からの ns）。recovery 判定用。
     last_success_ns: AtomicU64,
+    /// pipelined（候補 B）: 出力時に child がその block を未完了で stale 出力した回数。B の判定軸。
+    stale_count: AtomicU64,
+    /// pipelined（候補 B）: slot 再利用不可（child が 2 block 以上遅延）で submit を見送った回数。
+    stall_count: AtomicU64,
 }
 
 impl RtStats {
@@ -119,6 +133,8 @@ impl RtStats {
             callback_max_ns: AtomicU64::new(0),
             post_peak_bits: AtomicU32::new(0),
             last_success_ns: AtomicU64::new(0),
+            stale_count: AtomicU64::new(0),
+            stall_count: AtomicU64::new(0),
         })
     }
 
@@ -460,127 +476,235 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
         (*region).child_processed.store(0, Ordering::Relaxed);
     }
 
-    let region_ptr_send = RegionPtr(region);
-    let cb_stats = stats.clone();
-    let mut req: u64 = warm_req;
-    let mut phase: f64 = 0.0;
     // cpal の fatal error（device 切断 / HAL 障害）でストリームが callback 配送を止めると、残りの
     // 計測窓は無音のまま teardown され `measurement_valid: true` の誤データになりうる。error callback
     // でも同じ sentinel を立て、go/no-go を誤導しないようにする。
-    let stream_err_invalid = measurement_invalid.clone();
+    let stream = if cli.pipelined {
+        // ===== candidate B: one-block-pipelined（host は spin しない）=====
+        let region_ptr_send = RegionPtr(region);
+        let cb_stats = stats.clone();
+        let stream_err_invalid = measurement_invalid.clone();
+        // req = 直近に submit 成功した seq。primed=false の初回は読むべき前回 submit が無い。
+        let mut req: u64 = warm_req;
+        let mut phase: f64 = 0.0;
+        let mut primed = false;
+        device.build_output_stream(
+            &cpal_config,
+            move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                let cb_start = Instant::now();
+                let r = region_ptr_send.get();
+                let frames = data.len() / CHANNELS;
+                let n = frames.min(MAX_FRAMES);
+                let count = n * CHANNELS;
+                if frames > MAX_FRAMES {
+                    cb_stats.frames_clamped.fetch_add(1, Ordering::Relaxed);
+                }
 
-    let stream = device.build_output_stream(
-        &cpal_config,
-        move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-            let cb_start = Instant::now();
-            let r = region_ptr_send.get();
-            let frames = data.len() / CHANNELS;
-            let n = frames.min(MAX_FRAMES);
-            let count = n * CHANNELS;
-            if frames > MAX_FRAMES {
-                // 全幅を round-trip できていない（部分ブロックのみ）。結果で警告するため記録。
-                cb_stats.frames_clamped.fetch_add(1, Ordering::Relaxed);
-            }
+                let mut peak: f32 = 0.0;
 
-            // --- 1-outstanding request モデル ---
-            // 前の request が完了（seq_done が req に追いついている）したときのみ新規 request を発行する。
-            // こうすると、child が（生きていて遅延中でも・crash 後 respawn 待ちでも）前 req の input を
-            // 読んでいる最中に host が input を上書きすることが無く、クロスプロセスのデータ競合を
-            // 構造的に排除する（high-load で live child が timeout を超過した場合の UB を防ぐ）。
-            let prev_done = unsafe { (*r).seq_done.load(Ordering::Acquire) } >= req;
-
-            let mut peak: f32 = 0.0;
-            if prev_done {
-                // input にテストトーンを書く。
-                // SAFETY: 前 req は完了済（seq_done >= req）= child は前 req の input 読み出しを終え
-                // seq_done を Release 済。よってここでは host が input の唯一の writer（child は次の
-                // seq_request を観測するまで input/output に触れない）。
-                unsafe {
-                    let inp = (*r).input.as_mut_ptr();
-                    for f in 0..n {
-                        phase += phase_inc;
-                        if phase >= std::f64::consts::TAU {
-                            phase -= std::f64::consts::TAU;
+                // --- 出力: 前回 submit した seq `req` の結果を読む（child は ~1 block 分の時間があった）---
+                if primed {
+                    let done = unsafe { (*r).seq_done.load(Ordering::Acquire) } >= req;
+                    if done {
+                        // fresh: この seq の slot の output を出力にコピー。
+                        // SAFETY: seq_done >= req を Acquire 観測 → child の output 書き込みが可視。
+                        // 2-outstanding guard により host はこの slot を上書きしていない。
+                        unsafe {
+                            let out = (*r).output.as_ptr().add(slot_offset(req));
+                            for (i, slot) in data.iter_mut().enumerate().take(count) {
+                                let v = *out.add(i);
+                                *slot = v;
+                                peak = peak.max(v.abs());
+                            }
                         }
-                        let s = (phase.sin() as f32) * 0.5;
-                        *inp.add(f * CHANNELS) = s;
-                        *inp.add(f * CHANNELS + 1) = s;
-                    }
-                    (*r).n_frames.store(n as u32, Ordering::Relaxed);
-                }
-                // publish: Release で seq_request を進める（n_frames/input 書き込みが child から可視に）。
-                req += 1;
-                unsafe {
-                    (*r).seq_request.store(req, Ordering::Release);
-                }
-
-                // --- bounded spin で child の done を待つ（RT は無制限ブロックしない）---
-                let t0 = Instant::now();
-                let mut got = false;
-                loop {
-                    if unsafe { (*r).seq_done.load(Ordering::Acquire) } >= req {
-                        got = true;
-                        break;
-                    }
-                    if t0.elapsed() >= timeout {
-                        break;
-                    }
-                    std::hint::spin_loop();
-                }
-                // spin 直後の時刻を一度だけ読み、round-trip と last_success の両方に使う
-                // （hot-path の clock 読みを 1 回に減らす）。
-                let now = Instant::now();
-                let rt_ns = (now - t0).as_nanos() as u64;
-
-                if got {
-                    // SAFETY: done を Acquire で観測済 → child の output 書き込みが可視。
-                    unsafe {
-                        let out = (*r).output.as_ptr();
-                        for (i, slot) in data.iter_mut().enumerate().take(count) {
-                            let v = *out.add(i);
-                            *slot = v;
-                            peak = peak.max(v.abs());
+                        for s in data.iter_mut().skip(count) {
+                            *s = 0.0;
                         }
+                        cb_stats.success_count.fetch_add(1, Ordering::Relaxed);
+                        cb_stats.last_success_ns.store(
+                            (Instant::now() - t_start).as_nanos() as u64,
+                            Ordering::Relaxed,
+                        );
+                    } else {
+                        // stale: child がこの block を未完了 → silence（stale policy）。B の判定軸。
+                        // production は直前 block の repeat が選択肢だが spike は silence で stale 率を測る。
+                        for s in data.iter_mut() {
+                            *s = 0.0;
+                        }
+                        cb_stats.stale_count.fetch_add(1, Ordering::Relaxed);
                     }
-                    // フレーム超過分（n < frames）は無音で埋める。
-                    for s in data.iter_mut().skip(count) {
+                } else {
+                    // priming: 読むべき前回 submit がまだ無い → 無音。
+                    for s in data.iter_mut() {
                         *s = 0.0;
                     }
-                    cb_stats.record_roundtrip(rt_ns);
-                    cb_stats
-                        .last_success_ns
-                        .store((now - t_start).as_nanos() as u64, Ordering::Relaxed);
+                }
+
+                // --- submit: 新 seq を child に渡す（spin しない）---
+                // slot 再利用安全: 新 seq の slot の前 occupant = new_seq-2。seq_done >= new_seq-2 を要求。
+                let new_seq = req + 1;
+                let slot_free =
+                    unsafe { (*r).seq_done.load(Ordering::Acquire) } >= new_seq.saturating_sub(2);
+                if slot_free {
+                    let off = slot_offset(new_seq);
+                    // SAFETY: 上の guard で new_seq の slot の前 occupant は完了済 = child は触れない。
+                    // n_frames は固定 buffer で常に同値（可変 block 化するなら slot 毎に持つ必要あり）。
+                    unsafe {
+                        let inp = (*r).input.as_mut_ptr().add(off);
+                        for f in 0..n {
+                            phase += phase_inc;
+                            if phase >= std::f64::consts::TAU {
+                                phase -= std::f64::consts::TAU;
+                            }
+                            let s = (phase.sin() as f32) * 0.5;
+                            *inp.add(f * CHANNELS) = s;
+                            *inp.add(f * CHANNELS + 1) = s;
+                        }
+                        (*r).n_frames.store(n as u32, Ordering::Relaxed);
+                        (*r).seq_request.store(new_seq, Ordering::Release);
+                    }
+                    req = new_seq;
+                    primed = true;
                 } else {
-                    // この req は timeout = glitch-to-silence。req は outstanding のまま残り、次の
-                    // callback は prev_done=false となって child が追いつくまで input を上書きしない。
+                    // stall: child が 2 block 以上遅延し slot 再利用不可 → submit 見送り（req 据え置き）。
+                    cb_stats.stall_count.fetch_add(1, Ordering::Relaxed);
+                }
+
+                cb_stats
+                    .post_peak_bits
+                    .fetch_max(peak.to_bits(), Ordering::Relaxed);
+                cb_stats
+                    .callback_max_ns
+                    .fetch_max(cb_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+                cb_stats.frames_total.fetch_add(n as u64, Ordering::Relaxed);
+            },
+            move |err| {
+                eprintln!("[cpal err] {err}");
+                stream_err_invalid.store(true, Ordering::Relaxed);
+            },
+            None,
+        )?
+    } else {
+        // ===== sync / candidate A（host が bounded spin で待つ）=====
+        let region_ptr_send = RegionPtr(region);
+        let cb_stats = stats.clone();
+        let stream_err_invalid = measurement_invalid.clone();
+        let mut req: u64 = warm_req;
+        let mut phase: f64 = 0.0;
+        device.build_output_stream(
+            &cpal_config,
+            move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                let cb_start = Instant::now();
+                let r = region_ptr_send.get();
+                let frames = data.len() / CHANNELS;
+                let n = frames.min(MAX_FRAMES);
+                let count = n * CHANNELS;
+                if frames > MAX_FRAMES {
+                    // 全幅を round-trip できていない（部分ブロックのみ）。結果で警告するため記録。
+                    cb_stats.frames_clamped.fetch_add(1, Ordering::Relaxed);
+                }
+
+                // --- 1-outstanding request モデル ---
+                // 前の request が完了（seq_done が req に追いついている）したときのみ新規 request を発行する。
+                // こうすると、child が（生きていて遅延中でも・crash 後 respawn 待ちでも）前 req の input を
+                // 読んでいる最中に host が input を上書きすることが無く、クロスプロセスのデータ競合を
+                // 構造的に排除する（high-load で live child が timeout を超過した場合の UB を防ぐ）。
+                let prev_done = unsafe { (*r).seq_done.load(Ordering::Acquire) } >= req;
+
+                let mut peak: f32 = 0.0;
+                if prev_done {
+                    // 新 seq へ進めてから、その seq の slot に input を書く（child も slot_offset(req) で読む）。
+                    req += 1;
+                    let off = slot_offset(req);
+                    // SAFETY: 前 req は完了済（seq_done >= req-1）= 新 seq の slot の前 occupant（req-2）も
+                    // 完了している（1-outstanding）。よって host がこの slot の唯一の writer（child は次の
+                    // seq_request を観測するまで input/output に触れない）。
+                    unsafe {
+                        let inp = (*r).input.as_mut_ptr().add(off);
+                        for f in 0..n {
+                            phase += phase_inc;
+                            if phase >= std::f64::consts::TAU {
+                                phase -= std::f64::consts::TAU;
+                            }
+                            let s = (phase.sin() as f32) * 0.5;
+                            *inp.add(f * CHANNELS) = s;
+                            *inp.add(f * CHANNELS + 1) = s;
+                        }
+                        (*r).n_frames.store(n as u32, Ordering::Relaxed);
+                    }
+                    // publish: Release で seq_request を進める（n_frames/input 書き込みが child から可視に）。
+                    unsafe {
+                        (*r).seq_request.store(req, Ordering::Release);
+                    }
+
+                    // --- bounded spin で child の done を待つ（RT は無制限ブロックしない）---
+                    let t0 = Instant::now();
+                    let mut got = false;
+                    loop {
+                        if unsafe { (*r).seq_done.load(Ordering::Acquire) } >= req {
+                            got = true;
+                            break;
+                        }
+                        if t0.elapsed() >= timeout {
+                            break;
+                        }
+                        std::hint::spin_loop();
+                    }
+                    // spin 直後の時刻を一度だけ読み、round-trip と last_success の両方に使う
+                    // （hot-path の clock 読みを 1 回に減らす）。
+                    let now = Instant::now();
+                    let rt_ns = (now - t0).as_nanos() as u64;
+
+                    if got {
+                        // SAFETY: done を Acquire で観測済 → child の output 書き込みが可視。slot は req と一致。
+                        unsafe {
+                            let out = (*r).output.as_ptr().add(slot_offset(req));
+                            for (i, slot) in data.iter_mut().enumerate().take(count) {
+                                let v = *out.add(i);
+                                *slot = v;
+                                peak = peak.max(v.abs());
+                            }
+                        }
+                        // フレーム超過分（n < frames）は無音で埋める。
+                        for s in data.iter_mut().skip(count) {
+                            *s = 0.0;
+                        }
+                        cb_stats.record_roundtrip(rt_ns);
+                        cb_stats
+                            .last_success_ns
+                            .store((now - t_start).as_nanos() as u64, Ordering::Relaxed);
+                    } else {
+                        // この req は timeout = glitch-to-silence。req は outstanding のまま残り、次の
+                        // callback は prev_done=false となって child が追いつくまで input を上書きしない。
+                        for s in data.iter_mut() {
+                            *s = 0.0;
+                        }
+                        cb_stats.overrun_count.fetch_add(1, Ordering::Relaxed);
+                    }
+                } else {
+                    // 前 req がまだ outstanding（child が遅延 or crash 後 respawn 待ち）。input を上書きせず
+                    // glitch-to-silence する。child が前 req を完了（or respawn 子が処理）すれば次から再開。
                     for s in data.iter_mut() {
                         *s = 0.0;
                     }
                     cb_stats.overrun_count.fetch_add(1, Ordering::Relaxed);
                 }
-            } else {
-                // 前 req がまだ outstanding（child が遅延 or crash 後 respawn 待ち）。input を上書きせず
-                // glitch-to-silence する。child が前 req を完了（or respawn 子が処理）すれば次から再開。
-                for s in data.iter_mut() {
-                    *s = 0.0;
-                }
-                cb_stats.overrun_count.fetch_add(1, Ordering::Relaxed);
-            }
 
-            cb_stats
-                .post_peak_bits
-                .fetch_max(peak.to_bits(), Ordering::Relaxed);
-            cb_stats
-                .callback_max_ns
-                .fetch_max(cb_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
-            cb_stats.frames_total.fetch_add(n as u64, Ordering::Relaxed);
-        },
-        move |err| {
-            eprintln!("[cpal err] {err}");
-            stream_err_invalid.store(true, Ordering::Relaxed);
-        },
-        None,
-    )?;
+                cb_stats
+                    .post_peak_bits
+                    .fetch_max(peak.to_bits(), Ordering::Relaxed);
+                cb_stats
+                    .callback_max_ns
+                    .fetch_max(cb_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+                cb_stats.frames_total.fetch_add(n as u64, Ordering::Relaxed);
+            },
+            move |err| {
+                eprintln!("[cpal err] {err}");
+                stream_err_invalid.store(true, Ordering::Relaxed);
+            },
+            None,
+        )?
+    };
     stream.play()?;
 
     // --- 計測（main スレッドは待つだけ）------------------------------------
@@ -603,7 +727,51 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
     }
     let invalid = measurement_invalid.load(Ordering::Relaxed);
 
-    // --- 結果出力 -----------------------------------------------------------
+    // --- 結果出力（pipelined / 候補 B は判定軸が stale 率なので専用ブロック）-------------------
+    if cli.pipelined {
+        let frames_total = stats.frames_total.load(Ordering::Relaxed);
+        let fresh = stats.success_count.load(Ordering::Relaxed);
+        let stale = stats.stale_count.load(Ordering::Relaxed);
+        let stall = stats.stall_count.load(Ordering::Relaxed);
+        let cb_max = stats.callback_max_ns.load(Ordering::Relaxed);
+        let post_peak = f32::from_bits(stats.post_peak_bits.load(Ordering::Relaxed));
+        let frames_clamped = stats.frames_clamped.load(Ordering::Relaxed);
+        // 出力 callback 総数 = fresh + stale（priming の無音 callback 〜1 は除外）。
+        let output_cbs = fresh + stale;
+        let avg_frames = frames_total.checked_div(output_cbs.max(1)).unwrap_or(0);
+        let block_budget_ns = avg_frames * 1_000_000_000 / sample_rate as u64;
+        let stale_pct = if output_cbs > 0 {
+            stale as f64 * 100.0 / output_cbs as f64
+        } else {
+            0.0
+        };
+
+        println!();
+        println!("=== orbit-sandbox-spike (pipelined / candidate B) ===");
+        if invalid {
+            println!(
+                "MEASUREMENT INVALID — cpal/watchdog failure (see stderr); 数値は信頼できない。"
+            );
+        }
+        println!("measurement_valid:     {}", !invalid);
+        println!("sample_rate:           {sample_rate}");
+        println!("output_callbacks:      {output_cbs}");
+        println!("avg_frames_per_cb:     {avg_frames}");
+        println!("block_budget_ns:       ~{block_budget_ns}");
+        println!("pipelined_fresh:       {fresh}");
+        println!("pipelined_stale:       {stale}");
+        println!("pipelined_stall:       {stall}");
+        println!("stale_pct:             {stale_pct:.4}");
+        println!("callback_max_ns:       {cb_max}");
+        println!("post_mix_peak:         {post_peak:.5}");
+        if frames_clamped > 0 {
+            println!("WARNING: {frames_clamped} callbacks exceeded MAX_FRAMES ({MAX_FRAMES})");
+        }
+        println!("=====================================================");
+        return Ok(());
+    }
+
+    // --- 結果出力（sync / 候補 A）-------------------------------------------
     let frames_total = stats.frames_total.load(Ordering::Relaxed);
     let frames_clamped = stats.frames_clamped.load(Ordering::Relaxed);
     let success = stats.success_count.load(Ordering::Relaxed);

--- a/rust/crates/orbit-sandbox-spike/src/bin/sandbox-host.rs
+++ b/rust/crates/orbit-sandbox-spike/src/bin/sandbox-host.rs
@@ -86,8 +86,8 @@ fn parse_args() -> anyhow::Result<Cli> {
     if cli.in_process && (cli.pipelined || cli.child_rt_priority) {
         anyhow::bail!("--in-process cannot be combined with --pipelined / --child-rt-priority");
     }
-    // --child-rt-priority は RT period 算出に buffer_frames が要る。未指定だと黙って 512 を仮定し
-    // 誤った period で child を RT 設定してしまう（altitude review）。明示を要求する。
+    // --child-rt-priority は RT period 算出に buffer_frames が要る。未指定でも run() の .expect() で
+    // panic はするが、parse_args 段階で明示エラーにする方が分かりやすい（altitude review）。
     if cli.child_rt_priority && cli.buffer_frames.is_none() {
         anyhow::bail!("--child-rt-priority requires --buffer-frames (RT period を確定するため)");
     }
@@ -183,8 +183,9 @@ fn is_recovered(respawns: u64, last_success_ns: u64, last_respawn_ns: u64) -> bo
 
 /// 生ポインタを cpal callback（Send 要求）に渡すためのラッパ。
 /// SAFETY: ポインタは run() が保持する mmap を指す。stream は mmap より先に drop されるので
-/// callback 実行中は常に有効。バッファ競合は 1-outstanding 不変条件（host は前 req 完了後のみ input を
-/// 上書きする）+ seq_done の Release/Acquire で排除されるので、別スレッドへの送付も健全。
+/// callback 実行中は常に有効。バッファ競合は slot 再利用不変条件 — sync は 1-outstanding（host は前 req
+/// 完了後のみ submit）、pipelined は 2-outstanding guard（host は slot の前 occupant 完了を確認してから
+/// submit）— と seq_done の Release/Acquire で排除されるので、別スレッドへの送付も健全。
 struct RegionPtr(*mut SharedRegion);
 unsafe impl Send for RegionPtr {}
 
@@ -534,8 +535,9 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
                     let done = unsafe { (*r).seq_done.load(Ordering::Acquire) } >= req;
                     if done {
                         // fresh: この seq の slot の output を出力にコピー。
-                        // SAFETY: seq_done >= req を Acquire 観測 → child の output 書き込みが可視。
-                        // 2-outstanding guard により host はこの slot を上書きしていない。
+                        // SAFETY: seq_done >= req を Acquire 観測 → child は seq req を処理し終え output
+                        // 書き込みが可視。child が次にこの slot を触るのは seq req+2 の処理時だが、それは
+                        // host が未だ submit していない（req+1 が直近の submit 上限）ので競合は無い。
                         unsafe {
                             let out = (*r).output.as_ptr().add(slot_offset(req));
                             for (i, slot) in data.iter_mut().enumerate().take(count) {
@@ -730,6 +732,9 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
         } else {
             0.0
         };
+        // pipelined + --child-rt-priority の併用は許可（host 軸 vs child 軸）。RT 条件を記録しないと
+        // 後で baseline と比較したとき条件差が見えなくなるので必ず出力する（silent-failure review）。
+        let rt_applied = unsafe { (*region).rt_active.load(Ordering::Relaxed) };
 
         println!();
         println!("=== orbit-sandbox-spike (pipelined / candidate B) ===");
@@ -740,6 +745,8 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
         }
         println!("measurement_valid:     {}", !invalid);
         println!("sample_rate:           {sample_rate}");
+        println!("child_rt_priority:     {}", cli.child_rt_priority);
+        println!("child_rt_applied:      {rt_applied}");
         println!("output_callbacks:      {output_cbs}");
         println!("avg_frames_per_cb:     {avg_frames}");
         println!("block_budget_ns:       ~{block_budget_ns}");
@@ -774,6 +781,9 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
     let last_respawn = last_respawn_ns.load(Ordering::Relaxed);
     let last_success = stats.last_success_ns.load(Ordering::Relaxed);
     let child_processed = unsafe { (*region).child_processed.load(Ordering::Relaxed) };
+    // 要求された RT 優先度が child で実際に適用されたか（stderr のみだと redirect で失われ「効果なし」と
+    // 誤読されるため stdout に出す・silent-failure review）。--child-rt-priority 無しなら false のまま。
+    let rt_applied = unsafe { (*region).rt_active.load(Ordering::Relaxed) };
 
     let avg_frames = frames_total.checked_div(callbacks).unwrap_or(0);
     let block_budget_ns = avg_frames * 1_000_000_000 / sample_rate as u64;
@@ -795,6 +805,7 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
     println!("measurement_valid:     {}", !invalid);
     println!("sample_rate:           {sample_rate}");
     println!("child_rt_priority:     {}", cli.child_rt_priority);
+    println!("child_rt_applied:      {rt_applied}");
     println!("total_callbacks:       {callbacks}");
     println!("avg_frames_per_cb:     {avg_frames}");
     println!("block_budget_ns:       ~{block_budget_ns}");

--- a/rust/crates/orbit-sandbox-spike/src/bin/sandbox-host.rs
+++ b/rust/crates/orbit-sandbox-spike/src/bin/sandbox-host.rs
@@ -81,6 +81,16 @@ fn parse_args() -> anyhow::Result<Cli> {
             other => anyhow::bail!("Unknown argument: {other}"),
         }
     }
+    // --in-process は child を使わない対照なので、child 系フラグと併用すると黙って無視され
+    // 「3 実験のどれでもない」誤計測になる（altitude review）。明示的に弾く。
+    if cli.in_process && (cli.pipelined || cli.child_rt_priority) {
+        anyhow::bail!("--in-process cannot be combined with --pipelined / --child-rt-priority");
+    }
+    // --child-rt-priority は RT period 算出に buffer_frames が要る。未指定だと黙って 512 を仮定し
+    // 誤った period で child を RT 設定してしまう（altitude review）。明示を要求する。
+    if cli.child_rt_priority && cli.buffer_frames.is_none() {
+        anyhow::bail!("--child-rt-priority requires --buffer-frames (RT period を確定するため)");
+    }
     Ok(cli)
 }
 
@@ -218,6 +228,53 @@ fn spawn_child(
     Ok(cmd.spawn()?)
 }
 
+// ---- shared helpers -----------------------------------------------------
+
+/// 出力デバイスを開き `(device, StreamConfig, sample_rate)` を返す（`run` / `run_in_process` 共用）。
+fn open_device(
+    buffer_frames: Option<u32>,
+) -> anyhow::Result<(cpal::Device, cpal::StreamConfig, u32)> {
+    let cpal_host = cpal::default_host();
+    let device = cpal_host
+        .default_output_device()
+        .ok_or_else(|| anyhow::anyhow!("no default output device"))?;
+    let sample_rate = device.default_output_config()?.sample_rate().0;
+    let cpal_config = cpal::StreamConfig {
+        channels: CHANNELS as u16,
+        sample_rate: cpal::SampleRate(sample_rate),
+        buffer_size: match buffer_frames {
+            Some(f) => cpal::BufferSize::Fixed(f),
+            None => cpal::BufferSize::Default,
+        },
+    };
+    Ok((device, cpal_config, sample_rate))
+}
+
+/// 全ストリーム共通の cpal error callback を作る: ログ出力 + `measurement_invalid` を立てる。
+/// device 切断等で callback 配送が止まると無音のまま teardown され誤データになるのを sentinel で可視化。
+fn err_callback(mi: Arc<std::sync::atomic::AtomicBool>) -> impl FnMut(cpal::StreamError) {
+    move |err| {
+        eprintln!("[cpal err] {err}");
+        mi.store(true, Ordering::Relaxed);
+    }
+}
+
+/// shared input slot にテストトーン（220Hz サイン・振幅 0.5）を `n` フレーム書く（sync / pipelined 共用）。
+///
+/// # Safety
+/// `inp` は確保済み input slot の先頭で、`n * CHANNELS` 要素ぶん書き込み可能であること。
+unsafe fn fill_tone_block(inp: *mut f32, n: usize, phase: &mut f64, phase_inc: f64) {
+    for f in 0..n {
+        *phase += phase_inc;
+        if *phase >= std::f64::consts::TAU {
+            *phase -= std::f64::consts::TAU;
+        }
+        let s = ((*phase).sin() as f32) * 0.5;
+        *inp.add(f * CHANNELS) = s;
+        *inp.add(f * CHANNELS + 1) = s;
+    }
+}
+
 // ---- entry --------------------------------------------------------------
 
 fn main() -> anyhow::Result<()> {
@@ -234,20 +291,7 @@ fn main() -> anyhow::Result<()> {
 /// callback_max の「tiny」基準を較正する。また「この機材/CoreAudio が 64f を in-process でクリーンに
 /// 出せるか」を独立に検証する（host 側 tail が CoreAudio/OS 由来なら in-process でも spike する）。
 fn run_in_process(cli: &Cli) -> anyhow::Result<()> {
-    let cpal_host = cpal::default_host();
-    let device = cpal_host
-        .default_output_device()
-        .ok_or_else(|| anyhow::anyhow!("no default output device"))?;
-    let default_cfg = device.default_output_config()?;
-    let sample_rate = default_cfg.sample_rate().0;
-    let cpal_config = cpal::StreamConfig {
-        channels: CHANNELS as u16,
-        sample_rate: cpal::SampleRate(sample_rate),
-        buffer_size: match cli.buffer_frames {
-            Some(f) => cpal::BufferSize::Fixed(f),
-            None => cpal::BufferSize::Default,
-        },
-    };
+    let (device, cpal_config, sample_rate) = open_device(cli.buffer_frames)?;
     println!(
         "audio: {} Hz, {} ch, buffer={:?} (IN-PROCESS control)",
         sample_rate, CHANNELS, cpal_config.buffer_size
@@ -257,10 +301,7 @@ fn run_in_process(cli: &Cli) -> anyhow::Result<()> {
     let cb_stats = stats.clone();
     let phase_inc = 2.0 * std::f64::consts::PI * 220.0 / sample_rate as f64;
     let mut phase: f64 = 0.0;
-    // cpal の fatal error（device 切断等）で callback 配送が止まると無音のまま teardown され
-    // measurement_valid:true の誤データになりうる。error callback でも sentinel を立てる。
     let measurement_invalid = Arc::new(std::sync::atomic::AtomicBool::new(false));
-    let err_flag = measurement_invalid.clone();
 
     let stream = device.build_output_stream(
         &cpal_config,
@@ -289,10 +330,7 @@ fn run_in_process(cli: &Cli) -> anyhow::Result<()> {
                 .fetch_add(frames as u64, Ordering::Relaxed);
             cb_stats.success_count.fetch_add(1, Ordering::Relaxed);
         },
-        move |err| {
-            eprintln!("[cpal err] {err}");
-            err_flag.store(true, Ordering::Relaxed);
-        },
+        err_callback(measurement_invalid.clone()),
         None,
     )?;
     stream.play()?;
@@ -338,17 +376,14 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
     println!("shm: {}", shm_path.display());
 
     // --- 出力デバイスを先に開く（RT period 算出に sample_rate が要る）-------------------------
-    let cpal_host = cpal::default_host();
-    let device = cpal_host
-        .default_output_device()
-        .ok_or_else(|| anyhow::anyhow!("no default output device"))?;
-    let default_cfg = device.default_output_config()?;
-    let sample_rate = default_cfg.sample_rate().0;
+    let (device, cpal_config, sample_rate) = open_device(cli.buffer_frames)?;
 
     // candidate A: child を RT に上げる場合の period(µs) = block period = buffer_frames / sample_rate。
-    // buffer_frames 未指定（Default）時は 512 を仮定（A 計測時は常に --buffer-frames を渡す運用）。
+    // --child-rt-priority は --buffer-frames 必須（parse_args で検証済）なので unwrap で良い。
     let rt_period_us = if cli.child_rt_priority {
-        let frames = cli.buffer_frames.unwrap_or(512) as u64;
+        let frames =
+            cli.buffer_frames
+                .expect("--buffer-frames required with --child-rt-priority") as u64;
         Some(frames * 1_000_000 / sample_rate as u64)
     } else {
         None
@@ -420,15 +455,7 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
         })
     };
 
-    // --- cpal 出力ストリーム（device は run() 冒頭で開済み）----------------------------------
-    let cpal_config = cpal::StreamConfig {
-        channels: CHANNELS as u16,
-        sample_rate: cpal::SampleRate(sample_rate),
-        buffer_size: match cli.buffer_frames {
-            Some(f) => cpal::BufferSize::Fixed(f),
-            None => cpal::BufferSize::Default,
-        },
-    };
+    // --- cpal 出力ストリーム（device/config は run() 冒頭で open_device 済み）-----------------
     println!(
         "audio: {} Hz, {} ch, buffer={:?}, round_trip_timeout={}us, child_rt_priority={}",
         sample_rate,
@@ -517,27 +544,17 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
                                 peak = peak.max(v.abs());
                             }
                         }
-                        for s in data.iter_mut().skip(count) {
-                            *s = 0.0;
-                        }
+                        data[count..].fill(0.0); // フレーム超過分は無音
                         cb_stats.success_count.fetch_add(1, Ordering::Relaxed);
-                        cb_stats.last_success_ns.store(
-                            (Instant::now() - t_start).as_nanos() as u64,
-                            Ordering::Relaxed,
-                        );
                     } else {
                         // stale: child がこの block を未完了 → silence（stale policy）。B の判定軸。
                         // production は直前 block の repeat が選択肢だが spike は silence で stale 率を測る。
-                        for s in data.iter_mut() {
-                            *s = 0.0;
-                        }
+                        data.fill(0.0);
                         cb_stats.stale_count.fetch_add(1, Ordering::Relaxed);
                     }
                 } else {
                     // priming: 読むべき前回 submit がまだ無い → 無音。
-                    for s in data.iter_mut() {
-                        *s = 0.0;
-                    }
+                    data.fill(0.0);
                 }
 
                 // --- submit: 新 seq を child に渡す（spin しない）---
@@ -550,16 +567,7 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
                     // SAFETY: 上の guard で new_seq の slot の前 occupant は完了済 = child は触れない。
                     // n_frames は固定 buffer で常に同値（可変 block 化するなら slot 毎に持つ必要あり）。
                     unsafe {
-                        let inp = (*r).input.as_mut_ptr().add(off);
-                        for f in 0..n {
-                            phase += phase_inc;
-                            if phase >= std::f64::consts::TAU {
-                                phase -= std::f64::consts::TAU;
-                            }
-                            let s = (phase.sin() as f32) * 0.5;
-                            *inp.add(f * CHANNELS) = s;
-                            *inp.add(f * CHANNELS + 1) = s;
-                        }
+                        fill_tone_block((*r).input.as_mut_ptr().add(off), n, &mut phase, phase_inc);
                         (*r).n_frames.store(n as u32, Ordering::Relaxed);
                         (*r).seq_request.store(new_seq, Ordering::Release);
                     }
@@ -578,10 +586,7 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
                     .fetch_max(cb_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
                 cb_stats.frames_total.fetch_add(n as u64, Ordering::Relaxed);
             },
-            move |err| {
-                eprintln!("[cpal err] {err}");
-                stream_err_invalid.store(true, Ordering::Relaxed);
-            },
+            err_callback(stream_err_invalid),
             None,
         )?
     } else {
@@ -620,20 +625,9 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
                     // 完了している（1-outstanding）。よって host がこの slot の唯一の writer（child は次の
                     // seq_request を観測するまで input/output に触れない）。
                     unsafe {
-                        let inp = (*r).input.as_mut_ptr().add(off);
-                        for f in 0..n {
-                            phase += phase_inc;
-                            if phase >= std::f64::consts::TAU {
-                                phase -= std::f64::consts::TAU;
-                            }
-                            let s = (phase.sin() as f32) * 0.5;
-                            *inp.add(f * CHANNELS) = s;
-                            *inp.add(f * CHANNELS + 1) = s;
-                        }
+                        fill_tone_block((*r).input.as_mut_ptr().add(off), n, &mut phase, phase_inc);
                         (*r).n_frames.store(n as u32, Ordering::Relaxed);
-                    }
-                    // publish: Release で seq_request を進める（n_frames/input 書き込みが child から可視に）。
-                    unsafe {
+                        // publish: Release で seq_request を進める（n_frames/input が child から可視に）。
                         (*r).seq_request.store(req, Ordering::Release);
                     }
 
@@ -656,19 +650,17 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
                     let rt_ns = (now - t0).as_nanos() as u64;
 
                     if got {
-                        // SAFETY: done を Acquire で観測済 → child の output 書き込みが可視。slot は req と一致。
+                        // SAFETY: done を Acquire で観測済 → child の output 書き込みが可視。slot は req と一致
+                        // （input 書き込みで使った off と同じ）。
                         unsafe {
-                            let out = (*r).output.as_ptr().add(slot_offset(req));
+                            let out = (*r).output.as_ptr().add(off);
                             for (i, slot) in data.iter_mut().enumerate().take(count) {
                                 let v = *out.add(i);
                                 *slot = v;
                                 peak = peak.max(v.abs());
                             }
                         }
-                        // フレーム超過分（n < frames）は無音で埋める。
-                        for s in data.iter_mut().skip(count) {
-                            *s = 0.0;
-                        }
+                        data[count..].fill(0.0); // フレーム超過分（n < frames）は無音
                         cb_stats.record_roundtrip(rt_ns);
                         cb_stats
                             .last_success_ns
@@ -676,17 +668,13 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
                     } else {
                         // この req は timeout = glitch-to-silence。req は outstanding のまま残り、次の
                         // callback は prev_done=false となって child が追いつくまで input を上書きしない。
-                        for s in data.iter_mut() {
-                            *s = 0.0;
-                        }
+                        data.fill(0.0);
                         cb_stats.overrun_count.fetch_add(1, Ordering::Relaxed);
                     }
                 } else {
                     // 前 req がまだ outstanding（child が遅延 or crash 後 respawn 待ち）。input を上書きせず
                     // glitch-to-silence する。child が前 req を完了（or respawn 子が処理）すれば次から再開。
-                    for s in data.iter_mut() {
-                        *s = 0.0;
-                    }
+                    data.fill(0.0);
                     cb_stats.overrun_count.fetch_add(1, Ordering::Relaxed);
                 }
 
@@ -698,10 +686,7 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
                     .fetch_max(cb_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
                 cb_stats.frames_total.fetch_add(n as u64, Ordering::Relaxed);
             },
-            move |err| {
-                eprintln!("[cpal err] {err}");
-                stream_err_invalid.store(true, Ordering::Relaxed);
-            },
+            err_callback(stream_err_invalid),
             None,
         )?
     };

--- a/rust/crates/orbit-sandbox-spike/src/bin/sandbox-host.rs
+++ b/rust/crates/orbit-sandbox-spike/src/bin/sandbox-host.rs
@@ -6,11 +6,13 @@
 //!
 //! 使い方:
 //!   sandbox-host [--measure-secs N] [--buffer-frames F] [--round-trip-timeout-us US]
-//!                [--child-crash-after-blocks N] [--gain G]
+//!                [--child-crash-after-blocks N] [--gain G] [--child-rt-priority]
 //!
 //! Gate1（RT round-trip が block budget に収まるか）: crash 無しで実行しレイテンシ分布を見る。
 //! Gate2（子の crash 封じ込め + watchdog 復帰）: --child-crash-after-blocks N で実行し、
 //!   respawn 後に round-trip が再開し audio が復帰することを確認する。
+//! candidate A（#350）: --child-rt-priority で子を RT(time-constraint)優先度にし、worst-case
+//!   tail が同期ベースライン（Step0）より縮むかを比較する。
 
 #![allow(unsafe_code)]
 
@@ -33,6 +35,9 @@ struct Cli {
     /// > 0 なら最初の子を「N ブロック後 segfault」で起動し Gate2 を駆動する。respawn 後は clean。
     child_crash_after_blocks: u64,
     gain: f32,
+    /// true なら spawn する子に --rt-priority を渡し RT(time-constraint)スケジュールにする
+    /// （candidate A・#350）。period は buffer_frames + sample_rate から導く。
+    child_rt_priority: bool,
 }
 
 fn parse_args() -> anyhow::Result<Cli> {
@@ -43,6 +48,7 @@ fn parse_args() -> anyhow::Result<Cli> {
         round_trip_timeout_us: 5000,
         child_crash_after_blocks: 0,
         gain: 0.5,
+        child_rt_priority: false,
     };
     while let Some(arg) = args.next() {
         let mut next = || {
@@ -55,6 +61,7 @@ fn parse_args() -> anyhow::Result<Cli> {
             "--round-trip-timeout-us" => cli.round_trip_timeout_us = next()?.parse()?,
             "--child-crash-after-blocks" => cli.child_crash_after_blocks = next()?.parse()?,
             "--gain" => cli.gain = next()?.parse()?,
+            "--child-rt-priority" => cli.child_rt_priority = true,
             other => anyhow::bail!("Unknown argument: {other}"),
         }
     }
@@ -168,11 +175,23 @@ fn child_exe_path() -> anyhow::Result<PathBuf> {
     Ok(dir.join("sandbox-child"))
 }
 
-fn spawn_child(child_exe: &Path, shm: &Path, crash_after: u64) -> anyhow::Result<Child> {
+/// child を起動する。`rt_period_us` が Some なら子を RT(time-constraint)優先度で起動する
+/// （candidate A）。初回・watchdog respawn の双方が同じ rt 設定で子を立てる。
+fn spawn_child(
+    child_exe: &Path,
+    shm: &Path,
+    crash_after: u64,
+    rt_period_us: Option<u64>,
+) -> anyhow::Result<Child> {
     let mut cmd = Command::new(child_exe);
     cmd.arg("--shm").arg(shm);
     if crash_after > 0 {
         cmd.arg("--crash-after-blocks").arg(crash_after.to_string());
+    }
+    if let Some(period_us) = rt_period_us {
+        cmd.arg("--rt-priority")
+            .arg("--rt-period-us")
+            .arg(period_us.to_string());
     }
     Ok(cmd.spawn()?)
 }
@@ -198,9 +217,31 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
     }
     println!("shm: {}", shm_path.display());
 
+    // --- 出力デバイスを先に開く（RT period 算出に sample_rate が要る）-------------------------
+    let cpal_host = cpal::default_host();
+    let device = cpal_host
+        .default_output_device()
+        .ok_or_else(|| anyhow::anyhow!("no default output device"))?;
+    let default_cfg = device.default_output_config()?;
+    let sample_rate = default_cfg.sample_rate().0;
+
+    // candidate A: child を RT に上げる場合の period(µs) = block period = buffer_frames / sample_rate。
+    // buffer_frames 未指定（Default）時は 512 を仮定（A 計測時は常に --buffer-frames を渡す運用）。
+    let rt_period_us = if cli.child_rt_priority {
+        let frames = cli.buffer_frames.unwrap_or(512) as u64;
+        Some(frames * 1_000_000 / sample_rate as u64)
+    } else {
+        None
+    };
+
     // --- child を起動（最初の子は crash arg を載せる場合がある）-----------------------------
     let child_exe = child_exe_path()?;
-    let first_child = spawn_child(&child_exe, &shm_path, cli.child_crash_after_blocks)?;
+    let first_child = spawn_child(
+        &child_exe,
+        &shm_path,
+        cli.child_crash_after_blocks,
+        rt_period_us,
+    )?;
     let child = Arc::new(Mutex::new(first_child));
 
     // --- watchdog -----------------------------------------------------------
@@ -240,8 +281,8 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
             };
             if let Some(status) = exited {
                 eprintln!("[watchdog] child exited ({status:?}); respawning clean child");
-                // respawn は crash arg 無し → clean な子 → audio 復帰。
-                match spawn_child(&child_exe, &shm_path, 0) {
+                // respawn は crash arg 無し → clean な子 → audio 復帰。RT 設定は初回と揃える。
+                match spawn_child(&child_exe, &shm_path, 0, rt_period_us) {
                     Ok(newc) => {
                         *child.lock().unwrap() = newc;
                         respawn_count.fetch_add(1, Ordering::Relaxed);
@@ -259,13 +300,7 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
         })
     };
 
-    // --- cpal 出力ストリーム -------------------------------------------------
-    let cpal_host = cpal::default_host();
-    let device = cpal_host
-        .default_output_device()
-        .ok_or_else(|| anyhow::anyhow!("no default output device"))?;
-    let default_cfg = device.default_output_config()?;
-    let sample_rate = default_cfg.sample_rate().0;
+    // --- cpal 出力ストリーム（device は run() 冒頭で開済み）----------------------------------
     let cpal_config = cpal::StreamConfig {
         channels: CHANNELS as u16,
         sample_rate: cpal::SampleRate(sample_rate),
@@ -275,8 +310,12 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
         },
     };
     println!(
-        "audio: {} Hz, {} ch, buffer={:?}, round_trip_timeout={}us",
-        sample_rate, CHANNELS, cpal_config.buffer_size, cli.round_trip_timeout_us
+        "audio: {} Hz, {} ch, buffer={:?}, round_trip_timeout={}us, child_rt_priority={}",
+        sample_rate,
+        CHANNELS,
+        cpal_config.buffer_size,
+        cli.round_trip_timeout_us,
+        cli.child_rt_priority
     );
 
     let stats = RtStats::new();
@@ -498,6 +537,7 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
     }
     println!("measurement_valid:     {}", !invalid);
     println!("sample_rate:           {sample_rate}");
+    println!("child_rt_priority:     {}", cli.child_rt_priority);
     println!("total_callbacks:       {callbacks}");
     println!("avg_frames_per_cb:     {avg_frames}");
     println!("block_budget_ns:       ~{block_budget_ns}");

--- a/rust/crates/orbit-sandbox-spike/src/lib.rs
+++ b/rust/crates/orbit-sandbox-spike/src/lib.rs
@@ -32,7 +32,7 @@
 use std::fs::OpenOptions;
 use std::io;
 use std::path::Path;
-use std::sync::atomic::{AtomicU32, AtomicU64};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64};
 
 use memmap2::MmapMut;
 
@@ -72,6 +72,10 @@ pub struct SharedRegion {
     pub gain_bits: AtomicU32,
     /// child が処理したブロック総数（観測用。recovery の進行を可視化）。
     pub child_processed: AtomicU64,
+    /// child が RT(time-constraint)優先度の適用に成功したか（candidate A・#350）。child が
+    /// 起動時に書き、host が結果に出力する。`--child-rt-priority` 要求が実際に効いたかを stdout で
+    /// 可視化し、RT 設定の silent fail（stderr のみ）を「効果なし」と誤読するのを防ぐ。
+    pub rt_active: AtomicBool,
     /// host -> child のインターリーブ入力（ping-pong: SLOTS 個の block。seq&1 で index）。
     pub input: [f32; BUF_LEN * SLOTS],
     /// child -> host のインターリーブ出力（ping-pong: SLOTS 個の block。seq&1 で index）。

--- a/rust/crates/orbit-sandbox-spike/src/lib.rs
+++ b/rust/crates/orbit-sandbox-spike/src/lib.rs
@@ -9,13 +9,22 @@
 //!    を書く → `seq_done = seq_request` を **Release** で store。
 //! 3. host: `seq_done` を **Acquire** で読む（>= 自分の req なら）→ output が可視 → 出力にコピー。
 //!
-//! **1-outstanding request 不変条件**: host は前 req が完了（`seq_done >= req`）したことを確認して
-//! からのみ次の `input` を上書きする（host 側の callback でこれを enforce）。よって child が前 req の
-//! `input` を読んでいる間に host が `input` を上書きすることは無く、`output` は seq_done の Release/
-//! Acquire で覆われる。この不変条件のもとでバッファアクセスは時間的に排他化され、生ポインタ経由の
-//! `&mut [f32]` 形成も健全（この不変条件が破れると live-but-slow child との間でデータ競合 = UB になる）。
-//! macOS に futex は無いが、RT 側は **bounded spin**（timeout 付き）で待つため別プロセスを
-//! 無制限にブロックしない（`ClapTeardownGuard` の busy-wait-with-deadline と同型）。
+//! **ping-pong バッファ（#350）**: `input` / `output` は各 2 slot を持ち、seq の偶奇
+//! （[`slot_offset`]）で交替する。slot を分けることで「host が seq s の slot を書く」のと
+//! 「child が seq s-1 の slot を読む」が別領域になり、pipelined モード（host が spin せず 1 block
+//! ずらして読む）でも torn read を起こさない。全モードが seq&1 で index する（child も同様・モード非依存）。
+//!
+//! **不変条件（slot 再利用の安全）**:
+//! - **sync / candidate A（1-outstanding）**: host は前 req が完了（`seq_done >= req`）してからのみ
+//!   次を submit する。新 seq s の slot を書く前、その slot の前 occupant は s-2 で、`seq_done >= s-1`
+//!   （= 1-outstanding 条件）が s-2 完了を含意するので slot は空。
+//! - **pipelined（2-outstanding）**: host は新 seq s を submit する前に `seq_done >= s-2`（s の slot の
+//!   前 occupant の完了）を確認する。満たさなければ submit を見送る（stall）。
+//!
+//! いずれの不変条件下でもバッファアクセスは時間的に排他化され、生ポインタ経由の `&mut [f32]` 形成も
+//! 健全（不変条件が破れると live-but-slow child との間でデータ競合 = UB になる）。
+//! macOS に futex は無いが、sync の RT 側は **bounded spin**（timeout 付き）で待つため別プロセスを
+//! 無制限にブロックしない（`ClapTeardownGuard` の busy-wait-with-deadline と同型）。pipelined は spin しない。
 
 // 共有メモリは生ポインタ経由でクロスプロセス参照するため unsafe FFI 同等。
 #![allow(unsafe_code)]
@@ -31,8 +40,17 @@ use memmap2::MmapMut;
 pub const MAX_FRAMES: usize = 4096;
 /// チャンネル数（stereo 固定）。
 pub const CHANNELS: usize = 2;
-/// インターリーブ済みバッファ長（フレーム × チャンネル）。
+/// 1 slot（= 1 ブロック）のインターリーブ済みバッファ長（フレーム × チャンネル）。
 pub const BUF_LEN: usize = MAX_FRAMES * CHANNELS;
+/// ping-pong の slot 数（seq の偶奇で交替）。
+pub const SLOTS: usize = 2;
+
+/// seq に対応する slot の開始要素オフセット（ping-pong: seq の偶奇で 2 slot を交替する）。
+/// host / child の双方がこれで `input` / `output` を index する（モード非依存）。
+#[inline]
+pub fn slot_offset(seq: u64) -> usize {
+    (seq & 1) as usize * BUF_LEN
+}
 
 /// 親子で共有する制御ブロック + audio バッファ。
 ///
@@ -54,10 +72,10 @@ pub struct SharedRegion {
     pub gain_bits: AtomicU32,
     /// child が処理したブロック総数（観測用。recovery の進行を可視化）。
     pub child_processed: AtomicU64,
-    /// host -> child のインターリーブ入力。
-    pub input: [f32; BUF_LEN],
-    /// child -> host のインターリーブ出力。
-    pub output: [f32; BUF_LEN],
+    /// host -> child のインターリーブ入力（ping-pong: SLOTS 個の block。seq&1 で index）。
+    pub input: [f32; BUF_LEN * SLOTS],
+    /// child -> host のインターリーブ出力（ping-pong: SLOTS 個の block。seq&1 で index）。
+    pub output: [f32; BUF_LEN * SLOTS],
 }
 
 /// 共有領域のバイトサイズ（mmap ファイルサイズ）。
@@ -194,12 +212,25 @@ mod tests {
     // クロスプロセスで共有する以上、レイアウトが壊れると親子で別物を読む。サイズ/整列の回帰を捕捉。
     #[test]
     fn region_size_and_align() {
-        // mmap ファイルサイズはバッファ 2 本ぶんを下回らない。
-        assert!(REGION_BYTES >= 2 * BUF_LEN * std::mem::size_of::<f32>());
+        // mmap ファイルサイズは input/output 各 SLOTS 本ぶん（計 2*SLOTS ブロック）を下回らない。
+        assert!(REGION_BYTES >= 2 * SLOTS * BUF_LEN * std::mem::size_of::<f32>());
         // align(64) 指定どおり。mmap のページ整列で満たされる前提の値。
         assert_eq!(std::mem::align_of::<SharedRegion>(), 64);
         // BUF_LEN = フレーム × チャンネル。
         assert_eq!(BUF_LEN, MAX_FRAMES * CHANNELS);
+    }
+
+    // ping-pong index: seq の偶奇で 0 / BUF_LEN を交替し、連続 seq は必ず別 slot を指す。
+    #[test]
+    fn slot_offset_alternates_by_parity() {
+        assert_eq!(slot_offset(0), 0);
+        assert_eq!(slot_offset(1), BUF_LEN);
+        assert_eq!(slot_offset(2), 0);
+        assert_eq!(slot_offset(3), BUF_LEN);
+        // 連続する seq は別 slot（pipelined で s と s-1 が衝突しない前提）。
+        for s in 0..10u64 {
+            assert_ne!(slot_offset(s), slot_offset(s + 1));
+        }
     }
 
     // ns → mach abs 単位の変換（abs = ns * denom / numer）。timebase 比に応じた値と境界を確認。

--- a/rust/crates/orbit-sandbox-spike/src/lib.rs
+++ b/rust/crates/orbit-sandbox-spike/src/lib.rs
@@ -99,6 +99,94 @@ pub fn region_ptr(mmap: &MmapMut) -> *mut SharedRegion {
     mmap.as_ptr() as *mut SharedRegion
 }
 
+// ---- candidate A: child RT スレッド優先度（mach time-constraint）-----------------------------
+//
+// Step0 spike は同期 round-trip の worst-case tail（~2〜4ms・buffer 非依存）が scheduling jitter
+// 由来だと突き止めた。child の spin スレッドは通常優先度なのでプリエンプトされうる。candidate A は
+// child を mach `THREAD_TIME_CONSTRAINT_POLICY`（macOS の RT スケジューリング）に上げ、その tail が
+// 縮むか測る（#350）。host callback は既に CoreAudio の RT スレッド上なので host 側は変えない。
+
+/// ns を mach absolute-time 単位へ変換する（`abs = ns * denom / numer`）。`u32` で飽和。
+///
+/// `mach_timebase_info` の `numer`/`denom` は「1 abs tick = numer/denom ns」を表す
+/// （Apple Silicon は 125/3 ≈ 41.67ns/tick、Intel は 1/1）。time-constraint policy の各フィールドは
+/// abs tick 単位なので ns を変換して渡す。`numer == 0`（timebase 取得失敗）は 0 を返す。
+pub fn ns_to_mach_abs(ns: u64, numer: u32, denom: u32) -> u32 {
+    if numer == 0 {
+        return 0;
+    }
+    let abs = ns as u128 * denom as u128 / numer as u128;
+    abs.min(u32::MAX as u128) as u32
+}
+
+/// 呼び出しスレッドを RT（time-constraint）スケジューリングに上げる（macOS）。
+///
+/// `period_ns` = 仕事が届く周期（= block period）、`computation_ns` = 周期内の想定計算時間、
+/// `constraint_ns` = 計算を終えるべき期限（>= computation）。spike 用なので失敗は呼び出し側で
+/// ログするだけ（通常優先度のまま継続し、計測は RT 無効として読める）。
+///
+/// 注意（verdict に明記する前提）: 連続 spin するスレッドに time-constraint を付けても、macOS は
+/// computation 予算を超過し続けるスレッドを demote しうる。production の隔離プロセスは spin ではなく
+/// block/wake で待つべきで、本 spike の数値は「RT tail の floor」を測るものであり production 値ではない。
+#[cfg(target_os = "macos")]
+pub fn set_realtime_thread(
+    period_ns: u64,
+    computation_ns: u64,
+    constraint_ns: u64,
+) -> io::Result<()> {
+    use mach2::kern_return::KERN_SUCCESS;
+    use mach2::mach_init::mach_thread_self;
+    use mach2::mach_time::{mach_timebase_info, mach_timebase_info_data_t};
+    use mach2::thread_policy::{
+        thread_policy_set, thread_time_constraint_policy_data_t, THREAD_TIME_CONSTRAINT_POLICY,
+        THREAD_TIME_CONSTRAINT_POLICY_COUNT,
+    };
+
+    let mut tb = mach_timebase_info_data_t { numer: 0, denom: 0 };
+    // SAFETY: timebase 比率（numer/denom）を tb に書き込む mach 呼び出し。
+    unsafe {
+        mach_timebase_info(&mut tb);
+    }
+
+    let mut policy = thread_time_constraint_policy_data_t {
+        period: ns_to_mach_abs(period_ns, tb.numer, tb.denom),
+        computation: ns_to_mach_abs(computation_ns, tb.numer, tb.denom),
+        constraint: ns_to_mach_abs(constraint_ns, tb.numer, tb.denom),
+        // 0 = 計算中はプリエンプトされにくい（tail floor を測る意図）。
+        preemptible: 0,
+    };
+
+    // SAFETY: mach_thread_self() は呼び出しスレッドの send right を返す（プロセス生存中の leak は許容）。
+    // policy を THREAD_TIME_CONSTRAINT_POLICY_COUNT 個の integer_t としてレイアウト一致で渡す。
+    let kr = unsafe {
+        thread_policy_set(
+            mach_thread_self(),
+            THREAD_TIME_CONSTRAINT_POLICY,
+            (&mut policy as *mut thread_time_constraint_policy_data_t).cast(),
+            THREAD_TIME_CONSTRAINT_POLICY_COUNT,
+        )
+    };
+    if kr == KERN_SUCCESS {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "thread_policy_set(TIME_CONSTRAINT) failed: kr={kr}"
+        )))
+    }
+}
+
+/// 非 macOS フォールバック（本 spike は macOS 専用だが workspace は ubuntu CI でもビルドされる）。
+#[cfg(not(target_os = "macos"))]
+pub fn set_realtime_thread(
+    _period_ns: u64,
+    _computation_ns: u64,
+    _constraint_ns: u64,
+) -> io::Result<()> {
+    Err(io::Error::other(
+        "RT thread policy is only implemented on macOS",
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -112,5 +200,18 @@ mod tests {
         assert_eq!(std::mem::align_of::<SharedRegion>(), 64);
         // BUF_LEN = フレーム × チャンネル。
         assert_eq!(BUF_LEN, MAX_FRAMES * CHANNELS);
+    }
+
+    // ns → mach abs 単位の変換（abs = ns * denom / numer）。timebase 比に応じた値と境界を確認。
+    #[test]
+    fn ns_to_mach_abs_converts_by_timebase() {
+        // Intel timebase（1 tick = 1 ns）: 変換は恒等。
+        assert_eq!(ns_to_mach_abs(1_000, 1, 1), 1_000);
+        // Apple Silicon timebase（1 tick = 125/3 ns ≈ 41.67ns）: ns→tick は ns*3/125。
+        assert_eq!(ns_to_mach_abs(1_000, 125, 3), 1_000 * 3 / 125); // = 24
+                                                                    // timebase 取得失敗（numer == 0）は 0 を返す（0 除算を避ける）。
+        assert_eq!(ns_to_mach_abs(1_000, 0, 3), 0);
+        // u32 飽和（巨大 ns でも overflow しない）。
+        assert_eq!(ns_to_mach_abs(u64::MAX, 1, 1), u32::MAX);
     }
 }


### PR DESCRIPTION
## 概要

γ staging の次段（Step0 #348/PR #349 の後）。Step0 verdict §6 の **latency policy fork を
計測して決める**（"run before you plan"）feasibility spike。owner 方針（DAW 並み小バッファ性能が
目標）により 64f/32f を edge case ではなく**性能ゴール**として扱う。

`orbit-sandbox-spike` の `sandbox-host` に 3 モードを追加して計測した。

## 計測結果（MacBook Pro arm64・44100Hz・release・同一機材）

| モード | 64f callback_max | 64f stale率 | 判定 |
|--------|-----------------:|------------:|:-----|
| sync（Step0 baseline）| ~2.7-3.1ms（185-211%）| — | 違反 |
| 候補 A（child RT 優先度）| ~2-2.75ms（縮まず・run2 で 154 overruns）| — | **棄却** |
| in-process 対照 | **6µs（0.41%）** | — | clean（owner 主張を裏付け）|
| **候補 B（pipelined）** | **6.8µs（0.47%）** | **≈0.11%** | **採用** |

- **候補 A 棄却**: RT 優先度は ~2ms tail を縮めず、連続 spin スレッドへの time-constraint が macOS
  demote を招き不安定化。→ tail は child プリエンプト由来でなく **host 側**。
- **in-process 対照**: 64f で worst 6µs = クリーン。→ ~2ms tail は OS floor ではなく **sandbox
  round-trip 待ち固有**。「ネイティブ楽器=in-process は小バッファ OK」を実機で裏付け。
- **候補 B 採用**: host が spin しないので callback_max が全 buffer（32-256f）で <0.5% budget =
  **tail 消滅**。stale 率は 256/128f=0% / 64f≈0.1% / 32f≈0.45%。**out-of-process sandbox を
  32f まで小バッファで feasible にする**。

## 代償（γ 本実装で織り込む）

1. 1 block の出力遅延（pipeline 固有）。
2. stale <0.5%（@32-64f）。production は repeat-previous（spike は silence で stale 率を測定）。
3. 32f で slot 再利用圧（stall 数件）→ slot 3 化を検討。

## 変更

- `lib.rs`: ping-pong バッファ（input/output 各 2 slot・`slot_offset()` で `seq&1` index・child も）
  + slot 再利用不変条件（sync=1-outstanding / pipelined=2-outstanding）を doc 化 + mach RT ヘルパ
  `set_realtime_thread`（macOS）/ `ns_to_mach_abs`（純関数・テスト付き）。
- `sandbox-child`: `--rt-priority`/`--rt-period-us`・slot indexing。
- `sandbox-host`: `--child-rt-priority`/`--in-process`/`--pipelined` の 3 計測モード。
- `Cargo.toml`: mach2（macOS 限定 target 依存・MIT/Apache）。
- docs: `POST_2.0_GAMMA_LATENCY_FORK_SPIKE.md` verdict + WORK_LOG 6.175。

## 次

γ 本実装で pipelined（候補 B）採用 → event/param IPC → daemon 統合 → cutover #108。

Refs #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)