### PR TITLE
feat(vscode-extension): MCP save_file / get_document_text (#392)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -25,6 +25,7 @@ PR #394 の `/code:pr-review-team` round 1（4 専門レビュアー並列: code
 - **comment（Minor）**: `get_document_text` の description が `get_editor_state` のフィールド列挙で `language` を落としていた → 追加
 - **test（Minor）**: gated E2E に **isDirty no-op 分岐**の検証を追加（clean な状態で2回目の `save_file` → `'no changes to save'` を確認）— このガードが存在する唯一の理由の novel logic を固定
 - 据え置き（既知/pre-existing）: active-editor スコープの取り違えリスク（path 版は #392 で follow-on と明記済み）
+- **既知の限界（durable 記録）**: scheme ガードは全ダイアログ経路を塞がない — file-scheme のドキュメントでも `save()` が **disk-conflict（ロード後にディスク側が変更）や上書き確認**で対話ダイアログにブロックし得る。timeout 未実装。現状の MCP tool 面（全編集が `open_file` → `edit_replace` 経由）では unreachable のため defer。tool 面拡張時に再評価（docstring にも明記）
 - レビュアーは既存スラッシュコマンドの内蔵指定どおり Sonnet（comment-analyzer は Haiku）で起動・オーケストレーション/検品は Opus main。code-reviewer 2 体とも「16→18 ツール整合・Host allowlist 不変・sibling パターン準拠」を実機ビルド + 全 suite 実行で裏取り
 
 ### 6.204 feat(vscode-extension): MCP save_file / get_document_text — persist live-jam edits to disk (#392) (Jul 8, 2026)

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,16 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.205 fix(vscode-extension): pr-review-team round 1 — save_file headless-hang guard (#394) (Jul 8, 2026)
+
+PR #394 の `/code:pr-review-team` round 1（4 専門レビュアー並列: code-reviewer ×2 / silent-failure-hunter / pr-test-analyzer / comment-analyzer）。**Critical=0**。**Important=1** + Minor 数件を対応。全 suite グリーン維持。
+
+- **silent-failure（Important）**: `save_file` の `document.save()` が **untitled/no-path バッファでヘッドレス時に無限ハング**（"Save As" ダイアログ待ち）— ログも残らずエージェントには沈黙に見える（#392 の動機＝ヘッドレス live-jam 回収がまさにこの穴）。`doc.uri.scheme !== 'file'` ガードで早期に loud fail。加えて save 失敗（false 返却 / throw）を output channel にログ（`get_log` で可視化）+ `openFileForAgent` に倣い try/catch を追加
+- **comment（Minor）**: `get_document_text` の description が `get_editor_state` のフィールド列挙で `language` を落としていた → 追加
+- **test（Minor）**: gated E2E に **isDirty no-op 分岐**の検証を追加（clean な状態で2回目の `save_file` → `'no changes to save'` を確認）— このガードが存在する唯一の理由の novel logic を固定
+- 据え置き（既知/pre-existing）: active-editor スコープの取り違えリスク（path 版は #392 で follow-on と明記済み）
+- レビュアーは既存スラッシュコマンドの内蔵指定どおり Sonnet（comment-analyzer は Haiku）で起動・オーケストレーション/検品は Opus main。code-reviewer 2 体とも「16→18 ツール整合・Host allowlist 不変・sibling パターン準拠」を実機ビルド + 全 suite 実行で裏取り
+
 ### 6.204 feat(vscode-extension): MCP save_file / get_document_text — persist live-jam edits to disk (#392) (Jul 8, 2026)
 
 #388 Agent Bridge の follow-on（#392）。MCP `edit_replace` はエディタバッファのみを書き換えディスク保存しない（auto-save もオフ）ため、ライブセッション終了後に演奏された最終状態のファイルを agent が回収できなかった（2026-07-07 の live jam では osascript Cmd+S で救出＝Accessibility 権限依存で headless 不可）。エディタ配管ツール2本を追加:

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,19 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.204 feat(vscode-extension): MCP save_file / get_document_text — persist live-jam edits to disk (#392) (Jul 8, 2026)
+
+#388 Agent Bridge の follow-on（#392）。MCP `edit_replace` はエディタバッファのみを書き換えディスク保存しない（auto-save もオフ）ため、ライブセッション終了後に演奏された最終状態のファイルを agent が回収できなかった（2026-07-07 の live jam では osascript Cmd+S で救出＝Accessibility 権限依存で headless 不可）。エディタ配管ツール2本を追加:
+
+- **`save_file`**: アクティブドキュメントを `document.save()` で保存。`isDirty` ガードで分岐（未変更なら no-op で ok・保存 fsPath を message に）— `document.save()` が clean 時に false を返すか true を返すかの曖昧さを無害化。dirty で save が false のときだけ error
+- **`get_document_text`**: アクティブドキュメントの全文を構造化して返す（`{ path, text }`・no-editor 時は両 null）。既存 `get_editor_state` は path/cursor/selection/lineCount/isDirty のみで本文が取れず、`edit_replace` 適用確認・diff 検証に使えなかった問題を解消
+- 両ツールとも **active-editor 限定**（既存 `edit_replace`/`get_editor_state` と一貫）。issue の「(or path 指定)」版は今回作らず follow-on 扱い
+- 配線: `mcp-server.ts`（`DocumentText` 型 + `OrbitScoreToolHandlers` + `buildServer` 登録）、`extension.ts`（`saveFileForAgent`/`getDocumentTextForAgent` + handlers）。error 封筒は `toToolResult`、snapshot は `get_editor_state` と同型の inline JSON を再利用（新規ヘルパー無し）
+- テスト: stub suite を 16→18 ツールに更新 + `get_document_text` round-trip 1本追加。gated E2E に「`edit_replace` 後の buffer を `get_document_text` で確認 → `save_file` → ディスク上の内容に置換が反映されていることを検証」ステップを追加
+- **spec**: WCTM_SYSTEM_SPEC §3.1 は WCTM 演奏ランタイムの概念的ツール例（`get_performance_features`/`evaluate_orbitscore`/`get_session_tail`）で拡張ホスト側の現行ツールを網羅列挙していないため、エディタ配管ツール追加に spec-first 更新は不要と判断
+- 実装は Sonnet 委譲、計画・検品は main（Opus）。ビルド + 全 suite 1281 passed / 29 skipped（回帰なし）+ lint clean + gated E2E クリーンにスキップ確認
+- **/simplify**（4 観点並列）: reuse/simplification/efficiency = 変更なし。**altitude 1件を適用** — gated E2E が tracked fixture（`kick_loop.orbs`）を直接開いて `save_file` で上書きし `afterAll` の `writeFileSync` で restore する band-aid だった → 既存 `tmpRoot` scratch dir にコピーして開く方式へ（basename 保持で path 断定 assertion は維持）。capture + restore ブロックを削除し「プロセスクラッシュ / restore 失敗で tracked file が dirty のまま残る」リスククラスを構造的に解消（net LOC 減）
+
 ### 6.203 docs: pr-review-team round 2 convergence record (#393) (Jul 8, 2026)
 
 round 2 = 独立検証 2 体（fix 検証 + regression sweep）で **Critical=0 / Important=0 を裏取り**し収束。両者が round 1 の全 5 修正を RESOLVED 判定（Host 検証は正規クライアント通過をテストで確認・anchorFit 遷移ログはエッジのみ発火・armDelay の代数を手計算とテスト双方で検証・tempo 変更テストの 1500 境界も再導出で一致）。唯一の Minor（palette 経路が write 失敗時も flash する）を `cd08d5d` で修正（不達時は警告ログのみで早期 return）。最終 CI 4 チェック全 pass・全 suite 1280 passed。マージは owner 指示待ち。

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -2111,6 +2111,13 @@ function getEditorStateForAgent(): EditorState {
  * has no unsaved changes, since `document.save()` resolving `false` is
  * ambiguous between "nothing to save" and "save failed" — checking `isDirty`
  * first sidesteps that ambiguity.
+ *
+ * Rejects a document with no on-disk path (uri.scheme !== 'file', e.g. an
+ * untitled buffer): `document.save()` on such a document pops an interactive
+ * "Save As" dialog and never resolves in a headless/agent-driven session — the
+ * exact live-jam recovery scenario this tool exists for. Fail loudly instead of
+ * hanging silently. Save failures (false return or a thrown error) are logged
+ * to the output channel so `get_log` surfaces why a persist did not happen.
  */
 async function saveFileForAgent(): Promise<CommandResult> {
   const editor = vscode.window.activeTextEditor
@@ -2118,14 +2125,29 @@ async function saveFileForAgent(): Promise<CommandResult> {
     return { ok: false, error: 'no active editor' }
   }
   const doc = editor.document
+  if (doc.uri.scheme !== 'file') {
+    return {
+      ok: false,
+      error: `cannot save — document has no file path (scheme: ${doc.uri.scheme})`,
+    }
+  }
   if (!doc.isDirty) {
     return { ok: true, message: `no changes to save (already saved): ${doc.uri.fsPath}` }
   }
-  const saved = await doc.save()
-  if (!saved) {
-    return { ok: false, error: `save failed: ${doc.uri.fsPath}` }
+  try {
+    const saved = await doc.save()
+    if (!saved) {
+      outputChannel?.appendLine(
+        `❌ save_file: document.save() returned false for ${doc.uri.fsPath}`,
+      )
+      return { ok: false, error: `save failed: ${doc.uri.fsPath}` }
+    }
+    return { ok: true, message: `saved: ${doc.uri.fsPath}` }
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    outputChannel?.appendLine(`❌ save_file: ${reason} (${doc.uri.fsPath})`)
+    return { ok: false, error: `save failed: ${reason}` }
   }
-  return { ok: true, message: `saved: ${doc.uri.fsPath}` }
 }
 
 /** Full text of the active document for the MCP `get_document_text` tool. Fields are null when no editor is active. */

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -2118,6 +2118,13 @@ function getEditorStateForAgent(): EditorState {
  * exact live-jam recovery scenario this tool exists for. Fail loudly instead of
  * hanging silently. Save failures (false return or a thrown error) are logged
  * to the output channel so `get_log` surfaces why a persist did not happen.
+ *
+ * Known limitation: the scheme guard does not cover every dialog path — a
+ * file-scheme document can still block on an interactive prompt when
+ * `save()` detects a disk conflict (the file changed on disk since load) or
+ * an overwrite confirmation. No timeout is implemented; this path is
+ * unreachable through the current MCP tool surface (all edits flow through
+ * `open_file` → `edit_replace`), so re-evaluate if the tool surface widens.
  */
 async function saveFileForAgent(): Promise<CommandResult> {
   const editor = vscode.window.activeTextEditor

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -21,6 +21,7 @@ import {
   type AudioDevicesResult,
   type CommandResult,
   type DiagnosticSeverityLabel,
+  type DocumentText,
   type EditReplaceInput,
   type EditorState,
   type EngineState,
@@ -367,6 +368,8 @@ export async function activate(context: vscode.ExtensionContext) {
           runSelection: () => runSelectionForAgent(),
           editReplace: (args) => editReplaceForAgent(args),
           getEditorState: () => getEditorStateForAgent(),
+          saveFile: () => saveFileForAgent(),
+          getDocumentText: () => getDocumentTextForAgent(),
           getDiagnostics: (filePath) => getDiagnosticsForAgent(filePath),
           getLog: (lines) => getLogForAgent(lines),
           analyzeAudio: (wavPath) => analyzeAudioForAgent(wavPath),
@@ -2099,6 +2102,40 @@ function getEditorStateForAgent(): EditorState {
     lineCount: doc.lineCount,
     isDirty: doc.isDirty,
   }
+}
+
+/**
+ * Save the active document to disk for the MCP `save_file` tool. edit_replace
+ * only mutates the in-memory buffer, so this is the only way an agent can
+ * persist a live-edited or live-played file (#392). A no-op when the document
+ * has no unsaved changes, since `document.save()` resolving `false` is
+ * ambiguous between "nothing to save" and "save failed" — checking `isDirty`
+ * first sidesteps that ambiguity.
+ */
+async function saveFileForAgent(): Promise<CommandResult> {
+  const editor = vscode.window.activeTextEditor
+  if (!editor) {
+    return { ok: false, error: 'no active editor' }
+  }
+  const doc = editor.document
+  if (!doc.isDirty) {
+    return { ok: true, message: `no changes to save (already saved): ${doc.uri.fsPath}` }
+  }
+  const saved = await doc.save()
+  if (!saved) {
+    return { ok: false, error: `save failed: ${doc.uri.fsPath}` }
+  }
+  return { ok: true, message: `saved: ${doc.uri.fsPath}` }
+}
+
+/** Full text of the active document for the MCP `get_document_text` tool. Fields are null when no editor is active. */
+function getDocumentTextForAgent(): DocumentText {
+  const editor = vscode.window.activeTextEditor
+  if (!editor) {
+    return { path: null, text: null }
+  }
+  const doc = editor.document
+  return { path: doc.uri.fsPath, text: doc.getText() }
 }
 
 /**

--- a/packages/vscode-extension/src/mcp-server.ts
+++ b/packages/vscode-extension/src/mcp-server.ts
@@ -134,6 +134,12 @@ export interface EditorState {
   isDirty: boolean | null
 }
 
+/** Full text of the active document for get_document_text. Fields are null when no editor is active. */
+export interface DocumentText {
+  path: string | null
+  text: string | null
+}
+
 /** Diagnostic severities as reported by get_diagnostics, spelled out (not numeric) for agent readability. */
 export type DiagnosticSeverityLabel = 'error' | 'warning' | 'info' | 'hint'
 export interface DiagnosticEntry {
@@ -183,6 +189,8 @@ export interface OrbitScoreToolHandlers {
   runSelection(): Promise<CommandResult> | CommandResult
   editReplace(args: EditReplaceInput): Promise<CommandResult> | CommandResult
   getEditorState(): EditorState
+  saveFile(): Promise<CommandResult> | CommandResult
+  getDocumentText(): DocumentText
   getDiagnostics(path?: string): FileDiagnostics[]
   getLog(lines?: number): string[]
   analyzeAudio(wavPath: string): Promise<AnalyzeAudioResult> | AnalyzeAudioResult
@@ -474,6 +482,34 @@ function buildServer(version: string, handlers: OrbitScoreToolHandlers): McpServ
         'editor is active.',
     },
     async () => ({ content: [{ type: 'text', text: JSON.stringify(handlers.getEditorState()) }] }),
+  )
+
+  server.registerTool(
+    'save_file',
+    {
+      title: 'Save File',
+      description:
+        'Save the active document to disk (document.save()). edit_replace only ' +
+        'rewrites the in-memory editor buffer — it does not persist to disk (auto-save ' +
+        'is off) — so use save_file to persist the state played during a live session ' +
+        'or the result of an edit. A no-op (returns ok) when the document has no ' +
+        'unsaved changes.',
+    },
+    async () => toToolResult(await handlers.saveFile()),
+  )
+
+  server.registerTool(
+    'get_document_text',
+    {
+      title: 'Get Document Text',
+      description:
+        'Return the full text of the active document. get_editor_state only reports ' +
+        'metadata (path, cursor, selection, line count, dirty state) — use ' +
+        'get_document_text to confirm an edit_replace was applied or to diff the ' +
+        'buffer against the file on disk. path and text are both null when no editor ' +
+        'is active.',
+    },
+    async () => ({ content: [{ type: 'text', text: JSON.stringify(handlers.getDocumentText()) }] }),
   )
 
   server.registerTool(

--- a/packages/vscode-extension/src/mcp-server.ts
+++ b/packages/vscode-extension/src/mcp-server.ts
@@ -504,7 +504,7 @@ function buildServer(version: string, handlers: OrbitScoreToolHandlers): McpServ
       title: 'Get Document Text',
       description:
         'Return the full text of the active document. get_editor_state only reports ' +
-        'metadata (path, cursor, selection, line count, dirty state) — use ' +
+        'metadata (path, language, cursor, selection, line count, dirty state) — use ' +
         'get_document_text to confirm an edit_replace was applied or to diff the ' +
         'buffer against the file on disk. path and text are both null when no editor ' +
         'is active.',

--- a/tests/e2e/orbitstudio-mcp-gated.spec.ts
+++ b/tests/e2e/orbitstudio-mcp-gated.spec.ts
@@ -250,6 +250,13 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
         'save_file did not persist the edit_replace change to disk',
       ).toBe(true)
 
+      // Save again with nothing pending: the document is now clean, so this
+      // exercises the isDirty no-op branch — the guard's whole reason to exist.
+      // It must read as "clean" (ok, no write), NOT as a save failure.
+      const saveNoopRes = await client.call('save_file')
+      expect(saveNoopRes.isError, saveNoopRes.text).toBe(false)
+      expect(saveNoopRes.text).toContain('no changes to save')
+
       const tempoLineIndex = kickLoopLines.findIndex((line) => line.includes('global.tempo(120)'))
       expect(tempoLineIndex, 'global.tempo(120) line not found in kick_loop.orbs fixture').not.toBe(
         -1,

--- a/tests/e2e/orbitstudio-mcp-gated.spec.ts
+++ b/tests/e2e/orbitstudio-mcp-gated.spec.ts
@@ -89,6 +89,11 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
   let child: ChildProcess | undefined
   let client: McpClient | undefined
   let tmpRoot: string | undefined
+  // #392: save_file persists to disk (unlike edit_replace, which only touched
+  // the in-memory buffer). We open a scratch copy inside tmpRoot — not the
+  // tracked repo fixture — so the write lands in the temp dir that afterAll
+  // already removes, and never dirties a committed file.
+  let kickLoopWorkPath: string | undefined
 
   afterAll(async () => {
     // Teardown: best-effort, always runs, never throws past this hook.
@@ -127,6 +132,11 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
       fs.mkdirSync(userDataDir, { recursive: true })
       fs.mkdirSync(extensionsDir, { recursive: true })
       const captureWavPath = path.join(tmpRoot, 'capture.wav')
+      // Scratch copy of the kick-loop fixture (basename preserved so the
+      // languageId/path assertions below still hold): save_file writes here,
+      // inside the tmpRoot that afterAll removes, instead of the tracked fixture.
+      kickLoopWorkPath = path.join(tmpRoot, 'kick_loop.orbs')
+      fs.copyFileSync(KICK_LOOP_FIXTURE, kickLoopWorkPath)
       const port = 39400 + Math.floor(Math.random() * 200)
 
       // ── 2. Launch: `orbs` CLI with the extension in dev mode ──
@@ -184,7 +194,7 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
       ).toBeGreaterThanOrEqual(1)
 
       // ── 5. Open kick_loop.orbs, sanity-check editor state, run the whole file ──
-      const openKickRes = await client.call('open_file', { path: KICK_LOOP_FIXTURE })
+      const openKickRes = await client.call('open_file', { path: kickLoopWorkPath })
       expect(openKickRes.isError, openKickRes.text).toBe(false)
       await sleep(500)
 
@@ -199,7 +209,7 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
       // (not diagnostic_case.orbs, opened just before it) is the active document.
       expect(editorState.path?.endsWith('kick_loop.orbs')).toBe(true)
 
-      const kickLoopContent = fs.readFileSync(KICK_LOOP_FIXTURE, 'utf8')
+      const kickLoopContent = fs.readFileSync(kickLoopWorkPath, 'utf8')
       const kickLoopLines = kickLoopContent.split('\n')
       const totalLines = kickLoopLines.length
 
@@ -221,6 +231,24 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
         replace: 'global.tempo(180)',
       })
       expect(editRes.isError, editRes.text).toBe(false)
+
+      // ── 6a. #392: get_document_text sees the buffer edit; save_file persists it ──
+      const docTextRes = await client.call('get_document_text')
+      const docTextAfterEdit = JSON.parse(docTextRes.text) as {
+        path: string | null
+        text: string | null
+      }
+      expect(docTextAfterEdit.text?.includes('global.tempo(180)')).toBe(true)
+      expect(docTextAfterEdit.text?.includes('global.tempo(120)')).toBe(false)
+
+      const saveRes = await client.call('save_file')
+      expect(saveRes.isError, saveRes.text).toBe(false)
+
+      const savedFixtureContent = fs.readFileSync(kickLoopWorkPath, 'utf8')
+      expect(
+        savedFixtureContent.includes('global.tempo(180)'),
+        'save_file did not persist the edit_replace change to disk',
+      ).toBe(true)
 
       const tempoLineIndex = kickLoopLines.findIndex((line) => line.includes('global.tempo(120)'))
       expect(tempoLineIndex, 'global.tempo(120) line not found in kick_loop.orbs fixture').not.toBe(

--- a/tests/vscode-extension/mcp-server.spec.ts
+++ b/tests/vscode-extension/mcp-server.spec.ts
@@ -11,6 +11,7 @@ import {
   type AudioDevicesResult,
   type FlashConfigResult,
   type EditorState,
+  type DocumentText,
   type AnalyzeAudioResult,
 } from '../../packages/vscode-extension/src/mcp-server'
 
@@ -111,6 +112,16 @@ function createStubHandlers(overrides: Partial<OrbitScoreToolHandlers> = {}): {
         isDirty: null,
       }
       return state
+    },
+    saveFile: () => {
+      record('saveFile', [])
+      const result: CommandResult = { ok: true, message: 'saved: /tmp/stub.orbs' }
+      return result
+    },
+    getDocumentText: () => {
+      record('getDocumentText', [])
+      const result: DocumentText = { path: null, text: null }
+      return result
     },
     getDiagnostics: (path) => {
       record('getDiagnostics', [path])
@@ -322,7 +333,7 @@ describe('OrbitScore MCP server (real HTTP, stub handlers)', () => {
     expect((res.headers['mcp-session-id'] as string).length).toBeGreaterThan(0)
   })
 
-  it('tools/list contains all 16 tools; evaluate_orbitscore requires code:string', async () => {
+  it('tools/list contains all 18 tools; evaluate_orbitscore requires code:string', async () => {
     const { handlers } = createStubHandlers()
     handle = await startTestServer(handlers)
     const client = new McpTestClient(handle.port)
@@ -345,6 +356,8 @@ describe('OrbitScore MCP server (real HTTP, stub handlers)', () => {
       'run_selection',
       'edit_replace',
       'get_editor_state',
+      'save_file',
+      'get_document_text',
       'force_kill_scsynth',
       'list_audio_devices',
       'select_audio_device',
@@ -383,6 +396,28 @@ describe('OrbitScore MCP server (real HTTP, stub handlers)', () => {
 
     const call = calls.find((c) => c.name === 'evaluate')
     expect(call?.args[0]).toBe(code)
+  })
+
+  it('tools/call get_document_text round-trips path/text and records the call', async () => {
+    const docText: DocumentText = { path: '/tmp/session.orbs', text: 'global.tempo(140)\n' }
+    let getDocumentTextCalled = false
+    const { handlers } = createStubHandlers({
+      getDocumentText: () => {
+        getDocumentTextCalled = true
+        return docText
+      },
+    })
+    handle = await startTestServer(handlers)
+    const client = new McpTestClient(handle.port)
+    await client.connect()
+
+    const res = await client.toolsCall('get_document_text')
+
+    expect(res.status).toBe(200)
+    const body = res.json as JsonRpcOk<ToolCallResult>
+    expect(body.result.isError).toBeFalsy()
+    expect(JSON.parse(body.result.content[0]!.text)).toEqual(docText)
+    expect(getDocumentTextCalled).toBe(true)
   })
 
   it('handler error surfaces as isError:true with text starting with "error:"', async () => {


### PR DESCRIPTION
## 概要

#388 Agent Bridge の follow-on（Closes #392）。MCP `edit_replace` はエディタバッファのみを書き換えてディスク保存しない（auto-save もオフ）ため、ライブセッション終了後に演奏された最終状態のファイルを agent が回収できなかった（2026-07-07 の live jam では osascript Cmd+S で救出＝Accessibility 権限依存で headless 不可）。エディタ配管ツールを2本追加する。

## 変更内容

- **`save_file`**: アクティブドキュメントを `document.save()` で保存。`isDirty` ガードで分岐（未変更なら no-op で ok・保存 fsPath を message に）— `document.save()` が clean 時に返す真偽値の曖昧さを無害化。dirty で save が false のときだけ error
- **`get_document_text`**: アクティブドキュメントの全文を構造化して返す（`{ path, text }`・no-editor 時は両 null）。既存 `get_editor_state` は path/cursor/selection/lineCount/isDirty のみで本文が取れず、`edit_replace` 適用確認・diff 検証に使えなかった問題を解消
- 両ツールとも **active-editor 限定**（既存 `edit_replace`/`get_editor_state` と一貫）。issue の「(or path 指定)」版は follow-on 扱い
- 配線は `toToolResult` / `get_editor_state` 同型 inline JSON を再利用（新規ヘルパー無し）
- stub suite を 16→18 ツールに更新 + `get_document_text` round-trip テスト追加
- gated E2E に「`edit_replace` 後の buffer を `get_document_text` で確認 → `save_file` → ディスク上の内容に置換が反映されていることを検証」ステップを追加

## spec 判断

WCTM_SYSTEM_SPEC §3.1 は WCTM 演奏ランタイムの概念的ツール例で拡張ホスト側の現行ツールを網羅列挙していないため、エディタ配管ツール追加に spec-first 更新は不要と判断。

## テスト

- ビルド + 全 suite 1281 passed / 29 skipped（回帰なし）+ lint clean
- gated E2E（実機 device 必要）はローカルでクリーンにスキップ確認
- **/simplify**（4 観点並列）: reuse/simplification/efficiency = 変更なし。altitude 1件を適用 — gated E2E の tracked fixture 直接書き換え + `afterAll` restore の band-aid を `tmpRoot` scratch copy 方式に置換し、tracked file が dirty のまま残るリスククラスを構造的に解消

## 実装体制

計画・検品は main（Opus）、実装は Sonnet 委譲。

🤖 Generated with [Claude Code](https://claude.com/claude-code)