### PR TITLE
chore(ci): add pre-push hook running Rust fmt/clippy/deny to prevent CI failure emails

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+# pre-push hook for OrbitScore — Rust CI checks をローカルで先回り（#352）。
+#
+# 目的: Rust の fmt/clippy/cargo-deny 違反が GitHub の `Rust CI` で初めて落ち、失敗メールが
+# 飛ぶのを防ぐ。push に rust/ の変更が含まれるときだけローカルでチェックを回す
+# （rust/ を触らない push は素通り＝待ち時間ゼロ）。
+#
+# ⚠️ 下記コマンドは .github/workflows/rust-ci.yml と手動同期（drift 注意・CI 側を変えたら要追従）:
+#   - Format check       : cargo fmt --all --check
+#   - Clippy (default)   : cargo clippy --workspace --all-targets --locked -- -D warnings
+#   - Clippy (clap-host) : cargo clippy -p orbit-audio-daemon --features clap-host --all-targets --locked -- -D warnings
+#   - license/dep gate   : cargo deny check（cargo-deny 未インストール時は skip = fail-open）
+# cargo test は実行時間が長いため対象外（CI で非ゲートテストを検証・MVP・必要なら follow-on）。
+#
+# 一時的にスキップしたい場合（非推奨）: git push --no-verify
+
+# 全 0（空含む）の OID 判定。新規ブランチ push / ブランチ削除 push の検出に使う。
+is_zero() { case "$1" in *[!0]*) return 1 ;; *) return 0 ;; esac; }
+
+die() { echo "[pre-push] ✗ $1"; exit 1; }
+
+# push 対象に rust/ の変更が含まれるか stdin で判定。
+# git は pre-push の stdin に各 ref 1 行ずつ「<local_ref> <local_oid> <remote_ref> <remote_oid>」を渡す
+# （ref 名は使わないので _ で読み捨てる）。
+rust_in_push() {
+  while read -r _ local_oid _ remote_oid; do
+    is_zero "$local_oid" && continue   # ブランチ削除 push はスキップ
+    if is_zero "$remote_oid"; then
+      # 新規ブランチ: origin/main からの差分で判定。base が解決できない（fresh/shallow clone・
+      # default branch 名違い等）場合は skip せず fail-closed でチェックを走らせる
+      # ── ここで skip すると rust 失敗が CI に出てメール源になるため（silent-failure review）。
+      base=$(git rev-parse --verify --quiet origin/main) || {
+        echo "[pre-push] origin/main を解決できません — 新規ブランチを安全側でチェック対象にします。"
+        return 0
+      }
+      range="$base..$local_oid"
+    else
+      range="$remote_oid..$local_oid"  # 既存ブランチ: remote 先端からの差分
+    fi
+    # git diff 失敗時は空出力 → fail-open（hook のバグで正規 push をブロックしない・CI が backstop）。
+    # 新規ブランチの base 不在は上で fail-closed 済。ここは git diff が稀に失敗する場合向け。
+    git diff --name-only "$range" 2>/dev/null | grep -q '^rust/' && return 0
+  done
+  return 1
+}
+
+rust_in_push || exit 0
+
+echo "[pre-push] rust/ changed — running Rust CI checks…"
+cd rust || die "cannot cd into rust/"
+
+cargo fmt --all --check ||
+  die "cargo fmt --check failed — run 'cargo fmt --all' in rust/ and re-commit."
+cargo clippy --workspace --all-targets --locked -- -D warnings ||
+  die "clippy (default features) failed."
+cargo clippy -p orbit-audio-daemon --features clap-host --all-targets --locked -- -D warnings ||
+  die "clippy (clap-host feature) failed."
+
+# cargo-deny は別 CI ジョブ（license/dependency gate）。未インストール時は skip して push を通す
+# （fail-open＝hook が全 rust push をブロックしない・CI が backstop）。成功バナーは実際に
+# 走ったチェックだけを表記する（deny skip 時に「全部通った」と誤認させない・silent-failure review）。
+if command -v cargo-deny >/dev/null 2>&1; then
+  cargo deny check || die "cargo deny check failed."
+  echo "[pre-push] ✓ Rust checks passed (fmt + clippy + cargo-deny)."
+else
+  echo "[pre-push] cargo-deny not installed — skipping (CI の license/dependency gate で検査される)"
+  echo "[pre-push] ✓ fmt + clippy passed (cargo-deny は未実行 — CI が backstop)."
+fi


### PR DESCRIPTION
## 背景

Rust の feature ブランチで、修正前の中間 push が GitHub `Rust CI` で落ち、**失敗メール**が届く事象が発生していた（例: PR #351 の `795d87289` で `Clippy (default features)` 失敗 → 後続 commit で解消、最新は green）。

### 根本原因
`.husky/pre-commit` は `npx lint-staged` + `npm test` + `npm run build` の **TS/JS 専用**で、Rust の `cargo fmt`/`cargo clippy`/`cargo deny` をローカルで一切回していない。さらに Rust-only commit は（sandbox で `npm test` がタイムアウトするため）`--no-verify` で通すので、Rust の違反がローカル素通り → GitHub CI で初めて落ちてメールになる。Rust CI は **fmt/clippy ジョブ**と **license/dependency gate（cargo-deny）**の 2 ジョブがあり、どちらの失敗もメール源になる。

## 対応

`.husky/pre-push` を新設。**push に `rust/` の変更が含まれるときだけ** Rust CI 相当のローカルチェックを回す:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy -p orbit-audio-daemon --features clap-host --all-targets --locked -- -D warnings`
- `cargo deny check`（`cargo-deny` 未インストール時は skip = fail-open）

`rust/` を触らない push（TS のみ等）は素通り＝待ち時間ゼロ。失敗する Rust は GitHub に届く前にローカルでブロックされ、`main` の失敗可視性は維持。

### 実装メモ
- husky v9（`.husky/_/pre-push` ラッパーは既存・user hook を追加するだけ）
- git pre-push の stdin（`<local_ref> <local_oid> <remote_ref> <remote_oid>`）から push 範囲を求め、`rust/` 差分の有無で判定
- 新規ブランチ（`remote_oid` 全0）は `origin/main` からの差分で判定
- `sh -e` 実行のため、全コマンドを `||`/`if`/`while` で guard（errexit 安全）
- **fail-open 方針**: 判定の `git diff` 失敗や `cargo-deny` 未インストールでは push を通す（hook のバグが正規 push をブロックしない・CI が backstop）
- `cargo test` は実行時間が長く gated test も CI で auto-skip のため対象外（MVP・必要なら follow-on）

## テスト（3 パスを実機検証）

- ✅ **pass**: `rust/` 変更を含む range + clean tree → fmt + clippy(default/clap-host) + cargo deny 実行 → exit 0
- ✅ **fail**: `rust/` 変更 + fmt 違反を仕込む → fmt --check で exit 1（push ブロック）→ ファイル復元 clean
- ✅ **skip**: `rust/` 変更なし → このブランチ自身の push（新規 + force-update）で hook がスキップして push 成功

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)