### PR TITLE
feat(engine): VST3 hosting Phase 0+1 — host, OOP effect, gated validation

### DIFF
--- a/docs/development/POST_2.0_PLUGIN_HOST_KNOWHOW.md
+++ b/docs/development/POST_2.0_PLUGIN_HOST_KNOWHOW.md
@@ -1,0 +1,87 @@
+# プラグインホスト実装ノウハウ — フォーマット共通のホスト責務（VST3 / AU / CLAP）
+
+**日付**: 2026-07-08
+**由来**: VST3 hosting Phase 0（#381）で得た実証知見を、将来の **CLAP/VST3/AU 併用パイプライン**（正本 §format-neutral substrate・`POST_2.0_PLUGIN_STRATEGY.html`）に効く形で一般化したもの。
+**エビデンス強度**: VST3 の節は本セッションで**非サンドボックス実測**した一次事実（commit 参照）。AU / CLAP への対応づけは**構造的推論**（CLAP は本 repo の `orbit-clap-host` で一部裏取り・AU は未実装ゆえ推論多め）。推論箇所は明記する。
+
+---
+
+## 0. なぜこの doc があるか
+
+VST3 を「最小ホスト」で叩くと、実市販コレクションの多くが crash / fail した。だが原因を一次調査すると、**プラグイン側の問題ではなく「ホストが VST3 契約を守っていない／厳しすぎる」だけ**だった。同じ責務は AU/CLAP にも存在する。ここで責務を抽象化しておけば、フォーマットを足すたびに同じ轍を踏まずに済む（owner 要望: 「AU/CLAP を混ぜるとき良いことがある」）。
+
+**中核原則（最重要・全フォーマット共通）**:
+
+> **商用ホストは、optional / advisory なメソッドが「非 OK」を返しても致命扱いにしてはいけない。**
+> プラグインは仕様上の optional メソッドを実装しない自由がある。DAW（JUCE 系ホスト含む）はこれを許容して続行する。ホストが `kResultOk` 以外を一律エラーにすると、正常なプラグインが「動かない」と誤判定される。
+
+---
+
+## 1. フォーマット共通のホスト責務（対応表）
+
+| 責務 | VST3（本セッション実証） | AU（推論） | CLAP（`orbit-clap-host` 参照） |
+|---|---|---|---|
+| **モジュールのロード** | `.vst3` を **CFBundle として** load し、**実 `CFBundleRef` を `bundleEntry` に渡す**（raw dlopen + null は不可） | `.component` を `AudioComponent` 経由でインスタンス化（バンドルは OS が管理） | `.clap` を dlopen し `clap_entry` シンボル → `init(path)` |
+| **host context の提供** | `IComponent::initialize` に **`IHostApplication`**（`getName` + `IMessage`/`IAttributeList` を createInstance で供給） | `AUAudioUnit` に host 情報 / `AUHostCallbacks` | `clap_host` struct（name/version + 拡張 query コールバック） |
+| **component/controller の生成・接続** | IComponent と IEditController を生成 → `setComponentHandler` → **`IConnectionPoint` で双方向 connect** → state 同期 | AU は単一オブジェクト（分離なし・パラメータは AUParameterTree） | 単一 plugin オブジェクト（分離なし） |
+| **I/O バスの query→調停→activate** | `getBusCount`/`getBusInfo` → `setBusArrangements` → `activateBus` | `AUAudioUnit.inputBusses/outputBusses` に `AVAudioFormat` を設定 → `allocateRenderResources` | `audio-ports` 拡張で port 構成を query |
+| **optional/advisory 戻りの非致命化** | `setProcessing`=`kNotImplemented(3)` / `setBusArrangements`=`kResultFalse(1)` を**成功扱い** | AU の非対応プロパティ / `kAudioUnitErr_*` の一部を許容 | 拡張が null（未対応）でも続行 |
+| **process データの完全性** | 非 null の空 `IEventList`/`IParameterChanges` + 有効な `ProcessContext` | `AURenderPullInputBlock` / timestamp | `clap_process` に in/out events・steady_time |
+| **teardown の順序と単一スレッド** | processor→component→factory→bundle の**宣言/drop 順**・home thread 単一スレッド | `deallocateRenderResources`→release | `stop_processing`→`deactivate`→`destroy` を home thread |
+
+---
+
+## 2. VST3 で実証した具体的教訓（本セッションの一次事実）
+
+最小ホスト（56% load・crash 36）から **arm64 商用 VST3 の 99.7%（329/330）load・crash 0** まで到達した。効いた 4 修正:
+
+1. **バンドルロードを CFBundle 正規経路に**（`CFBundleCreate`→`CFBundleLoadExecutable`→`CFBundleGetFunctionPointerForName`・**実 `CFBundleRef` を `bundleEntry` に渡す**）。
+   - **効果**: Native Instruments 全群（Kontakt/Massive/FM8/Reaktor 等）の **SIGSEGV が消滅**（36→0）。NI ランタイムは `CFBundleRef` から resources/frameworks/license path を解決するため、`null` を渡すと null deref でクラッシュしていた。
+   - ★ 最重要教訓: **macOS プラグインは「実バンドル参照」を entry point が要求しうる**。raw dlopen で symbol だけ取る近道は商用プラグインで壊れる。
+2. **`setProcessing` の `kNotImplemented(3)` を許容**。
+   - **効果**: iZotope 全群（Ozone/RX/Neutron/Vinyl/Vocal Doubler/Relay 54個）が回復。iZotope は `setProcessing` を実装せず `kNotImplemented` を返すだけで、これは VST3 的に合法。ホストの `is_ok()` が `kResultOk` しか通さなかったのが唯一のバグ。
+3. **`setBusArrangements` の `kResultFalse(1)` を advisory 扱い**（プラグイン既定 arrangement で続行）。
+   - **効果**: ARIA Player（Garritan 音源）等が load。`setBusArrangements` は host 提案であり、拒否するプラグインは自分の既定構成で動く。JUCE も致命扱いしない。
+4. **host context（`IHostApplication`）+ component-controller ハンドシェイク**の実装（土台）。単独では NI/iZotope を救わなかったが、正しいホストに必要な基盤。
+
+**tresult マッピング（vst3-rs / com-scrape・macOS）**: `kResultOk=0` / `kResultTrue=0` / `kResultFalse=1` / `kInvalidArgument=2` / `kNotImplemented=3`。**非 OK を一律 error にせず、`kInvalidArgument` 等の真のエラーとだけ区別する。**
+
+commits: `c0bd90c`(CFBundle) / `ee4d3bd`(kNotImplemented) / `eaa21d0`(setBusArrangements) / verdict=`POST_2.0_VST3_STEP0_SPIKE.md`。
+
+---
+
+## 3. AU / CLAP への対応づけ（推論・未検証を含む）
+
+同じ責務が別 API 名で現れる。フォーマットを足すとき「§1 の各行を新 API で埋める」作業になる。
+
+- **AU（AudioUnit v3 / AUAudioUnit）** — 未実装ゆえ推論:
+  - バンドルは OS（AudioComponent registry）が管理するので CFBundleRef 問題は起きにくいが、**entitlement `com.apple.security.cs.disable-library-validation`** が必要（OrbitStudio Phase 3 で見込み済み）。
+  - optional プロパティ / render error の一部を許容する必要（VST3 の kNotImplemented 教訓と同型のはず）。
+  - bus/format は `AVAudioFormat` を input/output busses に設定 → `allocateRenderResources`。VST3 の setBusArrangements に対応。
+- **CLAP** — 本 repo `orbit-clap-host` で一部裏取り済み:
+  - host struct のコールバック（拡張 query）が VST3 の IHostApplication に相当。拡張が null（未対応）でも続行する設計＝「非対応を致命にしない」原則の CLAP 版。
+  - effect/instrument 判定は `audio-ports`（VST3 の getBusCount に対応）。CLAP は `has_audio_input`（`orbit-clap-host/src/processor.rs`）で判定していた。★ **フォーマットごとに判定 API が違う**ので取り違え注意（VST3 は `getBusCount(kAudio,kInput)>0`）。
+
+**設計含意**: format-neutral substrate（M1 `EffectChildSupervisor` / `orbit-audio-sandbox` transport）は既にフォーマット非依存。各フォーマットの host アダプタが §1 の責務を自分の API で満たせば、同一 substrate に載る。
+
+---
+
+## 4. 計測のノウハウ（重要・再現時の落とし穴）
+
+- **サンドボックスは crash を大幅に水増しする**。コマンドサンドボックス下で sweep すると、プラグイン init の正当な動作（`/bin/ps`・`/Volumes` 読み・helper spawn・license 通信）が SIGKILL され**偽 crash** になる。本セッションで crash が **220（sandbox）→ 36（非サンドボックス）→ 0（修正後）** と動いた。**プラグイン互換の計測は必ず非サンドボックスで**行う。
+- **1 プラグイン = 1 サブプロセスで隔離**（segfault/hang が sweep 全体を巻き込まない・Obj-C グローバル class namespace 汚染も回避）。exit code を `256 - signal` で crash/hang/fail に分類。
+- **アーキ判定**: `lipo -archs` で `arm64` を含まない Intel-only プラグインは「ホストの fail」でなく「arch 除外」に分類（Rosetta 終息前提で arm64-native が対象）。
+- **委譲分担**: 重い実装・広い探索は codex（サンドボックス下でも可）、**実測はサンドボックス外で呼び出し側**が行う（[[delegate-heavy-work-to-codex-verify-from-answer]]）。
+
+---
+
+## 5. 未解決 / Phase 1+ への申し送り
+
+- **厳密な buffer 整合**: `setBusArrangements` を advisory 化した分、実際の process buffer チャネル数はプラグインの `getBusArrangement` 実値に合わせるべき（現 spike は stereo 仮定）。multi-out / sidechain / mono も同様（既知 gap）。
+- **instrument 経路**: audio_in=0 のプラグイン（Kontakt/Massive 等）は Phase 0 では load のみ。note-in→audio-out の add-mix は Phase 3（M2 instrument IPC 後）。
+- **Komplete Kontrol**（NI host-in-host ラッパー）は sweep で変動（単独 probe では load）。重い wrapper 系は個別対応が要るかもしれない。
+- 正本の I/O サーフェス完全カバー要件（audio bus multi-out/sidechain・note/MIDI in+out・CC・note expression/MPE/MIDI2）は Phase 1-2 で honor する（[[orbitscore-engine-fundamental-effects-as-plugins]]）。
+
+---
+
+**要約**: プラグインホスティングの成否は、派手な DSP でなく **「契約の細部（実バンドル参照・optional 戻りの許容・バス調停・host context）を守るか」** で決まる。この責務は VST3/AU/CLAP 共通であり、VST3 で確立したチェックリスト（§1）を各フォーマットに横展開すれば、混在パイプラインへの道が最短になる。

--- a/docs/development/POST_2.0_VST3_HOSTING_PLAN.md
+++ b/docs/development/POST_2.0_VST3_HOSTING_PLAN.md
@@ -142,11 +142,17 @@ Phase 3  VST3 instrument (production, OOP)            ← M2 landing 後に code
   3. `setupProcessing`（`ProcessSetup`: sample rate / max block size / realtime）→ `setActive(true)` → `setProcessing(true)`。
   4. `process(ProcessData)` を 1 block 分呼ぶ（既知の入力サンプル）。
   5. 逆順で teardown（`setProcessing(false)`→`setActive(false)`→`terminate`→factory drop）。**drop 順は `orbit-clap-host/src/effect.rs:58-68` の field-order 規律を VST3 用に踏襲。**
-- **テスト対象プラグイン**: ライセンスがクリーンで振る舞いが closed-form に予測できる単純な VST3 effect（例: gain のみのプラグイン。無ければ最小 gain VST3 を自作するか、SDK 同梱の `again` サンプルを VST3 でビルド）。
-- **受け入れ基準（offline・device 不要）**: 既知入力に対する 1 block 出力が **closed-form oracle と sample-exact**（gain plugin なら入力 × gain と bit 一致、許容誤差は f32 丸めのみ）。`#[ignore]` gated test でなく通常 `cargo test` で回せる offline test にする（プラグイン dylib の存在は test 内で skip 判定してよい）。
-- 🛑 **STOP gate**: 手書き COM で sample-exact な 1 block が出せない／`vst3` crate の API surface が hosting に不足している場合、**Phase 1 以降は全て moot**。verdict doc（`docs/development/POST_2.0_VST3_STEP0_SPIKE.md`）に事実を記録し owner に報告。GO 判定なら工数見積りを添える。
+- **テスト対象プラグイン（2 系統・両方必須）**:
+  - **① sample-exact oracle**: 振る舞いが closed-form に予測できる自作 gain VST3。`vst3` crate 同梱の `examples/gain.rs`（`out = gain × in`・smoothing なし・純 Rust）を cdylib 化し macOS `.vst3` バンドルに package する（**C++ SDK 不要**）。**我々が挙動を完全に把握している既知プラグイン**であることが要点。
+  - **② 実市販プラグイン（ABI 検証・load-bearing）**: インストール済みの**本物の VST3**（実 Steinberg C++ SDK でコンパイル・`/Library/Audio/Plug-Ins/VST3/`）を最低 1 つ load→process→drop する。
+- **受け入れ基準（offline・device 不要）**:
+  - **① sample-exact**: 既知入力に対する 1 block 出力が **oracle と sample-exact**（`in × gain` と bit 一致・許容誤差 f32 丸めのみ）。`process()` の音声データパス意味論を証明する。
+  - **② 実プラグイン ABI 適合**: ②の本物プラグインが**クラッシュせず** factory 取得 → IComponent instantiate → IAudioProcessor query → setupProcessing → process 1 block を通し、**妥当な出力**（無音入力→無音・既知入力→非発散）を返す。🔴 **①だけでは binding ABI の正しさは証明されない**（Rust プラグイン ↔ Rust ホストは同じ `vst3` crate の ABI 解釈を共有するため、**相互に一貫して間違っていても PASS しうる**）。②が実 SDK 製プラグインとの適合を担保する load-bearing な判定。
+  - どちらも `#[ignore]` gated でなく通常 `cargo test` で回せる offline test（dylib 不在時は test 内 skip 判定可・ただし ② は「skip=未検証」を verdict に明記）。
+- **compatibility sweep（Phase 0 の診断出力・gate ではない）**: ②のホストが動いたら、`/Library/Audio/Plug-Ins/VST3/` の全 VST3 に対し best-effort で load→query→（可能なら process）→drop を回し、**pass / fail / crash / hang の互換マトリクス**を verdict doc に記録する。crash/hang するプラグインは Phase 1+ の triage 対象としてマークするだけ（Phase 0 gate は ②の代表 1 つで足りる）。★ **北極星 = 市販 VST3 コレクション全体の互換性**（owner 意図「最終的には全部試す」）。exhaustive な per-plugin correctness（各プラグインの I/O サーフェス・MPE 等の honor）は Phase 1+ の継続作業。
+- 🛑 **STOP gate**: ①で手書き COM が sample-exact な 1 block を出せない／②で実市販プラグインが 1 つも load→process を通せない／`vst3` crate の API surface が hosting に不足している場合、**Phase 1 以降は全て moot**。verdict doc（`docs/development/POST_2.0_VST3_STEP0_SPIKE.md`）に事実を記録し owner に報告。GO 判定なら工数見積りを添える。
 
-**Phase 0 完了条件**: 0a pass + 0b sample-exact + verdict doc。**この gate を越えるまで Phase 1 に着手しない。**
+**Phase 0 完了条件**: 0a pass + 0b ① sample-exact + 0b ② 実市販プラグイン load-bearing PASS + compatibility sweep 記録 + verdict doc。**この gate を越えるまで Phase 1 に着手しない。**
 
 ---
 

--- a/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
+++ b/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
@@ -138,6 +138,19 @@ de-risk 失敗後、`/ask-codex:research` で一次調査 → **NI SIGSEGV の�
 
 ⇒ **crash 0・NI 回復・iZotope 回復。arm64 対応はほぼ全カバー**（残は Intel-only 3 個のみ = arch 除外）。教訓: 商用 host は optional メソッドの `kNotImplemented` を成功扱いにする（VST3 SDK / JUCE 準拠）。
 
+### 最終 sweep（非サンドボックス・全 333・全修正後）
+
+| 指標 | 最小 spike | 最終 |
+|---|---|---|
+| genuine crash | 36 | **0** |
+| effect 処理OK | 188 | **271** |
+| instrument load | 51 | 57 |
+| **load 成功計** | 239 | **328 / 333（98%）** |
+
+残 未 load 5 = Intel-only 3（MODO BASS/Philharmonik 2/Super 8・arch 除外）+ arm64 端 2（ARIA Player=Garritan 音源・Komplete Kontrol=NI host-in-host ラッパー）。
+**arm64 対応での load 成功率 = 328/330 = 99%**。crash 0・hang 1。
+⇒ **最小 spike の feasibility 実証にとどまらず、3 つのホスト側修正（CFBundleRef / setProcessing kNotImplemented 許容 / host context+controller）で NI・iZotope 含む arm64 商用コレクションの 99% をロード可能に到達。**
+
 ---
 
 ## 7. 工数見積り（Phase 1 — production OOP effect）

--- a/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
+++ b/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
@@ -130,6 +130,14 @@ de-risk 失敗後、`/ask-codex:research` で一次調査 → **NI SIGSEGV の�
 残 crash/fail 60 件 = Intel-only 3（MODO BASS/Philharmonik 2/Super 8・arch 除外）+ **iZotope 54** + OTHER 2 + NI 1。
 ⇒ **crash ゼロ・NI 回復済み。arm64 対応 100% に残る主課題は iZotope 54 の `setProcessing:3` 一点にほぼ集約。**
 
+### 🟢 iZotope も回復（2026-07-08・1 行修正）
+
+`/ask-codex:research` で判明: **`setProcessing` の戻り `3` = `kNotImplemented`**（vst3-rs tresult: OK=0/False=1/InvalidArg=2/**NotImplemented=3**）。iZotope は setProcessing を実装せず kNotImplemented を返すだけで **VST3 的に合法**。JUCE も非致命として続行する（`warnOnFailureIfImplemented`）。**ホストの `is_ok()` が `kResultOk` しか通さず 3 を hard error にしていたのが唯一のバグ** — iZotope は壊れていなかった。
+
+修正（1 行）: `setProcessing` の結果が `kNotImplemented` の場合はロード失敗にしない。**実測（非サンドボックス）: Vinyl/Ozone 11/RX 11/Neutron 5/Vocal Doubler/Relay = 全て load+process 成功**。NI 回帰なし。
+
+⇒ **crash 0・NI 回復・iZotope 回復。arm64 対応はほぼ全カバー**（残は Intel-only 3 個のみ = arch 除外）。教訓: 商用 host は optional メソッドの `kNotImplemented` を成功扱いにする（VST3 SDK / JUCE 準拠）。
+
 ---
 
 ## 7. 工数見積り（Phase 1 — production OOP effect）

--- a/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
+++ b/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
@@ -3,7 +3,8 @@
 **Issue**: #381 / Epic #292
 **正本 plan**: [`POST_2.0_VST3_HOSTING_PLAN.md`](POST_2.0_VST3_HOSTING_PLAN.md) §Phase 0
 **日付**: 2026-07-08
-**判定**: 🟢 **GO** — 手書き COM で実市販 VST3 をホストできることを実証。Phase 1（production OOP effect）へ進む。
+**推奨**: 🟢 **GO 推奨（最終判定は owner）** — 手書き COM で実市販 VST3 をホストできることを実証。GO なら Phase 1（production OOP effect）へ。
+**判定**: ⬜ owner 判定待ち（この spike は STOP 条件に非該当・下記エビデンスに基づき owner が GO / NO-GO / 保留を決定する）。
 
 ---
 

--- a/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
+++ b/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
@@ -115,7 +115,20 @@ de-risk 失敗後、`/ask-codex:research` で一次調査 → **NI SIGSEGV の�
 - **NI = 回復**: Battery 4/FM8/Massive/Kontakt 8 = **load 成功**（instrument＝audio_in 0・Phase 0 は正常に未 process）/ Reaktor 6/Guitar Rig 7/Bite = **load+process 成功**（effect）。7/7 が crash→load。**owner 最重要の Kontakt/Massive/FM8 が動く**。
 - **iZotope = 未解決**: Vinyl/Ozone 11/RX 11/Neutron 5 = **`setProcessing: 3` fail のまま**。CFBundle+controller では救えず、別要因（bus 再調停の詳細 or objc class 重複）が残存 → 追加調査要。
 
-⇒ 「NI/iZotope は解けない」は**早計だった**。NI は CFBundle 修正で回復。iZotope は残課題。oracle は全変更後も sample-exact 維持（機構非退行）。全 sweep の回復数は本 doc 更新予定。
+⇒ 「NI/iZotope は解けない」は**早計だった**。NI は CFBundle 修正で回復。iZotope は残課題。oracle は全変更後も sample-exact 維持（機構非退行）。
+
+**full sweep（非サンドボックス・全 333・CFBundle 後）**:
+
+| 指標 | 0b spike | CFBundle 後 | 差 |
+|---|---|---|---|
+| genuine crash | 36 | **0** | 全滅解消 |
+| effect 処理OK | 188 | 216 | +28 |
+| instrument load | 51 | 57 | +6 |
+| **load 成功計** | 239 | **273 / 333（82%）** | +34 |
+
+ベンダー別 load 成功: **NI 2→37/39（実質全回復）** / iZotope 0→0/54（未解決）/ OTHER ほぼ全 load。
+残 crash/fail 60 件 = Intel-only 3（MODO BASS/Philharmonik 2/Super 8・arch 除外）+ **iZotope 54** + OTHER 2 + NI 1。
+⇒ **crash ゼロ・NI 回復済み。arm64 対応 100% に残る主課題は iZotope 54 の `setProcessing:3` 一点にほぼ集約。**
 
 ---
 

--- a/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
+++ b/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
@@ -90,6 +90,20 @@ feasibility は十分に立証された。カバレッジを上げる道（host 
 
 これらは正本 plan の Phase 1（1a-1d）で対称実装する。**Phase 0 gate（① + ② + sweep）には非該当**（gate は代表実プラグインで通過済み）。
 
+### 🔴 de-risk 検証（2026-07-08・仮説は否定された）
+
+owner の最重要ベンダー = NI/iZotope のため、上記 1・2 を spike ホストに前倒し実装して回復するか実測した（codex 実装・Opus が非サンドボックス実測）:
+- **最小 IHostApplication**（getName + IMessage/IAttributeList createInstance）を `initialize` に渡す。
+- **bus arrangement 調停**（getBusArrangement→setBusArrangements→activateBus・mono/stereo 既定）。
+
+**結果 = 効果なし**。sweep は BEFORE=AFTER で完全同一（188/109/36）。直接 probe（新バイナリ・非サンドボックス）でも:
+- NI（Battery 4 / FM8 / Massive）= **SIG11 crash のまま**
+- iZotope（Vinyl / Ozone 11）= **`setProcessing: 3` fail のまま**
+
+⇒ 「host context で NI が、bus 調停で iZotope が直る」という §6①②の推定は**実証で否定**。両ベンダーはより深い要因（NI: Native Access/ランタイム依存 or 完全な host 実装・iZotope: objc class 重複 or 特殊調停）を要し、**Phase 1 の軽い host 拡張では解けない**。oracle は de-risk 後も sample-exact 維持（機構は非退行）。de-risk コードは branch に保持（host context/bus 調停自体は Phase 1 で必要な正しい方向）。
+
+**GO 判定への含意（owner 判断材料）**: 汎用 VST3 effect のホストは実証済み（UA 全カタログ・IK AmpliTube/ARC 等 188 個）だが、**最重要 2 ベンダー（NI/iZotope）は簡単には動かず、深い調査（成功保証なし）が要る**。この事実を踏まえて owner が GO/NO-GO/保留を決める。
+
 ---
 
 ## 7. 工数見積り（Phase 1 — production OOP effect）

--- a/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
+++ b/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
@@ -1,0 +1,120 @@
+# VST3 Hosting Phase 0 (Step0 spike) — Verdict
+
+**Issue**: #381 / Epic #292
+**正本 plan**: [`POST_2.0_VST3_HOSTING_PLAN.md`](POST_2.0_VST3_HOSTING_PLAN.md) §Phase 0
+**日付**: 2026-07-08
+**判定**: 🟢 **GO** — 手書き COM で実市販 VST3 をホストできることを実証。Phase 1（production OOP effect）へ進む。
+
+---
+
+## 1. サマリ
+
+VST3 の最大リスク =「Rust で COM を unsafe に手書きしてホストする」を、最小・offline・device 不要の spike で retire した。
+
+- **0a（license 監査）= PASS**。deny.toml 無改変で通過。
+- **0b ①（sample-exact oracle）= PASS**。自作 gain VST3 の出力が bit-exact 一致。
+- **0b ②（実市販プラグイン ABI 適合）= PASS**。実 Steinberg-SDK 製プラグインが load→process→drop。
+- **compatibility sweep**: 実市販 VST3 コレクション 333 個を best-effort で probe。**最小ホストで 56%（188/333）が load+process 成功・71% が load 成功**。真の crash は 11%（36/333）で**ほぼ全て Native Instruments フレームワーク**に集中（均一な ABI バグではない）。
+
+feasibility は十分に立証された。カバレッジを上げる道（host context + bus arrangement 調停）は Phase 1 の明確な作業項目。
+
+---
+
+## 2. 0a — license 監査（PASS）
+
+- `orbit-vst3-host` に `vst3 = "0.3"` を追加し `cargo tree` を実測。
+- **全 transitive 依存 = `vst3 v0.3.0` → `com-scrape-types v0.1.1` の 2 crate のみ**（bindgen/clang-sys 系なし）。
+- 両者とも **`MIT OR Apache-2.0`**（展開済み Cargo.toml source で一次裏取り・vst3 は LICENSE-APACHE/MIT 同梱）。deny.toml allow list 内。
+- host 実装で追加した `libloading = "0.8"` = **ISC**（allow list 内）。
+- `cargo deny check licenses` = **licenses ok**。**deny.toml は無改変**（STOP 条件の allow list 改変は発生せず）。
+
+---
+
+## 3. 0b ① — sample-exact oracle（PASS）
+
+- **oracle**: `vst3` crate 同梱 `examples/gain.rs`（`out = gain × in`・smoothing なし・純 Rust）を vendored した `orbit-vst3-gain-oracle`。`package-oracle.sh` で macOS `.vst3` バンドル生成（C++ SDK 不要）。
+- **test**（`tests/offline.rs::gain_oracle_is_sample_exact`・通常 `cargo test`・skip なし）:
+  - param 変更なし → `output == input`（恒等・bit 一致）
+  - param id 0 = 0.5 → `output_l/r[i].to_bits() == (input[i] * 0.5).to_bits()`（**厳密 bit-exact**）
+- **独立再検証済み**（呼び出し側 Opus が実 dylib に対し再実行）: 512 frames stereo で PASS。
+
+> ★ 注意: ① は「Rust plugin ↔ Rust host が同じ `vst3` crate の ABI 解釈を共有」するため、これ**だけ**では ABI の対 SDK 適合を証明しない。② がその load-bearing 検証（下記）。
+
+---
+
+## 4. 0b ② — 実市販プラグイン ABI 適合（PASS）
+
+- `tests/offline.rs::real_vst3_abi_loads_processes_and_drops`: `/Library/Audio/Plug-Ins/VST3/` の優先候補→全件から**最初に load できた実プラグイン**を probe subprocess で load→setupProcessing→process（無音 + 既知入力）→drop。全滅なら panic（loud STOP gate・silent-skip 禁止）。
+- **独立再検証済み（非サンドボックス）**: `V-Pan` / `ARC 4`（IK）/ `AmpliTube 5`（IK）が **load+process 成功**（`processed:true`・出力の NaN/Inf/発散なしを probe が検証）。
+- 実 Steinberg-SDK 製プラグインが我々の手書き COM ホスト経由で実際に process() を通し kResultOk + 妥当出力を返した ⇒ **binding ABI は実 SDK と適合**（owner 提起の「相互一貫的に間違い」懸念をクリア）。
+
+---
+
+## 5. compatibility sweep — 実コレクション互換マトリクス
+
+`sweep.sh`（1 プラグイン = 1 サブプロセスで crash 隔離・timeout 20s）を `/Library/Audio/Plug-Ins/VST3/` 全体に実行。JSON から精分類:
+
+| 分類 | 件数 | 割合 |
+|---|---|---|
+| **effect 処理OK**（load + process 成功） | **188** | 56% |
+| instrument（load成功・audio_in=0・Phase 0 は正常に未 process） | 49 | 15% |
+| host-limit fail（load できたが setProcessing 失敗 / load=false・非 crash） | 59 | 18% |
+| **genuine crash**（signal 死） | 36 | 11% |
+| hang | 0 | 0% |
+| （JSON 未パース） | 1 | — |
+
+**load 成功（effect_ok + instrument）= 237 / 333 = 71%。**
+
+### 🔴 重大な計測上の注意（サンドボックス汚染）
+
+初回 sweep は codex のコマンド**サンドボックス下**で走り、crash=220（66%）と出た。これは **artifact**:
+- サンドボックスが `/bin/ps`・`/Volumes` 読み・helper spawn 等プラグイン init の正当な動作を SIGKILL → 偽 crash 化（例: `V-Pan` は sandbox で crash・非サンドボックスで PASS / `ARC 4`・`AmpliTube 5` も同様に反転）。
+- **非サンドボックスで再走した結果が上表**（真の crash は 220 → **36**・約 6 倍の水増しが解消）。
+- 教訓: **VST3 sweep はサンドボックス外で計測する**（プラグイン init は環境依存動作を伴う）。raw 結果は `target/vst3-sweep-*.txt`（gitignore・非コミット）。
+
+### genuine crash 36 件の内訳
+
+**ほぼ全て Native Instruments フレームワーク**: Kontakt(7/8) / Massive(X) / FM8 / Reaktor 6 / Guitar Rig(6/7) / Maschine 2 / Komplete Kontrol / Battery 4 / NI Solid 系（EQ/Bus Comp/Dynamics）/ VC 系（160/2A/76）/ Replika / Raum / Phasis / Flair / Choral / Bite / Dirt / Driver / Freak 等。
+→ 単一ベンダーの共通ランタイムに集中 ⇒ **均一な host ABI バグではなく、NI ランタイムが最小ホストに欠けている前提（host context / IHostApplication 等）を要求している**と推定。Phase 1 の host context 実装で多くが解消する見込み（要検証）。
+
+---
+
+## 6. spike で判明したホスト制約（= Phase 1 の作業項目）
+
+最小 spike ホストは意図的に以下を省いた。これが host-limit fail(59) / 一部 crash(36) の主因:
+
+1. **null host context**: `IComponent::initialize(null)` を渡している。IHostApplication / IComponentHandler を context から query するプラグインは null を掴んで fail/crash する（NI 群が該当と推定）。→ Phase 1 で**最小 IHostApplication を実装**。
+2. **bus arrangement 未調停**: `IAudioProcessor::setBusArrangements` / `IComponent::activateBus` を呼んでいない。これを要求するプラグインは `setProcessing` が失敗（iZotope `setProcessing: 3` が該当）。→ Phase 1 で**宣言 bus を query→arrange→activate**（[[orbitscore-engine-fundamental-effects-as-plugins]] の I/O サーフェス完全カバー要件とも一致）。
+3. **単一 stereo 固定**: multi-out / sidechain / mono 等の bus 構成は未対応（現 M1 と同じ既知 gap）。
+
+これらは正本 plan の Phase 1（1a-1d）で対称実装する。**Phase 0 gate（① + ② + sweep）には非該当**（gate は代表実プラグインで通過済み）。
+
+---
+
+## 7. 工数見積り（Phase 1 — production OOP effect）
+
+正本 plan §Phase 1 の 1a-1d に加え、本 spike で判明した host context / bus 調停を織り込む。
+
+| 項目 | 規模感 | 備考 |
+|---|---|---|
+| 1a `orbit-vst3-host` production 化（spike を公開 API 整理・`PostProcessor` 実装） | 中 | spike が土台済み |
+| host context（最小 IHostApplication）実装 | 中 | crash 36 の主因解消・**NI カバレッジ回復の鍵** |
+| bus arrangement 調停（setBusArrangements/activateBus） | 中 | host-limit 59 の主因解消 |
+| 1b effect/instrument 判定（getBusCount・spike で実装済み） | 小 | overwrite/add-mix の取り違え注意 |
+| 1c `orbit-vst3-effect-child`（`orbit-clap-effect-child` 対称コピー） | 中 | transport 無改変流用 |
+| 1d daemon supervisor format 汎化（`ORBIT_EFFECT_FORMAT`） | 小 | spawn/watchdog/respawn は format 非依存 |
+| offline oracle parity + gated 実機 harness | 中 | CLAP 側パターン複製 |
+
+委譲: 1a-1d は codex（file-anchored）。host context の COM 設計は Opus checkpoint 推奨。
+
+---
+
+## 8. 成果物（Phase 0 で追加/変更したファイル）
+
+- `rust/crates/orbit-vst3-host/`（Cargo.toml・`src/lib.rs` = 手書き COM host・`src/bin/vst3_probe.rs`・`tests/offline.rs`・`sweep.sh`）
+- `rust/crates/orbit-vst3-gain-oracle/`（vendored gain.rs oracle・`package-oracle.sh`）
+- `rust/Cargo.toml`（member 追加）・`rust/Cargo.lock`
+- `docs/development/POST_2.0_VST3_HOSTING_PLAN.md`（Phase 0 受け入れ基準を 2 系統 + sweep に強化）
+- 本 verdict doc
+
+検証: `cargo fmt --check` / `cargo clippy --workspace --all-targets --locked -- -D warnings` / `cargo deny check licenses` / `cargo test -p orbit-vst3-host`（①② とも skip なしで PASS）を独立再実行し全 green。

--- a/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
+++ b/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
@@ -104,6 +104,19 @@ owner の最重要ベンダー = NI/iZotope のため、上記 1・2 を spike �
 
 **GO 判定への含意（owner 判断材料）**: 汎用 VST3 effect のホストは実証済み（UA 全カタログ・IK AmpliTube/ARC 等 188 個）だが、**最重要 2 ベンダー（NI/iZotope）は簡単には動かず、深い調査（成功保証なし）が要る**。この事実を踏まえて owner が GO/NO-GO/保留を決める。
 
+### 🟢 続報（2026-07-08・research → CFBundle 実装で NI 回復）
+
+de-risk 失敗後、`/ask-codex:research` で一次調査 → **NI SIGSEGV の主因 = `BundleEntry(ptr::null_mut())`**（NI ランタイムが `CFBundleRef` から resources/frameworks/license path を引くため null deref）と判明。codex:rescue で実装:
+- **macOS bundle ロードを CFBundle 正規経路に**（`CFBundleCreate`→`CFBundleLoadExecutable`→`CFBundleGetFunctionPointerForName`・**実 CFBundleRef を BundleEntry に渡す**）。`core-foundation-sys 0.8`（MIT/Apache・allow list 内）採用・`libloading` 除去。
+- component-controller ハンドシェイク（controller 生成→initialize→setComponentHandler→IConnectionPoint connect→state 同期）。
+- process データ完全化（非 null 空 IEventList/IParameterChanges + ProcessContext + `canProcessSampleSize`）。
+
+**実測（非サンドボックス・代表）**:
+- **NI = 回復**: Battery 4/FM8/Massive/Kontakt 8 = **load 成功**（instrument＝audio_in 0・Phase 0 は正常に未 process）/ Reaktor 6/Guitar Rig 7/Bite = **load+process 成功**（effect）。7/7 が crash→load。**owner 最重要の Kontakt/Massive/FM8 が動く**。
+- **iZotope = 未解決**: Vinyl/Ozone 11/RX 11/Neutron 5 = **`setProcessing: 3` fail のまま**。CFBundle+controller では救えず、別要因（bus 再調停の詳細 or objc class 重複）が残存 → 追加調査要。
+
+⇒ 「NI/iZotope は解けない」は**早計だった**。NI は CFBundle 修正で回復。iZotope は残課題。oracle は全変更後も sample-exact 維持（機構非退行）。全 sweep の回復数は本 doc 更新予定。
+
 ---
 
 ## 7. 工数見積り（Phase 1 — production OOP effect）

--- a/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
+++ b/docs/development/POST_2.0_VST3_STEP0_SPIKE.md
@@ -147,9 +147,15 @@ de-risk 失敗後、`/ask-codex:research` で一次調査 → **NI SIGSEGV の�
 | instrument load | 51 | 57 |
 | **load 成功計** | 239 | **328 / 333（98%）** |
 
-残 未 load 5 = Intel-only 3（MODO BASS/Philharmonik 2/Super 8・arch 除外）+ arm64 端 2（ARIA Player=Garritan 音源・Komplete Kontrol=NI host-in-host ラッパー）。
-**arm64 対応での load 成功率 = 328/330 = 99%**。crash 0・hang 1。
-⇒ **最小 spike の feasibility 実証にとどまらず、3 つのホスト側修正（CFBundleRef / setProcessing kNotImplemented 許容 / host context+controller）で NI・iZotope 含む arm64 商用コレクションの 99% をロード可能に到達。**
+**全ホスト側修正後の最終 sweep（全 333）**: crash **0**・load 成功 **329/333（98%）**・**arm64 対応 329/330 = 99.7%**。残 arm64 = Komplete Kontrol 1（NI host-in-host ラッパー・重い／単独 probe では instrument load 成功＝sweep 内変動）。真の除外 = Intel-only 3（MODO BASS/Philharmonik 2/Super 8・arch 除外）。
+
+⇒ **feasibility 実証にとどまらず、4 つのホスト側修正で arm64 商用 VST3 を実質全カバー（99.7%・crash 0）**:
+1. **CFBundleRef ロード**（NI crash 36→0・`BundleEntry(null)` が主因）
+2. **`setProcessing` kNotImplemented(3) 許容**（iZotope 54 回復）
+3. **`setBusArrangements` kResultFalse advisory 化**（ARIA Player 等）
+4. host context(IHostApplication)+component-controller ハンドシェイク
+
+**共通教訓（ノウハウ）: 商用 VST3 ホストは optional/advisory メソッド（setProcessing/setBusArrangements 等）の非 OK 戻り（kNotImplemented/kResultFalse）を致命扱いにしてはいけない。VST3 SDK / JUCE VST3PluginFormat がこれを許容する。**
 
 ---
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,16 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.209 feat(engine): VST3 de-risk — host context + bus 調停は NI/iZotope を救わず（#381） (Jul 8, 2026)
+
+owner 最重要ベンダー NI/iZotope 救済の de-risk（Phase 1 前倒し）を codex に委譲実装し Opus が非サンドボックス実測 → **効果なし**。
+
+- **実装（codex・oracle 非退行）**: 最小 IHostApplication（getName + IMessage/IAttributeList createInstance）を `initialize` に渡す（null 廃止）+ bus arrangement 調停（getBusArrangement→setBusArrangements→activateBus・mono/stereo 既定）。oracle sample-exact 維持・fmt/clippy/deny green
+- **実測（Opus・非サンドボックス）**: sweep BEFORE=AFTER 完全同一（188/109/36）。直接 probe でも NI（Battery 4/FM8/Massive）= SIG11 crash のまま・iZotope（Vinyl/Ozone 11）= `setProcessing:3` fail のまま
+- **結論**: 「host context で NI・bus 調停で iZotope が直る」推定は**実証で否定**。両者は深い要因（NI=Native Access/ランタイム依存・iZotope=objc class 重複/特殊調停）を要し軽い拡張では解けない
+- **arch 分類追加**: Intel-only（arm64 なし）= MODO BASS/Philharmonik 2/Super 8 は「アーキ非対応＝除外」（ホスト fail でない・Rosetta 終息前提で arm64-native 対象）
+- de-risk コードは branch 保持（host context/bus 調停自体は Phase 1 で必要な正しい方向・非退行）。ノウハウ doc は「成功後」の owner 指示によりペンディング（task #4）
+
 ### 6.208 feat(engine): VST3 Phase 0-0b host spike — GO verdict (188/333 effects host) (#381) (Jul 8, 2026)
 
 VST3 hosting Phase 0（#381）の 0b（手書き COM host spike）を codex に委譲し実装完了 → **GO 判定**。verdict doc = `docs/development/POST_2.0_VST3_STEP0_SPIKE.md`。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,15 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.213 docs(engine): プラグインホスト実装ノウハウ（VST3/AU/CLAP 共通責務）（#381） (Jul 8, 2026)
+
+owner 要望（AU/CLAP 混在の将来価値）で、VST3 Phase 0 の実証知見を format 共通のホスト責務として一般化。`docs/development/POST_2.0_PLUGIN_HOST_KNOWHOW.md`。
+
+- **中核原則**: 商用ホストは optional/advisory メソッドの非 OK 戻り（kNotImplemented/kResultFalse）を致命扱いにしない（VST3 SDK/JUCE 準拠）
+- **責務対応表**: モジュールロード / host context / component-controller 接続 / I/O バス調停 / 非OK戻り許容 / process データ完全性 / teardown を **VST3（実証）↔ AU（推論）↔ CLAP（orbit-clap-host 一部裏取り）** で対応づけ
+- VST3 の 4 修正を一次事実として記録 + 計測ノウハウ（サンドボックス水増し・1 plugin 1 process・arch 除外）+ Phase 1+ 申し送り（厳密 buffer 整合・instrument 経路）
+- エビデンス強度を明記（VST3=実測 / AU=推論 / CLAP=一部裏取り）
+
 ### 6.212 fix(engine): VST3 setBusArrangements advisory 化 — arm64 端 2 も解決（#381） (Jul 8, 2026)
 
 arm64 の残 2 エッジケースを解消し、arm64 商用 VST3 を実質全カバー。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,23 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.219 fix(engine): VST3 host 系を macOS 限定に cfg-gate — Linux CI リンク失敗を解消（#397） (Jul 11, 2026)
+
+PR #397 の Rust CI `fmt / clippy / test`（`ubuntu-latest` = Linux）が **Test ステップでリンク失敗**していた（head `2df6fc4`）。真因: `orbit-vst3-host` が `core-foundation-sys` 経由で CoreFoundation（macOS framework）シンボル（`CFBundleCreate`/`kCFAllocatorDefault`/`CFBundleGetFunctionPointerForName` 等）を参照 → Linux に該当シンボル無し → 実行ファイル最終リンクで undefined symbol。clippy が通っていたのは最終リンクしないため。VST3+CoreFoundation は原理的に macOS 専用なので、Linux では該当コードを不在にする（in-place cfg gate）。
+
+- **gate 対象（`cargo metadata` で機械的に列挙・全 host リンクターゲット）**:
+  - `orbit-vst3-host/src/lib.rs`: crate-root `#![cfg(target_os = "macos")]`（Linux は空 lib・CF 参照消滅）
+  - `orbit-vst3-host/src/bin/vst3_probe.rs`（bin）: 全 item に per-item `#[cfg(macos)]` + 非 macOS stub `fn main() -> ExitCode`（空 main 不可のため）
+  - `orbit-vst3-host/tests/offline.rs`: `#![cfg(macos)]`（非 `#[ignore]` の 4 テスト = Linux リンク失敗の主因）
+  - `orbit-vst3-host/Cargo.toml`: `core-foundation-sys` を `[target.'cfg(target_os = "macos")'.dependencies]` へ（Linux 依存グラフから脱落）・`vst3` は unconditional 据置（純 Rust・gain-oracle も引く）
+  - `orbit-vst3-effect-child/src/main.rs`（bin）: per-item `#[cfg(macos)]` + 非 macOS stub main
+  - `orbit-vst3-effect-child/tests/cli.rs`・`real_plugin_gated.rs`: `#![cfg(macos)]`
+- **据置（正当性を一次情報で確認）**: `oracle_parity.rs` は host 非参照（`orbit_audio_sandbox` のみ）で **gate しない** — Test1 は Linux で `package-oracle.sh`（`set -euo pipefail` + `.dylib` ハードコード → `.so` 環境で `exit 1`）により loud-skip、Test2 は純 sandbox で **Linux 実行される貴重な cross-platform カバレッジ**。gain-oracle（CF 非依存 cdylib）・daemon（vst3 非依存・child は名前 spawn）も無変更
+- **検証（Opus 非サンドボックス・macOS-local）**: `fmt --all --check`=0 / `clippy --workspace --all-targets --locked -D warnings`（+ clap-host/outproc-effect feature）clean / `test --workspace --locked` 全 test result **0 failed**（daemon `protocol` 19 passed = サンドボックスの loopback 偽 fail を回避）/ `oracle_parity` 2 テスト PASS（sample-exact 維持 = per-item cfg が macOS item を落としていない証拠）/ `deny check licenses` ok
+- **レビュー（三層収束・[[consult-layering-by-error-type]]）**: fable（fresh file-reading agent）が完全性で 2 ターゲット漏れ（vst3_probe bin・offline.rs）を捕捉 → advisor（Opus 4.8）が枠組みで「macOS-green ≠ Linux-links / 受け入れは新 SHA の Linux CI green」を指摘 → Opus fresh general-purpose 監査が 5 観点すべて合格を一次情報で裏取り
+- **役割**: 計画=Opus / 実装=codex 委譲（fresh・差分は仕様通り）/ 検証・監査=Opus 非サンドボックス + fresh agent
+- **受け入れ**: macOS-local 無退行は実測済。**完了は「新 SHA の Linux `rust-ci.yml` green」を確認するまで保留**（この gate が修正の本来目的を検証する唯一の経路）
+
 ### 6.218 fix(engine): VST3 host PR #397 レビュー収束 — bus honest 化・CI 緑・テスト補完（#397） (Jul 10, 2026)
 
 PR #397 の `/code:pr-review-team`（4 レビュアー並列: code-reviewer/silent-failure-hunter/pr-test-analyzer/comment-analyzer + CI）で挙がった Critical/Important を 0 に収束。独立 round-2 再レビューで裏取り（自己判断で宣言しない）。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,15 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.212 fix(engine): VST3 setBusArrangements advisory 化 — arm64 端 2 も解決（#381） (Jul 8, 2026)
+
+arm64 の残 2 エッジケースを解消し、arm64 商用 VST3 を実質全カバー。
+
+- **Komplete Kontrol = 実は既に loaded**（instrument・audio_in 0/out 16）。「fail」は sweep 分類の綾（Phase 0 が instrument を process しないだけ）＝真の失敗でない
+- **ARIA Player = `setBusArrangements failed: 1`(kResultFalse) で hard-fail**。research どおり setBusArrangements は advisory（JUCE も致命扱いしない・プラグイン既定 arrangement で動作）→ **最終失敗を非致命化**（1 行相当・plugin 既定 arrangement で続行・厳密 buffer 整合は Phase 1）
+- **実測（Opus・非サンドボックス）**: ARIA Player = loaded:true（instrument）。回帰なし（Ozone/Reaktor 継続）。clippy/deny clean
+- kNotImplemented(6.211)・setBusArrangements(本件) いずれも「商用 host は optional/advisory メソッドの非 OK 戻りを致命にしない」という同一教訓
+
 ### 6.211 fix(engine): VST3 setProcessing kNotImplemented 許容 — iZotope 全回復（#381） (Jul 8, 2026)
 
 `/ask-codex:research` → 1 行修正で iZotope クラッシュ… ではなく fail を解消。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,19 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.208 feat(engine): VST3 Phase 0-0b host spike — GO verdict (188/333 effects host) (#381) (Jul 8, 2026)
+
+VST3 hosting Phase 0（#381）の 0b（手書き COM host spike）を codex に委譲し実装完了 → **GO 判定**。verdict doc = `docs/development/POST_2.0_VST3_STEP0_SPIKE.md`。
+
+- **0b 実装（codex 委譲・独立検証済み）**: `orbit-vst3-host` に手書き COM host（dlopen→GetPluginFactory→IComponent→IAudioProcessor→setupProcessing→setActive→setProcessing→process→逆順 teardown・field 宣言順で drop 順確定・`getBusCount(kAudio,kInput)` で effect/instrument 判定）。追加 dep `libloading=0.8`（ISC・allow list 内）
+- **① sample-exact PASS（独立再検証）**: gain oracle を param なし→恒等・param 0.5→`to_bits()` 厳密 bit-exact。skip なしで実 dylib ロード比較
+- **② 実市販プラグイン ABI 適合 PASS（独立再検証・非サンドボックス）**: V-Pan / ARC 4 / AmpliTube 5 が load→process→drop 成功（processed:true・NaN/Inf/発散なし）。実 Steinberg-SDK 製プラグインで process() 実走 ⇒ binding ABI が実 SDK と適合（owner の「相互一貫的に間違い」懸念クリア）
+- **compatibility sweep（実コレクション 333 個）**: 最小ホストで **effect 処理OK 188/333(56%)・load 成功 237/333(71%)**・instrument 49・host-limit fail 59・**genuine crash 36(11%)**・hang 0
+- **🔴 サンドボックス汚染を発見・是正**: codex 初回 sweep はコマンドサンドボックス下で crash=220(66%) と誤出力（`/bin/ps` ブロック等でプラグイン init が SIGKILL → 偽 crash）。**非サンドボックスで再走 → 真の crash は 36（6倍水増しが解消）**。V-Pan/ARC 4/AmpliTube 5 は sandbox=crash → 非sandbox=PASS に反転。教訓: VST3 sweep はサンドボックス外で計測
+- **genuine crash 36 = ほぼ全て Native Instruments**（Kontakt/Massive/FM8/Reaktor/Guitar Rig/Maschine/NI Solid・VC 系）→ 均一 ABI バグでなく NI ランタイムが host context 前提を要求と推定
+- **Phase 1 作業項目を特定**: (1) null host context → 最小 IHostApplication 実装（crash 36 の主因・NI 回復の鍵）(2) bus arrangement 未調停（setBusArrangements/activateBus）→ host-limit 59 の主因（iZotope setProcessing:3）(3) 単一 stereo 固定の解消。いずれも Phase 0 gate 非該当（gate は代表実プラグインで通過）
+- **独立検証**: fmt/clippy(`-D warnings`)/deny(licenses ok)/`cargo test -p orbit-vst3-host`（①② skip なし PASS）を Opus が再実行し全 green
+
 ### 6.207 feat(engine): VST3 Phase 0-0a license audit PASS + gain oracle scaffold (#381) (Jul 8, 2026)
 
 VST3 hosting Phase 0（#381）の 0a（license 監査）を実行し PASS。0b（host spike）の sample-exact oracle をスキャフォールドした。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,16 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.211 fix(engine): VST3 setProcessing kNotImplemented 許容 — iZotope 全回復（#381） (Jul 8, 2026)
+
+`/ask-codex:research` → 1 行修正で iZotope クラッシュ… ではなく fail を解消。
+
+- **research 発見**: `setProcessing` の戻り `3` = **`kNotImplemented`**（vst3-rs tresult: OK=0/False=1/InvalidArg=2/NotImplemented=3）。iZotope は setProcessing 未実装で kNotImplemented を返すだけ＝**VST3 的に合法**。JUCE も非致命扱い。ホストの `is_ok()` が 3 を hard error にしていたのが唯一のバグ（iZotope は壊れていない）
+- **修正（Opus・1 行）**: `setProcessing` 結果が `kNotImplemented` ならロード失敗にしない
+- **実測（Opus・非サンドボックス）**: Vinyl/Ozone 11/RX 11/Neutron 5/Vocal Doubler/Relay = **全て load+process 成功**。NI 回帰なし（Bite/Reaktor 6 継続）
+- **到達点**: crash 0・NI 回復・iZotope 回復 → arm64 ほぼ全カバー（残=Intel-only 3個のみ）。教訓=商用 host は optional メソッドの kNotImplemented を成功扱いに（SDK/JUCE 準拠）
+- 全 sweep 最終数値は継続実測
+
 ### 6.210 feat(engine): VST3 CFBundle load path — NI 全回復・iZotope は残課題（#381） (Jul 8, 2026)
 
 `/ask-codex:research`（一次調査）→ codex:rescue 実装で NI クラッシュを解消。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,19 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.220 fix(engine): VST3 host unsafe memory-safety 監査 + hardening 3件（#397） (Jul 11, 2026)
+
+中核の手書き unsafe COM FFI（`orbit-vst3-host/src/lib.rs`・80 unsafe blocks）に対し、`/code:pr-review-team`（汎用 correctness）が構造的に狙わない **memory-safety/UB 次元**の外部第二意見を実施。@claude bot は pr-review-team と同一モデルファミリで盲点が相関するため除外し、**codex（cross-family）+ fresh Opus（非著者）を並列 adversarial 監査 → advisor で tie-break**（[[consult-layering-by-error-type]] の分担）。
+
+- **判定: memory-safety blocker なし**。codex の唯一の blocker 主張「F1 = `process_block` の `&self` + self バッファへの raw `*mut` = aliasing UB」は **false positive**。advisor が rule-dispositive に判定: `&self`（run_process の receiver）は構造体バイト（Vec の ptr/len/cap ヘッダ）を freeze するが、**別割り当てのヒープ要素は freeze しない**（retag は Vec 内部 `NonNull` 越しにヒープを追わない）+ run_process は当該 buffer を `&[f32]` として再借用しない → raw 書き込みは健全。/simplify で alloc 除去したばかりの RT hot path を**非バグで churn しない**（codex の restructure 案は将来 slice 再借用が入った時への任意 future-proofing に留める）。
+- **hardening 3件（非 blocking・owner scope 判断で in-PR 修正）**:
+  - **4a**（fresh Opus が捕捉・著者 codex は「バス一致」の思い込みで見逃し = authorship-decorrelation の payoff）: `verify_primary_bus_is_stereo` に **negotiated `getBusArrangement` popcount 検証**を追加。`getBusInfo().channelCount==2` は満たすが実際の arrangement popcount>2 の非適合プラグインが固定 2-wide `channelBuffers32` を OOB index するのを防ぐ。`getBusArrangement` 非 ok 時は getBusInfo にフォールバック（`Option<i32>`）し over-reject を回避（回帰なし）。
+  - **3a/3b**（両監査一致・`process_stereo` = offline/probe 経路）: 入力を self scratch に copy して **writable provenance** 化 + `frames > load-max` guard（`ProcessBlockTooLarge`）+ `run_process` の `numSamples` を `i32::try_from`→`kInvalidArgument` で checked cast 化。
+  - **F4 却下**: `ComPtr::from_raw`=owning・`createInstance`=+1 で balanced（Opus が com-scrape-types source で裏取り）。
+- **検証（Opus 非サンドボックス）**: fmt=0 / clippy --workspace（+clap-host/outproc-effect）clean / test --workspace 全 0 failed（daemon `protocol` 19・`oracle_parity` sample-exact 2 PASS = per-fix で挙動不変）/ deny ok。F1 の RT hot path aliasing 構造は無改変（run_process が buffer を slice 再借用しない不変条件を維持）。
+- **役割**: 監査=codex + fresh Opus 並列 / tie-break=advisor / 実装=codex 委譲（main が差分レビューで 4a の `getBusArrangement` 非 ok→reject の over-reject 回帰リスクを捕捉し softening 指示）/ 検証=Opus 非サンドボックス。
+- **受け入れ**: 新 SHA の Linux CI green を確認してから完了。
+
 ### 6.219 fix(engine): VST3 host 系を macOS 限定に cfg-gate — Linux CI リンク失敗を解消（#397） (Jul 11, 2026)
 
 PR #397 の Rust CI `fmt / clippy / test`（`ubuntu-latest` = Linux）が **Test ステップでリンク失敗**していた（head `2df6fc4`）。真因: `orbit-vst3-host` が `core-foundation-sys` 経由で CoreFoundation（macOS framework）シンボル（`CFBundleCreate`/`kCFAllocatorDefault`/`CFBundleGetFunctionPointerForName` 等）を参照 → Linux に該当シンボル無し → 実行ファイル最終リンクで undefined symbol。clippy が通っていたのは最終リンクしないため。VST3+CoreFoundation は原理的に macOS 専用なので、Linux では該当コードを不在にする（in-place cfg gate）。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,23 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.216 test(engine): VST3 Phase 1 daemon 経路 gated + フル arm64 sweep PASS（#381） (Jul 10, 2026)
+
+Phase 1 の VST3 を **① production daemon 経路（supervisor/pipelined/respawn/RT）** と **② 全 arm64 プラグイン machinery** の 2 面で実機検証。offline smoke（6.215）が「child+transport が実プラグインを生き延びるか」を、本項が「production driver 層」と「全体カバレッジ」を担う（advisor が B/C は役割分担と判定・step-back 無し）。
+
+- **順序判断（advisor/Fable）**: 「daemon で全 sweep 1 回」案は `outproc_effect_gated.rs` が device 束縛＋実時間＋parity assert 非汎用の三重で非現実的 → **B（offline 全 sweep・純計算）→ C（daemon を代表数個）** が最適・手戻り無しと確定
+- **C = daemon 経路 gated（`orbit-audio-daemon/tests/outproc_effect_vst3_gated.rs`・新規・feature `outproc-effect`・全 #[ignore]）**: CLAP 版 `outproc_effect_gated.rs` を VST3 にミラー。production コード無改変（`PluginFormat::Vst3`/`ORBIT_EFFECT_FORMAT` は Phase 1 実装済み）
+  - **C1 parity**（VST3 gain oracle gain=1.0）: ratio **1.00000**・fresh_delta 1117/1128・errors 0 → PASS
+  - **C2 kill→respawn**: respawn 0→1・fresh after respawn 18→259・ratio 1.0 → PASS
+  - **C3 stale-rate**: [64f] 0.162% / [32f] 0.000%・cb_max ~31µs（20ms 予算内）→ PASS
+  - **C4 commercial smoke**（env `ORBIT_EFFECT_PLUGIN` 駆動）代表 4 effect: Guitar Rig 7 / Reaktor 6 / Ozone 11 / Vinyl すべて crash-free・respawn 0・errors 0 → PASS（Vinyl は ratio 1.033 で実 DSP 着色が可視・Reaktor は patch 未ロードで無音=想定内）
+  - **warm-up fix**: C1/C2 の固定 sleep（CLAP から verbatim の 800/600ms）は VST3 の CFBundle load latency に不足し fresh=0 で false-fail → **wait-until-productive ポーリング + delta 測定**に修正（post-respawn の同根欠陥も修正・test-only・production 無改変）
+- **B = フル arm64 sweep（offline・非サンドボックス・914.5s・333プラグイン）**: **Effect PASS 271 + Instrument PASS 49 = 320 PASS・genuine crash 0**
+  - Crash 分類 10 = すべて **probe 20s timeout hang**（実 crash でない）: UJAM Beatmaker `BM-*` 7 + USYNTH + Virtual Pianist（サンプル大量ロード）+ Komplete Kontrol（NI host-wrapper・Phase 0 でも変動既知）。slow-load であり deadlock でない見込み（long-timeout 再 probe で確認予定）
+  - Skip 3 = Intel-only（MODO BASS / Philharmonik 2 / Super 8）を arm64 フィルタが正しく除外
+- **役割**: 計画/順序判断=Opus（advisor 経由）/ C 実装+warm-up fix=sonnet5 委譲 / 実機計測（C1-C4 + フル sweep）=Opus 非サンドボックス
+- **残**: 10 slow-loader の long-timeout 再 probe（owner 判断）・PR 化（/simplify + pr-review-team・トークン都合で延期中）
+
 ### 6.215 test(engine): VST3 Phase 1 gated 実機検証ハーネス + curated smoke PASS（#381） (Jul 10, 2026)
 
 Phase 1 の OOP effect 経路を **実市販プラグイン（NI/iZotope arm64）** に通す gated 検証ハーネスを実装し、curated 代表セットで非サンドボックス実測 PASS。合成 oracle（sample-exact 済）に対し、実プラグインは closed-form が無いため **machinery smoke**（load/process/isolation が crash 0 で生き延びるか）に限定。musical DSP correctness は owner listening の follow-on として分離（誠実な wording をコメント/サマリに明記）。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,17 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.214 feat(engine): VST3 Phase 1 — production OOP effect（daemon 統合）（#381） (Jul 8, 2026)
+
+in-process 実証済み VST3 host を daemon の out-of-process サブストレート（crash 隔離・respawn）に載せた。CLAP effect child と対称。codex 実装・Opus 非サンドボックス検証。
+
+- **`orbit-vst3-effect-child`（新）**: `orbit-clap-effect-child` の transport loop 対称コピー・処理部のみ `Vst3EffectProcessor::process_block` に差し替え・clack 非リンク。CLI（--shm/--plugin/--plugin-id/--sample-rate）と protocol は同一
+- **`Vst3EffectProcessor::process_block`（追加）**: interleaved stereo を planar scratch 経由で VST3 process()・bus 判定で overwrite(effect)/add-mix(instrument)。setProcessing kNotImplemented 許容・setBusArrangements advisory は維持
+- **daemon supervisor 汎化**: `OutProcEffectConfig` に `PluginFormat{Clap,Vst3}`・`from_env` が `ORBIT_EFFECT_FORMAT`（既定 clap で後方互換）で child_exe 選択。spawn/watchdog/respawn は無改変
+- **検証（Opus・非サンドボックス）**: offline oracle parity `vst3_gain_oracle_oop_child_is_sample_exact_passthrough` PASS（共有メモリ経由 OOP child で sample-exact）+ in-process closed-form PASS。CLAP 非退行（child 4 + supervisor 9 tests）。fmt/clippy/deny clean
+- gated 実機 harness（`real_plugin_gated.rs`・#[ignore]）は owner 同席・トークン回復後に Opus が非サンドボックス実行
+- レビュー（/simplify + pr-review-team）はトークン都合でマージ前に延期実施
+
 ### 6.213 docs(engine): プラグインホスト実装ノウハウ（VST3/AU/CLAP 共通責務）（#381） (Jul 8, 2026)
 
 owner 要望（AU/CLAP 混在の将来価値）で、VST3 Phase 0 の実証知見を format 共通のホスト責務として一般化。`docs/development/POST_2.0_PLUGIN_HOST_KNOWHOW.md`。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,20 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.215 test(engine): VST3 Phase 1 gated 実機検証ハーネス + curated smoke PASS（#381） (Jul 10, 2026)
+
+Phase 1 の OOP effect 経路を **実市販プラグイン（NI/iZotope arm64）** に通す gated 検証ハーネスを実装し、curated 代表セットで非サンドボックス実測 PASS。合成 oracle（sample-exact 済）に対し、実プラグインは closed-form が無いため **machinery smoke**（load/process/isolation が crash 0 で生き延びるか）に限定。musical DSP correctness は owner listening の follow-on として分離（誠実な wording をコメント/サマリに明記）。
+
+- **設計ゲート = advisor(Fable) + adversarial-review(codex) の 2 レビュー**を実装前に通した。主要指摘を反映:
+  - **dry-passthrough 誤 PASS の穴**（process() 失敗時に child が入力を素通し→出力=入力で有限値になり従来の出力検査を誤 PASS）→ child 統計を露出して `process_errors==0` と `processed==期待ブロック数` を assert
+  - **timeout に plugin load 時間が食い込む**（初回ブロックは load を含む）→ 初回だけ長い deadline
+  - **分類は out-of-process**（instrument crash が effect ゲートに混入しない）→ 既存 `vst3_probe` の JSON `audio_in` で分類
+- **A（`orbit-audio-sandbox/offline.rs`・既存非破壊で追加）**: `render_through_child_sync_with_options(..., RenderOptions{first_block_timeout, block_timeout}) -> (Vec<f32>, ChildStats{processed, process_errors})`。既存 4 引数 `render_through_child_sync` は既定 opts の薄いラッパ（6 caller 非破壊）。stats は最終 `seq_done` Acquire 後・QUIT 前に読む（happens-before: child は fetch_add を seq_done Release より前に実行）
+- **B（`orbit-vst3-effect-child/tests/real_plugin_gated.rs`・#[ignore]）**: `vst3_probe`（別プロセス・20s timeout・std のみ）で分類 → **effect(audio_in>0)=ゲート / instrument(audio_in=0)=informational / probe crash・load-fail=surfaced 非 gating**。effect は sine を block[64,128]で駆動し crash 無し・process_errors 0・processed 一致・有限・abs≤8 を要求。loaded effect がゲートを破った時のみ panic。plugin 選択は env（`ORBIT_GATED_VST3_PLUGINS` / `_DIR` / `_ALL` / `_MAX`）+ curated 既定
+- **実測（Opus・非サンドボックス・curated 11個・34.5s）**: effect 8（Reaktor 6/Guitar Rig 7/Ozone 11/Neutron 5/RX 11 Voice De-noise/Nectar 4/Vinyl/Relay）全 PASS・**process_errors 0**、instrument 3（Kontakt 8/Massive X/FM8）informational PASS・crash 0。objc duplicate-class / qt.qml ログはプラグイン自身の良性警告で実 crash 0
+- **役割**: 計画確定=Opus（orchestrator）/ A レビュー+B 実装+全ゲート検証=sonnet5 委譲 / 実機計測=Opus 非サンドボックス。fmt/clippy/build/非gatedテスト/deny すべて clean
+- **残**: daemon 経路（`ORBIT_EFFECT_FORMAT=vst3` の supervisor/pipelined/respawn/stale）の gated は別途（C・adversarial-review が「手離れ」に必須と判定）。フル sweep（`ORBIT_GATED_VST3_ALL=1`）は owner 判断
+
 ### 6.214 feat(engine): VST3 Phase 1 — production OOP effect（daemon 統合）（#381） (Jul 8, 2026)
 
 in-process 実証済み VST3 host を daemon の out-of-process サブストレート（crash 隔離・respawn）に載せた。CLAP effect child と対称。codex 実装・Opus 非サンドボックス検証。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,17 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.217 perf(engine): VST3 host /simplify — RT hot-path alloc 除去で stale 0%（#397） (Jul 10, 2026)
+
+PR #397 の `/simplify`（4 cleanup agent 並列: reuse/simplification/efficiency/altitude）で確定した cleanup を `orbit-vst3-host/src/lib.rs` に適用（sonnet5 委譲・単一ファイル 150+/166-）。
+
+- **① RT alloc 除去（efficiency・最重要）**: `process_block` が毎ブロック `ParameterChanges::empty()`×2 + `EventList::empty()`×2（`ComWrapper::new`=Arc heap 確保）していた → `load()` で field 構築し再利用
+- **② process context cache**: `IProcessContextRequirements` の毎ブロック COM query → `load()` で 1 回 query して flags を field cache
+- **③ `run_process` helper 抽出**: `process_stereo`/`process_block` の `ProcessData` 組立重複を集約（3 agent 一致指摘）
+- **④-⑥**: dead field `max_samples_per_block` + no-op Drop 除去 / `json_escape` per-char Vec 除去 / `probe_plugin` 4段ネスト平坦化
+- **skip（follow-up/低価値）**: effect-child transport loop 共有化（merged clap crate に触れる）・CfString/CfUrl generic 化・test 信号式/extract_* prologue
+- **検証（Opus 非サンドボックス）**: oracle sample-exact 両テスト PASS（挙動不変）+ **daemon gated 再実行で stale rate 改善**: C1 fresh 1129/1129(100%)・C3 [64f]&[32f] とも **stale_pct 0.000%（前 0.162%/0.105%）**。RT alloc 除去が実測で timing を締めた。fmt/clippy/deny clean
+
 ### 6.216 test(engine): VST3 Phase 1 daemon 経路 gated + フル arm64 sweep PASS（#381） (Jul 10, 2026)
 
 Phase 1 の VST3 を **① production daemon 経路（supervisor/pipelined/respawn/RT）** と **② 全 arm64 プラグイン machinery** の 2 面で実機検証。offline smoke（6.215）が「child+transport が実プラグインを生き延びるか」を、本項が「production driver 層」と「全体カバレッジ」を担う（advisor が B/C は役割分担と判定・step-back 無し）。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,21 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.218 fix(engine): VST3 host PR #397 レビュー収束 — bus honest 化・CI 緑・テスト補完（#397） (Jul 10, 2026)
+
+PR #397 の `/code:pr-review-team`（4 レビュアー並列: code-reviewer/silent-failure-hunter/pr-test-analyzer/comment-analyzer + CI）で挙がった Critical/Important を 0 に収束。独立 round-2 再レビューで裏取り（自己判断で宣言しない）。
+
+- **CI 緑化**: `orbit-clap-host/discovery.rs:63-66` の冗長 `&`（clippy 1.97 `useless_borrows_in_formatting`・この PR の diff 外の既存問題が CI を塞いでいた）を除去
+- **Critical**: crate doc（`orbit-vst3-host` lib.rs/Cargo.toml）を「Phase 0 spike/offline」→ Phase 1 production に更新 / `PluginFormat::from_env_value`・`default_child_name` の unit test 追加 / `ChildStats` の非 gated テスト追加（synthetic child で `processed`/`process_errors` を assert・dry-passthrough 誤 PASS 穴の CI 側ガード）
+- **Important（挙動変更・bus honest 化）**:
+  - `verify_primary_bus_is_stereo`（I1）: load 時に primary(index0) バスが stereo でなければ reject。silent audio corruption を explicit load-fail に。instrument は input 検査を skip・multi-bus の stereo bus0 は通す
+  - `activate_primary_bus_only`（I2）: activate を index0 バスのみに（`run_process` が 1 バスしか記述しない契約と一致・多バス OOB 回避）+ activateBus 失敗を eprintln
+  - `bundleEntry` false → `Err(BundleLoad)`（I3）: get_factory 前に abort（JUCE 準拠・success 側は `bundle_exit_called` 正しく設定）
+  - `process_block` guard・`is_ok` の unit test 追加 / field-order コメント正確化 / `real_plugin_gated.rs` の壊れた cross-ref 修正
+- **検証（Opus 非サンドボックス）**: oracle sample-exact PASS（挙動不変）+ daemon gated C1-C3 PASS（stale [64f]&[32f] 0.000%）+ **フル sweep v2（733s・333個）**: Effect 268 PASS + Instrument 58 PASS・**genuine crash 0**・test ok。**I1 の唯一の影響 = MIDI Guitar 3（8ch input bus）を honest に load-reject**（silent 誤処理の解消）。UJAM Beatmaker 7 が Crash→Instrument に回復。fmt/clippy/deny clean
+- **役割**: レビュー起動/統合/収束判定=Opus（pr-review-team skill）/ fix 適用=sonnet5 委譲（session 上限で途中終了も実質完了・Opus が検証）/ 実機再測定=Opus 非サンドボックス
+- **残**: advisor 相談 → bot（@claude）second-opinion → owner マージ判断
+
 ### 6.217 perf(engine): VST3 host /simplify — RT hot-path alloc 除去で stale 0%（#397） (Jul 10, 2026)
 
 PR #397 の `/simplify`（4 cleanup agent 並列: reuse/simplification/efficiency/altitude）で確定した cleanup を `orbit-vst3-host/src/lib.rs` に適用（sonnet5 委譲・単一ファイル 150+/166-）。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,15 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.207 feat(engine): VST3 Phase 0-0a license audit PASS + gain oracle scaffold (#381) (Jul 8, 2026)
+
+VST3 hosting Phase 0（#381）の 0a（license 監査）を実行し PASS。0b（host spike）の sample-exact oracle をスキャフォールドした。
+
+- **0a license 監査 PASS（STOP gate クリア）**: 新 crate `orbit-vst3-host` に `vst3 = "0.3"` を追加し `cargo tree` を実測 → 全 transitive 依存 = `vst3 v0.3.0` → `com-scrape-types v0.1.1` の 2 crate のみ（bindgen/clang-sys 系なし・plan の予測どおり）。両者とも `MIT OR Apache-2.0`（展開済み Cargo.toml source で一次裏取り・vst3 は LICENSE-APACHE/MIT 同梱）で deny.toml allow list 内。`cargo deny check licenses` = **licenses ok**。**deny.toml 書き換え不要**（STOP 条件の allow list 改変は発生せず）
+- **oracle 発見 → SDK ビルド不要化**: 市販 VST3 は gain smoothing で block 1 が sample-exact にならず・マシンに VST3 SDK 無し、という制約だったが、`vst3` crate が**純 Rust の `examples/gain.rs`（`out = gain × in`・smoothing なし）を同梱**。これを vendored した crate `orbit-vst3-gain-oracle`（cdylib）を作成 → `package-oracle.sh` で macOS `.vst3` バンドル（`target/vst3-fixtures/GainOracle.vst3`・gitignore 下）に生成。`GetPluginFactory`/`BundleEntry` エクスポート確認済み。**既知挙動を我々が持つ oracle**（binary は commit しない・script で再現）
+- **spec 強化（owner レビュー反映・spec-first）**: Phase 0 受け入れ基準を **2 系統**に書き換え。① sample-exact oracle（自作 gain・data-path 意味論）+ ② **実市販プラグイン load-bearing**（ABI 適合）。🔴 理由 = Rust プラグイン ↔ Rust ホストは同じ `vst3` crate の ABI 解釈を共有 → **相互に一貫して間違っていても ① は PASS しうる**。② が実 Steinberg SDK 製プラグインとの適合を担保。さらに **compatibility sweep**（`/Library/Audio/Plug-Ins/VST3/` 全 VST3 を best-effort で load→process→drop し pass/fail/crash/hang マトリクスを診断出力・gate ではない）を追加。★北極星 = 市販 VST3 コレクション全体の互換性（owner「最終的には全部試す」）
+- **残**: 0b host spike（手書き COM で load→process→drop・`orbit-clap-host` 対称）= codex 委譲予定。① sample-exact + ② 実プラグイン + sweep + verdict doc（`POST_2.0_VST3_STEP0_SPIKE.md`）で Phase 0 完了条件
+
 ### 6.206 docs(engine): VST3 hosting implementation plan — effect + instrument, symmetric to CLAP (#395) (Jul 8, 2026)
 
 VST3 プラグインホスティングの実装計画 doc（`docs/development/POST_2.0_VST3_HOSTING_PLAN.md`）を起こした。owner 意図の核心 =「**音源系プラグインとエフェクト系プラグインの両カテゴリをホスト**」（VST3/CLAP 併用ではない）・VST3 主眼・既存 CLAP 資産と対称。実装は `/codex:rescue` 委譲前提で、codex が会話文脈なしで迷わない粒度（各 Phase を実在ファイルの path:line → 手順 → offline 優先の受け入れ基準 → STOP gate で記述）。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,15 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.210 feat(engine): VST3 CFBundle load path — NI 全回復・iZotope は残課題（#381） (Jul 8, 2026)
+
+`/ask-codex:research`（一次調査）→ codex:rescue 実装で NI クラッシュを解消。
+
+- **research 発見**: NI SIGSEGV の主因 = `BundleEntry(ptr::null_mut())`（NI ランタイムが CFBundleRef から resources/frameworks/license path を解決するため null deref）。前回 de-risk が効かなかった真因
+- **実装（codex）**: macOS bundle ロードを CFBundle 正規経路に（CFBundleCreate→LoadExecutable→GetFunctionPointerForName・**実 CFBundleRef を BundleEntry に渡す**）+ component-controller ハンドシェイク（controller 生成/initialize/setComponentHandler/IConnectionPoint connect/state 同期）+ process データ完全化（空 IEventList/IParameterChanges/ProcessContext/canProcessSampleSize）。`core-foundation-sys 0.8`（MIT/Apache・allow list 内）採用・`libloading` 除去。oracle sample-exact 維持・fmt/clippy/deny green（codex 報告）
+- **実測（Opus・非サンドボックス・代表）**: **NI 7/7 が crash→load 成功**（Battery 4/FM8/Massive/Kontakt 8=instrument load・Reaktor 6/Guitar Rig 7/Bite=effect load+process）。owner 最重要 Kontakt/Massive/FM8 が動く。**iZotope は setProcessing:3 のまま未解決**（Vinyl/Ozone/RX/Neutron・別要因＝bus 再調停詳細 or objc 衝突）
+- 全 sweep の回復数は継続実測中。次 = iZotope root-cause + full sweep 数値
+
 ### 6.209 feat(engine): VST3 de-risk — host context + bus 調停は NI/iZotope を救わず（#381） (Jul 8, 2026)
 
 owner 最重要ベンダー NI/iZotope 救済の de-risk（Phase 1 前倒し）を codex に委譲実装し Opus が非サンドボックス実測 → **効果なし**。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -29,8 +29,9 @@ Phase 1 の VST3 を **① production daemon 経路（supervisor/pipelined/respa
   - **C4 commercial smoke**（env `ORBIT_EFFECT_PLUGIN` 駆動）代表 4 effect: Guitar Rig 7 / Reaktor 6 / Ozone 11 / Vinyl すべて crash-free・respawn 0・errors 0 → PASS（Vinyl は ratio 1.033 で実 DSP 着色が可視・Reaktor は patch 未ロードで無音=想定内）
   - **warm-up fix**: C1/C2 の固定 sleep（CLAP から verbatim の 800/600ms）は VST3 の CFBundle load latency に不足し fresh=0 で false-fail → **wait-until-productive ポーリング + delta 測定**に修正（post-respawn の同根欠陥も修正・test-only・production 無改変）
 - **B = フル arm64 sweep（offline・非サンドボックス・914.5s・333プラグイン）**: **Effect PASS 271 + Instrument PASS 49 = 320 PASS・genuine crash 0**
-  - Crash 分類 10 = すべて **probe 20s timeout hang**（実 crash でない）: UJAM Beatmaker `BM-*` 7 + USYNTH + Virtual Pianist（サンプル大量ロード）+ Komplete Kontrol（NI host-wrapper・Phase 0 でも変動既知）。slow-load であり deadlock でない見込み（long-timeout 再 probe で確認予定）
+  - Crash 分類 10 = すべて **probe 20s timeout hang**（実 crash でない）。**120s 再 probe で決着**: UJAM Beatmaker `BM-*` 7 は `loaded:true/audio_in:0/audio_out:16` で**正常ロード（16-out instrument・sample content で 20s 超過しただけ）= 回復**。残 3（Komplete Kontrol=NI 全ライブラリ scan / USYNTH / Virtual Pianist=UJAM 大量 content）は >120s の激重 load で、**いずれも instrument（Phase 1 effect スコープ外・Phase 3 の async load 課題）**
   - Skip 3 = Intel-only（MODO BASS / Philharmonik 2 / Super 8）を arm64 フィルタが正しく除外
+  - **確定カバレッジ**: arm64 **Effect 271 全 PASS・genuine crash 0**（Phase 1 スコープ実質 100%）/ Instrument 49+回復7=56 ロード可・3 は分単位 load の host-wrapper/巨大音源
 - **役割**: 計画/順序判断=Opus（advisor 経由）/ C 実装+warm-up fix=sonnet5 委譲 / 実機計測（C1-C4 + フル sweep）=Opus 非サンドボックス
 - **残**: 10 slow-loader の long-timeout 再 probe（owner 判断）・PR 化（/simplify + pr-review-team・トークン都合で延期中）
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1030,7 +1030,7 @@ dependencies = [
 name = "orbit-vst3-host"
 version = "0.0.1"
 dependencies = [
- "libloading",
+ "core-foundation-sys",
  "vst3",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1030,6 +1030,7 @@ dependencies = [
 name = "orbit-vst3-host"
 version = "0.0.1"
 dependencies = [
+ "libloading",
  "vst3",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1020,6 +1020,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "orbit-vst3-effect-child"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "orbit-audio-sandbox",
+ "orbit-vst3-host",
+]
+
+[[package]]
 name = "orbit-vst3-gain-oracle"
 version = "0.0.1"
 dependencies = [

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -242,6 +242,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76abbdb2907f6fd97fb6bc0b7be96b77d328f2dd9669d1075cc03369ed22154"
 
 [[package]]
+name = "com-scrape-types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce183b975b8fc736a20919c4002717255fbd867df575c792aeefa9a56a73ad0"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1020,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "orbit-vst3-gain-oracle"
+version = "0.0.1"
+dependencies = [
+ "vst3",
+]
+
+[[package]]
+name = "orbit-vst3-host"
+version = "0.0.1"
+dependencies = [
+ "vst3",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,6 +1785,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "vst3"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31e3fe7a6f028ded8c5a9984cf283319e6dc63572c9b71da1d4ee9d71d3b6bf"
+dependencies = [
+ "com-scrape-types",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "crates/orbit-clap-spike",
   "crates/orbit-clap-host",
   "crates/orbit-clap-effect-child",
+  "crates/orbit-vst3-effect-child",
   "crates/orbit-sandbox-spike",
   "crates/orbit-audio-sandbox",
   "crates/orbit-vst3-host",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,8 @@ members = [
   "crates/orbit-clap-effect-child",
   "crates/orbit-sandbox-spike",
   "crates/orbit-audio-sandbox",
+  "crates/orbit-vst3-host",
+  "crates/orbit-vst3-gain-oracle",
 ]
 # 🔴 orbit-link-audio(GPL 隔離 crate)は **member にしない**。
 # member にすると default の `cargo build` / cargo-deny がこの GPL crate を root として

--- a/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
@@ -910,4 +910,40 @@ mod tests {
         stop.store(true, Ordering::Relaxed);
         handle.join().expect("process loop thread joins");
     }
+
+    // C2（pr-review-team）: format 選択の純関数は device/child プロセス不要で CI 常時実行できるのに
+    // gated テストからしか経由されていなかった。env value 解決 + child binary 名の対応表を直接固定する。
+    #[test]
+    fn plugin_format_from_env_value_defaults_to_clap() {
+        assert_eq!(PluginFormat::from_env_value(None), Ok(PluginFormat::Clap));
+    }
+
+    #[test]
+    fn plugin_format_from_env_value_accepts_known_values() {
+        assert_eq!(
+            PluginFormat::from_env_value(Some("vst3".to_owned())),
+            Ok(PluginFormat::Vst3)
+        );
+        assert_eq!(
+            PluginFormat::from_env_value(Some("clap".to_owned())),
+            Ok(PluginFormat::Clap)
+        );
+    }
+
+    #[test]
+    fn plugin_format_from_env_value_rejects_unknown_values() {
+        assert!(PluginFormat::from_env_value(Some("au".to_owned())).is_err());
+    }
+
+    #[test]
+    fn plugin_format_default_child_name_matches_format() {
+        assert_eq!(
+            PluginFormat::Clap.default_child_name(),
+            "orbit-clap-effect-child"
+        );
+        assert_eq!(
+            PluginFormat::Vst3.default_child_name(),
+            "orbit-vst3-effect-child"
+        );
+    }
 }

--- a/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
@@ -59,14 +59,49 @@ pub fn unique_shm_path() -> PathBuf {
     std::env::temp_dir().join(format!("orbit-outproc-effect-{pid}-{seq}.shm"))
 }
 
+/// OOP effect child が host する plugin format。transport/watchdog/respawn は format 非依存。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginFormat {
+    Clap,
+    Vst3,
+}
+
+impl PluginFormat {
+    fn from_env_value(value: Option<String>) -> Result<Self, String> {
+        match value.as_deref().unwrap_or("clap") {
+            "clap" => Ok(Self::Clap),
+            "vst3" => Ok(Self::Vst3),
+            other => Err(format!(
+                "ORBIT_EFFECT_FORMAT='{other}' is invalid (expected 'clap' or 'vst3')"
+            )),
+        }
+    }
+
+    fn default_child_name(self) -> &'static str {
+        match self {
+            Self::Clap => "orbit-clap-effect-child",
+            Self::Vst3 => "orbit-vst3-effect-child",
+        }
+    }
+
+    fn plugin_kind(self) -> &'static str {
+        match self {
+            Self::Clap => ".clap",
+            Self::Vst3 => ".vst3",
+        }
+    }
+}
+
 /// OOP effect の起動設定（child binary path + plugin）。`start_outproc_effect` と gated test が使う。
 /// sample_rate は device 確定後に渡すので含めない。
 pub struct OutProcEffectConfig {
-    /// effect child binary（`orbit-clap-effect-child`）のパス。
+    /// plugin format（既定 env は `clap`）。
+    pub format: PluginFormat,
+    /// effect child binary（format に応じた child）のパス。
     pub child_exe: PathBuf,
-    /// host する .clap バンドルのパス（load-time param のみ・M1 は per-block automation なし）。
+    /// host する plugin bundle のパス（load-time param のみ・M1 は per-block automation なし）。
     pub plugin: PathBuf,
-    /// CLAP plugin id（None なら単一プラグインの場合のみ OK）。
+    /// plugin id（CLAP は id、VST3 Phase 1 は CLI symmetry のため渡すだけ）。
     pub plugin_id: Option<String>,
     /// cpal に要求する固定バッファフレーム数（gated stale-rate harness が 32/64 を渡す）。`None` は
     /// device 既定（`BufferSize::Default`）。production の env 経路は通常 `None`。
@@ -75,20 +110,24 @@ pub struct OutProcEffectConfig {
 
 impl OutProcEffectConfig {
     /// 環境変数から設定を組む（production `start()` 用）:
+    /// - `ORBIT_EFFECT_FORMAT`: `clap` | `vst3`（省略時 `clap`）。
     /// - `ORBIT_EFFECT_CHILD_BIN`: child binary path（省略時は daemon exe と同一ディレクトリの
-    ///   `orbit-clap-effect-child`）。
-    /// - `ORBIT_EFFECT_PLUGIN`: .clap path（**必須**）。
+    ///   format 対応 child）。
+    /// - `ORBIT_EFFECT_PLUGIN`: plugin bundle path（**必須**）。
     /// - `ORBIT_EFFECT_PLUGIN_ID`: plugin id（任意）。
     pub fn from_env() -> Result<Self, String> {
+        let format = PluginFormat::from_env_value(std::env::var("ORBIT_EFFECT_FORMAT").ok())?;
         let child_exe = match std::env::var_os("ORBIT_EFFECT_CHILD_BIN") {
             Some(v) => PathBuf::from(v),
-            None => default_child_exe()?,
+            None => default_child_exe(format)?,
         };
         let plugin = std::env::var_os("ORBIT_EFFECT_PLUGIN")
             .map(PathBuf::from)
             .ok_or_else(|| {
-                "ORBIT_EFFECT_PLUGIN not set (out-of-process effect needs a .clap bundle path)"
-                    .to_string()
+                format!(
+                    "ORBIT_EFFECT_PLUGIN not set (out-of-process effect needs a {} bundle path)",
+                    format.plugin_kind()
+                )
             })?;
         let plugin_id = std::env::var("ORBIT_EFFECT_PLUGIN_ID").ok();
         // production は通常 device 既定。`ORBIT_EFFECT_BUFFER_FRAMES` で明示できる。**設定済みなのに無効**
@@ -106,6 +145,7 @@ impl OutProcEffectConfig {
             Err(_) => None, // 未設定 = device 既定
         };
         Ok(Self {
+            format,
             child_exe,
             plugin,
             plugin_id,
@@ -114,14 +154,14 @@ impl OutProcEffectConfig {
     }
 }
 
-/// daemon 実行ファイルと同一ディレクトリの `orbit-clap-effect-child` を child binary 既定パスとする
+/// daemon 実行ファイルと同一ディレクトリの format 対応 child を既定パスとする
 /// （spike の sibling-of-exe を踏襲・設計 §4.5）。インストール時は daemon と child が並んで置かれる前提。
-fn default_child_exe() -> Result<PathBuf, String> {
+fn default_child_exe(format: PluginFormat) -> Result<PathBuf, String> {
     let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
     let dir = exe
         .parent()
         .ok_or_else(|| "current_exe has no parent directory".to_string())?;
-    Ok(dir.join("orbit-clap-effect-child"))
+    Ok(dir.join(format.default_child_name()))
 }
 
 /// OOP effect の観測 signal（全 atomic・lock-free）。

--- a/rust/crates/orbit-audio-daemon/tests/outproc_effect_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_effect_gated.rs
@@ -27,7 +27,7 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 use orbit_audio_daemon::engine_wrap::EngineWrap;
-use orbit_audio_daemon::outproc_effect::OutProcEffectConfig;
+use orbit_audio_daemon::outproc_effect::{OutProcEffectConfig, PluginFormat};
 
 /// test-effect が乗算する固定 gain（plugin 側 `EFFECT_GAIN` と一致させること）。
 const EFFECT_GAIN: f32 = 0.5;
@@ -62,6 +62,7 @@ fn test_effect_dylib() -> PathBuf {
 /// loud に止める。各 test の共通セットアップ（dylib/child の二重解決と prereq 重複を 1 箇所に集約）。
 fn setup_test(buffer_frames: Option<u32>) -> (OutProcEffectConfig, PathBuf) {
     let cfg = OutProcEffectConfig {
+        format: PluginFormat::Clap,
         child_exe: child_exe(),
         plugin: test_effect_dylib(),
         plugin_id: None, // 単一プラグイン bundle なので id 省略可

--- a/rust/crates/orbit-audio-daemon/tests/outproc_effect_vst3_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_effect_vst3_gated.rs
@@ -1,0 +1,525 @@
+//! VST3 Phase 1 daemon 経路 gated 検証ハーネス（C・Issue #395 実装計画）: out-of-process VST3 effect が
+//! production daemon 経由で実機検証される gated テスト。CI は Rust gated 非実行（device なし）→
+//! **owner のローカル実機 RUN が唯一の根拠**。
+//!
+//! 本ファイルは `outproc_effect_gated.rs`（CLAP daemon gated・γ M1 PR-C）の**完全なミラー**。daemon の
+//! out-of-process effect supervisor（`orbit-audio-daemon/src/outproc_effect.rs`）は format 非依存
+//! （`PluginFormat::Clap` / `PluginFormat::Vst3`）にすでに production 対応済みなので、CLAP 版が検証する
+//! supervisor(spawn/watchdog/respawn) + `PipelinedEffectHost`(fresh/stale/stall) + RT callback の性質を
+//! そのまま VST3 に対して検証する。CLAP 版との違いは plugin/format 指定のみ（assert 値・tolerance・
+//! sleep 時間は CLAP 版を踏襲）。
+//!
+//! offline 同期 driver 経由の smoke（`orbit-vst3-effect-child/tests/real_plugin_gated.rs`）とは別物で、
+//! こちらは daemon supervisor（respawn/watchdog）と RT cpal callback を通す。
+//!
+//! 4 本:
+//! - **C1 parity**: VST3 gain oracle（`orbit-vst3-gain-oracle` = gain=1.0 sample-exact passthrough）を
+//!   daemon 経由で挟み、`post/dry ≈ 1.0` を検証する（CLAP 版の EFFECT_GAIN=0.5 parity と同じ構造・中心値
+//!   だけ oracle の gain=1.0 に変更）。
+//! - **C2 kill-test**: child を SIGKILL → daemon 生存 → watchdog respawn → fresh 処理が復帰する
+//!   （plugin 非依存・CLAP 版と同一 assert）。
+//! - **C3 stale-rate**: 32/64f の小バッファで stale_pct / callback_max を計測する（CLAP 版と同一 sanity
+//!   floor。SLOTS の最終判断は printed verdict を owner が読んで行う）。
+//! - **C4 commercial smoke**: `ORBIT_EFFECT_PLUGIN` env で指定した実市販 VST3 プラグインを daemon 経路に
+//!   流し、crash-free + respawn 無し + measurement_invalid でない + child_process_error_count==0 を
+//!   確認する（既知 gain が無いので parity assert はしない）。env 未指定は loud skip。
+//!
+//! 前提（実行前にビルドすること）:
+//!   cargo build -p orbit-vst3-effect-child
+//!   （C1/C2/C3 は VST3 gain oracle を `orbit-vst3-gain-oracle/package-oracle.sh` で自動 package する
+//!   ので事前ビルド不要。C4 は `ORBIT_EFFECT_PLUGIN` に実プラグインの .vst3 bundle path を渡す）
+//! 実行:
+//!   cargo test -p orbit-audio-daemon --features outproc-effect --test outproc_effect_vst3_gated -- --ignored --nocapture
+//!
+//! device / dylib / child binary が揃わない env（headless CI 等）では owner へ stop&report（手動 fallback）。
+
+#![cfg(feature = "outproc-effect")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use orbit_audio_daemon::engine_wrap::EngineWrap;
+use orbit_audio_daemon::outproc_effect::{OutProcEffectConfig, PluginFormat};
+
+/// VST3 gain oracle の固定 gain（`orbit-vst3-gain-oracle` は既定 gain=1.0 の sample-exact
+/// passthrough・`oracle_parity.rs` の in-process/OOP 両テストが根拠）。
+const ORACLE_GAIN: f32 = 1.0;
+/// gain 比の許容幅。CLAP 版（中心 0.5 に対し 0.4..=0.6 = ±20%）と同じ相対マージンを oracle の
+/// 中心 1.0 に適用する（resampling / peak 整列ずれの吸収は CLAP 版と同じ理由）。
+const RATIO_TOLERANCE: std::ops::RangeInclusive<f32> = (ORACLE_GAIN * 0.8)..=(ORACLE_GAIN * 1.2);
+/// RT 健全性の callback 所要時間上限（synth/clap gated と同じ保守的上限 20ms）。
+const CALLBACK_MAX_BUDGET_NS: u64 = 20_000_000;
+
+/// child の cold-start（CFBundle load + COM init）を待つ上限。VST3 の起動は CLAP の dlopen より重く、
+/// CLAP 版から流用した固定 sleep（800ms/600ms）では child が最初の block を出す前に測定/kill してしまう
+/// ことが実機診断（2026-07-10・Opus 非サンドボックス RUN）で判明した。fresh > 0（child が処理した出力を
+/// host が実際に読んだ）になるまで poll し、間に合わなければ本当に動いていないとみなして fail させる。
+const WARM_UP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// repo ルート相対パスを解決する（MANIFEST_DIR = rust/crates/orbit-audio-daemon）。
+fn repo_path(rel: &str) -> PathBuf {
+    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../..")).join(rel)
+}
+
+/// VST3 effect child binary（`orbit-vst3-effect-child`）のパスを解決する。
+///
+/// 別 crate の binary なので `CARGO_BIN_EXE_*` は使えない（CLAP 版 `child_exe()` と同じ理由）。test
+/// 実行ファイル（`target/<profile>/deps/<name>-<hash>`）の祖先から sibling binary を導く
+/// （profile 非依存）。
+fn vst3_child_exe() -> PathBuf {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop(); // test exe 名を除く → deps/
+    if p.ends_with("deps") {
+        p.pop(); // deps/ を除く → target/<profile>/
+    }
+    p.push("orbit-vst3-effect-child");
+    p
+}
+
+/// `orbit-vst3-gain-oracle/package-oracle.sh` を実行して `GainOracle.vst3` bundle を組み立て、絶対
+/// パスを返す（`oracle_parity.rs` の `package_oracle()` と同じスクリプトを同じ呼び方で使う）。
+fn package_oracle() -> PathBuf {
+    let script = repo_path("rust/crates/orbit-vst3-gain-oracle/package-oracle.sh");
+    let output = Command::new(&script).output().unwrap_or_else(|e| {
+        panic!(
+            "VST3 oracle packaging script 実行失敗 {}: {e}",
+            script.display()
+        )
+    });
+    assert!(
+        output.status.success(),
+        "VST3 oracle packaging 失敗 (status={}): {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    PathBuf::from(stdout.trim())
+}
+
+/// gated 前提（child binary / oracle bundle / 音源）を確認して config と音源 path を返す。揃わなければ
+/// panic で loud に止める（CLAP 版 `setup_test` の VST3 ミラー）。
+fn setup_test(buffer_frames: Option<u32>) -> (OutProcEffectConfig, PathBuf) {
+    let cfg = OutProcEffectConfig {
+        format: PluginFormat::Vst3,
+        child_exe: vst3_child_exe(),
+        plugin: package_oracle(),
+        plugin_id: None, // 単一プラグイン bundle なので id 省略可
+        buffer_frames,
+    };
+    let wav = repo_path("test-assets/audio/sine_440.wav");
+    assert!(
+        cfg.child_exe.exists(),
+        "VST3 effect child binary が無い: {} — 先に `cargo build -p orbit-vst3-effect-child`",
+        cfg.child_exe.display()
+    );
+    assert!(
+        cfg.plugin.exists(),
+        "VST3 gain oracle bundle が無い: {}",
+        cfg.plugin.display()
+    );
+    assert!(wav.exists(), "音源 WAV が無い: {}", wav.display());
+    (cfg, wav)
+}
+
+/// sine を 1 つ再生する（一定振幅 → dry/post peak 比が安定する）。
+fn play_sine(engine: &EngineWrap, wav: &Path) {
+    let sample = engine
+        .load_sample(wav.to_path_buf())
+        .expect("load sine sample");
+    let onset = engine.transport_or_uptime_sec() + 0.1;
+    engine
+        .play_at(&sample.sample_id, onset, 1.0, 0.0, 0.0, 0.0, 1.0, None)
+        .expect("play sine");
+}
+
+/// `cond` が真になるまで（または timeout まで）20ms 間隔で poll する。真で抜けたら true。
+fn wait_until(timeout: Duration, mut cond: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if cond() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    cond()
+}
+
+/// child が最初の fresh 出力（＝実際に処理済みの block）を host に届けるまで poll する。`WARM_UP_TIMEOUT`
+/// 経過しても fresh=0 のままなら false（本当に OOP 経路が動いていない場合はここで検出する）。
+fn wait_until_productive(engine: &EngineWrap) -> bool {
+    wait_until(WARM_UP_TIMEOUT, || {
+        engine
+            .outproc_effect_stats()
+            .map(|s| s.fresh > 0)
+            .unwrap_or(false)
+    })
+}
+
+// ── C1 parity: OOP VST3 effect が master bus を加工する（post/dry ≈ ORACLE_GAIN）───────────────
+#[test]
+#[ignore = "VST3 Phase1 C1: needs a real output device + built orbit-vst3-effect-child (local only)"]
+fn outproc_effect_vst3_processes_audio_via_daemon() {
+    let (cfg, wav) = setup_test(None);
+    let (engine, _guard) = EngineWrap::start_outproc_effect(cfg).expect("start OOP effect daemon");
+    play_sine(&engine, &wav);
+    // child の cold-start（CFBundle load + COM init）を待つ。固定 sleep だと child が最初の block を出す
+    // 前に測定してしまうことがある（診断根拠は WARM_UP_TIMEOUT のコメント参照）。
+    let productive = wait_until_productive(&engine);
+    assert!(
+        productive,
+        "warm-up timeout（{WARM_UP_TIMEOUT:?}）: child が一度も fresh 出力を出さなかった \
+         （OOP 経路が動いていない）"
+    );
+    // warm-up 中の stall/prime block を測定対象から除外する: peak をリセットし、fresh/callback_count は
+    // リセット API が無いのでここで基準点を記録して差分で測る。
+    engine.outproc_reset_peaks();
+    let baseline = engine.outproc_effect_stats().expect("stats");
+    let fresh_before = baseline.fresh;
+    let callback_count_before = baseline.callback_count;
+    // 安定した測定窓を確保する（多数の callback を集める）。
+    std::thread::sleep(Duration::from_millis(1500));
+
+    let s = engine
+        .outproc_effect_stats()
+        .expect("outproc stats available");
+    let cb = engine
+        .outproc_callback_stats()
+        .expect("callback stats available");
+    let fresh_delta = s.fresh.saturating_sub(fresh_before);
+    let callback_delta = s.callback_count.saturating_sub(callback_count_before);
+    let ratio = if s.dry_peak > 0.0 {
+        s.post_peak / s.dry_peak
+    } else {
+        0.0
+    };
+    println!("=== VST3 Phase1 C1 OOP effect parity verdict ===");
+    println!("dry_peak:            {:.5}", s.dry_peak);
+    println!("post_peak:           {:.5}", s.post_peak);
+    println!("ratio (post/dry):    {ratio:.5}  (expect ~{ORACLE_GAIN})");
+    println!(
+        "fresh / stale / stall (cumulative): {} / {} / {}",
+        s.fresh, s.stale, s.stall
+    );
+    println!("fresh_delta (post warm-up):   {fresh_delta}");
+    println!("callback_delta (post warm-up): {callback_delta}");
+    println!("callback_count:      {}", s.callback_count);
+    println!("callback_max_ns:     {}", cb.max_ns);
+    println!("callback_p99_ns:     {}", cb.p99_ns);
+    println!("respawn_count:       {}", s.respawn_count);
+    println!("child_proc_errors:   {}", s.child_process_error_count);
+    println!("==================================================");
+
+    assert!(
+        !s.measurement_invalid,
+        "respawn 失敗で計測無効（child binary を確認）"
+    );
+    assert!(
+        s.dry_peak > 0.01,
+        "engine が発音しなかった (dry_peak={:.5})。sample 再生経路を確認",
+        s.dry_peak
+    );
+    // fresh_delta > 0 = warm-up 後、child が処理した出力を host が実際に読んだ
+    // （dead child なら stale のみで fresh は増えない）。
+    assert!(
+        fresh_delta > 0,
+        "warm-up 後に fresh 出力を読めていない（OOP 経路が動いていない）"
+    );
+    // **持続的**に fresh を読めている（測定窓の過半数の callback が fresh）= effect が run 全体で
+    // 生きていた（CLAP 版 test-coverage review Important 1 の教訓を踏襲）。warm-up 中の stall は
+    // fresh_delta/callback_delta から除外済みなので、この閾値は warm-up の遅さに左右されない。
+    assert!(
+        fresh_delta > callback_delta / 2 && fresh_delta > 10,
+        "fresh が持続していない（fresh_delta={fresh_delta} / callback_delta={callback_delta}）\
+         — effect が run 途中で停止した疑い"
+    );
+    // serial insert の gain 比。余白は resampling / peak 整列のずれを吸収（理論値 ORACLE_GAIN）。
+    assert!(
+        RATIO_TOLERANCE.contains(&ratio),
+        "OOP VST3 effect gain 比が想定外: {ratio:.5}（期待 ~{ORACLE_GAIN}）。\
+         child の effect 適用 / transport 配線を確認"
+    );
+    assert!(s.callback_count > 0, "audio callback が回っていない");
+    assert!(
+        cb.max_ns < CALLBACK_MAX_BUDGET_NS,
+        "callback max が異常に大きい ({} ns ≈ {:.2} ms) — RT 違反の疑い",
+        cb.max_ns,
+        cb.max_ns as f64 / 1e6
+    );
+    // _guard drop で teardown（watchdog 停止 → QUIT → reap → unlink）。panic / UB なく完了することを検証。
+}
+
+// ── C2 kill-test: child SIGKILL → daemon 生存 → respawn → fresh 処理復帰 ──────────────────────
+#[test]
+#[ignore = "VST3 Phase1 C2: needs a real output device + built orbit-vst3-effect-child (local only)"]
+fn outproc_effect_vst3_survives_child_kill_and_respawns() {
+    let (cfg, wav) = setup_test(None);
+    let (engine, _guard) = EngineWrap::start_outproc_effect(cfg).expect("start OOP effect daemon");
+    play_sine(&engine, &wav);
+    // child の cold-start を待つ（固定 sleep だと kill 前に OOP effect がまだ動いていないことがある。
+    // 診断根拠は WARM_UP_TIMEOUT のコメント参照）。
+    let productive = wait_until_productive(&engine);
+    assert!(
+        productive,
+        "warm-up timeout（{WARM_UP_TIMEOUT:?}）: kill 前に OOP effect が fresh 出力を出さなかった"
+    );
+
+    // kill 前: effect が動いていること（fresh 処理 + gain 比）を確認。
+    let before = engine.outproc_effect_stats().expect("stats");
+    assert!(before.fresh > 0, "kill 前に OOP effect が動いていない");
+    let pid = before.current_child_pid;
+    assert!(pid != 0, "child PID が publish されていない");
+    let respawns_before = before.respawn_count;
+
+    // child を SIGKILL（C-ABI segfault 相当の異常終了を模す）。
+    let killed = Command::new("kill")
+        .arg("-9")
+        .arg(pid.to_string())
+        .status()
+        .expect("kill コマンド実行");
+    assert!(killed.success(), "kill -9 {pid} が失敗");
+
+    // watchdog が異常終了を検知して respawn するのを待つ（poll 20ms + spawn）。
+    let respawned = wait_until(Duration::from_secs(5), || {
+        engine
+            .outproc_effect_stats()
+            .map(|s| s.respawn_count > respawns_before)
+            .unwrap_or(false)
+    });
+    assert!(
+        respawned,
+        "watchdog が child crash 後に respawn しなかった（daemon 生存 + respawn を確認）"
+    );
+
+    // respawn 後の fresh 処理復帰を **新規** に計測する: peak をリセットし fresh の基準を取る。
+    engine.outproc_reset_peaks();
+    let fresh_after_respawn = engine.outproc_effect_stats().unwrap().fresh;
+
+    // 新 child の cold-start（CFBundle load + COM init）を待つ: respawn 直後の固定 sleep だと新 child が
+    // まだ productive になっていないことがある（kill 前と同じ理由・診断根拠は WARM_UP_TIMEOUT 参照）。
+    // fresh が respawn 前の基準を超えるまで poll する。
+    let recovered = wait_until(WARM_UP_TIMEOUT, || {
+        engine
+            .outproc_effect_stats()
+            .map(|s| s.fresh > fresh_after_respawn)
+            .unwrap_or(false)
+    });
+    // productive を確認した後、gain 比を安定させるため少し追加で block を蓄積する。
+    std::thread::sleep(Duration::from_millis(300));
+    let s = engine.outproc_effect_stats().expect("stats");
+    let ratio = if s.dry_peak > 0.0 {
+        s.post_peak / s.dry_peak
+    } else {
+        0.0
+    };
+    println!("=== VST3 Phase1 C2 OOP effect kill-test verdict ===");
+    println!("killed pid:          {pid}");
+    println!(
+        "respawn_count:       {} (before {})",
+        s.respawn_count, respawns_before
+    );
+    println!(
+        "fresh after respawn: {} -> {}",
+        fresh_after_respawn, s.fresh
+    );
+    println!("ratio (post/dry):    {ratio:.5}  (expect ~{ORACLE_GAIN})");
+    println!("measurement_invalid: {}", s.measurement_invalid);
+    println!("=====================================================");
+
+    assert!(!s.measurement_invalid, "respawn 失敗で計測無効");
+    assert!(
+        recovered,
+        "respawn 後 warm-up timeout（{WARM_UP_TIMEOUT:?}）以内に fresh 処理が復帰しなかった \
+         （新 child の cold-start が間に合わなかった疑い）"
+    );
+    // 新 child が fresh 出力を生み host が読んだ = repeat-previous でなく実処理が復帰した。
+    assert!(
+        s.fresh > fresh_after_respawn,
+        "respawn 後に fresh 処理が復帰していない（repeat-previous だけでは fresh は増えない）"
+    );
+    assert!(
+        RATIO_TOLERANCE.contains(&ratio),
+        "respawn 後の effect gain 比が想定外: {ratio:.5}（期待 ~{ORACLE_GAIN}）"
+    );
+    // _guard drop で teardown。
+}
+
+// ── C3 stale-rate: 32/64f 小バッファの viability 計測 → owner が SLOTS 2 vs 3 を決定 ──────────────
+#[test]
+#[ignore = "VST3 Phase1 C3: needs a real output device that supports small buffers (local only)"]
+fn outproc_effect_vst3_small_buffer_stale_rate() {
+    println!(
+        "=== VST3 Phase1 C3 OOP effect stale-rate verdict (SLOTS={}) ===",
+        orbit_audio_sandbox::SLOTS
+    );
+    for &frames in &[64u32, 32u32] {
+        let (cfg, wav) = setup_test(Some(frames));
+        let (engine, _guard) = match EngineWrap::start_outproc_effect(cfg) {
+            Ok(x) => x,
+            Err(e) => {
+                // device が当該バッファをサポートしない場合は skip（loud に記録）。
+                println!("[{frames}f] start 失敗（device が非対応の可能性）: {e} — skip");
+                continue;
+            }
+        };
+        play_sine(&engine, &wav);
+        // 多数の callback を集める（小バッファでは callback 頻度が高い）。
+        std::thread::sleep(Duration::from_secs(2));
+
+        let s = engine.outproc_effect_stats().expect("stats");
+        let cb = engine.outproc_callback_stats().expect("cb stats");
+        let total = s.fresh + s.stale;
+        let stale_pct = if total > 0 {
+            s.stale as f64 / total as f64 * 100.0
+        } else {
+            0.0
+        };
+        println!(
+            "[{frames}f] fresh={} stale={} stall={} stale_pct={stale_pct:.3}% \
+             cb_max={}ns cb_p99={}ns respawn={} invalid={}",
+            s.fresh, s.stale, s.stall, cb.max_ns, cb.p99_ns, s.respawn_count, s.measurement_invalid
+        );
+
+        // sanity floor（catastrophic でないこと）。SLOTS の最終判断は上の数値を owner が読んで行う。
+        assert!(
+            !s.measurement_invalid,
+            "[{frames}f] 計測無効（respawn 失敗）"
+        );
+        assert!(
+            total > 0,
+            "[{frames}f] callback が回っていない（fresh+stale=0）"
+        );
+        assert!(
+            cb.max_ns < CALLBACK_MAX_BUDGET_NS,
+            "[{frames}f] callback max が RT budget 超過: {} ns ≈ {:.2} ms",
+            cb.max_ns,
+            cb.max_ns as f64 / 1e6
+        );
+        // catastrophic stale（半数以上が間に合わない）は viability 無し。
+        assert!(
+            stale_pct < 50.0,
+            "[{frames}f] stale_pct が壊滅的: {stale_pct:.3}%（SLOTS={} で viability なし）",
+            orbit_audio_sandbox::SLOTS
+        );
+    }
+    println!("=================================================================");
+}
+
+// ── C4 commercial smoke: 実市販 VST3 プラグインを daemon 経路に流す（env 駆動・owner 実行用）───────
+//
+// 既知 gain が無いので parity assert はしない。crash-free（respawn 無し）+ measurement_invalid でない +
+// child_process_error_count==0 の smoke に限定する。`ORBIT_EFFECT_PLUGIN` 未設定は loud skip。
+#[test]
+#[ignore = "VST3 Phase1 C4: commercial plugin smoke — set ORBIT_EFFECT_PLUGIN to a real .vst3 bundle + real device (local only)"]
+fn outproc_effect_vst3_commercial_plugin_smoke() {
+    let Some(plugin_env) = std::env::var_os("ORBIT_EFFECT_PLUGIN") else {
+        println!(
+            "ORBIT_EFFECT_PLUGIN が未設定 — commercial VST3 smoke test を skip \
+             （実 .vst3 bundle の絶対パスを設定して実行すること）"
+        );
+        return;
+    };
+    let plugin = PathBuf::from(plugin_env);
+    assert!(
+        plugin.exists(),
+        "ORBIT_EFFECT_PLUGIN のパスが存在しない: {}",
+        plugin.display()
+    );
+    let child_exe = vst3_child_exe();
+    assert!(
+        child_exe.exists(),
+        "VST3 effect child binary が無い: {} — 先に `cargo build -p orbit-vst3-effect-child`",
+        child_exe.display()
+    );
+    let wav = repo_path("test-assets/audio/sine_440.wav");
+    assert!(wav.exists(), "音源 WAV が無い: {}", wav.display());
+
+    let cfg = OutProcEffectConfig {
+        format: PluginFormat::Vst3,
+        child_exe,
+        plugin: plugin.clone(),
+        plugin_id: std::env::var("ORBIT_EFFECT_PLUGIN_ID").ok(),
+        buffer_frames: None,
+    };
+
+    let (engine, _guard) = EngineWrap::start_outproc_effect(cfg).unwrap_or_else(|e| {
+        panic!(
+            "start OOP effect daemon 失敗（plugin={}）: {e}",
+            plugin.display()
+        )
+    });
+    play_sine(&engine, &wav);
+    // 市販プラグインは load/warm-up がさらに重い可能性があるため、固定 sleep 単体ではなく fresh 出力が
+    // 出るまで poll してから測定窓を追加する（parity は assert しないので timeout 自体は fail させず、
+    // loud に記録するだけに留める — crash-free / measurement_invalid のチェックは以降も続行する）。
+    let productive = wait_until_productive(&engine);
+    if !productive {
+        println!(
+            "[C4] warm-up timeout（{WARM_UP_TIMEOUT:?}）内に fresh 出力を確認できなかった \
+             — plugin load が重い可能性（parity は assert しないため以降の crash-free チェックは続行する）"
+        );
+    }
+    std::thread::sleep(Duration::from_millis(500));
+
+    let s = engine
+        .outproc_effect_stats()
+        .expect("outproc stats available");
+    let cb = engine
+        .outproc_callback_stats()
+        .expect("callback stats available");
+    let ratio = if s.dry_peak > 0.0 {
+        s.post_peak / s.dry_peak
+    } else {
+        0.0
+    };
+    println!(
+        "=== VST3 Phase1 C4 commercial plugin smoke verdict: {} ===",
+        plugin.display()
+    );
+    println!("dry_peak:            {:.5}", s.dry_peak);
+    println!("post_peak:           {:.5}", s.post_peak);
+    println!("ratio (post/dry):    {ratio:.5}  (unknown gain — not asserted)");
+    println!(
+        "fresh / stale / stall: {} / {} / {}",
+        s.fresh, s.stale, s.stall
+    );
+    println!("callback_count:      {}", s.callback_count);
+    println!("callback_max_ns:     {}", cb.max_ns);
+    println!("callback_p99_ns:     {}", cb.p99_ns);
+    println!("respawn_count:       {}", s.respawn_count);
+    println!("child_proc_errors:   {}", s.child_process_error_count);
+    println!("measurement_invalid: {}", s.measurement_invalid);
+    println!("=====================================================================");
+
+    assert!(
+        !s.measurement_invalid,
+        "計測無効（respawn 失敗）— plugin load / child spawn を確認（plugin={}）",
+        plugin.display()
+    );
+    assert!(
+        s.dry_peak > 0.01,
+        "engine が発音しなかった (dry_peak={:.5})。sample 再生経路を確認",
+        s.dry_peak
+    );
+    assert_eq!(
+        s.respawn_count,
+        0,
+        "commercial smoke 中に respawn が発生した = child crash の疑い（plugin={}）",
+        plugin.display()
+    );
+    assert_eq!(
+        s.child_process_error_count,
+        0,
+        "child 側で processing error が計測された（plugin={}）",
+        plugin.display()
+    );
+    assert!(
+        cb.max_ns < CALLBACK_MAX_BUDGET_NS,
+        "callback max が異常に大きい ({} ns ≈ {:.2} ms) — RT 違反の疑い（plugin={}）",
+        cb.max_ns,
+        cb.max_ns as f64 / 1e6,
+        plugin.display()
+    );
+    // gain 不明なので post/dry ratio は assert しない（printed verdict を owner が目視確認する）。
+    // _guard drop で teardown。
+}

--- a/rust/crates/orbit-audio-sandbox/src/lib.rs
+++ b/rust/crates/orbit-audio-sandbox/src/lib.rs
@@ -21,7 +21,10 @@ pub mod transport;
 
 pub use child::SandboxChildGuard;
 pub use host::PipelinedEffectHost;
-pub use offline::{max_abs_diff, render_in_process_gain, render_through_child_sync};
+pub use offline::{
+    max_abs_diff, render_in_process_gain, render_through_child_sync,
+    render_through_child_sync_with_options, ChildStats, RenderOptions,
+};
 pub use transport::{
     create_shared, open_shared, region_ptr, slot_index, slot_offset, SharedRegion, BUF_LEN,
     CHANNELS, CONTROL_QUIT, CONTROL_RUN, MAX_FRAMES, REGION_BYTES, SLOTS,

--- a/rust/crates/orbit-audio-sandbox/src/offline.rs
+++ b/rust/crates/orbit-audio-sandbox/src/offline.rs
@@ -20,8 +20,43 @@ use crate::transport::{
     create_shared, region_ptr, slot_index, slot_offset, BUF_LEN, CHANNELS, CONTROL_RUN,
 };
 
-/// 1 block の child 完了を待つ上限(これを超えたら child 死亡とみなしエラー)。
+/// 1 block の child 完了を待つ既定上限(これを超えたら child 死亡とみなしエラー)。
 const BLOCK_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// [`render_through_child_sync_with_options`] のタイムアウト設定。
+///
+/// **初回ブロックは plugin の load を含む**(child は shm を map 後・spin loop 前に plugin を
+/// load する)。重い商用プラグイン(サンプラ・認証チェックする effect)は load が数秒かかりうるので、
+/// 初回だけ長い deadline を許して「crash でないのに TimedOut で false-fail」を避ける。
+#[derive(Clone, Copy, Debug)]
+pub struct RenderOptions {
+    /// 最初のブロック(= plugin load を含む)の完了待ち上限。
+    pub first_block_timeout: Duration,
+    /// 2 ブロック目以降の完了待ち上限。
+    pub block_timeout: Duration,
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self {
+            first_block_timeout: BLOCK_TIMEOUT,
+            block_timeout: BLOCK_TIMEOUT,
+        }
+    }
+}
+
+/// child が回収した処理統計([`render_through_child_sync_with_options`] が返す)。
+///
+/// `process_errors == 0` かつ `processed == 期待ブロック数` を突き合わせることで、child が
+/// `process()` 失敗時に dry 素通しするだけ(出力=入力で有限値になり従来の出力検査を誤 PASS させる)
+/// のを検出できる。
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ChildStats {
+    /// child が `process()` を通したブロック総数(成功・失敗いずれもカウント)。
+    pub processed: u64,
+    /// うち `process()` が非 OK を返し dry 素通しになったブロック数。
+    pub process_errors: u64,
+}
 
 /// 同一プロセス内で複数 driver を回した時に共有メモリファイル名が衝突しないための連番。
 static SHM_SEQ: AtomicU64 = AtomicU64::new(0);
@@ -45,6 +80,27 @@ pub fn render_through_child_sync(
     block_frames: usize,
     child_args: &[&str],
 ) -> io::Result<Vec<f32>> {
+    let (out, _stats) = render_through_child_sync_with_options(
+        child_exe,
+        input,
+        block_frames,
+        child_args,
+        RenderOptions::default(),
+    )?;
+    Ok(out)
+}
+
+/// [`render_through_child_sync`] の変種で、per-block timeout を可変にし child の処理統計
+/// ([`ChildStats`])も返す。gated 実機検証で「重い商用プラグインの load が既定 5s を超えて false-fail」
+/// と「`process()` 失敗の dry 素通しによる誤 PASS」の両方を扱うために使う。既定 `opts` では
+/// [`render_through_child_sync`] と挙動が一致する(初回・以降とも 5s)。
+pub fn render_through_child_sync_with_options(
+    child_exe: &Path,
+    input: &[f32],
+    block_frames: usize,
+    child_args: &[&str],
+    opts: RenderOptions,
+) -> io::Result<(Vec<f32>, ChildStats)> {
     assert!(block_frames >= 1 && block_frames * CHANNELS <= BUF_LEN);
     let shm_path = unique_shm_path();
     let mmap = create_shared(&shm_path)?;
@@ -79,7 +135,13 @@ pub fn render_through_child_sync(
             (*region).seq_request.store(seq, Release);
         }
         // child 完了を待つ(bounded・offline は非 RT なので spin でなく yield で CPU を譲る)。
-        let deadline = Instant::now() + BLOCK_TIMEOUT;
+        // 初回ブロックは plugin load を含むため first_block_timeout を使う。
+        let timeout = if seq == 1 {
+            opts.first_block_timeout
+        } else {
+            opts.block_timeout
+        };
+        let deadline = Instant::now() + timeout;
         loop {
             if unsafe { (*region).seq_done.load(Acquire) } >= seq {
                 break;
@@ -103,8 +165,20 @@ pub fn render_through_child_sync(
             out.extend_from_slice(std::slice::from_raw_parts(src, count));
         }
     }
+    // 統計を回収してから teardown する。
+    // happens-before: child は `child_processed` / `child_process_error_count` の fetch_add を
+    // `seq_done.store(Release)` より前に行う(main.rs)。上のループは最終ブロックの
+    // `seq_done.load(Acquire)` を観測して抜けるので、その Acquire がこれら counter の全 increment を
+    // 可視化する。ゆえにここでの Relaxed load は最終ブロックまでの確定値を読む。CONTROL_QUIT を送る
+    // `drop(guard)` の **前** に読むこと(QUIT 後は child が終了へ向かい観測が競合しうる)。
+    let stats = unsafe {
+        ChildStats {
+            processed: (*region).child_processed.load(Relaxed),
+            process_errors: (*region).child_process_error_count.load(Relaxed),
+        }
+    };
     drop(guard);
-    Ok(out)
+    Ok((out, stats))
 }
 
 /// 2 つのバッファの要素ごと最大絶対差。長さが違えば `f32::INFINITY`。

--- a/rust/crates/orbit-audio-sandbox/tests/parity.rs
+++ b/rust/crates/orbit-audio-sandbox/tests/parity.rs
@@ -8,7 +8,8 @@
 use std::path::PathBuf;
 
 use orbit_audio_sandbox::{
-    max_abs_diff, render_in_process_gain, render_through_child_sync, CHANNELS,
+    max_abs_diff, render_in_process_gain, render_through_child_sync,
+    render_through_child_sync_with_options, RenderOptions, CHANNELS,
 };
 
 /// cargo がビルドした gain child binary の path。
@@ -59,4 +60,32 @@ fn out_of_process_unity_gain_is_passthrough() {
         .expect("child round-trip 成功");
     let diff = max_abs_diff(&through_child, &input);
     assert_eq!(diff, 0.0, "gain=1.0 は入力をそのまま返す(diff={diff})");
+}
+
+// C3(pr-review-team): `ChildStats`(processed/process_errors)が gated harness 経由でしか一切
+// assert されていなかった。実 synthetic child(gain child)で非 gated(CI 実行可)に固定する。
+#[test]
+fn child_stats_counts_processed_blocks_without_errors() {
+    let total_frames = 256;
+    let block_frames = 64;
+    let input = make_signal(total_frames);
+    let (out, stats) = render_through_child_sync_with_options(
+        &child_exe(),
+        &input,
+        block_frames,
+        &["--gain", "0.5"],
+        RenderOptions::default(),
+    )
+    .expect("child round-trip 成功");
+
+    assert_eq!(out.len(), input.len(), "出力長は入力長と一致");
+    assert_eq!(
+        stats.processed,
+        (total_frames / block_frames) as u64,
+        "256 frames / 64 block = 4 ブロック処理"
+    );
+    assert_eq!(
+        stats.process_errors, 0,
+        "gain child は process() に失敗しない"
+    );
 }

--- a/rust/crates/orbit-clap-host/src/discovery.rs
+++ b/rust/crates/orbit-clap-host/src/discovery.rs
@@ -60,10 +60,10 @@ impl PluginDescriptor {
 impl Display for PluginDescriptor {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match (&self.name, &self.version) {
-            (None, None) => write!(f, "{}", &self.id),
-            (Some(n), None) => write!(f, "{n} ({})", &self.id),
-            (None, Some(v)) => write!(f, "{} v{v}", &self.id),
-            (Some(n), Some(v)) => write!(f, "{n} ({}) v{v}", &self.id),
+            (None, None) => write!(f, "{}", self.id),
+            (Some(n), None) => write!(f, "{n} ({})", self.id),
+            (None, Some(v)) => write!(f, "{} v{v}", self.id),
+            (Some(n), Some(v)) => write!(f, "{n} ({}) v{v}", self.id),
         }
     }
 }

--- a/rust/crates/orbit-clap-spike/src/discovery.rs
+++ b/rust/crates/orbit-clap-spike/src/discovery.rs
@@ -59,10 +59,10 @@ impl PluginDescriptor {
 impl Display for PluginDescriptor {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match (&self.name, &self.version) {
-            (None, None) => write!(f, "{}", &self.id),
-            (Some(n), None) => write!(f, "{n} ({})", &self.id),
-            (None, Some(v)) => write!(f, "{} v{v}", &self.id),
-            (Some(n), Some(v)) => write!(f, "{n} ({}) v{v}", &self.id),
+            (None, None) => write!(f, "{}", self.id),
+            (Some(n), None) => write!(f, "{n} ({})", self.id),
+            (None, Some(v)) => write!(f, "{} v{v}", self.id),
+            (Some(n), Some(v)) => write!(f, "{n} ({}) v{v}", self.id),
         }
     }
 }

--- a/rust/crates/orbit-vst3-effect-child/Cargo.toml
+++ b/rust/crates/orbit-vst3-effect-child/Cargo.toml
@@ -1,0 +1,21 @@
+# orbit-vst3-effect-child — Phase 1 VST3 OOP effect child.
+#
+# CLAP child と同じ SharedRegion transport を使い、処理部だけ orbit-vst3-host の
+# Vst3EffectProcessor に差し替える。clack はリンクしない。
+[package]
+name = "orbit-vst3-effect-child"
+version.workspace = true
+edition = "2021"
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Out-of-process VST3 effect child hosting a real VST3 plugin over the orbit-audio-sandbox transport"
+
+[[bin]]
+name = "orbit-vst3-effect-child"
+path = "src/main.rs"
+
+[dependencies]
+orbit-vst3-host = { path = "../orbit-vst3-host" }
+orbit-audio-sandbox = { path = "../orbit-audio-sandbox" }
+anyhow = "1"

--- a/rust/crates/orbit-vst3-effect-child/src/main.rs
+++ b/rust/crates/orbit-vst3-effect-child/src/main.rs
@@ -13,15 +13,21 @@
 
 #![allow(unsafe_code)]
 
+#[cfg(target_os = "macos")]
 use std::path::PathBuf;
+#[cfg(target_os = "macos")]
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
+#[cfg(target_os = "macos")]
 use anyhow::{bail, Context, Result};
+#[cfg(target_os = "macos")]
 use orbit_audio_sandbox::{
     open_shared, region_ptr, slot_index, slot_offset, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_FRAMES,
 };
+#[cfg(target_os = "macos")]
 use orbit_vst3_host::Vst3EffectProcessor;
 
+#[cfg(target_os = "macos")]
 struct Args {
     shm: PathBuf,
     plugin: PathBuf,
@@ -29,6 +35,7 @@ struct Args {
     sample_rate: u32,
 }
 
+#[cfg(target_os = "macos")]
 fn parse_args() -> Result<Args> {
     let mut shm: Option<PathBuf> = None;
     let mut plugin: Option<PathBuf> = None;
@@ -58,6 +65,7 @@ fn parse_args() -> Result<Args> {
     })
 }
 
+#[cfg(target_os = "macos")]
 fn main() -> Result<()> {
     let args = parse_args()?;
     let mmap = open_shared(&args.shm).with_context(|| format!("open_shared({:?})", args.shm))?;
@@ -119,4 +127,10 @@ fn main() -> Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() -> std::process::ExitCode {
+    eprintln!("orbit-vst3-effect-child is macOS-only (VST3/CoreFoundation)");
+    std::process::ExitCode::FAILURE
 }

--- a/rust/crates/orbit-vst3-effect-child/src/main.rs
+++ b/rust/crates/orbit-vst3-effect-child/src/main.rs
@@ -1,0 +1,122 @@
+//! orbit-vst3-effect-child — Phase 1 VST3 effect child process.
+//!
+//! This is intentionally transport-identical to `orbit-clap-effect-child`: map
+//! [`orbit_audio_sandbox::SharedRegion`], copy each input slot into scratch, run the effect
+//! in-place, copy scratch to the output slot, and publish `seq_tag` / `seq_done`.
+//! The only functional difference is the processor: [`orbit_vst3_host::Vst3EffectProcessor`].
+//!
+//! CLI:
+//!   --shm <path>
+//!   --plugin <path>
+//!   --plugin-id <id>      accepted for CLI symmetry; unused by Phase 1 VST3 host
+//!   --sample-rate <u32>
+
+#![allow(unsafe_code)]
+
+use std::path::PathBuf;
+use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+
+use anyhow::{bail, Context, Result};
+use orbit_audio_sandbox::{
+    open_shared, region_ptr, slot_index, slot_offset, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_FRAMES,
+};
+use orbit_vst3_host::Vst3EffectProcessor;
+
+struct Args {
+    shm: PathBuf,
+    plugin: PathBuf,
+    plugin_id: Option<String>,
+    sample_rate: u32,
+}
+
+fn parse_args() -> Result<Args> {
+    let mut shm: Option<PathBuf> = None;
+    let mut plugin: Option<PathBuf> = None;
+    let mut plugin_id: Option<String> = None;
+    let mut sample_rate: u32 = 48_000;
+    let mut it = std::env::args().skip(1);
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--shm" => shm = Some(PathBuf::from(it.next().context("--shm に値が必要")?)),
+            "--plugin" => plugin = Some(PathBuf::from(it.next().context("--plugin に値が必要")?)),
+            "--plugin-id" => plugin_id = Some(it.next().context("--plugin-id に値が必要")?),
+            "--sample-rate" => {
+                sample_rate = it
+                    .next()
+                    .context("--sample-rate に値が必要")?
+                    .parse()
+                    .context("--sample-rate の parse")?
+            }
+            other => bail!("未知の引数: {other}"),
+        }
+    }
+    Ok(Args {
+        shm: shm.context("--shm は必須")?,
+        plugin: plugin.context("--plugin は必須")?,
+        plugin_id,
+        sample_rate,
+    })
+}
+
+fn main() -> Result<()> {
+    let args = parse_args()?;
+    let mmap = open_shared(&args.shm).with_context(|| format!("open_shared({:?})", args.shm))?;
+    let region = region_ptr(&mmap);
+
+    if let Some(plugin_id) = &args.plugin_id {
+        eprintln!(
+            "[orbit-vst3-effect-child] --plugin-id={plugin_id} は Phase 1 VST3 effect では未使用"
+        );
+    }
+
+    let (mut effect, _info) =
+        Vst3EffectProcessor::load(&args.plugin, args.sample_rate as f64, MAX_FRAMES as i32)
+            .with_context(|| format!("load VST3 effect {:?}", args.plugin))?;
+
+    let mut scratch = vec![0.0f32; BUF_LEN];
+    let mut process_errors: u64 = 0;
+
+    let mut last: u64 = 0;
+    loop {
+        if unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT {
+            break;
+        }
+        let cur = unsafe { (*region).seq_request.load(Acquire) };
+        if cur > last {
+            let idx = slot_index(cur);
+            let off = slot_offset(cur);
+            let count = unsafe {
+                let n = ((*region).n_frames[idx].load(Relaxed) as usize).min(MAX_FRAMES);
+                let count = n * CHANNELS;
+                let in_base = std::ptr::addr_of!((*region).input) as *const f32;
+                std::ptr::copy_nonoverlapping(in_base.add(off), scratch.as_mut_ptr(), count);
+                count
+            };
+
+            if !effect.process_block(&mut scratch[..count]) {
+                process_errors += 1;
+                unsafe {
+                    (*region).child_process_error_count.fetch_add(1, Relaxed);
+                }
+            }
+
+            unsafe {
+                let out_base = std::ptr::addr_of_mut!((*region).output) as *mut f32;
+                std::ptr::copy_nonoverlapping(scratch.as_ptr(), out_base.add(off), count);
+                (*region).child_processed.fetch_add(1, Relaxed);
+                (*region).seq_tag[idx].store(cur, Release);
+                (*region).seq_done.store(cur, Release);
+            }
+            last = cur;
+        } else {
+            std::hint::spin_loop();
+        }
+    }
+    if process_errors > 0 {
+        eprintln!(
+            "[orbit-vst3-effect-child] plugin.process() failed for {process_errors} block(s); \
+             affected blocks were passed through dry"
+        );
+    }
+    Ok(())
+}

--- a/rust/crates/orbit-vst3-effect-child/tests/cli.rs
+++ b/rust/crates/orbit-vst3-effect-child/tests/cli.rs
@@ -1,3 +1,5 @@
+#![cfg(target_os = "macos")]
+
 use std::process::Command;
 
 #[test]

--- a/rust/crates/orbit-vst3-effect-child/tests/cli.rs
+++ b/rust/crates/orbit-vst3-effect-child/tests/cli.rs
@@ -1,0 +1,41 @@
+use std::process::Command;
+
+#[test]
+fn child_without_shm_exits_nonzero() {
+    let child_exe = env!("CARGO_BIN_EXE_orbit-vst3-effect-child");
+    let status = Command::new(child_exe)
+        .args(["--plugin", "/nonexistent/x.vst3"])
+        .status()
+        .expect("child binary を起動");
+    assert!(!status.success(), "--shm 欠落時は非ゼロ終了すべき");
+}
+
+#[test]
+fn child_without_plugin_exits_nonzero() {
+    let child_exe = env!("CARGO_BIN_EXE_orbit-vst3-effect-child");
+    let status = Command::new(child_exe)
+        .args(["--shm", "/nonexistent/orbit-shm"])
+        .status()
+        .expect("child binary を起動");
+    assert!(!status.success(), "--plugin 欠落時は非ゼロ終了すべき");
+}
+
+#[test]
+fn child_unknown_arg_exits_nonzero() {
+    let child_exe = env!("CARGO_BIN_EXE_orbit-vst3-effect-child");
+    let status = Command::new(child_exe)
+        .args(["--bogus"])
+        .status()
+        .expect("child binary を起動");
+    assert!(!status.success(), "未知の引数は非ゼロ終了すべき");
+}
+
+#[test]
+fn child_flag_without_value_exits_nonzero() {
+    let child_exe = env!("CARGO_BIN_EXE_orbit-vst3-effect-child");
+    let status = Command::new(child_exe)
+        .args(["--shm"])
+        .status()
+        .expect("child binary を起動");
+    assert!(!status.success(), "値の無いフラグは非ゼロ終了すべき");
+}

--- a/rust/crates/orbit-vst3-effect-child/tests/oracle_parity.rs
+++ b/rust/crates/orbit-vst3-effect-child/tests/oracle_parity.rs
@@ -1,0 +1,75 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use orbit_audio_sandbox::{
+    max_abs_diff, render_in_process_gain, render_through_child_sync, CHANNELS, MAX_FRAMES,
+};
+
+const SAMPLE_RATE: &str = "48000";
+
+fn package_oracle() -> Option<PathBuf> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let script = manifest_dir
+        .parent()
+        .expect("crate has parent")
+        .join("orbit-vst3-gain-oracle")
+        .join("package-oracle.sh");
+    let output = Command::new(&script).output().ok()?;
+    if !output.status.success() {
+        eprintln!(
+            "oracle packaging failed: status={} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Some(PathBuf::from(stdout.trim()))
+}
+
+fn child_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_orbit-vst3-effect-child"))
+}
+
+fn make_signal(total_frames: usize) -> Vec<f32> {
+    (0..total_frames * CHANNELS)
+        .map(|i| {
+            let t = i as f32;
+            0.9 * ((t * 0.013).sin())
+        })
+        .collect()
+}
+
+#[test]
+fn vst3_gain_oracle_oop_child_is_sample_exact_passthrough() {
+    let Some(bundle) = package_oracle() else {
+        eprintln!("VST3 oracle build failed; loud skip for this machine");
+        return;
+    };
+    let plugin = bundle.to_str().expect("oracle path is UTF-8");
+
+    for &(total_frames, block_frames) in &[(64, 64), (256, 64), (300, 64), (512, 128)] {
+        let input = make_signal(total_frames);
+        let through_child = render_through_child_sync(
+            &child_exe(),
+            &input,
+            block_frames,
+            &["--plugin", plugin, "--sample-rate", SAMPLE_RATE],
+        )
+        .expect("child round-trip 成功");
+
+        assert_eq!(through_child.len(), input.len());
+        let diff = max_abs_diff(&through_child, &input);
+        assert_eq!(
+            diff, 0.0,
+            "default gain=1.0 oracle must be sample-exact passthrough(total={total_frames}, block={block_frames})"
+        );
+    }
+}
+
+#[test]
+fn vst3_gain_oracle_in_process_closed_form_remains_exact() {
+    let input = make_signal(MAX_FRAMES);
+    let reference = render_in_process_gain(&input, 1.0);
+    assert_eq!(max_abs_diff(&input, &reference), 0.0);
+}

--- a/rust/crates/orbit-vst3-effect-child/tests/real_plugin_gated.rs
+++ b/rust/crates/orbit-vst3-effect-child/tests/real_plugin_gated.rs
@@ -1,0 +1,8 @@
+#[test]
+#[ignore = "requires non-sandboxed commercial VST3 measurement environment"]
+fn commercial_vst3_oop_smoke_gated() {
+    eprintln!(
+        "Run a non-sandboxed sweep by setting ORBIT_EFFECT_FORMAT=vst3 and ORBIT_EFFECT_PLUGIN to \
+         the target .vst3 bundle, then drive the daemon OOP effect harness."
+    );
+}

--- a/rust/crates/orbit-vst3-effect-child/tests/real_plugin_gated.rs
+++ b/rust/crates/orbit-vst3-effect-child/tests/real_plugin_gated.rs
@@ -18,7 +18,9 @@
 //! ## 二層判定
 //! - **effect（`audio_in > 0`）= ゲート対象**: FAIL したらこのテスト全体を `panic!` させる。
 //! - **instrument（`audio_in == 0`）= informational**: 結果は記録するが gate しない
-//!   （多バス instrument は host 契約上 OOB read の可能性が既知 ── §lib.rs L800 台のコメント参照）。
+//!   （primary bus 以外の extra bus を持つ多バス instrument は host が単に配線しない ── OOB read
+//!   ではなく bus 0 が host の固定 stereo 幅と食い違う場合は load 時点で reject される。
+//!   `orbit-vst3-host/src/lib.rs` の `Vst3EffectProcessor::run_process` 直上コメント参照）。
 //! - probe 自体の load 失敗/crash/hang（kind 判定前）は **non-gating**（surfaced のみ）。
 //!
 //! ## 既知の limitation

--- a/rust/crates/orbit-vst3-effect-child/tests/real_plugin_gated.rs
+++ b/rust/crates/orbit-vst3-effect-child/tests/real_plugin_gated.rs
@@ -1,8 +1,587 @@
+//! Phase 1 VST3 OOP host — **実市販プラグイン**に対する machinery smoke（#381 follow-on）。
+//!
+//! ## このテストが証明すること・証明しないこと
+//! 証明するのは「Phase 1 の OOP host 機構（child spawn・SharedRegion transport・plugin
+//! load・process()・isolation）が実市販プラグイン（NI/iZotope 等 arm64）を crash 0 で生き延びる」
+//! ことだけ。合成 gain oracle（`oracle_parity.rs`）と違い商用プラグインには closed-form 参照が
+//! 無いため、**`process_errors == 0`（`process()` が非 OK を返し dry passthrough になっていない）
+//! ＋ 有限 ＋ 非発散（`|x| <= 8.0`）＋ 期待ブロック数の到達** をゲートにする。これは
+//! 「host が実際に `process()` を crash 無く完走させた証跡」であって **musical に正しい DSP の
+//! 証拠ではない**（音楽的正しさの検証は capture→owner 試聴の follow-on）。
+//!
+//! ## 分類 = out-of-process `vst3_probe`（Phase 0 資産・新規コード不要）
+//! 各プラグインをまず `vst3_probe`（別プロセス・20s timeout）で probe し、`audio_in` で
+//! effect/instrument を判定する。probe 自体の crash/hang はここで隔離され、`real_plugin_gated`
+//! 本体のプロセスには波及しない（「結果ベース分類」だと instrument の crash が誤って effect gate
+//! に混入しうる ── その穴をここで閉じる）。
+//!
+//! ## 二層判定
+//! - **effect（`audio_in > 0`）= ゲート対象**: FAIL したらこのテスト全体を `panic!` させる。
+//! - **instrument（`audio_in == 0`）= informational**: 結果は記録するが gate しない
+//!   （多バス instrument は host 契約上 OOB read の可能性が既知 ── §lib.rs L800 台のコメント参照）。
+//! - probe 自体の load 失敗/crash/hang（kind 判定前）は **non-gating**（surfaced のみ）。
+//!
+//! ## 既知の limitation
+//! `find_audio_module_class`（orbit-vst3-host/src/lib.rs）は factory の最初の Audio Module Class を
+//! 選ぶ。multi-component な VST3 bundle では意図しないクラスを選ぶ可能性がある（informational・
+//! 別 issue 相当・本テストはそれを検出も補正もしない）。
+//!
+//! ## 実行（非サンドボックス・実機のみ）
+//! ```text
+//! ORBIT_GATED_VST3_DIR=/Library/Audio/Plug-Ins/VST3 \
+//! cargo test -p orbit-vst3-effect-child --test real_plugin_gated -- --ignored --nocapture
+//! ```
+//! 既定は curated 代表セット（下記 `CURATED_NAMES`）。全プラグインを流すには
+//! `ORBIT_GATED_VST3_ALL=1`（`ORBIT_GATED_VST3_MAX` で上限）。個別指定は
+//! `ORBIT_GATED_VST3_PLUGINS`（`:` 区切りのフルパス）。
+
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use orbit_audio_sandbox::{render_through_child_sync_with_options, RenderOptions, CHANNELS};
+
+/// probe 1 本あたりの timeout（load が重い商用プラグイン向けに余裕を持たせる。sweep.sh の実績値
+/// 20s を踏襲）。
+const PROBE_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// effect 駆動の 1 ブロック目（plugin load を含む）の timeout。商用サンプラー等の重い load を吸収。
+const FIRST_BLOCK_TIMEOUT: Duration = Duration::from_secs(60);
+/// 2 ブロック目以降の timeout。
+const STEADY_BLOCK_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// 駆動する総フレーム数(64 と 128 の両方の倍数)。
+const TOTAL_FRAMES: usize = 2048;
+
+/// env 未指定時に流す代表セット(owner 環境に存在するものだけを実際には使う)。
+const CURATED_NAMES: &[&str] = &[
+    "Kontakt 8",
+    "Massive X",
+    "FM8",
+    "Reaktor 6",
+    "Guitar Rig 7",
+    "Ozone 11",
+    "Neutron 5",
+    "RX 11 Voice De-noise",
+    "Nectar 4",
+    "Vinyl",
+    "Relay",
+];
+
+const DEFAULT_VST3_DIR: &str = "/Library/Audio/Plug-Ins/VST3";
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum PluginKind {
+    Effect,
+    Instrument,
+    Unknown,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Outcome {
+    Pass,
+    Fail,
+    Skip,
+    Crash,
+}
+
+struct Row {
+    name: String,
+    kind: PluginKind,
+    outcome: Outcome,
+    detail: String,
+}
+
 #[test]
 #[ignore = "requires non-sandboxed commercial VST3 measurement environment"]
 fn commercial_vst3_oop_smoke_gated() {
+    let Some(probe_bin) = resolve_probe_bin() else {
+        eprintln!(
+            "[real_plugin_gated] vst3_probe binary を用意できなかった — このマシンでは loud skip"
+        );
+        return;
+    };
+
+    let plugins = resolve_plugins();
+    if plugins.is_empty() {
+        eprintln!(
+            "[real_plugin_gated] 対象 VST3 プラグインが無い(ORBIT_GATED_VST3_DIR 非在 or curated \
+             セットが 1 つも見つからない) — loud skip"
+        );
+        return;
+    }
+
+    let child_exe = PathBuf::from(env!("CARGO_BIN_EXE_orbit-vst3-effect-child"));
+    let mut rows: Vec<Row> = Vec::new();
+
+    for plugin in &plugins {
+        let name = plugin
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("<unknown>")
+            .to_owned();
+
+        match is_arm64(plugin) {
+            Some(true) => {}
+            Some(false) => {
+                rows.push(Row {
+                    name,
+                    kind: PluginKind::Unknown,
+                    outcome: Outcome::Skip,
+                    detail: "Intel-only bundle(arm64 スライス無し)".to_owned(),
+                });
+                continue;
+            }
+            None => {
+                rows.push(Row {
+                    name,
+                    kind: PluginKind::Unknown,
+                    outcome: Outcome::Skip,
+                    detail: "arch 判定不能(bundle 構造異常 or lipo 失敗)".to_owned(),
+                });
+                continue;
+            }
+        }
+
+        let Some(plugin_str) = plugin.to_str() else {
+            rows.push(Row {
+                name,
+                kind: PluginKind::Unknown,
+                outcome: Outcome::Skip,
+                detail: "非 UTF-8 パス".to_owned(),
+            });
+            continue;
+        };
+
+        let probe_run = match run_probe(&probe_bin, plugin, PROBE_TIMEOUT) {
+            Ok(r) => r,
+            Err(err) => {
+                rows.push(Row {
+                    name,
+                    kind: PluginKind::Unknown,
+                    outcome: Outcome::Crash,
+                    detail: format!("probe spawn 失敗: {err}"),
+                });
+                continue;
+            }
+        };
+
+        if probe_run.timed_out {
+            rows.push(Row {
+                name,
+                kind: PluginKind::Unknown,
+                outcome: Outcome::Crash,
+                detail: format!("probe が {PROBE_TIMEOUT:?} 以内に終了しなかった(hang)"),
+            });
+            continue;
+        }
+        let status = probe_run
+            .status
+            .expect("timed_out=false ならば status は Some");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::ExitStatusExt;
+            if let Some(sig) = status.signal() {
+                rows.push(Row {
+                    name,
+                    kind: PluginKind::Unknown,
+                    outcome: Outcome::Crash,
+                    detail: format!("probe がシグナル {sig} で終了(crash)"),
+                });
+                continue;
+            }
+        }
+
+        if !status.success() && probe_run.stdout.trim().is_empty() {
+            rows.push(Row {
+                name,
+                kind: PluginKind::Unknown,
+                outcome: Outcome::Crash,
+                detail: format!("probe が JSON 未出力のまま異常終了(status={status:?})"),
+            });
+            continue;
+        }
+
+        let json = probe_run.stdout.as_str();
+        let loaded = extract_bool(json, "loaded").unwrap_or(false);
+        if !loaded {
+            let error = extract_string(json, "error").unwrap_or_default();
+            rows.push(Row {
+                name,
+                kind: PluginKind::Unknown,
+                outcome: Outcome::Fail,
+                detail: format!("load 失敗(non-gating): {error}"),
+            });
+            continue;
+        }
+
+        let audio_in = extract_i32(json, "audio_in").unwrap_or(0);
+        let kind = if audio_in > 0 {
+            PluginKind::Effect
+        } else {
+            PluginKind::Instrument
+        };
+
+        let drive = drive_plugin(&child_exe, plugin_str);
+        let outcome = if drive.ok {
+            Outcome::Pass
+        } else {
+            Outcome::Fail
+        };
+        rows.push(Row {
+            name,
+            kind,
+            outcome,
+            detail: drive.detail,
+        });
+    }
+
     eprintln!(
-        "Run a non-sandboxed sweep by setting ORBIT_EFFECT_FORMAT=vst3 and ORBIT_EFFECT_PLUGIN to \
-         the target .vst3 bundle, then drive the daemon OOP effect harness."
+        "\n=== VST3 Phase 1 gated smoke summary (machinery only; not a DSP-correctness proof) ==="
     );
+    for row in &rows {
+        eprintln!(
+            "{:<6} {:<10} {:<28} {}",
+            format!("{:?}", row.outcome),
+            format!("{:?}", row.kind),
+            row.name,
+            row.detail
+        );
+    }
+    eprintln!("=========================================================================\n");
+
+    let effect_failures: Vec<&str> = rows
+        .iter()
+        .filter(|row| row.kind == PluginKind::Effect && row.outcome == Outcome::Fail)
+        .map(|row| row.name.as_str())
+        .collect();
+    assert!(
+        effect_failures.is_empty(),
+        "effect gate 破り(crash / process_errors>0 / 未処理ブロック / 非有限 / 発散): {effect_failures:?} \
+         — 詳細は上のサマリを参照"
+    );
+}
+
+/// [`orbit_vst3_host`] の `vst3_probe` バイナリを解決する。別 crate のバイナリなので
+/// `CARGO_BIN_EXE_*` は使えない(cargo はテスト対象パッケージ自身のバイナリにしか設定しない)。
+/// `sweep.sh`(Phase 0 spike)と同じ資産を自前 build してから、このテストバイナリと同じ
+/// target ディレクトリ配下(sibling)を解決する。`current_exe()` は `CARGO_TARGET_DIR` が
+/// 設定されていても実際の出力先を反映するため、環境変数を手で読んで再現するより頑健。
+fn resolve_probe_bin() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("ORBIT_VST3_PROBE_BIN") {
+        let p = PathBuf::from(p);
+        if p.exists() {
+            return Some(p);
+        }
+        eprintln!(
+            "[real_plugin_gated] ORBIT_VST3_PROBE_BIN={} が存在しない",
+            p.display()
+        );
+        return None;
+    }
+
+    let status = Command::new("cargo")
+        .args([
+            "build",
+            "-p",
+            "orbit-vst3-host",
+            "--bin",
+            "vst3_probe",
+            "--locked",
+        ])
+        .status();
+    match status {
+        Ok(s) if s.success() => {}
+        Ok(s) => {
+            eprintln!(
+                "[real_plugin_gated] `cargo build -p orbit-vst3-host --bin vst3_probe` が失敗(status={s})"
+            );
+            return None;
+        }
+        Err(err) => {
+            eprintln!(
+                "[real_plugin_gated] `cargo build -p orbit-vst3-host --bin vst3_probe` の起動に失敗: {err}"
+            );
+            return None;
+        }
+    }
+
+    let mut p = std::env::current_exe().ok()?;
+    p.pop(); // test 実行ファイル名を除く
+    if p.ends_with("deps") {
+        p.pop(); // deps/ を除く → target/<profile>/
+    }
+    p.push("vst3_probe");
+    if p.exists() {
+        Some(p)
+    } else {
+        eprintln!(
+            "[real_plugin_gated] vst3_probe binary が見つからない: {}(cargo build 後も未生成)",
+            p.display()
+        );
+        None
+    }
+}
+
+/// 対象プラグインの一覧を解決する。優先順位: `ORBIT_GATED_VST3_PLUGINS`(`:` 区切りフルパス) →
+/// `ORBIT_GATED_VST3_ALL=1` なら `ORBIT_GATED_VST3_DIR`(既定 `/Library/Audio/Plug-Ins/VST3`) 配下の
+/// 全 `*.vst3`(`ORBIT_GATED_VST3_MAX` で上限) → それ以外は curated 代表セット(存在するものだけ)。
+fn resolve_plugins() -> Vec<PathBuf> {
+    if let Ok(list) = std::env::var("ORBIT_GATED_VST3_PLUGINS") {
+        return list
+            .split(':')
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from)
+            .collect();
+    }
+
+    let dir = std::env::var("ORBIT_GATED_VST3_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(DEFAULT_VST3_DIR));
+    if !dir.is_dir() {
+        eprintln!(
+            "[real_plugin_gated] VST3 ディレクトリが無い: {} — loud skip",
+            dir.display()
+        );
+        return Vec::new();
+    }
+
+    if std::env::var("ORBIT_GATED_VST3_ALL").as_deref() == Ok("1") {
+        let max: usize = std::env::var("ORBIT_GATED_VST3_MAX")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(usize::MAX);
+        let mut entries: Vec<PathBuf> = std::fs::read_dir(&dir)
+            .into_iter()
+            .flatten()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("vst3"))
+            .collect();
+        entries.sort();
+        entries.truncate(max);
+        entries
+    } else {
+        CURATED_NAMES
+            .iter()
+            .map(|name| dir.join(format!("{name}.vst3")))
+            .filter(|p| p.exists())
+            .collect()
+    }
+}
+
+/// bundle の唯一の実行ファイル(`Contents/MacOS/<exe>`)が arm64 スライスを含むか。
+/// bundle 構造異常や `lipo` 失敗時は `None`(判定不能)。
+fn is_arm64(bundle: &Path) -> Option<bool> {
+    let macos_dir = bundle.join("Contents").join("MacOS");
+    let mut candidates: Vec<PathBuf> = std::fs::read_dir(&macos_dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_file())
+        .collect();
+    candidates.sort();
+    let exe = candidates.into_iter().next()?;
+
+    let output = Command::new("lipo").arg("-archs").arg(&exe).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let archs = String::from_utf8_lossy(&output.stdout);
+    Some(archs.split_whitespace().any(|a| a == "arm64"))
+}
+
+struct ProbeRun {
+    timed_out: bool,
+    status: Option<ExitStatus>,
+    stdout: String,
+}
+
+/// `probe_bin <plugin>` を別プロセスで `timeout` 以内に実行する。timeout 超過時は kill して
+/// crash/hang 扱いにする(std のみ・try_wait ポーリング)。stdout の読み取りは別スレッドに逃がす
+/// (poll ループ内で `read_to_string` するとパイプが埋まった場合にブロックしうるため)。
+fn run_probe(probe_bin: &Path, plugin: &Path, timeout: Duration) -> io::Result<ProbeRun> {
+    let mut child = Command::new(probe_bin)
+        .arg(plugin)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+    let mut stdout_pipe = child.stdout.take().expect("stdout is piped");
+    let (tx, rx) = mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stdout_pipe.read_to_string(&mut buf);
+        let _ = tx.send(buf);
+    });
+
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait()? {
+            Some(status) => break Some(status),
+            None => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    };
+    let stdout = rx.recv_timeout(Duration::from_secs(5)).unwrap_or_default();
+    let _ = reader.join();
+    Ok(ProbeRun {
+        timed_out: status.is_none(),
+        status,
+        stdout,
+    })
+}
+
+fn extract_bool(json: &str, key: &str) -> Option<bool> {
+    let needle = format!("\"{key}\":");
+    let idx = json.find(&needle)? + needle.len();
+    let rest = &json[idx..];
+    if rest.starts_with("true") {
+        Some(true)
+    } else if rest.starts_with("false") {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+fn extract_i32(json: &str, key: &str) -> Option<i32> {
+    let needle = format!("\"{key}\":");
+    let idx = json.find(&needle)? + needle.len();
+    let rest = json[idx..].trim_start();
+    let end = rest
+        .find(|c: char| !(c.is_ascii_digit() || c == '-'))
+        .unwrap_or(rest.len());
+    rest[..end].parse().ok()
+}
+
+/// `"error":null` または `"error":"..."`(`\"`/`\\` のみエスケープ済み。`to_json_line` の
+/// `json_escape` は他の制御文字をエスケープしないため、値に生の改行が含まれる可能性はある ──
+/// このパーサは `find` ベースで行分割に依存しないのでそれでも安全)。
+fn extract_string(json: &str, key: &str) -> Option<String> {
+    let needle = format!("\"{key}\":");
+    let idx = json.find(&needle)? + needle.len();
+    let rest = &json[idx..];
+    if rest.starts_with("null") {
+        return None;
+    }
+    let rest = rest.strip_prefix('"')?;
+    let mut out = String::new();
+    let mut chars = rest.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => match chars.next() {
+                Some('"') => out.push('"'),
+                Some('\\') => out.push('\\'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => break,
+            },
+            '"' => break,
+            other => out.push(other),
+        }
+    }
+    Some(out)
+}
+
+fn make_signal(total_frames: usize) -> Vec<f32> {
+    (0..total_frames * CHANNELS)
+        .map(|i| {
+            let t = i as f32;
+            0.9 * ((t * 0.013).sin())
+        })
+        .collect()
+}
+
+struct DriveOutcome {
+    ok: bool,
+    detail: String,
+}
+
+/// `plugin` を `child_exe`(OOP VST3 effect child)越しに block=[64,128] で駆動し、二層判定の
+/// gate 条件(TimedOut でない・process_errors==0・processed==期待ブロック数・全サンプル有限かつ
+/// `|x|<=8.0`)を確認する。effect にも instrument にも使う(instrument は呼び出し側で non-gating
+/// 扱いにする)。
+fn drive_plugin(child_exe: &Path, plugin: &str) -> DriveOutcome {
+    let input = make_signal(TOTAL_FRAMES);
+    for &block_frames in &[64usize, 128usize] {
+        let expected_blocks = (TOTAL_FRAMES / block_frames) as u64;
+        let opts = RenderOptions {
+            first_block_timeout: FIRST_BLOCK_TIMEOUT,
+            block_timeout: STEADY_BLOCK_TIMEOUT,
+        };
+        let result = render_through_child_sync_with_options(
+            child_exe,
+            &input,
+            block_frames,
+            &["--plugin", plugin, "--sample-rate", "48000"],
+            opts,
+        );
+        let (out, stats) = match result {
+            Ok(v) => v,
+            Err(err) => {
+                return DriveOutcome {
+                    ok: false,
+                    detail: format!(
+                        "block={block_frames}f: child round-trip 失敗(crash/hang の可能性): {err}"
+                    ),
+                };
+            }
+        };
+        if stats.process_errors != 0 {
+            return DriveOutcome {
+                ok: false,
+                detail: format!(
+                    "block={block_frames}f: process_errors={}(dry passthrough 発生)",
+                    stats.process_errors
+                ),
+            };
+        }
+        if stats.processed != expected_blocks {
+            return DriveOutcome {
+                ok: false,
+                detail: format!(
+                    "block={block_frames}f: processed={} != 期待{expected_blocks}",
+                    stats.processed
+                ),
+            };
+        }
+        if out.len() != input.len() {
+            return DriveOutcome {
+                ok: false,
+                detail: format!(
+                    "block={block_frames}f: 出力長不一致 {} != {}",
+                    out.len(),
+                    input.len()
+                ),
+            };
+        }
+        if let Some((idx, sample)) = out
+            .iter()
+            .enumerate()
+            .find(|(_, s)| !s.is_finite() || s.abs() > 8.0)
+        {
+            return DriveOutcome {
+                ok: false,
+                detail: format!(
+                    "block={block_frames}f: sample[{idx}]={sample} 非有限 or 発散(|x|>8.0)"
+                ),
+            };
+        }
+    }
+    DriveOutcome {
+        ok: true,
+        detail: "PASS(block 64f/128f, crash 0, process_errors 0, 全サンプル有限・非発散)"
+            .to_owned(),
+    }
 }

--- a/rust/crates/orbit-vst3-effect-child/tests/real_plugin_gated.rs
+++ b/rust/crates/orbit-vst3-effect-child/tests/real_plugin_gated.rs
@@ -37,6 +37,8 @@
 //! `ORBIT_GATED_VST3_ALL=1`（`ORBIT_GATED_VST3_MAX` で上限）。個別指定は
 //! `ORBIT_GATED_VST3_PLUGINS`（`:` 区切りのフルパス）。
 
+#![cfg(target_os = "macos")]
+
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};

--- a/rust/crates/orbit-vst3-gain-oracle/Cargo.toml
+++ b/rust/crates/orbit-vst3-gain-oracle/Cargo.toml
@@ -1,0 +1,25 @@
+# orbit-vst3-gain-oracle — Phase 0 (#381) sample-exact test oracle plugin.
+#
+# `vst3` crate 同梱 examples/gain.rs を vendored した VST3 gain プラグイン
+# （out = gain × in・smoothing なし・純 Rust・C++ SDK 不要）。
+# cdylib → macOS `.vst3` バンドルに package して orbit-vst3-host の
+# sample-exact 検証（0b ①）の既知挙動 oracle に使う。
+#
+# 正本: docs/development/POST_2.0_VST3_HOSTING_PLAN.md §Phase 0
+[package]
+name = "orbit-vst3-gain-oracle"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "VST3 gain test-oracle plugin for orbit-vst3-host Phase 0 spike (Issue #381)"
+publish = false
+
+[lib]
+name = "orbit_vst3_gain_oracle"
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+vst3 = "0.3"

--- a/rust/crates/orbit-vst3-gain-oracle/package-oracle.sh
+++ b/rust/crates/orbit-vst3-gain-oracle/package-oracle.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# package-oracle.sh — orbit-vst3-gain-oracle を macOS .vst3 バンドルに package する。
+#
+# Phase 0 (#381) の sample-exact 検証（0b ①）で使う既知挙動 oracle プラグイン。
+# cdylib をビルドし `<target>/vst3-fixtures/GainOracle.vst3` に組み立てる。
+# 成果物は target/ 配下（gitignore）なのでバイナリは repo に入らない。
+#
+# host spike / test はこのスクリプトを呼ぶか、同じパスを直接組み立てる。
+# 出力パスを stdout に print する（test harness が食えるように）。
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workspace_root="$(cd "$here/../.." && pwd)"   # rust/
+cd "$workspace_root"
+
+profile="${1:-debug}"
+if [ "$profile" = "release" ]; then
+  cargo build -p orbit-vst3-gain-oracle --release >&2
+else
+  cargo build -p orbit-vst3-gain-oracle >&2
+fi
+
+dylib="target/$profile/liborbit_vst3_gain_oracle.dylib"
+[ -f "$dylib" ] || { echo "dylib not found: $dylib" >&2; exit 1; }
+
+bundle="target/vst3-fixtures/GainOracle.vst3"
+rm -rf "$bundle"
+mkdir -p "$bundle/Contents/MacOS"
+cp "$dylib" "$bundle/Contents/MacOS/GainOracle"
+printf 'BNDL????' > "$bundle/Contents/PkgInfo"
+cat > "$bundle/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key><string>GainOracle</string>
+  <key>CFBundleIdentifier</key><string>com.signalcompose.orbitscore.gain-oracle</string>
+  <key>CFBundleName</key><string>GainOracle</string>
+  <key>CFBundlePackageType</key><string>BNDL</string>
+  <key>CFBundleSignature</key><string>????</string>
+  <key>CFBundleVersion</key><string>0.0.1</string>
+</dict>
+</plist>
+PLIST
+
+# 絶対パスを stdout に（test harness 用）。
+echo "$workspace_root/$bundle"

--- a/rust/crates/orbit-vst3-gain-oracle/src/lib.rs
+++ b/rust/crates/orbit-vst3-gain-oracle/src/lib.rs
@@ -1,0 +1,605 @@
+// orbit-vst3-gain-oracle — Phase 0 (#381) sample-exact test oracle.
+//
+// VENDORED verbatim from the `vst3` crate's `examples/gain.rs`
+// (vst3 v0.3.0, MIT OR Apache-2.0, github.com/coupler-rs/vst3-rs).
+// 挙動: out[i] = gain * in[i]（smoothing なし・default gain=1.0・2-in/2-out）。
+// このプラグインの挙動を我々が完全に把握していることが oracle たる要点。
+// host spike（orbit-vst3-host）はこの既知挙動を sample-exact に再現できねばならない。
+//
+// Processor CID: 6E332252-54224A00-AA69301A-F318797D
+// 正本: docs/development/POST_2.0_VST3_HOSTING_PLAN.md §Phase 0 (0b ①)
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+// vendored upstream code なので clippy の style/complexity 指摘は抑制（意味を変えない）。
+// CI は `clippy -D warnings`。upstream gain.rs の unnecessary_cast 等をここで許容する。
+#![allow(clippy::all)]
+
+use std::cell::Cell;
+use std::ffi::{c_char, c_void, CString};
+use std::str::FromStr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::{ptr, slice};
+
+use vst3::{uid, Class, ComRef, ComWrapper, Steinberg::Vst::*, Steinberg::*};
+
+fn copy_cstring(src: &str, dst: &mut [c_char]) {
+    let c_string = CString::new(src).unwrap_or_else(|_| CString::default());
+    let bytes = c_string.as_bytes_with_nul();
+
+    for (src, dst) in bytes.iter().zip(dst.iter_mut()) {
+        *dst = *src as c_char;
+    }
+
+    if bytes.len() > dst.len() {
+        if let Some(last) = dst.last_mut() {
+            *last = 0;
+        }
+    }
+}
+
+fn copy_wstring(src: &str, dst: &mut [TChar]) {
+    let mut len = 0;
+    for (src, dst) in src.encode_utf16().zip(dst.iter_mut()) {
+        *dst = src as TChar;
+        len += 1;
+    }
+
+    if len < dst.len() {
+        dst[len] = 0;
+    } else if let Some(last) = dst.last_mut() {
+        *last = 0;
+    }
+}
+
+unsafe fn len_wstring(string: *const TChar) -> usize {
+    let mut len = 0;
+
+    while *string.offset(len) != 0 {
+        len += 1;
+    }
+
+    len as usize
+}
+
+const PLUGIN_NAME: &'static str = "Gain (vst3-rs example plugin)";
+
+struct GainProcessor {
+    gain: AtomicU64,
+}
+
+impl Class for GainProcessor {
+    type Interfaces = (IComponent, IAudioProcessor, IProcessContextRequirements);
+}
+
+impl GainProcessor {
+    const CID: TUID = uid(0x6E332252, 0x54224A00, 0xAA69301A, 0xF318797D);
+
+    fn new() -> GainProcessor {
+        GainProcessor {
+            gain: AtomicU64::new(1.0f64.to_bits()),
+        }
+    }
+}
+
+impl IPluginBaseTrait for GainProcessor {
+    unsafe fn initialize(&self, _context: *mut FUnknown) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn terminate(&self) -> tresult {
+        kResultOk
+    }
+}
+
+impl IComponentTrait for GainProcessor {
+    unsafe fn getControllerClassId(&self, class_id: *mut TUID) -> tresult {
+        *class_id = GainController::CID;
+        kResultOk
+    }
+
+    unsafe fn setIoMode(&self, _mode: IoMode) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn getBusCount(&self, mediaType: MediaType, dir: BusDirection) -> i32 {
+        match mediaType as BusDirections {
+            MediaTypes_::kAudio => match dir as BusDirections {
+                BusDirections_::kInput => 1,
+                BusDirections_::kOutput => 1,
+                _ => 0,
+            },
+            MediaTypes_::kEvent => 0,
+            _ => 0,
+        }
+    }
+
+    unsafe fn getBusInfo(
+        &self,
+        mediaType: MediaType,
+        dir: BusDirection,
+        index: i32,
+        bus: *mut BusInfo,
+    ) -> tresult {
+        match mediaType as MediaTypes {
+            MediaTypes_::kAudio => match dir as BusDirections {
+                BusDirections_::kInput => match index {
+                    0 => {
+                        let bus = &mut *bus;
+
+                        bus.mediaType = MediaTypes_::kAudio as MediaType;
+                        bus.direction = BusDirections_::kInput as BusDirection;
+                        bus.channelCount = 2;
+                        copy_wstring("Input", &mut bus.name);
+                        bus.busType = BusTypes_::kMain as BusType;
+                        bus.flags = BusInfo_::BusFlags_::kDefaultActive as u32;
+
+                        kResultOk
+                    }
+                    _ => kInvalidArgument,
+                },
+                BusDirections_::kOutput => match index {
+                    0 => {
+                        let bus = &mut *bus;
+
+                        bus.mediaType = MediaTypes_::kAudio as MediaType;
+                        bus.direction = BusDirections_::kOutput as BusDirection;
+                        bus.channelCount = 2;
+                        copy_wstring("Output", &mut bus.name);
+                        bus.busType = BusTypes_::kMain as BusType;
+                        bus.flags = BusInfo_::BusFlags_::kDefaultActive as u32 as uint32;
+
+                        kResultOk
+                    }
+                    _ => kInvalidArgument,
+                },
+                _ => kInvalidArgument,
+            },
+            MediaTypes_::kEvent => kInvalidArgument,
+            _ => kInvalidArgument,
+        }
+    }
+
+    unsafe fn getRoutingInfo(
+        &self,
+        _in_info: *mut RoutingInfo,
+        _out_info: *mut RoutingInfo,
+    ) -> tresult {
+        kNotImplemented
+    }
+
+    unsafe fn activateBus(
+        &self,
+        _media_type: MediaType,
+        _dir: BusDirection,
+        _index: i32,
+        _state: TBool,
+    ) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn setActive(&self, _state: TBool) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn setState(&self, _state: *mut IBStream) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn getState(&self, _state: *mut IBStream) -> tresult {
+        kResultOk
+    }
+}
+
+impl IAudioProcessorTrait for GainProcessor {
+    unsafe fn setBusArrangements(
+        &self,
+        inputs: *mut SpeakerArrangement,
+        num_ins: i32,
+        outputs: *mut SpeakerArrangement,
+        num_outs: i32,
+    ) -> tresult {
+        if num_ins != 1 || num_outs != 1 {
+            return kResultFalse;
+        }
+
+        if *inputs != SpeakerArr::kStereo || *outputs != SpeakerArr::kStereo {
+            return kResultFalse;
+        }
+
+        kResultTrue
+    }
+
+    unsafe fn getBusArrangement(
+        &self,
+        dir: BusDirection,
+        index: i32,
+        arr: *mut SpeakerArrangement,
+    ) -> tresult {
+        match dir as BusDirections {
+            BusDirections_::kInput => {
+                if index == 0 {
+                    *arr = SpeakerArr::kStereo;
+                    kResultOk
+                } else {
+                    kInvalidArgument
+                }
+            }
+            BusDirections_::kOutput => {
+                if index == 0 {
+                    *arr = SpeakerArr::kStereo;
+                    kResultOk
+                } else {
+                    kInvalidArgument
+                }
+            }
+            _ => kInvalidArgument,
+        }
+    }
+
+    unsafe fn canProcessSampleSize(&self, symbolic_sample_size: i32) -> tresult {
+        match symbolic_sample_size as SymbolicSampleSizes {
+            SymbolicSampleSizes_::kSample32 => kResultOk as i32,
+            SymbolicSampleSizes_::kSample64 => kNotImplemented as i32,
+            _ => kInvalidArgument,
+        }
+    }
+
+    unsafe fn getLatencySamples(&self) -> u32 {
+        0
+    }
+
+    unsafe fn setupProcessing(&self, _setup: *mut ProcessSetup) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn setProcessing(&self, _state: TBool) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn process(&self, data: *mut ProcessData) -> tresult {
+        let process_data = &*data;
+
+        if let Some(param_changes) = ComRef::from_raw(process_data.inputParameterChanges) {
+            let param_count = param_changes.getParameterCount();
+            for param_index in 0..param_count {
+                if let Some(param_queue) =
+                    ComRef::from_raw(param_changes.getParameterData(param_index))
+                {
+                    let param_id = param_queue.getParameterId();
+                    let point_count = param_queue.getPointCount();
+
+                    match param_id {
+                        0 => {
+                            let mut sample_offset = 0;
+                            let mut value = 0.0;
+                            let result = param_queue.getPoint(
+                                point_count - 1,
+                                &mut sample_offset,
+                                &mut value,
+                            );
+
+                            if result == kResultTrue {
+                                self.gain.store(value.to_bits(), Ordering::Relaxed);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        let gain = f64::from_bits(self.gain.load(Ordering::Relaxed)) as f32;
+
+        let num_samples = process_data.numSamples as usize;
+
+        if process_data.numInputs != 1 || process_data.numOutputs != 1 {
+            return kResultOk;
+        }
+
+        let input_buses =
+            slice::from_raw_parts(process_data.inputs, process_data.numInputs as usize);
+        let output_buses =
+            slice::from_raw_parts(process_data.outputs, process_data.numOutputs as usize);
+
+        if input_buses[0].numChannels != 2 || output_buses[0].numChannels != 2 {
+            return kResultOk;
+        }
+
+        let input_channels = slice::from_raw_parts(
+            input_buses[0].__field0.channelBuffers32,
+            input_buses[0].numChannels as usize,
+        );
+        let output_channels = slice::from_raw_parts(
+            output_buses[0].__field0.channelBuffers32,
+            output_buses[0].numChannels as usize,
+        );
+
+        let input_l = slice::from_raw_parts(input_channels[0], num_samples);
+        let input_r = slice::from_raw_parts(input_channels[1], num_samples);
+        let output_l = slice::from_raw_parts_mut(output_channels[0], num_samples);
+        let output_r = slice::from_raw_parts_mut(output_channels[1], num_samples);
+
+        for i in 0..num_samples {
+            output_l[i] = gain * input_l[i];
+            output_r[i] = gain * input_r[i];
+        }
+
+        kResultOk
+    }
+
+    unsafe fn getTailSamples(&self) -> u32 {
+        0
+    }
+}
+
+impl IProcessContextRequirementsTrait for GainProcessor {
+    unsafe fn getProcessContextRequirements(&self) -> u32 {
+        0
+    }
+}
+
+struct GainController {
+    gain: Cell<f64>,
+}
+
+impl Class for GainController {
+    type Interfaces = (IEditController,);
+}
+
+impl GainController {
+    const CID: TUID = uid(0x1BA8A477, 0xEE0A4A2D, 0x80F50D14, 0x13D2EAA0);
+
+    fn new() -> GainController {
+        GainController {
+            gain: Cell::new(1.0),
+        }
+    }
+}
+
+impl IPluginBaseTrait for GainController {
+    unsafe fn initialize(&self, _context: *mut FUnknown) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn terminate(&self) -> tresult {
+        kResultOk
+    }
+}
+
+impl IEditControllerTrait for GainController {
+    unsafe fn setComponentState(&self, _state: *mut IBStream) -> tresult {
+        kNotImplemented
+    }
+
+    unsafe fn setState(&self, _state: *mut IBStream) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn getState(&self, _state: *mut IBStream) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn getParameterCount(&self) -> i32 {
+        1
+    }
+
+    unsafe fn getParameterInfo(&self, param_index: i32, info: *mut ParameterInfo) -> tresult {
+        match param_index {
+            0 => {
+                let info = &mut *info;
+
+                info.id = 0;
+                copy_wstring("Gain", &mut info.title);
+                copy_wstring("Gain", &mut info.shortTitle);
+                copy_wstring("", &mut info.units);
+                info.stepCount = 0;
+                info.defaultNormalizedValue = 1.0;
+                info.unitId = 0;
+                info.flags = ParameterInfo_::ParameterFlags_::kCanAutomate as i32;
+
+                kResultOk
+            }
+            _ => kInvalidArgument,
+        }
+    }
+
+    unsafe fn getParamStringByValue(
+        &self,
+        id: u32,
+        value_normalized: f64,
+        string: *mut String128,
+    ) -> tresult {
+        let slice = unsafe { &mut *string };
+
+        match id {
+            0 => {
+                let display = value_normalized.to_string();
+                copy_wstring(&display, slice);
+                kResultOk
+            }
+            _ => kInvalidArgument,
+        }
+    }
+
+    unsafe fn getParamValueByString(
+        &self,
+        id: u32,
+        string: *mut TChar,
+        value_normalized: *mut f64,
+    ) -> tresult {
+        match id {
+            0 => {
+                let len = len_wstring(string as *const TChar);
+                if let Ok(string) =
+                    String::from_utf16(slice::from_raw_parts(string as *const u16, len))
+                {
+                    if let Ok(value) = f64::from_str(&string) {
+                        *value_normalized = value;
+                        return kResultOk;
+                    }
+                }
+                kInvalidArgument
+            }
+            _ => kInvalidArgument,
+        }
+    }
+
+    unsafe fn normalizedParamToPlain(&self, id: u32, value_normalized: f64) -> f64 {
+        match id {
+            0 => value_normalized,
+            _ => 0.0,
+        }
+    }
+
+    unsafe fn plainParamToNormalized(&self, id: u32, plain_value: f64) -> f64 {
+        match id {
+            0 => plain_value,
+            _ => 0.0,
+        }
+    }
+
+    unsafe fn getParamNormalized(&self, id: u32) -> f64 {
+        match id {
+            0 => self.gain.get(),
+            _ => 0.0,
+        }
+    }
+
+    unsafe fn setParamNormalized(&self, id: u32, value: f64) -> tresult {
+        match id {
+            0 => {
+                self.gain.set(value);
+                kResultOk
+            }
+            _ => kInvalidArgument,
+        }
+    }
+
+    unsafe fn setComponentHandler(&self, _handler: *mut IComponentHandler) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn createView(&self, _name: *const c_char) -> *mut IPlugView {
+        ptr::null_mut()
+    }
+}
+
+struct Factory {}
+
+impl Class for Factory {
+    type Interfaces = (IPluginFactory,);
+}
+
+impl IPluginFactoryTrait for Factory {
+    unsafe fn getFactoryInfo(&self, info: *mut PFactoryInfo) -> tresult {
+        let info = &mut *info;
+
+        copy_cstring("Vendor", &mut info.vendor);
+        copy_cstring("https://example.com", &mut info.url);
+        copy_cstring("someone@example.com", &mut info.email);
+        info.flags = PFactoryInfo_::FactoryFlags_::kUnicode as int32;
+
+        kResultOk
+    }
+
+    unsafe fn countClasses(&self) -> i32 {
+        2
+    }
+
+    unsafe fn getClassInfo(&self, index: i32, info: *mut PClassInfo) -> tresult {
+        match index {
+            0 => {
+                let info = &mut *info;
+                info.cid = GainProcessor::CID;
+                info.cardinality = PClassInfo_::ClassCardinality_::kManyInstances as int32;
+                copy_cstring("Audio Module Class", &mut info.category);
+                copy_cstring(PLUGIN_NAME, &mut info.name);
+
+                kResultOk
+            }
+            1 => {
+                let info = &mut *info;
+                info.cid = GainController::CID;
+                info.cardinality = PClassInfo_::ClassCardinality_::kManyInstances as int32;
+                copy_cstring("Component Controller Class", &mut info.category);
+                copy_cstring(PLUGIN_NAME, &mut info.name);
+
+                kResultOk
+            }
+            _ => kInvalidArgument,
+        }
+    }
+
+    unsafe fn createInstance(
+        &self,
+        cid: FIDString,
+        iid: FIDString,
+        obj: *mut *mut c_void,
+    ) -> tresult {
+        let instance = match *(cid as *const TUID) {
+            GainProcessor::CID => Some(
+                ComWrapper::new(GainProcessor::new())
+                    .to_com_ptr::<FUnknown>()
+                    .unwrap(),
+            ),
+            GainController::CID => Some(
+                ComWrapper::new(GainController::new())
+                    .to_com_ptr::<FUnknown>()
+                    .unwrap(),
+            ),
+            _ => None,
+        };
+
+        if let Some(instance) = instance {
+            let ptr = instance.as_ptr();
+            ((*(*ptr).vtbl).queryInterface)(ptr, iid as *mut TUID, obj)
+        } else {
+            kInvalidArgument
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+#[no_mangle]
+extern "system" fn InitDll() -> bool {
+    true
+}
+
+#[cfg(target_os = "windows")]
+#[no_mangle]
+extern "system" fn ExitDll() -> bool {
+    true
+}
+
+#[cfg(target_os = "macos")]
+#[no_mangle]
+extern "system" fn BundleEntry(_bundle_ref: *mut c_void) -> bool {
+    true
+}
+
+#[cfg(target_os = "macos")]
+#[no_mangle]
+extern "system" fn BundleExit() -> bool {
+    true
+}
+
+#[cfg(target_os = "linux")]
+#[no_mangle]
+extern "system" fn ModuleEntry(_library_handle: *mut c_void) -> bool {
+    true
+}
+
+#[cfg(target_os = "linux")]
+#[no_mangle]
+extern "system" fn ModuleExit() -> bool {
+    true
+}
+
+#[no_mangle]
+extern "system" fn GetPluginFactory() -> *mut IPluginFactory {
+    ComWrapper::new(Factory {})
+        .to_com_ptr::<IPluginFactory>()
+        .unwrap()
+        .into_raw()
+}

--- a/rust/crates/orbit-vst3-host/Cargo.toml
+++ b/rust/crates/orbit-vst3-host/Cargo.toml
@@ -19,4 +19,5 @@ name = "orbit_vst3_host"
 path = "src/lib.rs"
 
 [dependencies]
+libloading = "0.8"
 vst3 = "0.3"

--- a/rust/crates/orbit-vst3-host/Cargo.toml
+++ b/rust/crates/orbit-vst3-host/Cargo.toml
@@ -1,0 +1,22 @@
+# orbit-vst3-host — in-process VST3 plugin hosting library for OrbitScore daemon.
+#
+# Phase 0 (#381) spike: VST3 の最大リスク = 「Rust で COM を unsafe に手書きしてホストする」を
+# 最小・offline で retire する。orbit-clap-host の構造対称コピー（将来 Phase 1 で production 化）。
+#
+# 正本: docs/development/POST_2.0_VST3_HOSTING_PLAN.md §Phase 0
+[package]
+name = "orbit-vst3-host"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "In-process VST3 plugin hosting library for OrbitScore daemon (Issue #381, Phase 0 spike)"
+publish = false
+
+[lib]
+name = "orbit_vst3_host"
+path = "src/lib.rs"
+
+[dependencies]
+vst3 = "0.3"

--- a/rust/crates/orbit-vst3-host/Cargo.toml
+++ b/rust/crates/orbit-vst3-host/Cargo.toml
@@ -20,5 +20,7 @@ name = "orbit_vst3_host"
 path = "src/lib.rs"
 
 [dependencies]
-core-foundation-sys = "0.8"
 vst3 = "0.3"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation-sys = "0.8"

--- a/rust/crates/orbit-vst3-host/Cargo.toml
+++ b/rust/crates/orbit-vst3-host/Cargo.toml
@@ -19,5 +19,5 @@ name = "orbit_vst3_host"
 path = "src/lib.rs"
 
 [dependencies]
-libloading = "0.8"
+core-foundation-sys = "0.8"
 vst3 = "0.3"

--- a/rust/crates/orbit-vst3-host/Cargo.toml
+++ b/rust/crates/orbit-vst3-host/Cargo.toml
@@ -1,9 +1,10 @@
 # orbit-vst3-host — in-process VST3 plugin hosting library for OrbitScore daemon.
 #
-# Phase 0 (#381) spike: VST3 の最大リスク = 「Rust で COM を unsafe に手書きしてホストする」を
-# 最小・offline で retire する。orbit-clap-host の構造対称コピー（将来 Phase 1 で production 化）。
+# Phase 1 (#381) production library: grew out of the Phase 0 offline feasibility spike (最大リスク
+# =「Rust で COM を unsafe に手書きしてホストする」の retire) into the production hosting surface
+# used in-process by orbit-vst3-effect-child (spawned/supervised by the daemon).
 #
-# 正本: docs/development/POST_2.0_VST3_HOSTING_PLAN.md §Phase 0
+# 正本: docs/development/POST_2.0_VST3_HOSTING_PLAN.md §Phase 0 / §Phase 1
 [package]
 name = "orbit-vst3-host"
 version.workspace = true
@@ -11,7 +12,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "In-process VST3 plugin hosting library for OrbitScore daemon (Issue #381, Phase 0 spike)"
+description = "In-process VST3 plugin hosting library for OrbitScore daemon (Issue #381, Phase 1 production)"
 publish = false
 
 [lib]

--- a/rust/crates/orbit-vst3-host/src/bin/vst3_probe.rs
+++ b/rust/crates/orbit-vst3-host/src/bin/vst3_probe.rs
@@ -1,7 +1,11 @@
+#[cfg(target_os = "macos")]
 use std::env;
+#[cfg(target_os = "macos")]
 use std::path::Path;
+#[cfg(target_os = "macos")]
 use std::process;
 
+#[cfg(target_os = "macos")]
 fn main() {
     let Some(path) = env::args().nth(1) else {
         eprintln!("usage: vst3_probe <plugin.vst3>");
@@ -13,4 +17,10 @@ fn main() {
     if !result.loaded || !result.processed {
         process::exit(1);
     }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() -> std::process::ExitCode {
+    eprintln!("vst3_probe is macOS-only (VST3/CoreFoundation)");
+    std::process::ExitCode::FAILURE
 }

--- a/rust/crates/orbit-vst3-host/src/bin/vst3_probe.rs
+++ b/rust/crates/orbit-vst3-host/src/bin/vst3_probe.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::path::Path;
+use std::process;
+
+fn main() {
+    let Some(path) = env::args().nth(1) else {
+        eprintln!("usage: vst3_probe <plugin.vst3>");
+        process::exit(2);
+    };
+
+    let result = orbit_vst3_host::probe_plugin(Path::new(&path));
+    println!("{}", result.to_json_line());
+    if !result.loaded || !result.processed {
+        process::exit(1);
+    }
+}

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -63,6 +63,10 @@ pub enum Vst3HostError {
         input: i32,
         output: i32,
     },
+    ProcessBlockTooLarge {
+        requested: usize,
+        max: usize,
+    },
     UnsupportedPrimaryBusLayout {
         direction: &'static str,
         channels: i32,
@@ -103,6 +107,12 @@ impl Display for Vst3HostError {
                 write!(
                     f,
                     "unsupported channel layout: input={input}, output={output}"
+                )
+            }
+            Self::ProcessBlockTooLarge { requested, max } => {
+                write!(
+                    f,
+                    "process block too large: requested={requested}, max={max}"
                 )
             }
             Self::UnsupportedPrimaryBusLayout {
@@ -496,7 +506,20 @@ impl Vst3EffectProcessor {
         }
 
         let frames = input_l.len();
-        let input_ptrs = [input_l.as_ptr() as *mut f32, input_r.as_ptr() as *mut f32];
+        if frames > self.process_input_l.len() {
+            return Err(Vst3HostError::ProcessBlockTooLarge {
+                requested: frames,
+                max: self.process_input_l.len(),
+            });
+        }
+
+        self.process_input_l[..frames].copy_from_slice(input_l);
+        self.process_input_r[..frames].copy_from_slice(input_r);
+
+        let input_ptrs = [
+            self.process_input_l.as_mut_ptr(),
+            self.process_input_r.as_mut_ptr(),
+        ];
         let output_ptrs = [output_l.as_mut_ptr(), output_r.as_mut_ptr()];
 
         // process_stereo is the non-RT probe/offline-parity path; gain varies per call, so unlike
@@ -591,6 +614,9 @@ impl Vst3EffectProcessor {
         frames: usize,
         parameter_changes: &ParameterChanges,
     ) -> tresult {
+        let Ok(num_samples) = i32::try_from(frames) else {
+            return kInvalidArgument;
+        };
         let processor = self
             .processor
             .as_ref()
@@ -615,7 +641,7 @@ impl Vst3EffectProcessor {
         let mut process_data = ProcessData {
             processMode: ProcessModes_::kRealtime as i32,
             symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
-            numSamples: frames as i32,
+            numSamples: num_samples,
             numInputs: if self.info.is_effect { 1 } else { 0 },
             numOutputs: 1,
             inputs: if self.info.is_effect {
@@ -856,10 +882,10 @@ fn configure_audio_buses(
     activate_primary_bus_only(component, BusDirections_::kOutput as i32, output_buses);
 
     // `run_process` は index 0 の primary バスの channel buffer を常に `DEFAULT_CHANNELS`(2) 幅の
-    // `[*mut f32; 2]` として組み立てる。primary バスが stereo でないプラグイン（mono effect 等）を
-    // 通すと OOB / 未初期化読み取りになるため、silent corruption ではなく load 失敗として reject する。
-    // multi-bus プラグインで bus 0 が stereo なら extra バスは単に使わないだけで許容する。
-    verify_primary_bus_is_stereo(component, input_buses, output_buses)?;
+    // `[*mut f32; 2]` として組み立てる。getBusInfo と、process() 時に plugin が実際に使う
+    // negotiated arrangement の両方で primary bus が stereo であることを確認できない場合は、
+    // silent corruption ではなく load 失敗として reject する。
+    verify_primary_bus_is_stereo(component, processor, input_buses, output_buses)?;
 
     Ok(())
 }
@@ -977,6 +1003,7 @@ fn activate_primary_bus_only(
 /// channel count, instead of letting `run_process` read/write out of bounds.
 fn verify_primary_bus_is_stereo(
     component: &ComPtr<IComponent>,
+    processor: &ComPtr<IAudioProcessor>,
     input_buses: i32,
     output_buses: i32,
 ) -> Result<(), Vst3HostError> {
@@ -988,6 +1015,16 @@ fn verify_primary_bus_is_stereo(
                 channels,
             });
         }
+        if let Some(channels) =
+            primary_bus_arrangement_channel_count(processor, BusDirections_::kInput as i32)
+        {
+            if channels != DEFAULT_CHANNELS as i32 {
+                return Err(Vst3HostError::UnsupportedPrimaryBusLayout {
+                    direction: "input",
+                    channels,
+                });
+            }
+        }
     }
     if output_buses > 0 {
         let channels = audio_bus_channel_count(component, BusDirections_::kOutput as i32, 0);
@@ -997,8 +1034,31 @@ fn verify_primary_bus_is_stereo(
                 channels,
             });
         }
+        if let Some(channels) =
+            primary_bus_arrangement_channel_count(processor, BusDirections_::kOutput as i32)
+        {
+            if channels != DEFAULT_CHANNELS as i32 {
+                return Err(Vst3HostError::UnsupportedPrimaryBusLayout {
+                    direction: "output",
+                    channels,
+                });
+            }
+        }
     }
     Ok(())
+}
+
+fn primary_bus_arrangement_channel_count(
+    processor: &ComPtr<IAudioProcessor>,
+    direction: BusDirection,
+) -> Option<i32> {
+    let mut arrangement = 0;
+    let result = unsafe { processor.getBusArrangement(direction, 0, &mut arrangement) };
+    if is_ok(result) {
+        Some(arrangement.count_ones() as i32)
+    } else {
+        None
+    }
 }
 
 fn ptr_or_null_mut<T>(values: &mut [T]) -> *mut T {

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -287,6 +287,10 @@ pub struct Vst3EffectProcessor {
     info: LoadedVst3Info,
     sample_rate: f64,
     max_samples_per_block: i32,
+    process_input_l: Vec<f32>,
+    process_input_r: Vec<f32>,
+    process_output_l: Vec<f32>,
+    process_output_r: Vec<f32>,
 }
 
 impl Vst3EffectProcessor {
@@ -394,6 +398,10 @@ impl Vst3EffectProcessor {
             info: info.clone(),
             sample_rate,
             max_samples_per_block,
+            process_input_l: vec![0.0; max_samples_per_block.max(0) as usize],
+            process_input_r: vec![0.0; max_samples_per_block.max(0) as usize],
+            process_output_l: vec![0.0; max_samples_per_block.max(0) as usize],
+            process_output_r: vec![0.0; max_samples_per_block.max(0) as usize],
         };
         Ok((processor, info))
     }
@@ -478,6 +486,96 @@ impl Vst3EffectProcessor {
             processed: true,
             is_effect: self.info.is_effect,
         })
+    }
+
+    /// Interleaved stereo f32 blockを in-place で処理する child / offline parity 用 API。
+    ///
+    /// effect（audio input busあり）は overwrite、instrument（audio input busなし）は add-mix。
+    /// 失敗時は `data` を dry のまま残して `false` を返す。
+    #[must_use]
+    pub fn process_block(&mut self, data: &mut [f32]) -> bool {
+        if !data.len().is_multiple_of(DEFAULT_CHANNELS) {
+            return false;
+        }
+        let frames = data.len() / DEFAULT_CHANNELS;
+        if frames > self.process_input_l.len() {
+            return false;
+        }
+
+        for frame in 0..frames {
+            let base = frame * DEFAULT_CHANNELS;
+            self.process_input_l[frame] = data[base];
+            self.process_input_r[frame] = data[base + 1];
+            self.process_output_l[frame] = 0.0;
+            self.process_output_r[frame] = 0.0;
+        }
+
+        let processor = self
+            .processor
+            .as_ref()
+            .expect("processor remains alive until drop");
+        let mut input_ptrs = [
+            self.process_input_l.as_mut_ptr(),
+            self.process_input_r.as_mut_ptr(),
+        ];
+        let mut output_ptrs = [
+            self.process_output_l.as_mut_ptr(),
+            self.process_output_r.as_mut_ptr(),
+        ];
+        let mut inputs = [AudioBusBuffers {
+            numChannels: DEFAULT_CHANNELS as i32,
+            silenceFlags: 0,
+            __field0: AudioBusBuffers__type0 {
+                channelBuffers32: input_ptrs.as_mut_ptr(),
+            },
+        }];
+        let mut outputs = [AudioBusBuffers {
+            numChannels: DEFAULT_CHANNELS as i32,
+            silenceFlags: 0,
+            __field0: AudioBusBuffers__type0 {
+                channelBuffers32: output_ptrs.as_mut_ptr(),
+            },
+        }];
+        let parameter_changes = ParameterChanges::empty();
+        let output_parameter_changes = ParameterChanges::empty();
+        let input_events = EventList::empty();
+        let output_events = EventList::empty();
+        let mut process_context = self.process_context();
+        let mut process_data = ProcessData {
+            processMode: ProcessModes_::kRealtime as i32,
+            symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
+            numSamples: frames as i32,
+            numInputs: if self.info.is_effect { 1 } else { 0 },
+            numOutputs: 1,
+            inputs: if self.info.is_effect {
+                inputs.as_mut_ptr()
+            } else {
+                ptr::null_mut()
+            },
+            outputs: outputs.as_mut_ptr(),
+            inputParameterChanges: parameter_changes.as_ptr(),
+            outputParameterChanges: output_parameter_changes.as_ptr(),
+            inputEvents: input_events.as_ptr(),
+            outputEvents: output_events.as_ptr(),
+            processContext: &mut process_context,
+        };
+
+        let result = unsafe { processor.process(&mut process_data) };
+        if !is_ok(result) {
+            return false;
+        }
+
+        for frame in 0..frames {
+            let base = frame * DEFAULT_CHANNELS;
+            if self.info.is_effect {
+                data[base] = self.process_output_l[frame];
+                data[base + 1] = self.process_output_r[frame];
+            } else {
+                data[base] += self.process_output_l[frame];
+                data[base + 1] += self.process_output_r[frame];
+            }
+        }
+        true
     }
 
     fn process_context(&self) -> ProcessContext {

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -1,0 +1,6 @@
+//! orbit-vst3-host — Phase 0 (#381) spike scaffold.
+//!
+//! Phase 0-0a では license 監査のみ（この crate に `vst3` を依存させ cargo tree / cargo deny を回す）。
+//! Phase 0-0b で手書き COM の最小 offline hosting spike を追加する（`orbit-clap-host` 対称）。
+//!
+//! 正本: docs/development/POST_2.0_VST3_HOSTING_PLAN.md §Phase 0

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -693,9 +693,11 @@ fn configure_audio_buses(
         );
         result = set_bus_arrangements(processor, &mut input_arrangements, &mut output_arrangements);
     }
-    if !is_ok(result) {
-        return Err(Vst3HostError::BusArrangement(result));
-    }
+    // setBusArrangements は advisory。kResultFalse を返すプラグイン（ARIA Player 等・特に
+    // instrument）はプラグイン既定の arrangement で動作する。JUCE も致命扱いしない。ここで
+    // hard-fail すると「host 提案 arrangement を拒否するだけ」のプラグインが全滅するので続行する。
+    // （厳密な buffer 整合は Phase 1 で getBusArrangement の実値に合わせる。）
+    let _ = result;
 
     activate_audio_buses(component, BusDirections_::kInput as i32, input_buses);
     activate_audio_buses(component, BusDirections_::kOutput as i32, output_buses);

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -1,6 +1,723 @@
-//! orbit-vst3-host — Phase 0 (#381) spike scaffold.
+//! orbit-vst3-host — Phase 0 (#381) in-process VST3 host spike.
 //!
-//! Phase 0-0a では license 監査のみ（この crate に `vst3` を依存させ cargo tree / cargo deny を回す）。
-//! Phase 0-0b で手書き COM の最小 offline hosting spike を追加する（`orbit-clap-host` 対称）。
-//!
-//! 正本: docs/development/POST_2.0_VST3_HOSTING_PLAN.md §Phase 0
+//! This crate intentionally implements only the offline feasibility surface needed by
+//! `docs/development/POST_2.0_VST3_HOSTING_PLAN.md` Phase 0: load a macOS `.vst3` bundle,
+//! instantiate the first "Audio Module Class", run one f32 stereo block, and tear down on the
+//! same home thread.
+
+use std::cell::Cell;
+use std::error::Error;
+use std::ffi::c_void;
+use std::fmt::{Display, Formatter};
+use std::fs;
+use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
+use std::ptr;
+use std::rc::Rc;
+
+use libloading::{Library, Symbol};
+use vst3::Steinberg::Vst::*;
+use vst3::Steinberg::*;
+use vst3::{Class, ComPtr, ComWrapper};
+
+const AUDIO_MODULE_CLASS: &str = "Audio Module Class";
+const DEFAULT_CHANNELS: usize = 2;
+
+type GetPluginFactory = unsafe extern "system" fn() -> *mut IPluginFactory;
+type BundleEntry = unsafe extern "system" fn(*mut c_void) -> bool;
+type BundleExit = unsafe extern "system" fn() -> bool;
+
+#[derive(Debug)]
+pub enum Vst3HostError {
+    Io { path: PathBuf, message: String },
+    InvalidBundle(PathBuf),
+    Dlopen(String),
+    MissingSymbol(&'static str),
+    NullFactory,
+    NoAudioModuleClass,
+    CreateInstance(tresult),
+    QueryAudioProcessor,
+    Initialize(tresult),
+    SetupProcessing(tresult),
+    SetActive(tresult),
+    SetProcessing(tresult),
+    Process(tresult),
+    UnsupportedChannels { input: i32, output: i32 },
+}
+
+impl Display for Vst3HostError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io { path, message } => write!(f, "{}: {message}", path.display()),
+            Self::InvalidBundle(path) => write!(f, "invalid VST3 bundle: {}", path.display()),
+            Self::Dlopen(message) => write!(f, "dlopen failed: {message}"),
+            Self::MissingSymbol(symbol) => write!(f, "missing symbol: {symbol}"),
+            Self::NullFactory => write!(f, "GetPluginFactory returned null"),
+            Self::NoAudioModuleClass => write!(f, "no Audio Module Class in VST3 factory"),
+            Self::CreateInstance(result) => {
+                write!(f, "IPluginFactory::createInstance failed: {result}")
+            }
+            Self::QueryAudioProcessor => write!(f, "queryInterface(IAudioProcessor) failed"),
+            Self::Initialize(result) => write!(f, "IComponent::initialize failed: {result}"),
+            Self::SetupProcessing(result) => {
+                write!(f, "IAudioProcessor::setupProcessing failed: {result}")
+            }
+            Self::SetActive(result) => write!(f, "IComponent::setActive failed: {result}"),
+            Self::SetProcessing(result) => {
+                write!(f, "IAudioProcessor::setProcessing failed: {result}")
+            }
+            Self::Process(result) => write!(f, "IAudioProcessor::process failed: {result}"),
+            Self::UnsupportedChannels { input, output } => {
+                write!(
+                    f,
+                    "unsupported channel layout: input={input}, output={output}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for Vst3HostError {}
+
+#[derive(Debug, Clone)]
+pub struct LoadedVst3Info {
+    pub name: String,
+    pub audio_inputs: i32,
+    pub audio_outputs: i32,
+    pub is_effect: bool,
+}
+
+pub struct ProcessReport {
+    pub processed: bool,
+    pub is_effect: bool,
+}
+
+struct LoadedLibrary {
+    library: Library,
+    bundle_exit_called: bool,
+}
+
+impl LoadedLibrary {
+    fn open(bundle_path: &Path) -> Result<Self, Vst3HostError> {
+        let dylib_path = resolve_vst3_executable(bundle_path)?;
+        let library = unsafe { Library::new(&dylib_path) }
+            .map_err(|error| Vst3HostError::Dlopen(format!("{}: {error}", dylib_path.display())))?;
+
+        let mut bundle_exit_called = false;
+        unsafe {
+            if let Ok(entry) = library.get::<BundleEntry>(b"BundleEntry\0") {
+                if entry(ptr::null_mut()) {
+                    bundle_exit_called = true;
+                }
+            }
+        }
+
+        Ok(Self {
+            library,
+            bundle_exit_called,
+        })
+    }
+
+    unsafe fn get_factory(&self) -> Result<ComPtr<IPluginFactory>, Vst3HostError> {
+        let get_factory: Symbol<'_, GetPluginFactory> = self
+            .library
+            .get(b"GetPluginFactory\0")
+            .map_err(|_| Vst3HostError::MissingSymbol("GetPluginFactory"))?;
+        let raw = get_factory();
+        ComPtr::from_raw(raw).ok_or(Vst3HostError::NullFactory)
+    }
+}
+
+impl Drop for LoadedLibrary {
+    fn drop(&mut self) {
+        if self.bundle_exit_called {
+            unsafe {
+                if let Ok(exit) = self.library.get::<BundleExit>(b"BundleExit\0") {
+                    let _ = exit();
+                }
+            }
+        }
+    }
+}
+
+/// Single-threaded VST3 effect processor.
+///
+/// `Rc` makes this type `!Send` and `!Sync`. Construct, process, and drop it on the same home
+/// thread. Field order is load-bearing: Rust drops fields top-to-bottom, so `processor` is released
+/// before `component`, then `factory`, and finally the dynamic library is unloaded.
+pub struct Vst3EffectProcessor {
+    processor: Option<ComPtr<IAudioProcessor>>,
+    component: Option<ComPtr<IComponent>>,
+    factory: Option<ComPtr<IPluginFactory>>,
+    _home_thread: PhantomData<Rc<()>>,
+    _library: LoadedLibrary,
+    info: LoadedVst3Info,
+    sample_rate: f64,
+    max_samples_per_block: i32,
+}
+
+impl Vst3EffectProcessor {
+    pub fn load(
+        bundle_path: &Path,
+        sample_rate: f64,
+        max_samples_per_block: i32,
+    ) -> Result<(Self, LoadedVst3Info), Vst3HostError> {
+        let library = LoadedLibrary::open(bundle_path)?;
+        let factory = unsafe { library.get_factory()? };
+        let class = find_audio_module_class(&factory)?;
+
+        let mut component_raw = ptr::null_mut();
+        let create_result = unsafe {
+            factory.createInstance(
+                class.cid.as_ptr() as FIDString,
+                IComponent_iid.as_ptr() as FIDString,
+                &mut component_raw,
+            )
+        };
+        if !is_ok(create_result) {
+            return Err(Vst3HostError::CreateInstance(create_result));
+        }
+        let component = unsafe { ComPtr::from_raw(component_raw as *mut IComponent) }
+            .ok_or(Vst3HostError::CreateInstance(create_result))?;
+
+        let init_result = unsafe { component.initialize(ptr::null_mut()) };
+        if !is_ok(init_result) {
+            return Err(Vst3HostError::Initialize(init_result));
+        }
+
+        let processor = component
+            .as_com_ref()
+            .cast::<IAudioProcessor>()
+            .ok_or(Vst3HostError::QueryAudioProcessor)?;
+
+        let mut setup = ProcessSetup {
+            processMode: ProcessModes_::kRealtime as i32,
+            symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
+            maxSamplesPerBlock: max_samples_per_block,
+            sampleRate: sample_rate,
+        };
+        let setup_result = unsafe { processor.setupProcessing(&mut setup) };
+        if !is_ok(setup_result) {
+            return Err(Vst3HostError::SetupProcessing(setup_result));
+        }
+
+        let input_buses = unsafe {
+            component.getBusCount(MediaTypes_::kAudio as i32, BusDirections_::kInput as i32)
+        };
+        let output_buses = unsafe {
+            component.getBusCount(MediaTypes_::kAudio as i32, BusDirections_::kOutput as i32)
+        };
+        let is_effect = input_buses > 0;
+
+        // Phase 0 only verifies the effect overwrite path. This detection is separate from CLAP's
+        // `has_audio_input`; treating an instrument as an effect would be silent-but-wrong because
+        // the dry signal would be overwritten instead of add-mixed.
+        let info = LoadedVst3Info {
+            name: class.name,
+            audio_inputs: input_buses,
+            audio_outputs: output_buses,
+            is_effect,
+        };
+
+        let active_result = unsafe { component.setActive(1) };
+        if !is_ok(active_result) {
+            return Err(Vst3HostError::SetActive(active_result));
+        }
+
+        let processing_result = unsafe { processor.setProcessing(1) };
+        if !is_ok(processing_result) {
+            return Err(Vst3HostError::SetProcessing(processing_result));
+        }
+
+        let processor = Self {
+            processor: Some(processor),
+            component: Some(component),
+            factory: Some(factory),
+            _home_thread: PhantomData,
+            _library: library,
+            info: info.clone(),
+            sample_rate,
+            max_samples_per_block,
+        };
+        Ok((processor, info))
+    }
+
+    pub fn info(&self) -> &LoadedVst3Info {
+        &self.info
+    }
+
+    pub fn process_stereo(
+        &mut self,
+        input_l: &[f32],
+        input_r: &[f32],
+        output_l: &mut [f32],
+        output_r: &mut [f32],
+        gain: Option<f64>,
+    ) -> Result<ProcessReport, Vst3HostError> {
+        if input_l.len() != input_r.len()
+            || input_l.len() != output_l.len()
+            || input_l.len() != output_r.len()
+        {
+            return Err(Vst3HostError::UnsupportedChannels {
+                input: input_l.len() as i32,
+                output: output_l.len() as i32,
+            });
+        }
+
+        let frames = input_l.len();
+        let processor = self
+            .processor
+            .as_ref()
+            .expect("processor remains alive until drop");
+
+        let mut input_ptrs = [input_l.as_ptr() as *mut f32, input_r.as_ptr() as *mut f32];
+        let mut output_ptrs = [output_l.as_mut_ptr(), output_r.as_mut_ptr()];
+        let mut inputs = [AudioBusBuffers {
+            numChannels: DEFAULT_CHANNELS as i32,
+            silenceFlags: 0,
+            __field0: AudioBusBuffers__type0 {
+                channelBuffers32: input_ptrs.as_mut_ptr(),
+            },
+        }];
+        let mut outputs = [AudioBusBuffers {
+            numChannels: DEFAULT_CHANNELS as i32,
+            silenceFlags: 0,
+            __field0: AudioBusBuffers__type0 {
+                channelBuffers32: output_ptrs.as_mut_ptr(),
+            },
+        }];
+
+        let parameter_changes = gain.map(ParameterChanges::single_gain);
+        let input_parameter_changes = parameter_changes
+            .as_ref()
+            .map(|changes| changes.as_ptr())
+            .unwrap_or(ptr::null_mut());
+
+        let mut process_data = ProcessData {
+            processMode: ProcessModes_::kRealtime as i32,
+            symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
+            numSamples: frames as i32,
+            numInputs: if self.info.is_effect { 1 } else { 0 },
+            numOutputs: 1,
+            inputs: if self.info.is_effect {
+                inputs.as_mut_ptr()
+            } else {
+                ptr::null_mut()
+            },
+            outputs: outputs.as_mut_ptr(),
+            inputParameterChanges: input_parameter_changes,
+            outputParameterChanges: ptr::null_mut(),
+            inputEvents: ptr::null_mut(),
+            outputEvents: ptr::null_mut(),
+            processContext: ptr::null_mut(),
+        };
+
+        let result = unsafe { processor.process(&mut process_data) };
+        if !is_ok(result) {
+            return Err(Vst3HostError::Process(result));
+        }
+        Ok(ProcessReport {
+            processed: true,
+            is_effect: self.info.is_effect,
+        })
+    }
+}
+
+impl Drop for Vst3EffectProcessor {
+    fn drop(&mut self) {
+        if let Some(processor) = self.processor.take() {
+            unsafe {
+                let _ = processor.setProcessing(0);
+            }
+        }
+        if let Some(component) = self.component.take() {
+            unsafe {
+                let _ = component.setActive(0);
+                let _ = component.terminate();
+            }
+        }
+        let _ = self.factory.take();
+        let _ = (self.sample_rate, self.max_samples_per_block);
+    }
+}
+
+struct AudioModuleClass {
+    cid: TUID,
+    name: String,
+}
+
+fn find_audio_module_class(
+    factory: &ComPtr<IPluginFactory>,
+) -> Result<AudioModuleClass, Vst3HostError> {
+    let count = unsafe { factory.countClasses() };
+    for index in 0..count {
+        let mut info = PClassInfo {
+            cid: [0; 16],
+            cardinality: 0,
+            category: [0; 32],
+            name: [0; 64],
+        };
+        let result = unsafe { factory.getClassInfo(index, &mut info) };
+        if !is_ok(result) {
+            continue;
+        }
+        if char8_array_to_string(&info.category) == AUDIO_MODULE_CLASS {
+            return Ok(AudioModuleClass {
+                cid: info.cid,
+                name: char8_array_to_string(&info.name),
+            });
+        }
+    }
+    Err(Vst3HostError::NoAudioModuleClass)
+}
+
+fn resolve_vst3_executable(bundle_path: &Path) -> Result<PathBuf, Vst3HostError> {
+    if bundle_path.extension().and_then(|ext| ext.to_str()) != Some("vst3") {
+        return Err(Vst3HostError::InvalidBundle(bundle_path.to_path_buf()));
+    }
+    let executable = read_cf_bundle_executable(bundle_path).or_else(|| {
+        bundle_path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .map(ToOwned::to_owned)
+    });
+    let executable = executable.ok_or_else(|| Vst3HostError::InvalidBundle(bundle_path.into()))?;
+    Ok(bundle_path.join("Contents").join("MacOS").join(executable))
+}
+
+fn read_cf_bundle_executable(bundle_path: &Path) -> Option<String> {
+    let plist_path = bundle_path.join("Contents").join("Info.plist");
+    let plist = fs::read_to_string(&plist_path).ok()?;
+    let key_pos = plist.find("<key>CFBundleExecutable</key>")?;
+    let after_key = &plist[key_pos..];
+    let string_start = after_key.find("<string>")? + "<string>".len();
+    let string_end = after_key[string_start..].find("</string>")?;
+    Some(
+        after_key[string_start..string_start + string_end]
+            .trim()
+            .to_owned(),
+    )
+}
+
+fn char8_array_to_string(data: &[i8]) -> String {
+    let nul = data
+        .iter()
+        .position(|value| *value == 0)
+        .unwrap_or(data.len());
+    let bytes = data[..nul]
+        .iter()
+        .map(|value| *value as u8)
+        .collect::<Vec<_>>();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+fn is_ok(result: tresult) -> bool {
+    result == kResultOk || result == kResultTrue
+}
+
+trait TuidPtr {
+    fn as_ptr(&self) -> *const i8;
+}
+
+impl TuidPtr for TUID {
+    fn as_ptr(&self) -> *const i8 {
+        self.as_slice().as_ptr()
+    }
+}
+
+struct ParameterChanges {
+    _wrapper: ComWrapper<HostParameterChanges>,
+    ptr: ComPtr<IParameterChanges>,
+}
+
+impl ParameterChanges {
+    fn single_gain(value: f64) -> Self {
+        let wrapper = ComWrapper::new(HostParameterChanges::new(0, value));
+        let ptr = wrapper
+            .to_com_ptr::<IParameterChanges>()
+            .expect("HostParameterChanges exposes IParameterChanges");
+        Self {
+            _wrapper: wrapper,
+            ptr,
+        }
+    }
+
+    fn as_ptr(&self) -> *mut IParameterChanges {
+        self.ptr.as_ptr()
+    }
+}
+
+struct HostParameterChanges {
+    queue: ComWrapper<HostParamValueQueue>,
+    queue_ptr: Cell<*mut IParamValueQueue>,
+}
+
+impl HostParameterChanges {
+    fn new(param_id: ParamID, value: ParamValue) -> Self {
+        Self {
+            queue: ComWrapper::new(HostParamValueQueue::new(param_id, value)),
+            queue_ptr: Cell::new(ptr::null_mut()),
+        }
+    }
+
+    fn queue_ptr(&self) -> *mut IParamValueQueue {
+        let existing = self.queue_ptr.get();
+        if !existing.is_null() {
+            return existing;
+        }
+        let ptr = self
+            .queue
+            .to_com_ptr::<IParamValueQueue>()
+            .expect("HostParamValueQueue exposes IParamValueQueue")
+            .into_raw();
+        self.queue_ptr.set(ptr);
+        ptr
+    }
+}
+
+impl Drop for HostParameterChanges {
+    fn drop(&mut self) {
+        let ptr = self.queue_ptr.get();
+        if !ptr.is_null() {
+            unsafe {
+                if let Some(queue) = ComPtr::from_raw(ptr) {
+                    drop(queue);
+                }
+            }
+        }
+    }
+}
+
+impl Class for HostParameterChanges {
+    type Interfaces = (IParameterChanges,);
+}
+
+impl IParameterChangesTrait for HostParameterChanges {
+    unsafe fn getParameterCount(&self) -> i32 {
+        1
+    }
+
+    unsafe fn getParameterData(&self, index: i32) -> *mut IParamValueQueue {
+        if index == 0 {
+            self.queue_ptr()
+        } else {
+            ptr::null_mut()
+        }
+    }
+
+    unsafe fn addParameterData(
+        &self,
+        _id: *const ParamID,
+        index: *mut i32,
+    ) -> *mut IParamValueQueue {
+        if !index.is_null() {
+            *index = 0;
+        }
+        self.queue_ptr()
+    }
+}
+
+struct HostParamValueQueue {
+    param_id: ParamID,
+    value: ParamValue,
+}
+
+impl HostParamValueQueue {
+    fn new(param_id: ParamID, value: ParamValue) -> Self {
+        Self { param_id, value }
+    }
+}
+
+impl Class for HostParamValueQueue {
+    type Interfaces = (IParamValueQueue,);
+}
+
+impl IParamValueQueueTrait for HostParamValueQueue {
+    unsafe fn getParameterId(&self) -> ParamID {
+        self.param_id
+    }
+
+    unsafe fn getPointCount(&self) -> i32 {
+        1
+    }
+
+    unsafe fn getPoint(
+        &self,
+        index: i32,
+        sample_offset: *mut i32,
+        value: *mut ParamValue,
+    ) -> tresult {
+        if index != 0 {
+            return kInvalidArgument;
+        }
+        if !sample_offset.is_null() {
+            *sample_offset = 0;
+        }
+        if !value.is_null() {
+            *value = self.value;
+        }
+        kResultTrue
+    }
+
+    unsafe fn addPoint(&self, _sample_offset: i32, _value: ParamValue, index: *mut i32) -> tresult {
+        if !index.is_null() {
+            *index = 0;
+        }
+        kResultFalse
+    }
+}
+
+pub fn probe_plugin(path: &Path) -> ProbeResult {
+    match Vst3EffectProcessor::load(path, 48_000.0, 512) {
+        Ok((mut processor, info)) => {
+            let input_l = vec![0.0; 512];
+            let input_r = vec![0.0; 512];
+            let mut output_l = vec![0.0; 512];
+            let mut output_r = vec![0.0; 512];
+            let mut error = None;
+            let processed = if info.is_effect {
+                match processor.process_stereo(
+                    &input_l,
+                    &input_r,
+                    &mut output_l,
+                    &mut output_r,
+                    None,
+                ) {
+                    Ok(_) => {
+                        if let Err(message) = validate_silent_block(&output_l, &output_r) {
+                            error = Some(message);
+                            false
+                        } else {
+                            let known_l = (0..512)
+                                .map(|i| (i as f32 - 128.0) / 512.0)
+                                .collect::<Vec<_>>();
+                            let known_r = (0..512)
+                                .map(|i| ((i as f32 * 3.0) - 256.0) / 1024.0)
+                                .collect::<Vec<_>>();
+                            output_l.fill(0.0);
+                            output_r.fill(0.0);
+                            match processor.process_stereo(
+                                &known_l,
+                                &known_r,
+                                &mut output_l,
+                                &mut output_r,
+                                None,
+                            ) {
+                                Ok(_) => match validate_known_block(&output_l, &output_r) {
+                                    Ok(()) => true,
+                                    Err(message) => {
+                                        error = Some(message);
+                                        false
+                                    }
+                                },
+                                Err(err) => {
+                                    error = Some(err.to_string());
+                                    false
+                                }
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        error = Some(err.to_string());
+                        false
+                    }
+                }
+            } else {
+                error = Some(
+                    "instrument/add-mix path detected; Phase 0 probe did not process".to_owned(),
+                );
+                false
+            };
+            ProbeResult {
+                name: info.name,
+                loaded: true,
+                audio_in: info.audio_inputs,
+                audio_out: info.audio_outputs,
+                processed,
+                error,
+            }
+        }
+        Err(error) => ProbeResult {
+            name: path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("<unknown>")
+                .to_owned(),
+            loaded: false,
+            audio_in: 0,
+            audio_out: 0,
+            processed: false,
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+fn validate_silent_block(left: &[f32], right: &[f32]) -> Result<(), String> {
+    for (label, samples) in [("left", left), ("right", right)] {
+        for (index, sample) in samples.iter().enumerate() {
+            if !sample.is_finite() {
+                return Err(format!("silent {label} sample {index} is not finite"));
+            }
+            if sample.abs() > 1.0e-3 {
+                return Err(format!(
+                    "silent {label} sample {index} exceeded noise floor: {sample}"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_known_block(left: &[f32], right: &[f32]) -> Result<(), String> {
+    for (label, samples) in [("left", left), ("right", right)] {
+        for (index, sample) in samples.iter().enumerate() {
+            if !sample.is_finite() {
+                return Err(format!("known {label} sample {index} is not finite"));
+            }
+            if sample.abs() > 8.0 {
+                return Err(format!("known {label} sample {index} diverged: {sample}"));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub struct ProbeResult {
+    pub name: String,
+    pub loaded: bool,
+    pub audio_in: i32,
+    pub audio_out: i32,
+    pub processed: bool,
+    pub error: Option<String>,
+}
+
+impl ProbeResult {
+    pub fn to_json_line(&self) -> String {
+        format!(
+            "{{\"name\":\"{}\",\"loaded\":{},\"audio_in\":{},\"audio_out\":{},\"processed\":{},\"error\":{}}}",
+            json_escape(&self.name),
+            self.loaded,
+            self.audio_in,
+            self.audio_out,
+            self.processed,
+            self.error
+                .as_ref()
+                .map(|error| format!("\"{}\"", json_escape(error)))
+                .unwrap_or_else(|| "null".to_owned())
+        )
+    }
+}
+
+fn json_escape(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(|ch| match ch {
+            '"' => "\\\"".chars().collect::<Vec<_>>(),
+            '\\' => "\\\\".chars().collect::<Vec<_>>(),
+            '\n' => "\\n".chars().collect::<Vec<_>>(),
+            '\r' => "\\r".chars().collect::<Vec<_>>(),
+            '\t' => "\\t".chars().collect::<Vec<_>>(),
+            _ => vec![ch],
+        })
+        .collect()
+}

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -9,6 +9,8 @@
 //! `process_block`) is exercised by `orbit-vst3-effect-child`, which is spawned/supervised by
 //! the daemon.
 
+#![cfg(target_os = "macos")]
+
 use std::cell::{Cell, RefCell};
 use std::error::Error;
 use std::ffi::{c_void, CString};

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -372,8 +372,11 @@ impl Vst3EffectProcessor {
             return Err(Vst3HostError::SetActive(active_result));
         }
 
+        // setProcessing は optional。kNotImplemented(=3) を返すプラグイン（例: iZotope
+        // Ozone/RX/Neutron 系）は多く、VST3 的に合法。JUCE も kNotImplemented を非致命として
+        // 続行する（warnOnFailureIfImplemented）。ここで hard error にすると iZotope 全滅する。
         let processing_result = unsafe { processor.setProcessing(1) };
-        if !is_ok(processing_result) {
+        if !is_ok(processing_result) && processing_result != kNotImplemented {
             return Err(Vst3HostError::SetProcessing(processing_result));
         }
 

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -286,7 +286,20 @@ pub struct Vst3EffectProcessor {
     _library: LoadedLibrary,
     info: LoadedVst3Info,
     sample_rate: f64,
-    max_samples_per_block: i32,
+    /// `IProcessContextRequirements` flags queried once at load time (`load()`). The plugin's
+    /// requirements do not change over its lifetime, so re-querying per block would be a wasted
+    /// COM `queryInterface` + call on the RT hot path.
+    process_context_requirements: u32,
+    /// Stateless stub `IParameterChanges`/`IEventList` instances shared by `process_stereo` and
+    /// `process_block`. `HostParameterChanges::empty()`/`HostEventList` always answer the same way
+    /// regardless of call count, so a single instance can be reused instead of allocating
+    /// (`ComWrapper::new` = `Arc`) on every block.
+    output_parameter_changes: ParameterChanges,
+    input_events: EventList,
+    output_events: EventList,
+    /// Empty input `IParameterChanges` for `process_block`, which never carries parameter
+    /// automation (unlike `process_stereo`'s optional per-call gain).
+    block_parameter_changes: ParameterChanges,
     process_input_l: Vec<f32>,
     process_input_r: Vec<f32>,
     process_output_l: Vec<f32>,
@@ -384,6 +397,18 @@ impl Vst3EffectProcessor {
             return Err(Vst3HostError::SetProcessing(processing_result));
         }
 
+        // Queried once: the plugin's process-context requirements are fixed for its lifetime, so
+        // `process_context()` reads this cache instead of re-querying `IProcessContextRequirements`
+        // on every block.
+        let process_context_requirements = unsafe {
+            processor
+                .as_com_ref()
+                .cast::<IProcessContextRequirements>()
+                .map(|requirements| requirements.getProcessContextRequirements())
+                .unwrap_or(0)
+        };
+
+        let scratch_len = max_samples_per_block.max(0) as usize;
         let processor = Self {
             processor: Some(processor),
             controller: controller_handshake.controller,
@@ -397,11 +422,15 @@ impl Vst3EffectProcessor {
             _library: library,
             info: info.clone(),
             sample_rate,
-            max_samples_per_block,
-            process_input_l: vec![0.0; max_samples_per_block.max(0) as usize],
-            process_input_r: vec![0.0; max_samples_per_block.max(0) as usize],
-            process_output_l: vec![0.0; max_samples_per_block.max(0) as usize],
-            process_output_r: vec![0.0; max_samples_per_block.max(0) as usize],
+            process_context_requirements,
+            output_parameter_changes: ParameterChanges::empty(),
+            input_events: EventList::empty(),
+            output_events: EventList::empty(),
+            block_parameter_changes: ParameterChanges::empty(),
+            process_input_l: vec![0.0; scratch_len],
+            process_input_r: vec![0.0; scratch_len],
+            process_output_l: vec![0.0; scratch_len],
+            process_output_r: vec![0.0; scratch_len],
         };
         Ok((processor, info))
     }
@@ -429,56 +458,16 @@ impl Vst3EffectProcessor {
         }
 
         let frames = input_l.len();
-        let processor = self
-            .processor
-            .as_ref()
-            .expect("processor remains alive until drop");
+        let input_ptrs = [input_l.as_ptr() as *mut f32, input_r.as_ptr() as *mut f32];
+        let output_ptrs = [output_l.as_mut_ptr(), output_r.as_mut_ptr()];
 
-        let mut input_ptrs = [input_l.as_ptr() as *mut f32, input_r.as_ptr() as *mut f32];
-        let mut output_ptrs = [output_l.as_mut_ptr(), output_r.as_mut_ptr()];
-        let mut inputs = [AudioBusBuffers {
-            numChannels: DEFAULT_CHANNELS as i32,
-            silenceFlags: 0,
-            __field0: AudioBusBuffers__type0 {
-                channelBuffers32: input_ptrs.as_mut_ptr(),
-            },
-        }];
-        let mut outputs = [AudioBusBuffers {
-            numChannels: DEFAULT_CHANNELS as i32,
-            silenceFlags: 0,
-            __field0: AudioBusBuffers__type0 {
-                channelBuffers32: output_ptrs.as_mut_ptr(),
-            },
-        }];
-
+        // process_stereo is the non-RT probe/offline-parity path; gain varies per call, so unlike
+        // process_block's `block_parameter_changes` this cannot be cached on `self`.
         let parameter_changes = gain
             .map(ParameterChanges::single_gain)
             .unwrap_or_else(ParameterChanges::empty);
-        let output_parameter_changes = ParameterChanges::empty();
-        let input_events = EventList::empty();
-        let output_events = EventList::empty();
-        let mut process_context = self.process_context();
 
-        let mut process_data = ProcessData {
-            processMode: ProcessModes_::kRealtime as i32,
-            symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
-            numSamples: frames as i32,
-            numInputs: if self.info.is_effect { 1 } else { 0 },
-            numOutputs: 1,
-            inputs: if self.info.is_effect {
-                inputs.as_mut_ptr()
-            } else {
-                ptr::null_mut()
-            },
-            outputs: outputs.as_mut_ptr(),
-            inputParameterChanges: parameter_changes.as_ptr(),
-            outputParameterChanges: output_parameter_changes.as_ptr(),
-            inputEvents: input_events.as_ptr(),
-            outputEvents: output_events.as_ptr(),
-            processContext: &mut process_context,
-        };
-
-        let result = unsafe { processor.process(&mut process_data) };
+        let result = self.run_process(input_ptrs, output_ptrs, frames, &parameter_changes);
         if !is_ok(result) {
             return Err(Vst3HostError::Process(result));
         }
@@ -510,57 +499,21 @@ impl Vst3EffectProcessor {
             self.process_output_r[frame] = 0.0;
         }
 
-        let processor = self
-            .processor
-            .as_ref()
-            .expect("processor remains alive until drop");
-        let mut input_ptrs = [
+        let input_ptrs = [
             self.process_input_l.as_mut_ptr(),
             self.process_input_r.as_mut_ptr(),
         ];
-        let mut output_ptrs = [
+        let output_ptrs = [
             self.process_output_l.as_mut_ptr(),
             self.process_output_r.as_mut_ptr(),
         ];
-        let mut inputs = [AudioBusBuffers {
-            numChannels: DEFAULT_CHANNELS as i32,
-            silenceFlags: 0,
-            __field0: AudioBusBuffers__type0 {
-                channelBuffers32: input_ptrs.as_mut_ptr(),
-            },
-        }];
-        let mut outputs = [AudioBusBuffers {
-            numChannels: DEFAULT_CHANNELS as i32,
-            silenceFlags: 0,
-            __field0: AudioBusBuffers__type0 {
-                channelBuffers32: output_ptrs.as_mut_ptr(),
-            },
-        }];
-        let parameter_changes = ParameterChanges::empty();
-        let output_parameter_changes = ParameterChanges::empty();
-        let input_events = EventList::empty();
-        let output_events = EventList::empty();
-        let mut process_context = self.process_context();
-        let mut process_data = ProcessData {
-            processMode: ProcessModes_::kRealtime as i32,
-            symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
-            numSamples: frames as i32,
-            numInputs: if self.info.is_effect { 1 } else { 0 },
-            numOutputs: 1,
-            inputs: if self.info.is_effect {
-                inputs.as_mut_ptr()
-            } else {
-                ptr::null_mut()
-            },
-            outputs: outputs.as_mut_ptr(),
-            inputParameterChanges: parameter_changes.as_ptr(),
-            outputParameterChanges: output_parameter_changes.as_ptr(),
-            inputEvents: input_events.as_ptr(),
-            outputEvents: output_events.as_ptr(),
-            processContext: &mut process_context,
-        };
 
-        let result = unsafe { processor.process(&mut process_data) };
+        let result = self.run_process(
+            input_ptrs,
+            output_ptrs,
+            frames,
+            &self.block_parameter_changes,
+        );
         if !is_ok(result) {
             return false;
         }
@@ -578,26 +531,78 @@ impl Vst3EffectProcessor {
         true
     }
 
+    /// Shared `AudioBusBuffers`/`ProcessData` assembly + `IAudioProcessor::process` call for
+    /// `process_stereo` and `process_block`. `input_ptrs`/`output_ptrs` must each point at
+    /// `frames` valid, writable (for output) `f32` samples for the lifetime of this call; both
+    /// callers guarantee this via their scratch buffers / caller-provided slices.
+    ///
+    /// `is_effect` bus wiring (numInputs/inputs null-vs-populated) lives here so both callers stay
+    /// in sync with the same effect/instrument branch.
+    fn run_process(
+        &self,
+        mut input_ptrs: [*mut f32; 2],
+        mut output_ptrs: [*mut f32; 2],
+        frames: usize,
+        parameter_changes: &ParameterChanges,
+    ) -> tresult {
+        let processor = self
+            .processor
+            .as_ref()
+            .expect("processor remains alive until drop");
+
+        let mut inputs = [AudioBusBuffers {
+            numChannels: DEFAULT_CHANNELS as i32,
+            silenceFlags: 0,
+            __field0: AudioBusBuffers__type0 {
+                channelBuffers32: input_ptrs.as_mut_ptr(),
+            },
+        }];
+        let mut outputs = [AudioBusBuffers {
+            numChannels: DEFAULT_CHANNELS as i32,
+            silenceFlags: 0,
+            __field0: AudioBusBuffers__type0 {
+                channelBuffers32: output_ptrs.as_mut_ptr(),
+            },
+        }];
+
+        let mut process_context = self.process_context();
+        let mut process_data = ProcessData {
+            processMode: ProcessModes_::kRealtime as i32,
+            symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
+            numSamples: frames as i32,
+            numInputs: if self.info.is_effect { 1 } else { 0 },
+            numOutputs: 1,
+            inputs: if self.info.is_effect {
+                inputs.as_mut_ptr()
+            } else {
+                ptr::null_mut()
+            },
+            outputs: outputs.as_mut_ptr(),
+            inputParameterChanges: parameter_changes.as_ptr(),
+            outputParameterChanges: self.output_parameter_changes.as_ptr(),
+            inputEvents: self.input_events.as_ptr(),
+            outputEvents: self.output_events.as_ptr(),
+            processContext: &mut process_context,
+        };
+
+        unsafe { processor.process(&mut process_data) }
+    }
+
     fn process_context(&self) -> ProcessContext {
         let mut state = ProcessContext_::StatesAndFlags_::kTempoValid
             | ProcessContext_::StatesAndFlags_::kTimeSigValid;
-        if let Some(processor) = self.processor.as_ref() {
-            if let Some(requirements) = processor.as_com_ref().cast::<IProcessContextRequirements>()
-            {
-                let required = unsafe { requirements.getProcessContextRequirements() };
-                if required & IProcessContextRequirements_::Flags_::kNeedTransportState != 0 {
-                    state |= ProcessContext_::StatesAndFlags_::kPlaying;
-                }
-                if required & IProcessContextRequirements_::Flags_::kNeedProjectTimeMusic != 0 {
-                    state |= ProcessContext_::StatesAndFlags_::kProjectTimeMusicValid;
-                }
-                if required & IProcessContextRequirements_::Flags_::kNeedTempo != 0 {
-                    state |= ProcessContext_::StatesAndFlags_::kTempoValid;
-                }
-                if required & IProcessContextRequirements_::Flags_::kNeedTimeSignature != 0 {
-                    state |= ProcessContext_::StatesAndFlags_::kTimeSigValid;
-                }
-            }
+        let required = self.process_context_requirements;
+        if required & IProcessContextRequirements_::Flags_::kNeedTransportState != 0 {
+            state |= ProcessContext_::StatesAndFlags_::kPlaying;
+        }
+        if required & IProcessContextRequirements_::Flags_::kNeedProjectTimeMusic != 0 {
+            state |= ProcessContext_::StatesAndFlags_::kProjectTimeMusicValid;
+        }
+        if required & IProcessContextRequirements_::Flags_::kNeedTempo != 0 {
+            state |= ProcessContext_::StatesAndFlags_::kTempoValid;
+        }
+        if required & IProcessContextRequirements_::Flags_::kNeedTimeSignature != 0 {
+            state |= ProcessContext_::StatesAndFlags_::kTimeSigValid;
         }
         ProcessContext {
             state,
@@ -657,7 +662,6 @@ impl Drop for Vst3EffectProcessor {
             }
         }
         let _ = self.factory.take();
-        let _ = (self.sample_rate, self.max_samples_per_block);
     }
 }
 
@@ -1473,63 +1477,9 @@ impl IParamValueQueueTrait for HostParamValueQueue {
 pub fn probe_plugin(path: &Path) -> ProbeResult {
     match Vst3EffectProcessor::load(path, 48_000.0, 512) {
         Ok((mut processor, info)) => {
-            let input_l = vec![0.0; 512];
-            let input_r = vec![0.0; 512];
-            let mut output_l = vec![0.0; 512];
-            let mut output_r = vec![0.0; 512];
-            let mut error = None;
-            let processed = if info.is_effect {
-                match processor.process_stereo(
-                    &input_l,
-                    &input_r,
-                    &mut output_l,
-                    &mut output_r,
-                    None,
-                ) {
-                    Ok(_) => {
-                        if let Err(message) = validate_silent_block(&output_l, &output_r) {
-                            error = Some(message);
-                            false
-                        } else {
-                            let known_l = (0..512)
-                                .map(|i| (i as f32 - 128.0) / 512.0)
-                                .collect::<Vec<_>>();
-                            let known_r = (0..512)
-                                .map(|i| ((i as f32 * 3.0) - 256.0) / 1024.0)
-                                .collect::<Vec<_>>();
-                            output_l.fill(0.0);
-                            output_r.fill(0.0);
-                            match processor.process_stereo(
-                                &known_l,
-                                &known_r,
-                                &mut output_l,
-                                &mut output_r,
-                                None,
-                            ) {
-                                Ok(_) => match validate_known_block(&output_l, &output_r) {
-                                    Ok(()) => true,
-                                    Err(message) => {
-                                        error = Some(message);
-                                        false
-                                    }
-                                },
-                                Err(err) => {
-                                    error = Some(err.to_string());
-                                    false
-                                }
-                            }
-                        }
-                    }
-                    Err(err) => {
-                        error = Some(err.to_string());
-                        false
-                    }
-                }
-            } else {
-                error = Some(
-                    "instrument/add-mix path detected; Phase 0 probe did not process".to_owned(),
-                );
-                false
+            let (processed, error) = match probe_effect_signal(&mut processor) {
+                Ok(()) => (true, None),
+                Err(message) => (false, Some(message)),
             };
             ProbeResult {
                 name: info.name,
@@ -1553,6 +1503,39 @@ pub fn probe_plugin(path: &Path) -> ProbeResult {
             error: Some(error.to_string()),
         },
     }
+}
+
+/// Runs the Phase 0 probe's two-pass signal check (silent-block then known-signal) against an
+/// already-loaded effect processor. Instruments (no audio input bus) are not processed — Phase 0
+/// only verifies the effect overwrite path (see `Vst3EffectProcessor::load`'s `is_effect` note).
+fn probe_effect_signal(processor: &mut Vst3EffectProcessor) -> Result<(), String> {
+    if !processor.info().is_effect {
+        return Err("instrument/add-mix path detected; Phase 0 probe did not process".to_owned());
+    }
+
+    let input_l = vec![0.0; 512];
+    let input_r = vec![0.0; 512];
+    let mut output_l = vec![0.0; 512];
+    let mut output_r = vec![0.0; 512];
+
+    processor
+        .process_stereo(&input_l, &input_r, &mut output_l, &mut output_r, None)
+        .map_err(|error| error.to_string())?;
+    validate_silent_block(&output_l, &output_r)?;
+
+    let known_l = (0..512)
+        .map(|i| (i as f32 - 128.0) / 512.0)
+        .collect::<Vec<_>>();
+    let known_r = (0..512)
+        .map(|i| ((i as f32 * 3.0) - 256.0) / 1024.0)
+        .collect::<Vec<_>>();
+    output_l.fill(0.0);
+    output_r.fill(0.0);
+
+    processor
+        .process_stereo(&known_l, &known_r, &mut output_l, &mut output_r, None)
+        .map_err(|error| error.to_string())?;
+    validate_known_block(&output_l, &output_r)
 }
 
 fn validate_silent_block(left: &[f32], right: &[f32]) -> Result<(), String> {
@@ -1612,15 +1595,16 @@ impl ProbeResult {
 }
 
 fn json_escape(value: &str) -> String {
-    value
-        .chars()
-        .flat_map(|ch| match ch {
-            '"' => "\\\"".chars().collect::<Vec<_>>(),
-            '\\' => "\\\\".chars().collect::<Vec<_>>(),
-            '\n' => "\\n".chars().collect::<Vec<_>>(),
-            '\r' => "\\r".chars().collect::<Vec<_>>(),
-            '\t' => "\\t".chars().collect::<Vec<_>>(),
-            _ => vec![ch],
-        })
-        .collect()
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
 }

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -1,9 +1,13 @@
-//! orbit-vst3-host — Phase 0 (#381) in-process VST3 host spike.
+//! orbit-vst3-host — Phase 1 (#381) in-process VST3 hosting library, used in-process by
+//! `orbit-vst3-effect-child`.
 //!
-//! This crate intentionally implements only the offline feasibility surface needed by
-//! `docs/development/POST_2.0_VST3_HOSTING_PLAN.md` Phase 0: load a macOS `.vst3` bundle,
-//! instantiate the first "Audio Module Class", run one f32 stereo block, and tear down on the
-//! same home thread.
+//! Load a macOS `.vst3` bundle, instantiate the first "Audio Module Class", negotiate the host
+//! context / edit-controller handshake and audio bus arrangement, and process f32 stereo blocks
+//! on the same home thread the plugin was loaded on. Grew out of the Phase 0 (#381) offline
+//! feasibility spike documented in `docs/development/POST_2.0_VST3_HOSTING_PLAN.md`; the
+//! production surface (host application/component-handler callbacks, bus negotiation,
+//! `process_block`) is exercised by `orbit-vst3-effect-child`, which is spawned/supervised by
+//! the daemon.
 
 use std::cell::{Cell, RefCell};
 use std::error::Error;
@@ -34,7 +38,10 @@ type BundleExit = unsafe extern "system" fn() -> bool;
 
 #[derive(Debug)]
 pub enum Vst3HostError {
-    Io { path: PathBuf, message: String },
+    Io {
+        path: PathBuf,
+        message: String,
+    },
     InvalidBundle(PathBuf),
     BundleLoad(String),
     MissingSymbol(&'static str),
@@ -50,7 +57,14 @@ pub enum Vst3HostError {
     SetActive(tresult),
     SetProcessing(tresult),
     Process(tresult),
-    UnsupportedChannels { input: i32, output: i32 },
+    UnsupportedChannels {
+        input: i32,
+        output: i32,
+    },
+    UnsupportedPrimaryBusLayout {
+        direction: &'static str,
+        channels: i32,
+    },
 }
 
 impl Display for Vst3HostError {
@@ -89,6 +103,13 @@ impl Display for Vst3HostError {
                     "unsupported channel layout: input={input}, output={output}"
                 )
             }
+            Self::UnsupportedPrimaryBusLayout {
+                direction,
+                channels,
+            } => write!(
+                f,
+                "primary {direction} bus is not stereo (expected {DEFAULT_CHANNELS} channels, got {channels})"
+            ),
         }
     }
 }
@@ -160,8 +181,16 @@ impl LoadedLibrary {
         if let Some(entry) = unsafe { loaded.function::<BundleEntry>("bundleEntry") }
             .or_else(|| unsafe { loaded.function::<BundleEntry>("BundleEntry") })
         {
+            // VST3/CFBundle convention: `bundleEntry` returning `false` means module init failed
+            // (JUCE treats this as a hard load failure too). Abort before `get_factory()` instead
+            // of silently continuing against an uninitialized module.
             if unsafe { entry(loaded.bundle.cast::<c_void>()) } {
                 loaded.bundle_exit_called = true;
+            } else {
+                return Err(Vst3HostError::BundleLoad(format!(
+                    "bundleEntry returned false: {}",
+                    bundle_path.display()
+                )));
             }
         }
 
@@ -271,8 +300,13 @@ impl Drop for CfUrl {
 /// Single-threaded VST3 effect processor.
 ///
 /// `Rc` makes this type `!Send` and `!Sync`. Construct, process, and drop it on the same home
-/// thread. Field order is load-bearing: Rust drops fields top-to-bottom, so `processor` is released
-/// before `component`, then `factory`, and finally the dynamic library is unloaded.
+/// thread. Shutdown call order (`setProcessing` → disconnect → `controller.terminate` →
+/// `component.setActive(0)`/`terminate`) is enforced by the hand-written `Drop::drop` body below
+/// via explicit `.take()` calls, not by field declaration order. Field order is load-bearing only
+/// for the *implicit* drop of the fields `Drop::drop` does not `.take()`: `_component_handler`
+/// and `_host_context` must be declared (and therefore dropped) before `_library`, so any COM
+/// callback objects backed by the plugin's vtables are released before the dynamic library is
+/// unloaded.
 pub struct Vst3EffectProcessor {
     processor: Option<ComPtr<IAudioProcessor>>,
     controller: Option<ComPtr<IEditController>>,
@@ -374,9 +408,11 @@ impl Vst3EffectProcessor {
             return Err(Vst3HostError::SetupProcessing(setup_result));
         }
 
-        // Phase 0 only verifies the effect overwrite path. This detection is separate from CLAP's
-        // `has_audio_input`; treating an instrument as an effect would be silent-but-wrong because
-        // the dry signal would be overwritten instead of add-mixed.
+        // `is_effect` drives both `process_block`'s overwrite-vs-add-mix branch (used in
+        // production by `orbit-vst3-effect-child`) and the probe / two-pass signal check below
+        // (`probe_effect_signal`), which only verifies the effect overwrite path. This detection
+        // is separate from CLAP's `has_audio_input`; treating an instrument as an effect would be
+        // silent-but-wrong because the dry signal would be overwritten instead of add-mixed.
         let info = LoadedVst3Info {
             name: class.name,
             audio_inputs: input_buses,
@@ -538,6 +574,14 @@ impl Vst3EffectProcessor {
     ///
     /// `is_effect` bus wiring (numInputs/inputs null-vs-populated) lives here so both callers stay
     /// in sync with the same effect/instrument branch.
+    ///
+    /// OOB note: only the primary (index 0) bus per direction is ever described here
+    /// (`numInputs`/`numOutputs` are always 0-or-1), always as a fixed `DEFAULT_CHANNELS`-wide
+    /// buffer. `verify_primary_bus_is_stereo` (called from `configure_audio_buses` at load time)
+    /// rejects plugins whose primary bus isn't stereo, so this fixed-width assembly cannot read
+    /// or write out of bounds for a plugin that passed load. Extra buses beyond index 0 on a
+    /// multi-bus plugin are simply never wired (known limitation, not a crash risk — see
+    /// `real_plugin_gated.rs`'s instrument commentary).
     fn run_process(
         &self,
         mut input_ptrs: [*mut f32; 2],
@@ -795,14 +839,26 @@ fn configure_audio_buses(
         );
         result = set_bus_arrangements(processor, &mut input_arrangements, &mut output_arrangements);
     }
-    // setBusArrangements は advisory。kResultFalse を返すプラグイン（ARIA Player 等・特に
-    // instrument）はプラグイン既定の arrangement で動作する。JUCE も致命扱いしない。ここで
-    // hard-fail すると「host 提案 arrangement を拒否するだけ」のプラグインが全滅するので続行する。
-    // （厳密な buffer 整合は Phase 1 で getBusArrangement の実値に合わせる。）
+    // setBusArrangements は advisory（any non-OK, not just kResultFalse）。この tresult を返す
+    // プラグイン（ARIA Player 等・特に instrument）はプラグイン既定の arrangement で動作する。
+    // JUCE も致命扱いしない。ここで hard-fail すると「host 提案 arrangement を拒否するだけ」の
+    // プラグインが全滅するので続行する。（厳密な buffer 整合は Phase 1 で getBusArrangement の
+    // 実値に合わせる。）
     let _ = result;
 
-    activate_audio_buses(component, BusDirections_::kInput as i32, input_buses);
-    activate_audio_buses(component, BusDirections_::kOutput as i32, output_buses);
+    // `run_process`（lib.rs 内 `Vst3EffectProcessor::run_process`）は index 0 の 1 bus しか
+    // process() に渡さない（`numInputs`/`numOutputs` は常に 0-or-1）。activate は process() が
+    // 実際に触るバスだけに絞り、plugin 側の active-bus bookkeeping を host の実際の呼び出しと
+    // 一致させる（多バス plugin で使わない bus を active のまま残す OOB リスクを避ける）。
+    activate_primary_bus_only(component, BusDirections_::kInput as i32, input_buses);
+    activate_primary_bus_only(component, BusDirections_::kOutput as i32, output_buses);
+
+    // `run_process` は index 0 の primary バスの channel buffer を常に `DEFAULT_CHANNELS`(2) 幅の
+    // `[*mut f32; 2]` として組み立てる。primary バスが stereo でないプラグイン（mono effect 等）を
+    // 通すと OOB / 未初期化読み取りになるため、silent corruption ではなく load 失敗として reject する。
+    // multi-bus プラグインで bus 0 が stereo なら extra バスは単に使わないだけで許容する。
+    verify_primary_bus_is_stereo(component, input_buses, output_buses)?;
+
     Ok(())
 }
 
@@ -893,12 +949,54 @@ fn arrangement_for_channels(channel_count: i32) -> SpeakerArrangement {
     }
 }
 
-fn activate_audio_buses(component: &ComPtr<IComponent>, direction: BusDirection, bus_count: i32) {
-    for index in 0..bus_count {
-        unsafe {
-            let _ = component.activateBus(MediaTypes_::kAudio as i32, direction, index, 1);
+/// Activates only bus index 0 for `direction` (if `bus_count > 0`). `run_process` describes a
+/// single bus per direction to `process()`, so only that bus needs to be active; extra buses on
+/// a multi-bus plugin are intentionally left inactive.
+fn activate_primary_bus_only(
+    component: &ComPtr<IComponent>,
+    direction: BusDirection,
+    bus_count: i32,
+) {
+    if bus_count <= 0 {
+        return;
+    }
+    // activateBus は advisory: 一部プラグインは常に非 OK を返すが、bus 未 activate でも process()
+    // が動くケースが多く（JUCE ホストも致命扱いしない）、失敗を診断 log に残すだけで続行する。
+    let result = unsafe { component.activateBus(MediaTypes_::kAudio as i32, direction, 0, 1) };
+    if !is_ok(result) {
+        eprintln!(
+            "[orbit-vst3-host] activateBus(direction={direction}, index=0) advisory failure: {result}"
+        );
+    }
+}
+
+/// `run_process` always wires the primary (index 0) bus as a `DEFAULT_CHANNELS`-wide (stereo)
+/// buffer. Reject load if either primary bus that will actually be processed reports a different
+/// channel count, instead of letting `run_process` read/write out of bounds.
+fn verify_primary_bus_is_stereo(
+    component: &ComPtr<IComponent>,
+    input_buses: i32,
+    output_buses: i32,
+) -> Result<(), Vst3HostError> {
+    if input_buses > 0 {
+        let channels = audio_bus_channel_count(component, BusDirections_::kInput as i32, 0);
+        if channels != DEFAULT_CHANNELS as i32 {
+            return Err(Vst3HostError::UnsupportedPrimaryBusLayout {
+                direction: "input",
+                channels,
+            });
         }
     }
+    if output_buses > 0 {
+        let channels = audio_bus_channel_count(component, BusDirections_::kOutput as i32, 0);
+        if channels != DEFAULT_CHANNELS as i32 {
+            return Err(Vst3HostError::UnsupportedPrimaryBusLayout {
+                direction: "output",
+                channels,
+            });
+        }
+    }
+    Ok(())
 }
 
 fn ptr_or_null_mut<T>(values: &mut [T]) -> *mut T {
@@ -1607,4 +1705,24 @@ fn json_escape(value: &str) -> String {
         }
     }
     escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // I6(pr-review-team): `is_ok` gates every tresult check in this crate (setup/activate/process
+    // ...) but had no direct unit test — pin the kResultOk/kResultTrue/kResultFalse/kNotImplemented
+    // truth table.
+    #[test]
+    fn is_ok_treats_result_ok_and_result_true_as_success() {
+        assert!(is_ok(kResultOk));
+        assert!(is_ok(kResultTrue));
+    }
+
+    #[test]
+    fn is_ok_treats_result_false_and_not_implemented_as_failure() {
+        assert!(!is_ok(kResultFalse));
+        assert!(!is_ok(kNotImplemented));
+    }
 }

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -5,17 +5,22 @@
 //! instantiate the first "Audio Module Class", run one f32 stereo block, and tear down on the
 //! same home thread.
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::error::Error;
-use std::ffi::c_void;
+use std::ffi::{c_void, CString};
 use std::fmt::{Display, Formatter};
-use std::fs;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 use std::ptr;
 use std::rc::Rc;
 
-use libloading::{Library, Symbol};
+use core_foundation_sys::base::{kCFAllocatorDefault, CFRelease};
+use core_foundation_sys::bundle::{
+    CFBundleCreate, CFBundleGetFunctionPointerForName, CFBundleLoadExecutable, CFBundleRef,
+    CFBundleUnloadExecutable,
+};
+use core_foundation_sys::string::{kCFStringEncodingUTF8, CFStringCreateWithCString, CFStringRef};
+use core_foundation_sys::url::{kCFURLPOSIXPathStyle, CFURLCreateWithFileSystemPath, CFURLRef};
 use vst3::Steinberg::Vst::*;
 use vst3::Steinberg::*;
 use vst3::{Class, ComPtr, ComWrapper};
@@ -31,14 +36,16 @@ type BundleExit = unsafe extern "system" fn() -> bool;
 pub enum Vst3HostError {
     Io { path: PathBuf, message: String },
     InvalidBundle(PathBuf),
-    Dlopen(String),
+    BundleLoad(String),
     MissingSymbol(&'static str),
     NullFactory,
     NoAudioModuleClass,
     CreateInstance(tresult),
     QueryAudioProcessor,
+    Controller(tresult),
     Initialize(tresult),
     BusArrangement(tresult),
+    SampleSize(tresult),
     SetupProcessing(tresult),
     SetActive(tresult),
     SetProcessing(tresult),
@@ -51,7 +58,7 @@ impl Display for Vst3HostError {
         match self {
             Self::Io { path, message } => write!(f, "{}: {message}", path.display()),
             Self::InvalidBundle(path) => write!(f, "invalid VST3 bundle: {}", path.display()),
-            Self::Dlopen(message) => write!(f, "dlopen failed: {message}"),
+            Self::BundleLoad(message) => write!(f, "CFBundle load failed: {message}"),
             Self::MissingSymbol(symbol) => write!(f, "missing symbol: {symbol}"),
             Self::NullFactory => write!(f, "GetPluginFactory returned null"),
             Self::NoAudioModuleClass => write!(f, "no Audio Module Class in VST3 factory"),
@@ -59,6 +66,7 @@ impl Display for Vst3HostError {
                 write!(f, "IPluginFactory::createInstance failed: {result}")
             }
             Self::QueryAudioProcessor => write!(f, "queryInterface(IAudioProcessor) failed"),
+            Self::Controller(result) => write!(f, "controller handshake failed: {result}"),
             Self::Initialize(result) => write!(f, "IComponent::initialize failed: {result}"),
             Self::BusArrangement(result) => {
                 write!(f, "IAudioProcessor::setBusArrangements failed: {result}")
@@ -66,6 +74,10 @@ impl Display for Vst3HostError {
             Self::SetupProcessing(result) => {
                 write!(f, "IAudioProcessor::setupProcessing failed: {result}")
             }
+            Self::SampleSize(result) => write!(
+                f,
+                "IAudioProcessor::canProcessSampleSize(kSample32) failed: {result}"
+            ),
             Self::SetActive(result) => write!(f, "IComponent::setActive failed: {result}"),
             Self::SetProcessing(result) => {
                 write!(f, "IAudioProcessor::setProcessing failed: {result}")
@@ -97,38 +109,84 @@ pub struct ProcessReport {
 }
 
 struct LoadedLibrary {
-    library: Library,
+    bundle: CFBundleRef,
     bundle_exit_called: bool,
 }
 
 impl LoadedLibrary {
     fn open(bundle_path: &Path) -> Result<Self, Vst3HostError> {
-        let dylib_path = resolve_vst3_executable(bundle_path)?;
-        let library = unsafe { Library::new(&dylib_path) }
-            .map_err(|error| Vst3HostError::Dlopen(format!("{}: {error}", dylib_path.display())))?;
+        if bundle_path.extension().and_then(|ext| ext.to_str()) != Some("vst3") {
+            return Err(Vst3HostError::InvalidBundle(bundle_path.to_path_buf()));
+        }
+        let bundle_path = bundle_path.canonicalize().map_err(|error| {
+            Vst3HostError::BundleLoad(format!("{}: {error}", bundle_path.display()))
+        })?;
+        let path_string = bundle_path.to_str().ok_or_else(|| {
+            Vst3HostError::BundleLoad(format!("non-UTF8 bundle path: {}", bundle_path.display()))
+        })?;
+        let cf_path = CfString::new(path_string)?;
+        let url = unsafe {
+            CFURLCreateWithFileSystemPath(
+                kCFAllocatorDefault,
+                cf_path.as_ref(),
+                kCFURLPOSIXPathStyle,
+                1,
+            )
+        };
+        let url = CfUrl::from_raw(url).ok_or_else(|| {
+            Vst3HostError::BundleLoad(format!(
+                "CFURLCreateWithFileSystemPath failed: {}",
+                bundle_path.display()
+            ))
+        })?;
+        let bundle = unsafe { CFBundleCreate(kCFAllocatorDefault, url.as_ref()) };
+        if bundle.is_null() {
+            return Err(Vst3HostError::BundleLoad(format!(
+                "CFBundleCreate failed: {}",
+                bundle_path.display()
+            )));
+        }
+        let mut loaded = Self {
+            bundle,
+            bundle_exit_called: false,
+        };
+        if unsafe { CFBundleLoadExecutable(loaded.bundle) } == 0 {
+            return Err(Vst3HostError::BundleLoad(format!(
+                "CFBundleLoadExecutable failed: {}",
+                bundle_path.display()
+            )));
+        }
 
-        let mut bundle_exit_called = false;
-        unsafe {
-            if let Ok(entry) = library.get::<BundleEntry>(b"BundleEntry\0") {
-                if entry(ptr::null_mut()) {
-                    bundle_exit_called = true;
-                }
+        if let Some(entry) = unsafe { loaded.function::<BundleEntry>("bundleEntry") }
+            .or_else(|| unsafe { loaded.function::<BundleEntry>("BundleEntry") })
+        {
+            if unsafe { entry(loaded.bundle.cast::<c_void>()) } {
+                loaded.bundle_exit_called = true;
             }
         }
 
-        Ok(Self {
-            library,
-            bundle_exit_called,
-        })
+        Ok(loaded)
     }
 
     unsafe fn get_factory(&self) -> Result<ComPtr<IPluginFactory>, Vst3HostError> {
-        let get_factory: Symbol<'_, GetPluginFactory> = self
-            .library
-            .get(b"GetPluginFactory\0")
-            .map_err(|_| Vst3HostError::MissingSymbol("GetPluginFactory"))?;
+        let get_factory = self
+            .function::<GetPluginFactory>("GetPluginFactory")
+            .ok_or(Vst3HostError::MissingSymbol("GetPluginFactory"))?;
         let raw = get_factory();
         ComPtr::from_raw(raw).ok_or(Vst3HostError::NullFactory)
+    }
+
+    unsafe fn function<T>(&self, name: &str) -> Option<T>
+    where
+        T: Copy,
+    {
+        let cf_name = CfString::new(name).ok()?;
+        let ptr = CFBundleGetFunctionPointerForName(self.bundle, cf_name.as_ref());
+        if ptr.is_null() {
+            None
+        } else {
+            Some(std::mem::transmute_copy(&ptr))
+        }
     }
 }
 
@@ -136,10 +194,76 @@ impl Drop for LoadedLibrary {
     fn drop(&mut self) {
         if self.bundle_exit_called {
             unsafe {
-                if let Ok(exit) = self.library.get::<BundleExit>(b"BundleExit\0") {
+                let exit = self
+                    .function::<BundleExit>("bundleExit")
+                    .or_else(|| self.function::<BundleExit>("BundleExit"));
+                if let Some(exit) = exit {
                     let _ = exit();
                 }
             }
+        }
+        unsafe {
+            CFBundleUnloadExecutable(self.bundle);
+            CFRelease(self.bundle.cast());
+        }
+    }
+}
+
+struct CfString(CFStringRef);
+
+impl CfString {
+    fn new(value: &str) -> Result<Self, Vst3HostError> {
+        let c_string = CString::new(value)
+            .map_err(|_| Vst3HostError::BundleLoad(format!("string contains NUL: {value}")))?;
+        let raw = unsafe {
+            CFStringCreateWithCString(
+                kCFAllocatorDefault,
+                c_string.as_ptr(),
+                kCFStringEncodingUTF8,
+            )
+        };
+        if raw.is_null() {
+            Err(Vst3HostError::BundleLoad(format!(
+                "CFStringCreateWithCString failed: {value}"
+            )))
+        } else {
+            Ok(Self(raw))
+        }
+    }
+
+    fn as_ref(&self) -> CFStringRef {
+        self.0
+    }
+}
+
+impl Drop for CfString {
+    fn drop(&mut self) {
+        unsafe {
+            CFRelease(self.0.cast());
+        }
+    }
+}
+
+struct CfUrl(CFURLRef);
+
+impl CfUrl {
+    fn from_raw(raw: CFURLRef) -> Option<Self> {
+        if raw.is_null() {
+            None
+        } else {
+            Some(Self(raw))
+        }
+    }
+
+    fn as_ref(&self) -> CFURLRef {
+        self.0
+    }
+}
+
+impl Drop for CfUrl {
+    fn drop(&mut self) {
+        unsafe {
+            CFRelease(self.0.cast());
         }
     }
 }
@@ -151,7 +275,11 @@ impl Drop for LoadedLibrary {
 /// before `component`, then `factory`, and finally the dynamic library is unloaded.
 pub struct Vst3EffectProcessor {
     processor: Option<ComPtr<IAudioProcessor>>,
+    controller: Option<ComPtr<IEditController>>,
+    component_connection: Option<ComPtr<IConnectionPoint>>,
+    controller_connection: Option<ComPtr<IConnectionPoint>>,
     component: Option<ComPtr<IComponent>>,
+    _component_handler: Option<ComWrapper<HostComponentHandler>>,
     _host_context: ComWrapper<HostApplication>,
     factory: Option<ComPtr<IPluginFactory>>,
     _home_thread: PhantomData<Rc<()>>,
@@ -200,6 +328,13 @@ impl Vst3EffectProcessor {
             .as_com_ref()
             .cast::<IAudioProcessor>()
             .ok_or(Vst3HostError::QueryAudioProcessor)?;
+        let sample_size_result =
+            unsafe { processor.canProcessSampleSize(SymbolicSampleSizes_::kSample32 as i32) };
+        if !is_ok(sample_size_result) {
+            return Err(Vst3HostError::SampleSize(sample_size_result));
+        }
+        let controller_handshake =
+            connect_controller(&factory, &component, &host_context, host_context_ptr)?;
 
         let input_buses = unsafe {
             component.getBusCount(MediaTypes_::kAudio as i32, BusDirections_::kInput as i32)
@@ -244,7 +379,11 @@ impl Vst3EffectProcessor {
 
         let processor = Self {
             processor: Some(processor),
+            controller: controller_handshake.controller,
+            component_connection: controller_handshake.component_connection,
+            controller_connection: controller_handshake.controller_connection,
             component: Some(component),
+            _component_handler: controller_handshake.component_handler,
             _host_context: host_context,
             factory: Some(factory),
             _home_thread: PhantomData,
@@ -301,11 +440,13 @@ impl Vst3EffectProcessor {
             },
         }];
 
-        let parameter_changes = gain.map(ParameterChanges::single_gain);
-        let input_parameter_changes = parameter_changes
-            .as_ref()
-            .map(|changes| changes.as_ptr())
-            .unwrap_or(ptr::null_mut());
+        let parameter_changes = gain
+            .map(ParameterChanges::single_gain)
+            .unwrap_or_else(ParameterChanges::empty);
+        let output_parameter_changes = ParameterChanges::empty();
+        let input_events = EventList::empty();
+        let output_events = EventList::empty();
+        let mut process_context = self.process_context();
 
         let mut process_data = ProcessData {
             processMode: ProcessModes_::kRealtime as i32,
@@ -319,11 +460,11 @@ impl Vst3EffectProcessor {
                 ptr::null_mut()
             },
             outputs: outputs.as_mut_ptr(),
-            inputParameterChanges: input_parameter_changes,
-            outputParameterChanges: ptr::null_mut(),
-            inputEvents: ptr::null_mut(),
-            outputEvents: ptr::null_mut(),
-            processContext: ptr::null_mut(),
+            inputParameterChanges: parameter_changes.as_ptr(),
+            outputParameterChanges: output_parameter_changes.as_ptr(),
+            inputEvents: input_events.as_ptr(),
+            outputEvents: output_events.as_ptr(),
+            processContext: &mut process_context,
         };
 
         let result = unsafe { processor.process(&mut process_data) };
@@ -335,6 +476,54 @@ impl Vst3EffectProcessor {
             is_effect: self.info.is_effect,
         })
     }
+
+    fn process_context(&self) -> ProcessContext {
+        let mut state = ProcessContext_::StatesAndFlags_::kTempoValid
+            | ProcessContext_::StatesAndFlags_::kTimeSigValid;
+        if let Some(processor) = self.processor.as_ref() {
+            if let Some(requirements) = processor.as_com_ref().cast::<IProcessContextRequirements>()
+            {
+                let required = unsafe { requirements.getProcessContextRequirements() };
+                if required & IProcessContextRequirements_::Flags_::kNeedTransportState != 0 {
+                    state |= ProcessContext_::StatesAndFlags_::kPlaying;
+                }
+                if required & IProcessContextRequirements_::Flags_::kNeedProjectTimeMusic != 0 {
+                    state |= ProcessContext_::StatesAndFlags_::kProjectTimeMusicValid;
+                }
+                if required & IProcessContextRequirements_::Flags_::kNeedTempo != 0 {
+                    state |= ProcessContext_::StatesAndFlags_::kTempoValid;
+                }
+                if required & IProcessContextRequirements_::Flags_::kNeedTimeSignature != 0 {
+                    state |= ProcessContext_::StatesAndFlags_::kTimeSigValid;
+                }
+            }
+        }
+        ProcessContext {
+            state,
+            sampleRate: self.sample_rate,
+            projectTimeSamples: 0,
+            systemTime: 0,
+            continousTimeSamples: 0,
+            projectTimeMusic: 0.0,
+            barPositionMusic: 0.0,
+            cycleStartMusic: 0.0,
+            cycleEndMusic: 0.0,
+            tempo: 120.0,
+            timeSigNumerator: 4,
+            timeSigDenominator: 4,
+            chord: Chord {
+                keyNote: 0,
+                rootNote: 0,
+                chordMask: 0,
+            },
+            smpteOffsetSubframes: 0,
+            frameRate: FrameRate {
+                framesPerSecond: 0,
+                flags: 0,
+            },
+            samplesToNextClock: 0,
+        }
+    }
 }
 
 impl Drop for Vst3EffectProcessor {
@@ -342,6 +531,22 @@ impl Drop for Vst3EffectProcessor {
         if let Some(processor) = self.processor.take() {
             unsafe {
                 let _ = processor.setProcessing(0);
+            }
+        }
+        if let (Some(component_connection), Some(controller_connection)) = (
+            self.component_connection.as_ref(),
+            self.controller_connection.as_ref(),
+        ) {
+            unsafe {
+                let _ = component_connection.disconnect(controller_connection.as_ptr());
+                let _ = controller_connection.disconnect(component_connection.as_ptr());
+            }
+        }
+        let _ = self.component_connection.take();
+        let _ = self.controller_connection.take();
+        if let Some(controller) = self.controller.take() {
+            unsafe {
+                let _ = controller.terminate();
             }
         }
         if let Some(component) = self.component.take() {
@@ -358,6 +563,95 @@ impl Drop for Vst3EffectProcessor {
 struct AudioModuleClass {
     cid: TUID,
     name: String,
+}
+
+struct ControllerHandshake {
+    controller: Option<ComPtr<IEditController>>,
+    component_connection: Option<ComPtr<IConnectionPoint>>,
+    controller_connection: Option<ComPtr<IConnectionPoint>>,
+    component_handler: Option<ComWrapper<HostComponentHandler>>,
+}
+
+fn connect_controller(
+    factory: &ComPtr<IPluginFactory>,
+    component: &ComPtr<IComponent>,
+    _host_context: &ComWrapper<HostApplication>,
+    host_context_ptr: *mut FUnknown,
+) -> Result<ControllerHandshake, Vst3HostError> {
+    let mut controller_cid = [0; 16];
+    let cid_result = unsafe { component.getControllerClassId(&mut controller_cid) };
+    if !is_ok(cid_result) {
+        return Ok(ControllerHandshake {
+            controller: None,
+            component_connection: None,
+            controller_connection: None,
+            component_handler: None,
+        });
+    }
+
+    let mut controller_raw = ptr::null_mut();
+    let create_result = unsafe {
+        factory.createInstance(
+            controller_cid.as_ptr() as FIDString,
+            IEditController_iid.as_ptr() as FIDString,
+            &mut controller_raw,
+        )
+    };
+    if !is_ok(create_result) {
+        return Err(Vst3HostError::Controller(create_result));
+    }
+    let controller = unsafe { ComPtr::from_raw(controller_raw as *mut IEditController) }
+        .ok_or(Vst3HostError::Controller(create_result))?;
+
+    let init_result = unsafe { controller.initialize(host_context_ptr) };
+    if !is_ok(init_result) {
+        return Err(Vst3HostError::Controller(init_result));
+    }
+
+    let component_handler = ComWrapper::new(HostComponentHandler);
+    let handler_ptr = component_handler
+        .as_com_ref::<IComponentHandler>()
+        .expect("HostComponentHandler exposes IComponentHandler")
+        .as_ptr();
+    let handler_result = unsafe { controller.setComponentHandler(handler_ptr) };
+    if !is_ok(handler_result) {
+        return Err(Vst3HostError::Controller(handler_result));
+    }
+
+    let component_connection = component.as_com_ref().cast::<IConnectionPoint>();
+    let controller_connection = controller.as_com_ref().cast::<IConnectionPoint>();
+    if let (Some(component_connection), Some(controller_connection)) =
+        (&component_connection, &controller_connection)
+    {
+        unsafe {
+            let _ = component_connection.connect(controller_connection.as_ptr());
+            let _ = controller_connection.connect(component_connection.as_ptr());
+        }
+    }
+
+    sync_component_state(component, &controller);
+
+    Ok(ControllerHandshake {
+        controller: Some(controller),
+        component_connection,
+        controller_connection,
+        component_handler: Some(component_handler),
+    })
+}
+
+fn sync_component_state(component: &ComPtr<IComponent>, controller: &ComPtr<IEditController>) {
+    let stream_wrapper = ComWrapper::new(MemoryStream::new());
+    let stream = stream_wrapper
+        .to_com_ptr::<IBStream>()
+        .expect("MemoryStream exposes IBStream");
+    let get_result = unsafe { component.getState(stream.as_ptr()) };
+    if is_ok(get_result) {
+        unsafe {
+            let mut pos = 0;
+            let _ = stream.seek(0, IBStream_::IStreamSeekMode_::kIBSeekSet as i32, &mut pos);
+            let _ = controller.setComponentState(stream.as_ptr());
+        }
+    }
 }
 
 fn configure_audio_buses(
@@ -379,14 +673,23 @@ fn configure_audio_buses(
         output_buses,
     );
 
-    let result = unsafe {
-        processor.setBusArrangements(
-            ptr_or_null_mut(&mut input_arrangements),
-            input_arrangements.len() as i32,
-            ptr_or_null_mut(&mut output_arrangements),
-            output_arrangements.len() as i32,
-        )
-    };
+    let mut result =
+        set_bus_arrangements(processor, &mut input_arrangements, &mut output_arrangements);
+    if !is_ok(result) {
+        input_arrangements = plugin_reported_arrangements(
+            processor,
+            BusDirections_::kInput as i32,
+            input_buses,
+            &input_arrangements,
+        );
+        output_arrangements = plugin_reported_arrangements(
+            processor,
+            BusDirections_::kOutput as i32,
+            output_buses,
+            &output_arrangements,
+        );
+        result = set_bus_arrangements(processor, &mut input_arrangements, &mut output_arrangements);
+    }
     if !is_ok(result) {
         return Err(Vst3HostError::BusArrangement(result));
     }
@@ -394,6 +697,43 @@ fn configure_audio_buses(
     activate_audio_buses(component, BusDirections_::kInput as i32, input_buses);
     activate_audio_buses(component, BusDirections_::kOutput as i32, output_buses);
     Ok(())
+}
+
+fn set_bus_arrangements(
+    processor: &ComPtr<IAudioProcessor>,
+    input_arrangements: &mut [SpeakerArrangement],
+    output_arrangements: &mut [SpeakerArrangement],
+) -> tresult {
+    unsafe {
+        processor.setBusArrangements(
+            ptr_or_null_mut(input_arrangements),
+            input_arrangements.len() as i32,
+            ptr_or_null_mut(output_arrangements),
+            output_arrangements.len() as i32,
+        )
+    }
+}
+
+fn plugin_reported_arrangements(
+    processor: &ComPtr<IAudioProcessor>,
+    direction: BusDirection,
+    bus_count: i32,
+    fallback: &[SpeakerArrangement],
+) -> Vec<SpeakerArrangement> {
+    (0..bus_count)
+        .map(|index| {
+            let mut arrangement = 0;
+            let result = unsafe { processor.getBusArrangement(direction, index, &mut arrangement) };
+            if is_ok(result) && arrangement != 0 {
+                arrangement
+            } else {
+                fallback
+                    .get(index as usize)
+                    .copied()
+                    .unwrap_or(SpeakerArr::kStereo)
+            }
+        })
+        .collect()
 }
 
 fn arrangements_for_direction(
@@ -485,34 +825,6 @@ fn find_audio_module_class(
         }
     }
     Err(Vst3HostError::NoAudioModuleClass)
-}
-
-fn resolve_vst3_executable(bundle_path: &Path) -> Result<PathBuf, Vst3HostError> {
-    if bundle_path.extension().and_then(|ext| ext.to_str()) != Some("vst3") {
-        return Err(Vst3HostError::InvalidBundle(bundle_path.to_path_buf()));
-    }
-    let executable = read_cf_bundle_executable(bundle_path).or_else(|| {
-        bundle_path
-            .file_stem()
-            .and_then(|stem| stem.to_str())
-            .map(ToOwned::to_owned)
-    });
-    let executable = executable.ok_or_else(|| Vst3HostError::InvalidBundle(bundle_path.into()))?;
-    Ok(bundle_path.join("Contents").join("MacOS").join(executable))
-}
-
-fn read_cf_bundle_executable(bundle_path: &Path) -> Option<String> {
-    let plist_path = bundle_path.join("Contents").join("Info.plist");
-    let plist = fs::read_to_string(&plist_path).ok()?;
-    let key_pos = plist.find("<key>CFBundleExecutable</key>")?;
-    let after_key = &plist[key_pos..];
-    let string_start = after_key.find("<string>")? + "<string>".len();
-    let string_end = after_key[string_start..].find("</string>")?;
-    Some(
-        after_key[string_start..string_start + string_end]
-            .trim()
-            .to_owned(),
-    )
 }
 
 fn char8_array_to_string(data: &[i8]) -> String {
@@ -735,14 +1047,179 @@ fn copy_wstring(src: &str, dst: &mut [TChar]) {
     }
 }
 
+struct HostComponentHandler;
+
+impl Class for HostComponentHandler {
+    type Interfaces = (IComponentHandler,);
+}
+
+impl IComponentHandlerTrait for HostComponentHandler {
+    unsafe fn beginEdit(&self, _id: ParamID) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn performEdit(&self, _id: ParamID, _value_normalized: ParamValue) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn endEdit(&self, _id: ParamID) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn restartComponent(&self, _flags: i32) -> tresult {
+        kResultOk
+    }
+}
+
+struct MemoryStream {
+    data: RefCell<Vec<u8>>,
+    pos: Cell<usize>,
+}
+
+impl MemoryStream {
+    fn new() -> Self {
+        Self {
+            data: RefCell::new(Vec::new()),
+            pos: Cell::new(0),
+        }
+    }
+}
+
+impl Class for MemoryStream {
+    type Interfaces = (IBStream,);
+}
+
+impl IBStreamTrait for MemoryStream {
+    unsafe fn read(
+        &self,
+        buffer: *mut c_void,
+        num_bytes: i32,
+        num_bytes_read: *mut i32,
+    ) -> tresult {
+        if buffer.is_null() || num_bytes < 0 {
+            return kInvalidArgument;
+        }
+        let data = self.data.borrow();
+        let pos = self.pos.get().min(data.len());
+        let available = data.len().saturating_sub(pos);
+        let to_read = available.min(num_bytes as usize);
+        ptr::copy_nonoverlapping(data[pos..].as_ptr(), buffer.cast::<u8>(), to_read);
+        self.pos.set(pos + to_read);
+        if !num_bytes_read.is_null() {
+            *num_bytes_read = to_read as i32;
+        }
+        kResultOk
+    }
+
+    unsafe fn write(
+        &self,
+        buffer: *mut c_void,
+        num_bytes: i32,
+        num_bytes_written: *mut i32,
+    ) -> tresult {
+        if buffer.is_null() || num_bytes < 0 {
+            return kInvalidArgument;
+        }
+        let bytes = std::slice::from_raw_parts(buffer.cast::<u8>(), num_bytes as usize);
+        let mut data = self.data.borrow_mut();
+        let pos = self.pos.get();
+        let end = pos.saturating_add(bytes.len());
+        if end > data.len() {
+            data.resize(end, 0);
+        }
+        data[pos..end].copy_from_slice(bytes);
+        self.pos.set(end);
+        if !num_bytes_written.is_null() {
+            *num_bytes_written = bytes.len() as i32;
+        }
+        kResultOk
+    }
+
+    unsafe fn seek(&self, pos: i64, mode: i32, result: *mut i64) -> tresult {
+        let len = self.data.borrow().len() as i64;
+        let base = match mode as u32 {
+            IBStream_::IStreamSeekMode_::kIBSeekSet => 0,
+            IBStream_::IStreamSeekMode_::kIBSeekCur => self.pos.get() as i64,
+            IBStream_::IStreamSeekMode_::kIBSeekEnd => len,
+            _ => return kInvalidArgument,
+        };
+        let new_pos = base.saturating_add(pos).max(0) as usize;
+        self.pos.set(new_pos);
+        if !result.is_null() {
+            *result = new_pos as i64;
+        }
+        kResultOk
+    }
+
+    unsafe fn tell(&self, pos: *mut i64) -> tresult {
+        if !pos.is_null() {
+            *pos = self.pos.get() as i64;
+        }
+        kResultOk
+    }
+}
+
+struct EventList {
+    _wrapper: ComWrapper<HostEventList>,
+    ptr: ComPtr<IEventList>,
+}
+
+impl EventList {
+    fn empty() -> Self {
+        let wrapper = ComWrapper::new(HostEventList);
+        let ptr = wrapper
+            .to_com_ptr::<IEventList>()
+            .expect("HostEventList exposes IEventList");
+        Self {
+            _wrapper: wrapper,
+            ptr,
+        }
+    }
+
+    fn as_ptr(&self) -> *mut IEventList {
+        self.ptr.as_ptr()
+    }
+}
+
+struct HostEventList;
+
+impl Class for HostEventList {
+    type Interfaces = (IEventList,);
+}
+
+impl IEventListTrait for HostEventList {
+    unsafe fn getEventCount(&self) -> i32 {
+        0
+    }
+
+    unsafe fn getEvent(&self, _index: i32, _event: *mut Event) -> tresult {
+        kInvalidArgument
+    }
+
+    unsafe fn addEvent(&self, _event: *mut Event) -> tresult {
+        kResultFalse
+    }
+}
+
 struct ParameterChanges {
     _wrapper: ComWrapper<HostParameterChanges>,
     ptr: ComPtr<IParameterChanges>,
 }
 
 impl ParameterChanges {
+    fn empty() -> Self {
+        let wrapper = ComWrapper::new(HostParameterChanges::empty());
+        let ptr = wrapper
+            .to_com_ptr::<IParameterChanges>()
+            .expect("HostParameterChanges exposes IParameterChanges");
+        Self {
+            _wrapper: wrapper,
+            ptr,
+        }
+    }
+
     fn single_gain(value: f64) -> Self {
-        let wrapper = ComWrapper::new(HostParameterChanges::new(0, value));
+        let wrapper = ComWrapper::new(HostParameterChanges::single(0, value));
         let ptr = wrapper
             .to_com_ptr::<IParameterChanges>()
             .expect("HostParameterChanges exposes IParameterChanges");
@@ -758,14 +1235,21 @@ impl ParameterChanges {
 }
 
 struct HostParameterChanges {
-    queue: ComWrapper<HostParamValueQueue>,
+    queue: Option<ComWrapper<HostParamValueQueue>>,
     queue_ptr: Cell<*mut IParamValueQueue>,
 }
 
 impl HostParameterChanges {
-    fn new(param_id: ParamID, value: ParamValue) -> Self {
+    fn empty() -> Self {
         Self {
-            queue: ComWrapper::new(HostParamValueQueue::new(param_id, value)),
+            queue: None,
+            queue_ptr: Cell::new(ptr::null_mut()),
+        }
+    }
+
+    fn single(param_id: ParamID, value: ParamValue) -> Self {
+        Self {
+            queue: Some(ComWrapper::new(HostParamValueQueue::new(param_id, value))),
             queue_ptr: Cell::new(ptr::null_mut()),
         }
     }
@@ -775,8 +1259,10 @@ impl HostParameterChanges {
         if !existing.is_null() {
             return existing;
         }
-        let ptr = self
-            .queue
+        let Some(queue) = self.queue.as_ref() else {
+            return ptr::null_mut();
+        };
+        let ptr = queue
             .to_com_ptr::<IParamValueQueue>()
             .expect("HostParamValueQueue exposes IParamValueQueue")
             .into_raw();
@@ -804,7 +1290,11 @@ impl Class for HostParameterChanges {
 
 impl IParameterChangesTrait for HostParameterChanges {
     unsafe fn getParameterCount(&self) -> i32 {
-        1
+        if self.queue.is_some() {
+            1
+        } else {
+            0
+        }
     }
 
     unsafe fn getParameterData(&self, index: i32) -> *mut IParamValueQueue {

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -38,6 +38,7 @@ pub enum Vst3HostError {
     CreateInstance(tresult),
     QueryAudioProcessor,
     Initialize(tresult),
+    BusArrangement(tresult),
     SetupProcessing(tresult),
     SetActive(tresult),
     SetProcessing(tresult),
@@ -59,6 +60,9 @@ impl Display for Vst3HostError {
             }
             Self::QueryAudioProcessor => write!(f, "queryInterface(IAudioProcessor) failed"),
             Self::Initialize(result) => write!(f, "IComponent::initialize failed: {result}"),
+            Self::BusArrangement(result) => {
+                write!(f, "IAudioProcessor::setBusArrangements failed: {result}")
+            }
             Self::SetupProcessing(result) => {
                 write!(f, "IAudioProcessor::setupProcessing failed: {result}")
             }
@@ -148,6 +152,7 @@ impl Drop for LoadedLibrary {
 pub struct Vst3EffectProcessor {
     processor: Option<ComPtr<IAudioProcessor>>,
     component: Option<ComPtr<IComponent>>,
+    _host_context: ComWrapper<HostApplication>,
     factory: Option<ComPtr<IPluginFactory>>,
     _home_thread: PhantomData<Rc<()>>,
     _library: LoadedLibrary,
@@ -180,7 +185,13 @@ impl Vst3EffectProcessor {
         let component = unsafe { ComPtr::from_raw(component_raw as *mut IComponent) }
             .ok_or(Vst3HostError::CreateInstance(create_result))?;
 
-        let init_result = unsafe { component.initialize(ptr::null_mut()) };
+        let host_context = ComWrapper::new(HostApplication);
+        let host_context_ptr = host_context
+            .as_com_ref::<IHostApplication>()
+            .expect("HostApplication exposes IHostApplication")
+            .as_ptr()
+            .cast::<FUnknown>();
+        let init_result = unsafe { component.initialize(host_context_ptr) };
         if !is_ok(init_result) {
             return Err(Vst3HostError::Initialize(init_result));
         }
@@ -189,6 +200,16 @@ impl Vst3EffectProcessor {
             .as_com_ref()
             .cast::<IAudioProcessor>()
             .ok_or(Vst3HostError::QueryAudioProcessor)?;
+
+        let input_buses = unsafe {
+            component.getBusCount(MediaTypes_::kAudio as i32, BusDirections_::kInput as i32)
+        };
+        let output_buses = unsafe {
+            component.getBusCount(MediaTypes_::kAudio as i32, BusDirections_::kOutput as i32)
+        };
+        let is_effect = input_buses > 0;
+
+        configure_audio_buses(&component, &processor, input_buses, output_buses)?;
 
         let mut setup = ProcessSetup {
             processMode: ProcessModes_::kRealtime as i32,
@@ -200,14 +221,6 @@ impl Vst3EffectProcessor {
         if !is_ok(setup_result) {
             return Err(Vst3HostError::SetupProcessing(setup_result));
         }
-
-        let input_buses = unsafe {
-            component.getBusCount(MediaTypes_::kAudio as i32, BusDirections_::kInput as i32)
-        };
-        let output_buses = unsafe {
-            component.getBusCount(MediaTypes_::kAudio as i32, BusDirections_::kOutput as i32)
-        };
-        let is_effect = input_buses > 0;
 
         // Phase 0 only verifies the effect overwrite path. This detection is separate from CLAP's
         // `has_audio_input`; treating an instrument as an effect would be silent-but-wrong because
@@ -232,6 +245,7 @@ impl Vst3EffectProcessor {
         let processor = Self {
             processor: Some(processor),
             component: Some(component),
+            _host_context: host_context,
             factory: Some(factory),
             _home_thread: PhantomData,
             _library: library,
@@ -346,6 +360,108 @@ struct AudioModuleClass {
     name: String,
 }
 
+fn configure_audio_buses(
+    component: &ComPtr<IComponent>,
+    processor: &ComPtr<IAudioProcessor>,
+    input_buses: i32,
+    output_buses: i32,
+) -> Result<(), Vst3HostError> {
+    let mut input_arrangements = arrangements_for_direction(
+        component,
+        processor,
+        BusDirections_::kInput as i32,
+        input_buses,
+    );
+    let mut output_arrangements = arrangements_for_direction(
+        component,
+        processor,
+        BusDirections_::kOutput as i32,
+        output_buses,
+    );
+
+    let result = unsafe {
+        processor.setBusArrangements(
+            ptr_or_null_mut(&mut input_arrangements),
+            input_arrangements.len() as i32,
+            ptr_or_null_mut(&mut output_arrangements),
+            output_arrangements.len() as i32,
+        )
+    };
+    if !is_ok(result) {
+        return Err(Vst3HostError::BusArrangement(result));
+    }
+
+    activate_audio_buses(component, BusDirections_::kInput as i32, input_buses);
+    activate_audio_buses(component, BusDirections_::kOutput as i32, output_buses);
+    Ok(())
+}
+
+fn arrangements_for_direction(
+    component: &ComPtr<IComponent>,
+    processor: &ComPtr<IAudioProcessor>,
+    direction: BusDirection,
+    bus_count: i32,
+) -> Vec<SpeakerArrangement> {
+    (0..bus_count)
+        .map(|index| {
+            let channel_count = audio_bus_channel_count(component, direction, index);
+            let mut arrangement = 0;
+            let result = unsafe { processor.getBusArrangement(direction, index, &mut arrangement) };
+            if is_ok(result) && arrangement != 0 {
+                arrangement
+            } else {
+                arrangement_for_channels(channel_count)
+            }
+        })
+        .collect()
+}
+
+fn audio_bus_channel_count(
+    component: &ComPtr<IComponent>,
+    direction: BusDirection,
+    index: i32,
+) -> i32 {
+    let mut bus = BusInfo {
+        mediaType: MediaTypes_::kAudio as i32,
+        direction,
+        channelCount: DEFAULT_CHANNELS as i32,
+        name: [0; 128],
+        busType: 0,
+        flags: 0,
+    };
+    let result =
+        unsafe { component.getBusInfo(MediaTypes_::kAudio as i32, direction, index, &mut bus) };
+    if is_ok(result) && bus.channelCount > 0 {
+        bus.channelCount
+    } else {
+        DEFAULT_CHANNELS as i32
+    }
+}
+
+fn arrangement_for_channels(channel_count: i32) -> SpeakerArrangement {
+    match channel_count {
+        1 => SpeakerArr::kMono,
+        2 => SpeakerArr::kStereo,
+        _ => SpeakerArr::kStereo,
+    }
+}
+
+fn activate_audio_buses(component: &ComPtr<IComponent>, direction: BusDirection, bus_count: i32) {
+    for index in 0..bus_count {
+        unsafe {
+            let _ = component.activateBus(MediaTypes_::kAudio as i32, direction, index, 1);
+        }
+    }
+}
+
+fn ptr_or_null_mut<T>(values: &mut [T]) -> *mut T {
+    if values.is_empty() {
+        ptr::null_mut()
+    } else {
+        values.as_mut_ptr()
+    }
+}
+
 fn find_audio_module_class(
     factory: &ComPtr<IPluginFactory>,
 ) -> Result<AudioModuleClass, Vst3HostError> {
@@ -422,6 +538,200 @@ trait TuidPtr {
 impl TuidPtr for TUID {
     fn as_ptr(&self) -> *const i8 {
         self.as_slice().as_ptr()
+    }
+}
+
+struct HostApplication;
+
+impl Class for HostApplication {
+    type Interfaces = (IHostApplication,);
+}
+
+impl IHostApplicationTrait for HostApplication {
+    unsafe fn getName(&self, name: *mut String128) -> tresult {
+        if name.is_null() {
+            return kInvalidArgument;
+        }
+        copy_wstring("OrbitScore VST3 Host Spike", &mut *name);
+        kResultOk
+    }
+
+    unsafe fn createInstance(
+        &self,
+        _cid: *mut TUID,
+        iid: *mut TUID,
+        obj: *mut *mut c_void,
+    ) -> tresult {
+        if obj.is_null() {
+            return kInvalidArgument;
+        }
+        *obj = ptr::null_mut();
+        if iid.is_null() {
+            return kInvalidArgument;
+        }
+
+        if *iid == IMessage_iid {
+            let ptr = ComWrapper::new(HostMessage::new())
+                .to_com_ptr::<IMessage>()
+                .expect("HostMessage exposes IMessage")
+                .into_raw();
+            *obj = ptr.cast::<c_void>();
+            kResultOk
+        } else if *iid == IAttributeList_iid {
+            let ptr = ComWrapper::new(HostAttributeList)
+                .to_com_ptr::<IAttributeList>()
+                .expect("HostAttributeList exposes IAttributeList")
+                .into_raw();
+            *obj = ptr.cast::<c_void>();
+            kResultOk
+        } else {
+            kNotImplemented
+        }
+    }
+}
+
+struct HostMessage {
+    message_id: Cell<*const i8>,
+    attributes: ComWrapper<HostAttributeList>,
+    attributes_ptr: Cell<*mut IAttributeList>,
+}
+
+impl HostMessage {
+    fn new() -> Self {
+        Self {
+            message_id: Cell::new(ptr::null()),
+            attributes: ComWrapper::new(HostAttributeList),
+            attributes_ptr: Cell::new(ptr::null_mut()),
+        }
+    }
+
+    fn attributes_ptr(&self) -> *mut IAttributeList {
+        let existing = self.attributes_ptr.get();
+        if !existing.is_null() {
+            return existing;
+        }
+        let ptr = self
+            .attributes
+            .to_com_ptr::<IAttributeList>()
+            .expect("HostAttributeList exposes IAttributeList")
+            .into_raw();
+        self.attributes_ptr.set(ptr);
+        ptr
+    }
+}
+
+impl Drop for HostMessage {
+    fn drop(&mut self) {
+        let ptr = self.attributes_ptr.get();
+        if !ptr.is_null() {
+            unsafe {
+                if let Some(attributes) = ComPtr::from_raw(ptr) {
+                    drop(attributes);
+                }
+            }
+        }
+    }
+}
+
+impl Class for HostMessage {
+    type Interfaces = (IMessage,);
+}
+
+impl IMessageTrait for HostMessage {
+    unsafe fn getMessageID(&self) -> FIDString {
+        self.message_id.get()
+    }
+
+    unsafe fn setMessageID(&self, id: FIDString) {
+        self.message_id.set(id);
+    }
+
+    unsafe fn getAttributes(&self) -> *mut IAttributeList {
+        self.attributes_ptr()
+    }
+}
+
+struct HostAttributeList;
+
+impl Class for HostAttributeList {
+    type Interfaces = (IAttributeList,);
+}
+
+impl IAttributeListTrait for HostAttributeList {
+    unsafe fn setInt(&self, _id: IAttributeList_::AttrID, _value: i64) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn getInt(&self, _id: IAttributeList_::AttrID, value: *mut i64) -> tresult {
+        if !value.is_null() {
+            *value = 0;
+        }
+        kResultFalse
+    }
+
+    unsafe fn setFloat(&self, _id: IAttributeList_::AttrID, _value: f64) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn getFloat(&self, _id: IAttributeList_::AttrID, value: *mut f64) -> tresult {
+        if !value.is_null() {
+            *value = 0.0;
+        }
+        kResultFalse
+    }
+
+    unsafe fn setString(&self, _id: IAttributeList_::AttrID, _string: *const TChar) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn getString(
+        &self,
+        _id: IAttributeList_::AttrID,
+        string: *mut TChar,
+        size_in_bytes: u32,
+    ) -> tresult {
+        if !string.is_null() && size_in_bytes >= std::mem::size_of::<TChar>() as u32 {
+            *string = 0;
+        }
+        kResultFalse
+    }
+
+    unsafe fn setBinary(
+        &self,
+        _id: IAttributeList_::AttrID,
+        _data: *const c_void,
+        _size_in_bytes: u32,
+    ) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn getBinary(
+        &self,
+        _id: IAttributeList_::AttrID,
+        data: *mut *const c_void,
+        size_in_bytes: *mut u32,
+    ) -> tresult {
+        if !data.is_null() {
+            *data = ptr::null();
+        }
+        if !size_in_bytes.is_null() {
+            *size_in_bytes = 0;
+        }
+        kResultFalse
+    }
+}
+
+fn copy_wstring(src: &str, dst: &mut [TChar]) {
+    let mut len = 0;
+    for (src, dst) in src.encode_utf16().zip(dst.iter_mut()) {
+        *dst = src;
+        len += 1;
+    }
+
+    if len < dst.len() {
+        dst[len] = 0;
+    } else if let Some(last) = dst.last_mut() {
+        *last = 0;
     }
 }
 

--- a/rust/crates/orbit-vst3-host/sweep.sh
+++ b/rust/crates/orbit-vst3-host/sweep.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workspace_root="$(cd "$here/../.." && pwd)"
+cd "$workspace_root"
+
+cargo build -p orbit-vst3-host --bin vst3_probe --locked >/dev/null
+probe="$workspace_root/target/debug/vst3_probe"
+out="$workspace_root/target/vst3-sweep-results.txt"
+tmp="$workspace_root/target/vst3-sweep-results.tmp"
+
+pass=0
+fail=0
+crash=0
+hang=0
+total=0
+
+: > "$tmp"
+while IFS= read -r plugin; do
+  total=$((total + 1))
+  name="$(basename "$plugin")"
+  set +e
+  line="$(python3 - "$probe" "$plugin" <<'PY' 2>&1
+import subprocess
+import sys
+
+probe = sys.argv[1]
+plugin = sys.argv[2]
+try:
+    completed = subprocess.run(
+        [probe, plugin],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=20,
+    )
+    print(completed.stdout, end="")
+    raise SystemExit(completed.returncode)
+except subprocess.TimeoutExpired as exc:
+    if exc.stdout:
+        print(exc.stdout, end="")
+    raise SystemExit(124)
+PY
+)"
+  code=$?
+  set -e
+  line="${line//$'\n'/\\n}"
+  if [ "$code" -eq 0 ]; then
+    pass=$((pass + 1))
+    printf 'pass\t%s\t%s\n' "$name" "$line" >> "$tmp"
+  elif [ "$code" -eq 124 ]; then
+    hang=$((hang + 1))
+    printf 'hang\t%s\t%s\n' "$name" "$line" >> "$tmp"
+  elif [ "$code" -gt 128 ]; then
+    crash=$((crash + 1))
+    printf 'crash\t%s\texit=%s %s\n' "$name" "$code" "$line" >> "$tmp"
+  else
+    fail=$((fail + 1))
+    printf 'fail\t%s\texit=%s %s\n' "$name" "$code" "$line" >> "$tmp"
+  fi
+done < <(find /Library/Audio/Plug-Ins/VST3 -maxdepth 1 -name '*.vst3' -print 2>/dev/null | sort)
+
+{
+  printf 'total=%s pass=%s fail=%s crash=%s hang=%s\n' "$total" "$pass" "$fail" "$crash" "$hang"
+  cat "$tmp"
+} > "$out"
+rm -f "$tmp"
+echo "$out"

--- a/rust/crates/orbit-vst3-host/tests/offline.rs
+++ b/rust/crates/orbit-vst3-host/tests/offline.rs
@@ -1,3 +1,5 @@
+#![cfg(target_os = "macos")]
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/rust/crates/orbit-vst3-host/tests/offline.rs
+++ b/rust/crates/orbit-vst3-host/tests/offline.rs
@@ -1,0 +1,161 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use orbit_vst3_host::Vst3EffectProcessor;
+
+const SAMPLE_RATE: f64 = 48_000.0;
+const FRAMES: usize = 512;
+
+#[test]
+fn gain_oracle_is_sample_exact() {
+    let Some(bundle) = package_oracle() else {
+        eprintln!("VST3 oracle build failed; loud skip for this machine");
+        return;
+    };
+
+    let (mut processor, info) = Vst3EffectProcessor::load(&bundle, SAMPLE_RATE, FRAMES as i32)
+        .unwrap_or_else(|error| {
+            panic!("failed to load oracle bundle {}: {error}", bundle.display())
+        });
+    assert!(info.is_effect, "oracle must be detected as an effect");
+    assert_eq!(info.audio_inputs, 1);
+    assert_eq!(info.audio_outputs, 1);
+
+    let (input_l, input_r) = known_stereo_input();
+    let mut output_l = vec![0.0; FRAMES];
+    let mut output_r = vec![0.0; FRAMES];
+
+    processor
+        .process_stereo(&input_l, &input_r, &mut output_l, &mut output_r, None)
+        .expect("oracle identity process");
+    assert_eq!(output_l, input_l, "default gain=1.0 left must be bit-exact");
+    assert_eq!(
+        output_r, input_r,
+        "default gain=1.0 right must be bit-exact"
+    );
+
+    output_l.fill(0.0);
+    output_r.fill(0.0);
+    processor
+        .process_stereo(&input_l, &input_r, &mut output_l, &mut output_r, Some(0.5))
+        .expect("oracle gain=0.5 process");
+
+    for (index, (actual, input)) in output_l.iter().zip(&input_l).enumerate() {
+        assert_eq!(
+            actual.to_bits(),
+            (*input * 0.5).to_bits(),
+            "gain=0.5 left sample {index}"
+        );
+    }
+    for (index, (actual, input)) in output_r.iter().zip(&input_r).enumerate() {
+        assert_eq!(
+            actual.to_bits(),
+            (*input * 0.5).to_bits(),
+            "gain=0.5 right sample {index}"
+        );
+    }
+}
+
+#[test]
+fn real_vst3_abi_loads_processes_and_drops() {
+    let candidates = real_plugin_candidates();
+    if candidates.is_empty() {
+        eprintln!("LOUD SKIP: no VST3 bundles found in /Library/Audio/Plug-Ins/VST3");
+        return;
+    }
+
+    let mut attempts = Vec::new();
+    for path in &candidates {
+        let output = Command::new(vst3_probe_path()).arg(path).output();
+        match output {
+            Ok(output) if output.status.success() => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                eprintln!("real VST3 ABI test loaded and processed: {}", stdout.trim());
+                return;
+            }
+            Ok(output) => attempts.push(format!(
+                "{}: status={} stdout={} stderr={}",
+                path.display(),
+                output.status,
+                String::from_utf8_lossy(&output.stdout).trim(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )),
+            Err(error) => attempts.push(format!(
+                "{}: failed to spawn probe: {error}",
+                path.display()
+            )),
+        }
+    }
+
+    panic!(
+        "STOP gate: no real VST3 plugin could load->setup->process among {} candidates:\n{}",
+        candidates.len(),
+        attempts.join("\n")
+    );
+}
+
+fn vst3_probe_path() -> PathBuf {
+    option_env!("CARGO_BIN_EXE_vst3_probe")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/vst3_probe")
+        })
+}
+
+fn package_oracle() -> Option<PathBuf> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let script = manifest_dir
+        .parent()
+        .expect("crate has parent")
+        .join("orbit-vst3-gain-oracle")
+        .join("package-oracle.sh");
+    let output = Command::new(&script).output().ok()?;
+    if !output.status.success() {
+        eprintln!(
+            "oracle packaging failed: status={} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Some(PathBuf::from(stdout.trim()))
+}
+
+fn known_stereo_input() -> (Vec<f32>, Vec<f32>) {
+    let left = (0..FRAMES)
+        .map(|i| (i as f32 - 128.0) / 512.0)
+        .collect::<Vec<_>>();
+    let right = (0..FRAMES)
+        .map(|i| ((i as f32 * 3.0) - 256.0) / 1024.0)
+        .collect::<Vec<_>>();
+    (left, right)
+}
+
+fn real_plugin_candidates() -> Vec<PathBuf> {
+    let root = Path::new("/Library/Audio/Plug-Ins/VST3");
+    let preferred = [
+        "Vocal Doubler.vst3",
+        "Vinyl.vst3",
+        "V-Pan.vst3",
+        "Relay.vst3",
+    ];
+    let mut paths = preferred
+        .iter()
+        .map(|name| root.join(name))
+        .filter(|path| path.exists())
+        .collect::<Vec<_>>();
+
+    if let Ok(entries) = fs::read_dir(root) {
+        let mut rest = entries
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("vst3"))
+            .filter(|path| !paths.contains(path))
+            .collect::<Vec<_>>();
+        rest.sort();
+        paths.extend(rest);
+    }
+    paths
+}

--- a/rust/crates/orbit-vst3-host/tests/offline.rs
+++ b/rust/crates/orbit-vst3-host/tests/offline.rs
@@ -57,6 +57,46 @@ fn gain_oracle_is_sample_exact() {
     }
 }
 
+// I5(pr-review-team): `process_block`'s guard clauses (non-multiple-of-channels length, scratch
+// overflow) return `false` before ever touching COM — untested until now.
+#[test]
+fn process_block_rejects_non_stereo_length() {
+    let Some(bundle) = package_oracle() else {
+        eprintln!("VST3 oracle build failed; loud skip for this machine");
+        return;
+    };
+    let (mut processor, _info) = Vst3EffectProcessor::load(&bundle, SAMPLE_RATE, FRAMES as i32)
+        .unwrap_or_else(|error| {
+            panic!("failed to load oracle bundle {}: {error}", bundle.display())
+        });
+
+    // Odd length: not a multiple of DEFAULT_CHANNELS(2).
+    let mut data = vec![0.25f32; 3];
+    assert!(
+        !processor.process_block(&mut data),
+        "non-multiple-of-channels length must be rejected"
+    );
+}
+
+#[test]
+fn process_block_rejects_frames_exceeding_scratch() {
+    let Some(bundle) = package_oracle() else {
+        eprintln!("VST3 oracle build failed; loud skip for this machine");
+        return;
+    };
+    let (mut processor, _info) = Vst3EffectProcessor::load(&bundle, SAMPLE_RATE, FRAMES as i32)
+        .unwrap_or_else(|error| {
+            panic!("failed to load oracle bundle {}: {error}", bundle.display())
+        });
+
+    // FRAMES(512) is the scratch length (max_samples_per_block); one frame beyond that must fail.
+    let mut data = vec![0.25f32; (FRAMES + 1) * 2];
+    assert!(
+        !processor.process_block(&mut data),
+        "frame count exceeding scratch length must be rejected"
+    );
+}
+
 #[test]
 fn real_vst3_abi_loads_processes_and_drops() {
     let candidates = real_plugin_candidates();


### PR DESCRIPTION
## 概要

VST3 プラグインホスティングの Phase 0（ホスト実証）+ Phase 1（production OOP effect / daemon 統合）と、実機 gated 検証を実装。実市販 VST3（NI/iZotope 等 arm64）を production daemon 経路で crash させず処理できることを実証した。

## 内容

### Phase 0 — 手書き COM VST3 ホスト（`orbit-vst3-host`）
- `.vst3` を CFBundle 正規経路で load（実 `CFBundleRef` を `bundleEntry` に渡す）
- effect/instrument 判定（`getBusCount(kAudio,kInput)>0`）・bus 調停・process
- **4 ホスト修正で arm64 商用 VST3 の 99.7%（329/330）load・crash 0**:
  1. CFBundle 正規ロード → NI（Kontakt/Massive 等）SIGSEGV 解消
  2. `setProcessing` の `kNotImplemented(3)` 許容 → iZotope 全回復
  3. `setBusArrangements` の `kResultFalse(1)` advisory 化 → ARIA 等
  4. host context（`IHostApplication`）+ component-controller ハンドシェイク
- 共通教訓: **商用ホストは optional/advisory の非 OK 戻りを致命にしない**（JUCE 準拠）

### Phase 1 — production OOP effect（daemon 統合）
- `orbit-vst3-effect-child`（CLAP child 対称・clack 非リンク）+ `Vst3EffectProcessor::process_block`
- daemon supervisor 汎化: `PluginFormat{Clap,Vst3}` / `ORBIT_EFFECT_FORMAT`（既定 clap 後方互換）
- daemon graph は clack-free（clack 実体は spawn child のみ）

### 実機 gated 検証（Opus 非サンドボックス）
- **offline machinery**: フル arm64 sweep 333個 = **Effect 271 全 PASS・genuine crash 0**（Intel-only 3 除外・10 slow-loader は UJAM 音源/KK host-wrapper で回復済み or Phase 3 スコープ）
- **daemon 経路（`outproc_effect_vst3_gated.rs`）**: C1 parity ratio 1.0 / C2 kill→respawn 復帰 / C3 stale [64f]0.16%[32f]0% / C4 commercial smoke 代表4 effect crash-free
- 検証設計は advisor(Fable) + adversarial-review(codex) の 2 レビューを実装前に通し、dry-passthrough 誤 PASS・warm-up 不足を捕捉

## 検証
- `cargo fmt` / `cargo clippy --workspace --all-targets -D warnings` / `cargo deny check licenses` clean（pre-push で担保）
- 非 gated テスト緑・gated 実機は #[ignore] で Opus 非サンドボックス実行
- 音楽的 DSP 正しさは owner listening の follow-on（machinery smoke に限定）

## スコープ外（follow-on）
- Phase 2 = M2 instrument IPC（note-in→audio-out）
- Phase 3 = VST3 instrument・slow-load instrument（KK/UJAM）の async load
- PR レビュー（/simplify + pr-review-team）はこの PR で実施

Refs #381