### PR TITLE
fix(engine): make in-process CLAP event ring lossless (bounded retry)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -25,9 +25,9 @@ M2 instrument IPC substrate（#398）の transport 容量設計を検討する�
 - **実装**: `push_with_bounded_retry<T>`（`rtrb::Producer<T>` 汎用・純粋関数・mutex 非依存）を新設し、最大200回・1ms間隔（≈200ms上限）で retry。真にタイムアウトした場合のみ `plugin_event_ring_overflow_count`（新規 `Arc<AtomicU64>`・`clap_process_errors` と同型の unconditional health-signal フィールド）を進めてエラーを返す。`push_plugin_event` はこのヘルパーを呼ぶだけに簡素化。
 - **可視化**: `ERROR_CODE_PLUGIN_EVENT_RING_OVERFLOW`（`protocol.rs`）を新設し、既存の 1Hz ticker（`CLAP_PROCESS_ERROR` 等と同型パターン）に配線。
 - **tokio ワーカー保護**: bounded retry で `plugin_note_on`/`plugin_note_off` が最大 ~200ms ブロックしうるようになったため、`session.rs` の `PluginNoteOn`/`PluginNoteOff` handler を `LoadPlugin` と同じ `tokio::task::spawn_blocking` パターンで包み、tokio ワーカースレッドを塞がないようにした。
-- **検証**: 新規 unit test 3本（`plugin_event_ring_retry_tests`・即座に成功／consumer drain 後に成功／真の overflow で counter 増分）が clap-host feature 下で全て PASS。`cargo build`(default/clap-host/outproc-effect)・`cargo clippy --all-targets -D warnings`(同3構成)・`cargo fmt --check`・`cargo test --workspace`(全緑)・`cargo deny check licenses`(ok)を確認。
+- **検証**: 初回コミットで新規 unit test 3本（`plugin_event_ring_retry_tests`・即座に成功／consumer drain 後に成功／真の overflow で counter 増分）を追加。以降 PR #402 の pr-review-team 反復（/simplify・カバレッジギャップ是正・`handle_command` dispatch 一本化）で `plugin_event_ring_retry_tests` に fatal outcome 早期リターン 1本を追加し、さらに `push_plugin_event_tests`（clap 未初期化時の `ClapUnavailable` 2本）・`plugin_note_spec_*`（配線 pin 2本）・`handle_plugin_note_*`（fn-pointer dispatch・spawn_blocking join-error 2本）・`tests/protocol.rs` の統合テスト（ring overflow warning 1本）を追加し、累計で新規 unit/integration test 11本。clap-host feature 下で全て PASS。`cargo build`(default/clap-host/outproc-effect)・`cargo clippy --all-targets -D warnings`(同3構成)・`cargo fmt --check`・`cargo test --workspace`(全緑)・`cargo deny check licenses`(ok)を確認。
 - **役割**: 発見=Fable(実コード確認込みレビュー) / 実装・検証=Opus main(直接実装・小規模のためサブエージェント委譲なし)。
-- **状態**: M2(#398)とは独立スコープ。PR 作成 → owner マージ待ち。
+- **状態**: M2(#398)とは独立スコープ。PR #402 iteration 3 レビュー収束（silent-failure-hunter/pr-test-analyzer/code-reviewer）を反映して cleanup 済み → owner マージ待ち。
 
 ### 6.220 fix(engine): VST3 host unsafe memory-safety 監査 + hardening 3件（#397） (Jul 11, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,18 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.221 fix(engine): in-process CLAP event ring を bounded retry で lossless 化（#400） (Jul 12, 2026)
+
+M2 instrument IPC substrate（#398）の transport 容量設計を検討する過程で、既存の in-process CLAP event ring（`orbit-audio-daemon/src/engine_wrap.rs` の `push_plugin_event`・1024 slot）に同種の欠陥（満杯時 drop-newest だが可視化カウンタなし・NoteOff drop で stuck note の可能性）が見つかり、Fable のレビューで「producer が RT スレッドでないため bounded retry だけで安価に lossless 化できる」と判明したため、M2 とは独立した issue として即着手した。
+
+- **実コード確認**: `push_plugin_event` の呼び出し元は `session.rs` の WS command handler（tokio async task・control スレッド）であり RT audio スレッドではない。consumer（`processor.rs` の `drain_to_event_buffer`）は毎 audio callback で ring を全量 drain するため、最大 1 callback 周期（buffer 設定によって ~1.3〜93ms）待てば空きが保証される。
+- **実装**: `push_with_bounded_retry<T>`（`rtrb::Producer<T>` 汎用・純粋関数・mutex 非依存）を新設し、最大200回・1ms間隔（≈200ms上限）で retry。真にタイムアウトした場合のみ `plugin_event_ring_overflow_count`（新規 `Arc<AtomicU64>`・`clap_process_errors` と同型の unconditional health-signal フィールド）を進めてエラーを返す。`push_plugin_event` はこのヘルパーを呼ぶだけに簡素化。
+- **可視化**: `ERROR_CODE_PLUGIN_EVENT_RING_OVERFLOW`（`protocol.rs`）を新設し、既存の 1Hz ticker（`CLAP_PROCESS_ERROR` 等と同型パターン）に配線。
+- **tokio ワーカー保護**: bounded retry で `plugin_note_on`/`plugin_note_off` が最大 ~200ms ブロックしうるようになったため、`session.rs` の `PluginNoteOn`/`PluginNoteOff` handler を `LoadPlugin` と同じ `tokio::task::spawn_blocking` パターンで包み、tokio ワーカースレッドを塞がないようにした。
+- **検証**: 新規 unit test 3本（`plugin_event_ring_retry_tests`・即座に成功／consumer drain 後に成功／真の overflow で counter 増分）が clap-host feature 下で全て PASS。`cargo build`(default/clap-host/outproc-effect)・`cargo clippy --all-targets -D warnings`(同3構成)・`cargo fmt --check`・`cargo test --workspace`(全緑)・`cargo deny check licenses`(ok)を確認。
+- **役割**: 発見=Fable(実コード確認込みレビュー) / 実装・検証=Opus main(直接実装・小規模のためサブエージェント委譲なし)。
+- **状態**: M2(#398)とは独立スコープ。PR 作成 → owner マージ待ち。
+
 ### 6.220 fix(engine): VST3 host unsafe memory-safety 監査 + hardening 3件（#397） (Jul 11, 2026)
 
 中核の手書き unsafe COM FFI（`orbit-vst3-host/src/lib.rs`・80 unsafe blocks）に対し、`/code:pr-review-team`（汎用 correctness）が構造的に狙わない **memory-safety/UB 次元**の外部第二意見を実施。@claude bot は pr-review-team と同一モデルファミリで盲点が相関するため除外し、**codex（cross-family）+ fresh Opus（非著者）を並列 adversarial 監査 → advisor で tie-break**（[[consult-layering-by-error-type]] の分担）。

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -89,8 +89,10 @@ pub struct EngineWrap {
     /// `push_plugin_event` が bounded retry（[`push_with_bounded_retry`]）の末に諦めた回数（本番は
     /// 常に 0 に近い想定・health signal）。event ring は audio callback が毎 block 全量 drain する
     /// ため満杯は一時的であり、真の drop はこの回数だけ発生する（M2 doc の「溢れても失わない」方針を
-    /// in-process ring に retrofit・issue #400）。`clap_process_errors` と同様 unconditional フィールド。
-    plugin_event_ring_overflow_count: Arc<AtomicU64>,
+    /// in-process ring に retrofit・issue #400）。`EngineWrap` は常に `Arc<EngineWrap>` として共有
+    /// されるため、`link_egress_drops`/`clap_process_errors` と異なり test 注入用の `_arc()` getter
+    /// が不要（この counter は本番書き込みのみ）で、プレーンな `AtomicU64` で足りる。
+    plugin_event_ring_overflow_count: AtomicU64,
     /// LinkAudio egress の control-side ハンドル（feature `link-audio` 専用・A4-2b-2）。
     /// reg-ring push / mpsc send が内部可変性（`&mut LinkAudioControl`）を要する一方、`EngineWrap`
     /// は `Arc` 共有で `&self` しか持てない。`Mutex` で内包することで `register_link_audio_channel`
@@ -153,37 +155,53 @@ const PLUGIN_EVENT_RETRY_INTERVAL: Duration = Duration::from_millis(1);
 #[cfg(feature = "clap-host")]
 const PLUGIN_EVENT_RETRY_MAX_ATTEMPTS: u32 = 200;
 
-/// `producer` へ bounded retry で push する。producer は audio callback（RT スレッド）ではなく
-/// 制御スレッド（WS handler 等）からのみ呼ばれる前提 — consumer 側が毎 callback で ring を
-/// 全量 drain するので、最大 1 callback 周期待てば空きが保証される。この性質を利用し、
-/// 満杯を「データ喪失」でなく「一時的なリトライ待ち」として扱う（M2 doc
-/// `docs/development/POST_2.0_GAMMA_M2_DESIGN.md` §4.4 の「溢れても失わない」方針を
-/// in-process ring に retrofit したもの・issue #400）。
+/// 1回の push 試行の結果。`Fatal` はリトライしても解決しない状態（mutex poisoned / clap 未初期化）
+/// を表し、bounded retry ループを即座に打ち切る。
+#[cfg(feature = "clap-host")]
+enum PushAttemptOutcome<T> {
+    Sent,
+    Full(T),
+    Fatal(WrapError),
+}
+
+/// `attempt` を bounded retry で呼び出す。producer は audio callback（RT スレッド）ではなく制御
+/// スレッド（WS handler 等）からのみ呼ばれる前提 — consumer 側が毎 callback で ring を全量 drain
+/// するので、最大 1 callback 周期待てば空きが保証される。この性質を利用し、満杯を「データ喪失」
+/// でなく「一時的なリトライ待ち」として扱う（M2 doc `docs/development/POST_2.0_GAMMA_M2_DESIGN.md`
+/// §4.4 の「溢れても失わない」方針を in-process ring に retrofit したもの・issue #400）。
 ///
-/// 真に `max_attempts` 尽きた場合のみ `overflow_count` を進めて item を返す（呼び出し元が
-/// エラーとして扱う）。
+/// **`attempt` は1回の試行につき1回だけ呼ばれ、mutex 等の lock 取得はその中で行い、`sleep` の
+/// 前に解放されていること**（呼び出し側の責務）。retry の待機中に共有 lock を握り続けると、
+/// 他の control-thread 操作（別セッションの LoadPlugin/PluginNoteOn 等）を最大
+/// `max_attempts × retry_interval` だけ足止めしてしまう（`load_plugin` の「lock は send までで
+/// 解放」規約と同じ理由・#402 レビュー指摘）。
+///
+/// 真に `max_attempts` 尽きた場合のみ `overflow_count` を進めてエラーを返す。
 #[cfg(feature = "clap-host")]
 fn push_with_bounded_retry<T>(
-    producer: &mut rtrb::Producer<T>,
+    mut attempt: impl FnMut(T) -> PushAttemptOutcome<T>,
     mut item: T,
     max_attempts: u32,
     retry_interval: Duration,
     overflow_count: &AtomicU64,
-) -> Result<(), T> {
+) -> Result<(), WrapError> {
     let attempts = max_attempts.max(1);
-    for attempt in 0..attempts {
-        match producer.push(item) {
-            Ok(()) => return Ok(()),
-            Err(rtrb::PushError::Full(returned)) => {
+    for i in 0..attempts {
+        match attempt(item) {
+            PushAttemptOutcome::Sent => return Ok(()),
+            PushAttemptOutcome::Fatal(e) => return Err(e),
+            PushAttemptOutcome::Full(returned) => {
                 item = returned;
-                if attempt + 1 < attempts {
+                if i + 1 < attempts {
                     std::thread::sleep(retry_interval);
                 }
             }
         }
     }
     overflow_count.fetch_add(1, Ordering::Relaxed);
-    Err(item)
+    Err(WrapError::Clap(
+        "plugin event ring full after bounded retry".into(),
+    ))
 }
 
 // link-audio と clap-host の併用は現状未対応（1 つの cpal callback で LinkAudio per-channel egress と
@@ -534,7 +552,7 @@ impl EngineWrap {
             stopped_play_ids: Mutex::new(HashSet::new()),
             link_egress_drops: Arc::new(AtomicU64::new(0)),
             clap_process_errors: Arc::new(AtomicU64::new(0)),
-            plugin_event_ring_overflow_count: Arc::new(AtomicU64::new(0)),
+            plugin_event_ring_overflow_count: AtomicU64::new(0),
             // 本番 `start()`（feature 時）が spawn 後に Some を注入する。test backend 経路は None。
             #[cfg(feature = "link-audio")]
             link: Mutex::new(None),
@@ -697,23 +715,39 @@ impl EngineWrap {
 
     #[cfg(feature = "clap-host")]
     fn push_plugin_event(&self, ev: orbit_clap_host::PluginEvent) -> Result<(), WrapError> {
-        let mut guard = self
-            .clap
-            .lock()
-            .map_err(|_| WrapError::Clap("clap mutex poisoned".into()))?;
-        let ctl = guard.as_mut().ok_or_else(|| {
-            WrapError::ClapUnavailable("clap host not initialized (test backend)".into())
-        })?;
         // event ring（1024 slot）が満杯でも、audio callback が毎 block 全量 drain するので
         // bounded retry で lossless 化する（#400）。真にタイムアウトした場合のみ error。
+        // mutex は各試行ごとに取得・解放し、sleep 中は保持しない（load_plugin と同じ「lock は
+        // send までで解放」規約・#402 レビュー指摘: sleep 中も保持すると他セッションの
+        // LoadPlugin/PluginNoteOn 等を最大リトライ時間だけ足止めしてしまう）。
         push_with_bounded_retry(
-            &mut ctl.event_tx,
+            |item| {
+                let mut guard = match self.clap.lock() {
+                    Ok(guard) => guard,
+                    Err(_) => {
+                        return PushAttemptOutcome::Fatal(WrapError::Clap(
+                            "clap mutex poisoned".into(),
+                        ))
+                    }
+                };
+                let ctl = match guard.as_mut() {
+                    Some(ctl) => ctl,
+                    None => {
+                        return PushAttemptOutcome::Fatal(WrapError::ClapUnavailable(
+                            "clap host not initialized (test backend)".into(),
+                        ))
+                    }
+                };
+                match ctl.event_tx.push(item) {
+                    Ok(()) => PushAttemptOutcome::Sent,
+                    Err(rtrb::PushError::Full(returned)) => PushAttemptOutcome::Full(returned),
+                }
+            },
             ev,
             PLUGIN_EVENT_RETRY_MAX_ATTEMPTS,
             PLUGIN_EVENT_RETRY_INTERVAL,
             &self.plugin_event_ring_overflow_count,
         )
-        .map_err(|_| WrapError::Clap("plugin event ring full after bounded retry".into()))
     }
 
     /// feature `clap-host` 無効ビルド用の stub。
@@ -1247,15 +1281,30 @@ fn short_uuid() -> String {
 #[cfg(feature = "clap-host")]
 #[cfg(test)]
 mod plugin_event_ring_retry_tests {
-    use super::{push_with_bounded_retry, Ordering};
+    use super::{push_with_bounded_retry, Ordering, PushAttemptOutcome};
     use std::sync::atomic::AtomicU64;
     use std::time::Duration;
+
+    /// test 用の1回試行クロージャ。本番の `push_plugin_event` と異なり mutex 越しではなく
+    /// `rtrb::Producer` を直接 push するだけ（lock scope の検証は責務外・retry ロジックのみ検証）。
+    fn attempt_push(producer: &mut rtrb::Producer<u32>, item: u32) -> PushAttemptOutcome<u32> {
+        match producer.push(item) {
+            Ok(()) => PushAttemptOutcome::Sent,
+            Err(rtrb::PushError::Full(returned)) => PushAttemptOutcome::Full(returned),
+        }
+    }
 
     #[test]
     fn succeeds_immediately_when_space_available() {
         let (mut tx, _rx) = rtrb::RingBuffer::<u32>::new(4);
         let overflow = AtomicU64::new(0);
-        let result = push_with_bounded_retry(&mut tx, 42, 5, Duration::from_millis(1), &overflow);
+        let result = push_with_bounded_retry(
+            |item| attempt_push(&mut tx, item),
+            42,
+            5,
+            Duration::from_millis(1),
+            &overflow,
+        );
         assert!(result.is_ok());
         assert_eq!(overflow.load(Ordering::Relaxed), 0);
     }
@@ -1272,7 +1321,13 @@ mod plugin_event_ring_retry_tests {
             let _ = rx.pop();
         });
 
-        let result = push_with_bounded_retry(&mut tx, 2, 50, Duration::from_millis(1), &overflow);
+        let result = push_with_bounded_retry(
+            |item| attempt_push(&mut tx, item),
+            2,
+            50,
+            Duration::from_millis(1),
+            &overflow,
+        );
         drain_handle.join().expect("drain thread should not panic");
 
         assert!(result.is_ok(), "should succeed once consumer drains space");
@@ -1290,13 +1345,43 @@ mod plugin_event_ring_retry_tests {
         let overflow = AtomicU64::new(0);
 
         // _rx を drain せずに保持したまま(＝満杯が解消しない)、少ない retry 回数で確実に諦めさせる。
-        let result = push_with_bounded_retry(&mut tx, 2, 3, Duration::from_millis(1), &overflow);
+        let result = push_with_bounded_retry(
+            |item| attempt_push(&mut tx, item),
+            2,
+            3,
+            Duration::from_millis(1),
+            &overflow,
+        );
 
         assert!(result.is_err(), "should give up after max_attempts");
         assert_eq!(
             overflow.load(Ordering::Relaxed),
             1,
             "overflow counter must increment exactly once on give-up"
+        );
+    }
+
+    #[test]
+    fn fatal_outcome_short_circuits_without_retry_or_overflow_count() {
+        let overflow = AtomicU64::new(0);
+        let mut calls = 0u32;
+        let result: Result<(), super::WrapError> = push_with_bounded_retry(
+            |_item| {
+                calls += 1;
+                PushAttemptOutcome::Fatal(super::WrapError::Clap("clap mutex poisoned".into()))
+            },
+            42u32,
+            5,
+            Duration::from_millis(1),
+            &overflow,
+        );
+
+        assert!(result.is_err(), "fatal outcome must propagate as an error");
+        assert_eq!(calls, 1, "fatal outcome must not retry");
+        assert_eq!(
+            overflow.load(Ordering::Relaxed),
+            0,
+            "fatal outcome is not an overflow (retrying would not have helped)"
         );
     }
 }

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -7,6 +7,8 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+#[cfg(feature = "clap-host")]
+use std::time::Duration;
 
 use orbit_audio_core::{resolve_slice_region, sanitize_rate, Engine, Sample};
 use orbit_audio_native::{
@@ -84,6 +86,11 @@ pub struct EngineWrap {
     /// 本番の error は clap mutex 内の `ClapProcessorStats::process_error_count` が供給するので、
     /// production read-path ではこの addend は常に 0（`link_egress_drops` と同設計）。
     clap_process_errors: Arc<AtomicU64>,
+    /// `push_plugin_event` が bounded retry（[`push_with_bounded_retry`]）の末に諦めた回数（本番は
+    /// 常に 0 に近い想定・health signal）。event ring は audio callback が毎 block 全量 drain する
+    /// ため満杯は一時的であり、真の drop はこの回数だけ発生する（M2 doc の「溢れても失わない」方針を
+    /// in-process ring に retrofit・issue #400）。`clap_process_errors` と同様 unconditional フィールド。
+    plugin_event_ring_overflow_count: Arc<AtomicU64>,
     /// LinkAudio egress の control-side ハンドル（feature `link-audio` 専用・A4-2b-2）。
     /// reg-ring push / mpsc send が内部可変性（`&mut LinkAudioControl`）を要する一方、`EngineWrap`
     /// は `Arc` 共有で `&self` しか持てない。`Mutex` で内包することで `register_link_audio_channel`
@@ -135,6 +142,49 @@ struct ClapControl {
 /// ゼロに保つ。
 #[cfg(feature = "clap-host")]
 const CLAP_MAX_FRAMES: u32 = 8192;
+
+/// event ring への bounded retry の再試行間隔。
+#[cfg(feature = "clap-host")]
+const PLUGIN_EVENT_RETRY_INTERVAL: Duration = Duration::from_millis(1);
+/// 最大再試行回数（≈200ms 上限）。event ring の consumer（audio callback）は毎 block ごとに
+/// ring を全量 drain するため、通常は最初の数回で空きが生まれる。この上限は大きめの buffer
+/// 構成（cpal callback 周期が長いケース）でも安全にカバーする余裕を持たせた値であり、
+/// 「ここまで待っても空かない」を真の overflow とみなす閾値。
+#[cfg(feature = "clap-host")]
+const PLUGIN_EVENT_RETRY_MAX_ATTEMPTS: u32 = 200;
+
+/// `producer` へ bounded retry で push する。producer は audio callback（RT スレッド）ではなく
+/// 制御スレッド（WS handler 等）からのみ呼ばれる前提 — consumer 側が毎 callback で ring を
+/// 全量 drain するので、最大 1 callback 周期待てば空きが保証される。この性質を利用し、
+/// 満杯を「データ喪失」でなく「一時的なリトライ待ち」として扱う（M2 doc
+/// `docs/development/POST_2.0_GAMMA_M2_DESIGN.md` §4.4 の「溢れても失わない」方針を
+/// in-process ring に retrofit したもの・issue #400）。
+///
+/// 真に `max_attempts` 尽きた場合のみ `overflow_count` を進めて item を返す（呼び出し元が
+/// エラーとして扱う）。
+#[cfg(feature = "clap-host")]
+fn push_with_bounded_retry<T>(
+    producer: &mut rtrb::Producer<T>,
+    mut item: T,
+    max_attempts: u32,
+    retry_interval: Duration,
+    overflow_count: &AtomicU64,
+) -> Result<(), T> {
+    let attempts = max_attempts.max(1);
+    for attempt in 0..attempts {
+        match producer.push(item) {
+            Ok(()) => return Ok(()),
+            Err(rtrb::PushError::Full(returned)) => {
+                item = returned;
+                if attempt + 1 < attempts {
+                    std::thread::sleep(retry_interval);
+                }
+            }
+        }
+    }
+    overflow_count.fetch_add(1, Ordering::Relaxed);
+    Err(item)
+}
 
 // link-audio と clap-host の併用は現状未対応（1 つの cpal callback で LinkAudio per-channel egress と
 // CLAP master-bus post-processor の render 順序を統合する設計が defer・Issue #340）。両方有効なビルドは
@@ -484,6 +534,7 @@ impl EngineWrap {
             stopped_play_ids: Mutex::new(HashSet::new()),
             link_egress_drops: Arc::new(AtomicU64::new(0)),
             clap_process_errors: Arc::new(AtomicU64::new(0)),
+            plugin_event_ring_overflow_count: Arc::new(AtomicU64::new(0)),
             // 本番 `start()`（feature 時）が spawn 後に Some を注入する。test backend 経路は None。
             #[cfg(feature = "link-audio")]
             link: Mutex::new(None),
@@ -653,10 +704,16 @@ impl EngineWrap {
         let ctl = guard.as_mut().ok_or_else(|| {
             WrapError::ClapUnavailable("clap host not initialized (test backend)".into())
         })?;
-        // event ring（1024 slot）満杯は drop して error。note rate は低く通常満杯にならない。
-        ctl.event_tx
-            .push(ev)
-            .map_err(|_| WrapError::Clap("plugin event ring full".into()))
+        // event ring（1024 slot）が満杯でも、audio callback が毎 block 全量 drain するので
+        // bounded retry で lossless 化する（#400）。真にタイムアウトした場合のみ error。
+        push_with_bounded_retry(
+            &mut ctl.event_tx,
+            ev,
+            PLUGIN_EVENT_RETRY_MAX_ATTEMPTS,
+            PLUGIN_EVENT_RETRY_INTERVAL,
+            &self.plugin_event_ring_overflow_count,
+        )
+        .map_err(|_| WrapError::Clap("plugin event ring full after bounded retry".into()))
     }
 
     /// feature `clap-host` 無効ビルド用の stub。
@@ -754,6 +811,15 @@ impl EngineWrap {
     #[cfg(not(feature = "clap-host"))]
     pub fn clap_process_error_count(&self) -> u64 {
         self.clap_process_errors.load(Ordering::Relaxed)
+    }
+
+    /// `push_plugin_event` の bounded retry が力尽きた回数（#400）。event ring は audio callback
+    /// が毎 block 全量 drain するため、通常は 0 のまま推移する health signal。1 Hz ticker が polling
+    /// して増加を `PLUGIN_EVENT_RING_OVERFLOW` WARNING で surface する。feature `clap-host` 無効
+    /// ビルドでも安全に呼べる（`clap_process_error_count` と同様 unconditional フィールド）。
+    pub fn plugin_event_ring_overflow_count(&self) -> u64 {
+        self.plugin_event_ring_overflow_count
+            .load(Ordering::Relaxed)
     }
 
     /// test harness / gated 計測用: OOP effect の観測スナップショット（fresh/stale/stall/respawn/
@@ -1176,6 +1242,63 @@ pub struct PlayHandle {
 
 fn short_uuid() -> String {
     Uuid::new_v4().simple().to_string()[..8].to_string()
+}
+
+#[cfg(feature = "clap-host")]
+#[cfg(test)]
+mod plugin_event_ring_retry_tests {
+    use super::{push_with_bounded_retry, Ordering};
+    use std::sync::atomic::AtomicU64;
+    use std::time::Duration;
+
+    #[test]
+    fn succeeds_immediately_when_space_available() {
+        let (mut tx, _rx) = rtrb::RingBuffer::<u32>::new(4);
+        let overflow = AtomicU64::new(0);
+        let result = push_with_bounded_retry(&mut tx, 42, 5, Duration::from_millis(1), &overflow);
+        assert!(result.is_ok());
+        assert_eq!(overflow.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn retries_then_succeeds_once_consumer_drains() {
+        let (mut tx, mut rx) = rtrb::RingBuffer::<u32>::new(1);
+        tx.push(1).expect("fill capacity 1");
+        let overflow = AtomicU64::new(0);
+
+        // audio callback が数 ms 後に ring を drain する状況を模擬する。
+        let drain_handle = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(5));
+            let _ = rx.pop();
+        });
+
+        let result = push_with_bounded_retry(&mut tx, 2, 50, Duration::from_millis(1), &overflow);
+        drain_handle.join().expect("drain thread should not panic");
+
+        assert!(result.is_ok(), "should succeed once consumer drains space");
+        assert_eq!(
+            overflow.load(Ordering::Relaxed),
+            0,
+            "successful retry must not count as overflow"
+        );
+    }
+
+    #[test]
+    fn gives_up_and_counts_overflow_when_ring_stays_full() {
+        let (mut tx, _rx) = rtrb::RingBuffer::<u32>::new(1);
+        tx.push(1).expect("fill capacity 1");
+        let overflow = AtomicU64::new(0);
+
+        // _rx を drain せずに保持したまま(＝満杯が解消しない)、少ない retry 回数で確実に諦めさせる。
+        let result = push_with_bounded_retry(&mut tx, 2, 3, Duration::from_millis(1), &overflow);
+
+        assert!(result.is_err(), "should give up after max_attempts");
+        assert_eq!(
+            overflow.load(Ordering::Relaxed),
+            1,
+            "overflow counter must increment exactly once on give-up"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -856,6 +856,19 @@ impl EngineWrap {
             .load(Ordering::Relaxed)
     }
 
+    /// test harness 用: `plugin_event_ring_overflow_count` を直接加算する注入 seam（#402
+    /// pr-test-analyzer 指摘: sibling counter `link_egress_drops_arc`/`clap_process_errors_arc` に
+    /// ある「1 Hz ticker の dedup latch（増加時のみ発火・据え置きでは再発火しない）」の integration
+    /// test パターンが、この counter にはまだ無かった）。他の2つと違い `Arc` を返さないのは、この
+    /// counter が別スレッドへ producer 側を outsource しない（`EngineWrap` 自身が bounded retry の
+    /// 末に直接書く）フィールドだから（struct 定義側の doc 参照）— `&self` 越しの直接 `fetch_add` で
+    /// 足りる。`#[doc(hidden)]` で公開 API としては扱わない。
+    #[doc(hidden)]
+    pub fn plugin_event_ring_overflow_inject(&self, n: u64) {
+        self.plugin_event_ring_overflow_count
+            .fetch_add(n, Ordering::Relaxed);
+    }
+
     /// test harness / gated 計測用: OOP effect の観測スナップショット（fresh/stale/stall/respawn/
     /// child error 等）。slot 数決定（stale 率）と child crash 生存（respawn）の検証に使う。`#[doc(hidden)]`。
     /// plugin 未起動 / outproc 無効 / poison 時は None（poison は warn で区別）。
@@ -1382,6 +1395,65 @@ mod plugin_event_ring_retry_tests {
             overflow.load(Ordering::Relaxed),
             0,
             "fatal outcome is not an overflow (retrying would not have helped)"
+        );
+    }
+}
+
+/// `push_plugin_event`（`plugin_note_on`/`plugin_note_off` の共通経路）を、test backend
+/// （`clap: Mutex<Option<ClapControl>>` が `None`）越しに直接叩く（#402 pr-test-analyzer 指摘: 上の
+/// `plugin_event_ring_retry_tests` は `push_with_bounded_retry` を bare `rtrb::Producer` クロージャで
+/// 検証するのみで、本番の `push_plugin_event` クロージャ（mutex lock/poison 分岐・
+/// `guard.as_mut() == None` → `ClapUnavailable` の Fatal 分岐）を一度も経由していなかった）。
+///
+/// `Sent` 分岐（実際に event ring へ push が成功する）と mutex-poisoned 分岐は、実 clap-host
+/// 初期化済み `EngineWrap`（`EngineWrap::start()` が spawn する専用スレッド + 実 audio stream）が
+/// 要るため practical でない。ここでは `start_with(StubBackend)` で到達可能な None/ClapUnavailable
+/// 分岐にスコープする。
+#[cfg(feature = "clap-host")]
+#[cfg(test)]
+mod push_plugin_event_tests {
+    use super::{EngineWrap, WrapError};
+    use crate::backend::StubBackend;
+
+    #[test]
+    fn plugin_note_on_returns_clap_unavailable_when_clap_not_initialized() {
+        let (engine, _guard) =
+            EngineWrap::start_with(StubBackend::default()).expect("stub backend starts");
+        let before = engine.plugin_event_ring_overflow_count();
+
+        let err = engine
+            .plugin_note_on(60, 0, 0.8)
+            .expect_err("test backend has no clap control (clap field is None)");
+
+        assert!(
+            matches!(err, WrapError::ClapUnavailable(_)),
+            "expected ClapUnavailable (Fatal short-circuit), got {err:?}"
+        );
+        assert_eq!(
+            engine.plugin_event_ring_overflow_count(),
+            before,
+            "Fatal short-circuit must not be counted as a bounded-retry overflow"
+        );
+    }
+
+    #[test]
+    fn plugin_note_off_returns_clap_unavailable_when_clap_not_initialized() {
+        let (engine, _guard) =
+            EngineWrap::start_with(StubBackend::default()).expect("stub backend starts");
+        let before = engine.plugin_event_ring_overflow_count();
+
+        let err = engine
+            .plugin_note_off(60, 0, 0.0)
+            .expect_err("test backend has no clap control (clap field is None)");
+
+        assert!(
+            matches!(err, WrapError::ClapUnavailable(_)),
+            "expected ClapUnavailable (Fatal short-circuit), got {err:?}"
+        );
+        assert_eq!(
+            engine.plugin_event_ring_overflow_count(),
+            before,
+            "Fatal short-circuit must not be counted as a bounded-retry overflow"
         );
     }
 }

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -91,7 +91,10 @@ pub struct EngineWrap {
     /// ため満杯は一時的であり、真の drop はこの回数だけ発生する（M2 doc の「溢れても失わない」方針を
     /// in-process ring に retrofit・issue #400）。`EngineWrap` は常に `Arc<EngineWrap>` として共有
     /// されるため、`link_egress_drops`/`clap_process_errors` と異なり test 注入用の `_arc()` getter
-    /// が不要（この counter は本番書き込みのみ）で、プレーンな `AtomicU64` で足りる。
+    /// が不要。本番の bounded retry 書き込みも test 注入用の
+    /// [`plugin_event_ring_overflow_inject`](Self::plugin_event_ring_overflow_inject)（#402）も、
+    /// producer 側を別スレッドへ outsource せず常に `&self` 経由で `EngineWrap` 自身が直接書くため、
+    /// `Arc` clone による cross-thread 共有が不要で、プレーンな `AtomicU64` で足りる。
     plugin_event_ring_overflow_count: AtomicU64,
     /// LinkAudio egress の control-side ハンドル（feature `link-audio` 専用・A4-2b-2）。
     /// reg-ring push / mpsc send が内部可変性（`&mut LinkAudioControl`）を要する一方、`EngineWrap`

--- a/rust/crates/orbit-audio-daemon/src/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/src/protocol.rs
@@ -101,6 +101,10 @@ pub const ERROR_CODE_OUTPROC_EFFECT_RESPAWN: &str = "OUTPROC_EFFECT_RESPAWN";
 /// repeat-previous が出続ける = effect 経路のみ恒久停止）。daemon が 1 Hz ticker で `measurement_invalid`
 /// を検知して一度だけ発火する（fire-once・γ M1 PR-C）。
 pub const ERROR_CODE_OUTPROC_EFFECT_INVALID: &str = "OUTPROC_EFFECT_INVALID";
+/// in-process CLAP event ring への push が bounded retry の末に力尽きた（真の event 喪失）。
+/// WARNING severity。control スレッドが cumulative counter に積み、daemon が 1 Hz ticker で
+/// 増加を検知して発火する（#400・M2 doc の「溢れても失わない」方針の in-process retrofit）。
+pub const ERROR_CODE_PLUGIN_EVENT_RING_OVERFLOW: &str = "PLUGIN_EVENT_RING_OVERFLOW";
 
 /// Daemon → Client の event（通知、id なし）。
 #[derive(Debug, Serialize)]

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -21,9 +21,9 @@ use crate::protocol::{
     Command, ErrorResponse, Event, Handshake, OkResponse, ProtocolError,
     ERROR_CODE_CLAP_PROCESS_ERROR, ERROR_CODE_DEVICE_LOST, ERROR_CODE_LINK_EGRESS_DROP,
     ERROR_CODE_OUTPROC_EFFECT_ERROR, ERROR_CODE_OUTPROC_EFFECT_INVALID,
-    ERROR_CODE_OUTPROC_EFFECT_RESPAWN, ERROR_CODE_STREAM_XRUN, ERROR_SEVERITY_FATAL,
-    ERROR_SEVERITY_WARNING, EVENT_DAEMON_ERROR, EVENT_PLAY_ENDED, EVENT_PLAY_STARTED,
-    EVENT_STREAM_STATS,
+    ERROR_CODE_OUTPROC_EFFECT_RESPAWN, ERROR_CODE_PLUGIN_EVENT_RING_OVERFLOW,
+    ERROR_CODE_STREAM_XRUN, ERROR_SEVERITY_FATAL, ERROR_SEVERITY_WARNING, EVENT_DAEMON_ERROR,
+    EVENT_PLAY_ENDED, EVENT_PLAY_STARTED, EVENT_STREAM_STATS,
 };
 
 /// writer task のキュー容量。過大に積まれると back pressure をかける。
@@ -82,6 +82,7 @@ pub async fn run(
             let mut last_clap_errors: u64 = 0;
             let mut last_outproc_errors: u64 = 0;
             let mut last_outproc_respawns: u64 = 0;
+            let mut last_plugin_event_ring_overflow: u64 = 0;
             let mut outproc_invalid_reported = false;
             let mut device_lost_reported = false;
             loop {
@@ -154,6 +155,24 @@ pub async fn run(
                         break;
                     }
                     last_clap_errors = clap_errors;
+                }
+
+                // in-process CLAP event ring への push が bounded retry の末に力尽きた（真の event
+                // 喪失）を非 RT で surface（#400）。通常は 0 のまま推移する health signal。
+                let plugin_event_overflow = engine.plugin_event_ring_overflow_count();
+                if plugin_event_overflow > last_plugin_event_ring_overflow {
+                    let evt = daemon_error_event(
+                        ERROR_SEVERITY_WARNING,
+                        ERROR_CODE_PLUGIN_EVENT_RING_OVERFLOW,
+                        format!(
+                            "plugin event ring overflowed after bounded retry ({plugin_event_overflow} \
+                             total); a NoteOn/NoteOff was lost",
+                        ),
+                    );
+                    if tx.send(to_json_or_fallback(&evt)).await.is_err() {
+                        break;
+                    }
+                    last_plugin_event_ring_overflow = plugin_event_overflow;
                 }
 
                 // out-of-process effect の health（γ M1 PR-C）を非 RT で surface。child の process() エラー
@@ -442,7 +461,9 @@ async fn handle_command(
                 ProtocolError::new("MALFORMED_REQUEST", "missing 'path' param"),
             ),
         },
-        // ロード済み CLAP プラグインへ NoteOn / NoteOff を送る（event ring 経由・非ブロッキング）。
+        // ロード済み CLAP プラグインへ NoteOn / NoteOff を送る（event ring 経由）。event ring が
+        // 満杯の場合は bounded retry（最大 ~200ms・#400）で lossless 化するため、tokio ワーカーを
+        // 塞がないよう LoadPlugin と同様 spawn_blocking に包む。
         // 注意: plugin 未ロード時（LoadPlugin 前 / load 失敗後）も protocol 層では成功応答を返すが、
         // audio thread は plugin が無ければ event を drain して捨てる（fire-and-forget ring の設計上、
         // ロード状態の同期確認は cross-thread round-trip が要るため行わない）。pre-load note は黙って落ちる。
@@ -451,9 +472,18 @@ async fn handle_command(
             Some(k) if k <= 127 => match parse_midi_channel(&params) {
                 Ok(channel) => {
                     let velocity = param_f64(&params, "velocity", 0.8).clamp(0.0, 1.0);
-                    match engine.plugin_note_on(k as u8, channel, velocity) {
-                        Ok(()) => ok(&id, json!({"status": "note_on", "key": k})),
-                        Err(e) => err(&id, wrap_err_to_protocol(&e)),
+                    let engine = engine.clone();
+                    let res = tokio::task::spawn_blocking(move || {
+                        engine.plugin_note_on(k as u8, channel, velocity)
+                    })
+                    .await;
+                    match res {
+                        Ok(Ok(())) => ok(&id, json!({"status": "note_on", "key": k})),
+                        Ok(Err(e)) => err(&id, wrap_err_to_protocol(&e)),
+                        Err(join_err) => err(
+                            &id,
+                            ProtocolError::new("INTERNAL_ERROR", join_err.to_string()),
+                        ),
                     }
                 }
                 Err(e) => err(&id, e),
@@ -470,9 +500,18 @@ async fn handle_command(
             Some(k) if k <= 127 => match parse_midi_channel(&params) {
                 Ok(channel) => {
                     let velocity = param_f64(&params, "velocity", 0.0).clamp(0.0, 1.0);
-                    match engine.plugin_note_off(k as u8, channel, velocity) {
-                        Ok(()) => ok(&id, json!({"status": "note_off", "key": k})),
-                        Err(e) => err(&id, wrap_err_to_protocol(&e)),
+                    let engine = engine.clone();
+                    let res = tokio::task::spawn_blocking(move || {
+                        engine.plugin_note_off(k as u8, channel, velocity)
+                    })
+                    .await;
+                    match res {
+                        Ok(Ok(())) => ok(&id, json!({"status": "note_off", "key": k})),
+                        Ok(Err(e)) => err(&id, wrap_err_to_protocol(&e)),
+                        Err(join_err) => err(
+                            &id,
+                            ProtocolError::new("INTERNAL_ERROR", join_err.to_string()),
+                        ),
                     }
                 }
                 Err(e) => err(&id, e),

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -468,62 +468,30 @@ async fn handle_command(
         // audio thread は plugin が無ければ event を drain して捨てる（fire-and-forget ring の設計上、
         // ロード状態の同期確認は cross-thread round-trip が要るため行わない）。pre-load note は黙って落ちる。
         // velocity は CLAP 期待レンジ 0.0..=1.0 に clamp する（範囲外は plugin 挙動が未定義になるため）。
-        "PluginNoteOn" => match params.get("key").and_then(|v| v.as_u64()) {
-            Some(k) if k <= 127 => match parse_midi_channel(&params) {
-                Ok(channel) => {
-                    let velocity = param_f64(&params, "velocity", 0.8).clamp(0.0, 1.0);
-                    let engine = engine.clone();
-                    let res = tokio::task::spawn_blocking(move || {
-                        engine.plugin_note_on(k as u8, channel, velocity)
-                    })
-                    .await;
-                    match res {
-                        Ok(Ok(())) => ok(&id, json!({"status": "note_on", "key": k})),
-                        Ok(Err(e)) => err(&id, wrap_err_to_protocol(&e)),
-                        Err(join_err) => err(
-                            &id,
-                            ProtocolError::new("INTERNAL_ERROR", join_err.to_string()),
-                        ),
-                    }
-                }
-                Err(e) => err(&id, e),
-            },
-            _ => err(
+        // NoteOn/NoteOff は key/channel 検証・spawn_blocking・応答整形が同型なので共通ヘルパーに
+        // まとめる（velocity 既定値・呼ぶ engine メソッド・status 文字列だけが異なる・#402 レビュー指摘）。
+        "PluginNoteOn" => {
+            handle_plugin_note(
                 &id,
-                ProtocolError::new(
-                    "MALFORMED_REQUEST",
-                    "missing or out-of-range 'key' (0..=127)",
-                ),
-            ),
-        },
-        "PluginNoteOff" => match params.get("key").and_then(|v| v.as_u64()) {
-            Some(k) if k <= 127 => match parse_midi_channel(&params) {
-                Ok(channel) => {
-                    let velocity = param_f64(&params, "velocity", 0.0).clamp(0.0, 1.0);
-                    let engine = engine.clone();
-                    let res = tokio::task::spawn_blocking(move || {
-                        engine.plugin_note_off(k as u8, channel, velocity)
-                    })
-                    .await;
-                    match res {
-                        Ok(Ok(())) => ok(&id, json!({"status": "note_off", "key": k})),
-                        Ok(Err(e)) => err(&id, wrap_err_to_protocol(&e)),
-                        Err(join_err) => err(
-                            &id,
-                            ProtocolError::new("INTERNAL_ERROR", join_err.to_string()),
-                        ),
-                    }
-                }
-                Err(e) => err(&id, e),
-            },
-            _ => err(
+                &params,
+                engine,
+                0.8,
+                "note_on",
+                EngineWrap::plugin_note_on,
+            )
+            .await
+        }
+        "PluginNoteOff" => {
+            handle_plugin_note(
                 &id,
-                ProtocolError::new(
-                    "MALFORMED_REQUEST",
-                    "missing or out-of-range 'key' (0..=127)",
-                ),
-            ),
-        },
+                &params,
+                engine,
+                0.0,
+                "note_off",
+                EngineWrap::plugin_note_off,
+            )
+            .await
+        }
         "PlayAt" => {
             let time_sec = param_f64(&params, "time_sec", 0.0);
             let gain = param_f64(&params, "gain", 1.0) as f32;
@@ -724,6 +692,48 @@ fn parse_midi_channel(params: &Value) -> Result<u8, ProtocolError> {
             "MALFORMED_REQUEST",
             "'channel' must be 0..=15",
         )),
+    }
+}
+
+/// `PluginNoteOn`/`PluginNoteOff` の共通本体（key/channel 検証・spawn_blocking・応答整形が
+/// 完全に同型なので集約する・#402 レビュー指摘）。`call` は `EngineWrap::plugin_note_on`/
+/// `plugin_note_off` を渡す。
+async fn handle_plugin_note(
+    id: &str,
+    params: &Value,
+    engine: &Arc<EngineWrap>,
+    default_velocity: f64,
+    status: &'static str,
+    call: fn(&EngineWrap, u8, u8, f64) -> Result<(), WrapError>,
+) -> Value {
+    match params.get("key").and_then(|v| v.as_u64()) {
+        Some(k) if k <= 127 => match parse_midi_channel(params) {
+            Ok(channel) => {
+                // velocity は CLAP 期待レンジ 0.0..=1.0 に clamp する（範囲外は plugin 挙動が
+                // 未定義になるため）。
+                let velocity = param_f64(params, "velocity", default_velocity).clamp(0.0, 1.0);
+                let engine = engine.clone();
+                let res =
+                    tokio::task::spawn_blocking(move || call(&engine, k as u8, channel, velocity))
+                        .await;
+                match res {
+                    Ok(Ok(())) => ok(id, json!({"status": status, "key": k})),
+                    Ok(Err(e)) => err(id, wrap_err_to_protocol(&e)),
+                    Err(join_err) => err(
+                        id,
+                        ProtocolError::new("INTERNAL_ERROR", join_err.to_string()),
+                    ),
+                }
+            }
+            Err(e) => err(id, e),
+        },
+        _ => err(
+            id,
+            ProtocolError::new(
+                "MALFORMED_REQUEST",
+                "missing or out-of-range 'key' (0..=127)",
+            ),
+        ),
     }
 }
 

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -859,4 +859,84 @@ mod tests {
         assert!(!validate_bpm(MAX_LINK_BPM + 1.0));
         assert!(!validate_bpm(f64::MAX));
     }
+
+    // #402 pr-test-analyzer: handle_plugin_note の fn-pointer dispatch（call fn / default_velocity /
+    // status 文字列の組み合わせ）が PluginNoteOn/PluginNoteOff の match arm 間で入れ替わっていない
+    // ことを pin する。実 `EngineWrap::plugin_note_on`/`plugin_note_off` を使うと（test backend では
+    // `clap: None` のため）常に ClapUnavailable で早期リターンし velocity が観測できないので、
+    // `call` fn だけを capture 用に差し替える（velocity の解決 = `param_f64(..., default_velocity)`
+    // は `call` を呼ぶ前に handle_plugin_note 内部で完結するため、この capture が唯一の観測手段）。
+    #[tokio::test]
+    async fn handle_plugin_note_forwards_correct_default_velocity_and_status() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        static CAPTURED_VELOCITY_BITS: AtomicU64 = AtomicU64::new(0);
+
+        fn capture_velocity(
+            _engine: &EngineWrap,
+            _key: u8,
+            _channel: u8,
+            velocity: f64,
+        ) -> Result<(), WrapError> {
+            CAPTURED_VELOCITY_BITS.store(velocity.to_bits(), Ordering::SeqCst);
+            Ok(())
+        }
+
+        let (engine, _guard) = EngineWrap::start_with(crate::backend::StubBackend::default())
+            .expect("stub backend starts");
+        let params = json!({"key": 60});
+
+        // "PluginNoteOn" 配線: default_velocity=0.8 / status="note_on"（handle_command 参照）。
+        let resp_on =
+            handle_plugin_note("id-on", &params, &engine, 0.8, "note_on", capture_velocity).await;
+        assert_eq!(
+            f64::from_bits(CAPTURED_VELOCITY_BITS.load(Ordering::SeqCst)),
+            0.8,
+            "PluginNoteOn: velocity 省略時は NoteOn 自身の既定 0.8 に解決されること（NoteOff の \
+             既定と入れ替わっていないこと）"
+        );
+        assert_eq!(resp_on["result"]["status"], "note_on");
+
+        // "PluginNoteOff" 配線: default_velocity=0.0 / status="note_off"。
+        let resp_off = handle_plugin_note(
+            "id-off",
+            &params,
+            &engine,
+            0.0,
+            "note_off",
+            capture_velocity,
+        )
+        .await;
+        assert_eq!(
+            f64::from_bits(CAPTURED_VELOCITY_BITS.load(Ordering::SeqCst)),
+            0.0,
+            "PluginNoteOff: velocity 省略時は NoteOff 自身の既定 0.0 に解決されること"
+        );
+        assert_eq!(resp_off["result"]["status"], "note_off");
+    }
+
+    // #402 pr-test-analyzer: handle_plugin_note の spawn_blocking join-error 分岐
+    // (`Err(join_err) => ProtocolError::new("INTERNAL_ERROR", ...)`) は、このPR以前は
+    // PluginNoteOn/Off が同期実行だったため存在しなかった失敗経路。call fn 内 panic → JoinError →
+    // INTERNAL_ERROR mapping を pin する。
+    #[tokio::test]
+    async fn handle_plugin_note_maps_spawn_blocking_join_error_to_internal_error() {
+        fn panicking_call(
+            _engine: &EngineWrap,
+            _key: u8,
+            _channel: u8,
+            _velocity: f64,
+        ) -> Result<(), WrapError> {
+            panic!("orbit-audio-daemon test: simulated panic inside spawn_blocking call fn");
+        }
+
+        let (engine, _guard) = EngineWrap::start_with(crate::backend::StubBackend::default())
+            .expect("stub backend starts");
+        let params = json!({"key": 60});
+
+        let resp =
+            handle_plugin_note("id-panic", &params, &engine, 0.8, "note_on", panicking_call).await;
+
+        assert_eq!(resp["error"]["code"], "INTERNAL_ERROR");
+    }
 }

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -336,6 +336,25 @@ async fn handle_command(
     tx: &mpsc::Sender<String>,
 ) -> Value {
     let Command { id, method, params } = cmd;
+
+    // PluginNoteOn/PluginNoteOff dispatch は `plugin_note_spec` を single source of truth として
+    // その外側でチェックする（method match の中に "PluginNoteOn" | "PluginNoteOff" literal を
+    // 別途置くと、同じ文字列集合が2箇所で独立に保守されてしまい、どちらか一方だけ更新された場合に
+    // 検出できない・#402 pr-review-team iteration 3 収束指摘: silent-failure-hunter/
+    // pr-test-analyzer/code-reviewer）。`plugin_note_spec` が `None` を返す method はここを
+    // 素通りして下の match に落ちる。
+    if let Some(spec) = plugin_note_spec(&method) {
+        return handle_plugin_note(
+            &id,
+            &params,
+            engine,
+            spec.default_velocity,
+            spec.status,
+            spec.call,
+        )
+        .await;
+    }
+
     match method.as_str() {
         "Ping" => ok(&id, Value::String("pong".to_string())),
         "GetStatus" => {
@@ -461,33 +480,9 @@ async fn handle_command(
                 ProtocolError::new("MALFORMED_REQUEST", "missing 'path' param"),
             ),
         },
-        // ロード済み CLAP プラグインへ NoteOn / NoteOff を送る（event ring 経由）。event ring が
-        // 満杯の場合は bounded retry（最大 ~200ms・#400）で lossless 化するため、tokio ワーカーを
-        // 塞がないよう LoadPlugin と同様 spawn_blocking に包む。
-        // 注意: plugin 未ロード時（LoadPlugin 前 / load 失敗後）も protocol 層では成功応答を返すが、
-        // audio thread は plugin が無ければ event を drain して捨てる（fire-and-forget ring の設計上、
-        // ロード状態の同期確認は cross-thread round-trip が要るため行わない）。pre-load note は黙って落ちる。
-        // velocity は CLAP 期待レンジ 0.0..=1.0 に clamp する（範囲外は plugin 挙動が未定義になるため）。
-        // NoteOn/NoteOff は key/channel 検証・spawn_blocking・応答整形が同型なので共通ヘルパーに
-        // まとめる（velocity 既定値・呼ぶ engine メソッド・status 文字列だけが異なる・#402 レビュー指摘）。
-        // 配線（default_velocity/status/call）は `plugin_note_spec` に集約する single source of truth
-        // で、ここでは matched method から引くだけにする（#402 pr-test-analyzer 指摘・iteration 2:
-        // StubBackend では `call` が clap 未初期化で即 `ClapUnavailable` に落ち velocity/status が
-        // response に現れないため、match arm へ literal を直書きするとコピペ取り違えを response 差分
-        // では検出できない。`plugin_note_spec` を直接 pin するテストで防ぐ）。
-        "PluginNoteOn" | "PluginNoteOff" => {
-            let spec = plugin_note_spec(&method)
-                .expect("matched arm implies PluginNoteOn/PluginNoteOff spec exists");
-            handle_plugin_note(
-                &id,
-                &params,
-                engine,
-                spec.default_velocity,
-                spec.status,
-                spec.call,
-            )
-            .await
-        }
+        // NoteOn / NoteOff（"PluginNoteOn" / "PluginNoteOff"）は関数先頭の `plugin_note_spec`
+        // ディスパッチで処理済みなので、ここには到達しない。event ring 経由の送出（bounded retry・
+        // #400）、key/channel 検証・spawn_blocking・応答整形の実体は `handle_plugin_note` を参照。
         "PlayAt" => {
             let time_sec = param_f64(&params, "time_sec", 0.0);
             let gain = param_f64(&params, "gain", 1.0) as f32;
@@ -698,10 +693,10 @@ struct PluginNoteSpec {
     call: fn(&EngineWrap, u8, u8, f64) -> Result<(), WrapError>,
 }
 
-/// `method` 文字列から [`PluginNoteSpec`] を解決する single source of truth。`handle_command` の
-/// `"PluginNoteOn"`/`"PluginNoteOff"` match arm と、下のテスト `plugin_note_spec_*` の両方がここを
-/// 参照する（#402 pr-test-analyzer 指摘・iteration 2）。`"PluginNoteOn"`/`"PluginNoteOff"` 以外は
-/// `None`。
+/// `method` 文字列から [`PluginNoteSpec`] を解決する single source of truth。`handle_command` 冒頭の
+/// dispatch（`"PluginNoteOn"`/`"PluginNoteOff"` を判定する唯一の箇所）と、下のテスト
+/// `plugin_note_spec_*` の両方がここを参照する（#402 pr-test-analyzer 指摘・iteration 2〜3）。
+/// `"PluginNoteOn"`/`"PluginNoteOff"` 以外は `None`。
 fn plugin_note_spec(method: &str) -> Option<PluginNoteSpec> {
     match method {
         "PluginNoteOn" => Some(PluginNoteSpec {
@@ -883,10 +878,11 @@ mod tests {
         assert!(!validate_bpm(f64::MAX));
     }
 
-    // #402 pr-test-analyzer 指摘（iteration 2）: `handle_command` の `"PluginNoteOn"`/`"PluginNoteOff"`
-    // match arm 自体（このテストではなく `plugin_note_spec` 経由の literal/fn-pointer 配線）が
-    // コピペで入れ替わっていないことを pin する。`handle_command` を実際に呼んで response を比較する
-    // 手は使えない: StubBackend では `call`（実 `EngineWrap::plugin_note_on`/`plugin_note_off`）が
+    // #402 pr-test-analyzer 指摘（iteration 2）: `handle_command` 冒頭の `"PluginNoteOn"`/
+    // `"PluginNoteOff"` dispatch 自体（このテストではなく `plugin_note_spec` 経由の literal/
+    // fn-pointer 配線）がコピペで入れ替わっていないことを pin する。`handle_command` を実際に
+    // 呼んで response を比較する手は使えない: StubBackend では `call`（実
+    // `EngineWrap::plugin_note_on`/`plugin_note_off`）が
     // clap 未初期化で即 `ClapUnavailable` に落ちるため、velocity/status は response に一切現れず、
     // PluginNoteOn/PluginNoteOff の応答が常に同一になってしまう（response 差分では検出不能）。
     // そのため `handle_command` が単一の真実源として参照する `plugin_note_spec` を直接 pin する。
@@ -936,9 +932,10 @@ mod tests {
     }
 
     // #402 pr-test-analyzer: handle_plugin_note の fn-pointer dispatch（call fn / default_velocity /
-    // status 文字列の組み合わせ）が PluginNoteOn/PluginNoteOff の match arm 間で入れ替わっていない
-    // ことを pin する。実 `EngineWrap::plugin_note_on`/`plugin_note_off` を使うと（test backend では
-    // `clap: None` のため）常に ClapUnavailable で早期リターンし velocity が観測できないので、
+    // status 文字列の組み合わせ）が PluginNoteOn/PluginNoteOff の `plugin_note_spec` 間で
+    // 入れ替わっていないことを pin する。実 `EngineWrap::plugin_note_on`/`plugin_note_off` を
+    // 使うと（test backend では `clap: None` のため）常に ClapUnavailable で早期リターンし
+    // velocity が観測できないので、
     // `call` fn だけを capture 用に差し替える（velocity の解決 = `param_f64(..., default_velocity)`
     // は `call` を呼ぶ前に handle_plugin_note 内部で完結するため、この capture が唯一の観測手段）。
     #[tokio::test]

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -470,25 +470,21 @@ async fn handle_command(
         // velocity は CLAP 期待レンジ 0.0..=1.0 に clamp する（範囲外は plugin 挙動が未定義になるため）。
         // NoteOn/NoteOff は key/channel 検証・spawn_blocking・応答整形が同型なので共通ヘルパーに
         // まとめる（velocity 既定値・呼ぶ engine メソッド・status 文字列だけが異なる・#402 レビュー指摘）。
-        "PluginNoteOn" => {
+        // 配線（default_velocity/status/call）は `plugin_note_spec` に集約する single source of truth
+        // で、ここでは matched method から引くだけにする（#402 pr-test-analyzer 指摘・iteration 2:
+        // StubBackend では `call` が clap 未初期化で即 `ClapUnavailable` に落ち velocity/status が
+        // response に現れないため、match arm へ literal を直書きするとコピペ取り違えを response 差分
+        // では検出できない。`plugin_note_spec` を直接 pin するテストで防ぐ）。
+        "PluginNoteOn" | "PluginNoteOff" => {
+            let spec = plugin_note_spec(&method)
+                .expect("matched arm implies PluginNoteOn/PluginNoteOff spec exists");
             handle_plugin_note(
                 &id,
                 &params,
                 engine,
-                0.8,
-                "note_on",
-                EngineWrap::plugin_note_on,
-            )
-            .await
-        }
-        "PluginNoteOff" => {
-            handle_plugin_note(
-                &id,
-                &params,
-                engine,
-                0.0,
-                "note_off",
-                EngineWrap::plugin_note_off,
+                spec.default_velocity,
+                spec.status,
+                spec.call,
             )
             .await
         }
@@ -695,6 +691,33 @@ fn parse_midi_channel(params: &Value) -> Result<u8, ProtocolError> {
     }
 }
 
+/// `PluginNoteOn`/`PluginNoteOff` の配線（`default_velocity`/`status`/`call`）。
+struct PluginNoteSpec {
+    default_velocity: f64,
+    status: &'static str,
+    call: fn(&EngineWrap, u8, u8, f64) -> Result<(), WrapError>,
+}
+
+/// `method` 文字列から [`PluginNoteSpec`] を解決する single source of truth。`handle_command` の
+/// `"PluginNoteOn"`/`"PluginNoteOff"` match arm と、下のテスト `plugin_note_spec_*` の両方がここを
+/// 参照する（#402 pr-test-analyzer 指摘・iteration 2）。`"PluginNoteOn"`/`"PluginNoteOff"` 以外は
+/// `None`。
+fn plugin_note_spec(method: &str) -> Option<PluginNoteSpec> {
+    match method {
+        "PluginNoteOn" => Some(PluginNoteSpec {
+            default_velocity: 0.8,
+            status: "note_on",
+            call: EngineWrap::plugin_note_on,
+        }),
+        "PluginNoteOff" => Some(PluginNoteSpec {
+            default_velocity: 0.0,
+            status: "note_off",
+            call: EngineWrap::plugin_note_off,
+        }),
+        _ => None,
+    }
+}
+
 /// `PluginNoteOn`/`PluginNoteOff` の共通本体（key/channel 検証・spawn_blocking・応答整形が
 /// 完全に同型なので集約する・#402 レビュー指摘）。`call` は `EngineWrap::plugin_note_on`/
 /// `plugin_note_off` を渡す。
@@ -858,6 +881,58 @@ mod tests {
         assert!(!validate_bpm(f64::NEG_INFINITY));
         assert!(!validate_bpm(MAX_LINK_BPM + 1.0));
         assert!(!validate_bpm(f64::MAX));
+    }
+
+    // #402 pr-test-analyzer 指摘（iteration 2）: `handle_command` の `"PluginNoteOn"`/`"PluginNoteOff"`
+    // match arm 自体（このテストではなく `plugin_note_spec` 経由の literal/fn-pointer 配線）が
+    // コピペで入れ替わっていないことを pin する。`handle_command` を実際に呼んで response を比較する
+    // 手は使えない: StubBackend では `call`（実 `EngineWrap::plugin_note_on`/`plugin_note_off`）が
+    // clap 未初期化で即 `ClapUnavailable` に落ちるため、velocity/status は response に一切現れず、
+    // PluginNoteOn/PluginNoteOff の応答が常に同一になってしまう（response 差分では検出不能）。
+    // そのため `handle_command` が単一の真実源として参照する `plugin_note_spec` を直接 pin する。
+    #[test]
+    fn plugin_note_spec_maps_default_velocity_and_status() {
+        let on = plugin_note_spec("PluginNoteOn").expect("PluginNoteOn has a spec");
+        assert_eq!(on.default_velocity, 0.8, "NoteOn の既定 velocity");
+        assert_eq!(on.status, "note_on");
+
+        let off = plugin_note_spec("PluginNoteOff").expect("PluginNoteOff has a spec");
+        assert_eq!(off.default_velocity, 0.0, "NoteOff の既定 velocity");
+        assert_eq!(off.status, "note_off");
+
+        assert!(
+            plugin_note_spec("Ping").is_none(),
+            "PluginNoteOn/Off 以外は None"
+        );
+    }
+
+    // fn-pointer の取り違え（`call` フィールドが逆の `EngineWrap` メソッドを指す）を pin する。
+    // `#[cfg(not(feature = "clap-host"))]` ビルドでは `plugin_note_on`/`plugin_note_off` の stub 本体が
+    // バイト同一（同じ `ClapUnavailable` を返すだけ）なため、コンパイラの identical code folding で
+    // 同一アドレスに畳まれ得るため、fn-pointer 比較が意味を持たない。よってこのテストは `clap-host` 有効
+    // ビルド限定（本体が `push_plugin_event` に異なる `PluginEvent` variant を渡すため区別できる）。
+    #[cfg(feature = "clap-host")]
+    #[test]
+    fn plugin_note_spec_dispatches_to_correct_engine_method() {
+        let on = plugin_note_spec("PluginNoteOn").expect("PluginNoteOn has a spec");
+        assert!(
+            std::ptr::fn_addr_eq(
+                on.call,
+                EngineWrap::plugin_note_on
+                    as fn(&EngineWrap, u8, u8, f64) -> Result<(), WrapError>
+            ),
+            "PluginNoteOn は EngineWrap::plugin_note_on を呼ぶこと（NoteOff と入れ替わっていないこと）"
+        );
+
+        let off = plugin_note_spec("PluginNoteOff").expect("PluginNoteOff has a spec");
+        assert!(
+            std::ptr::fn_addr_eq(
+                off.call,
+                EngineWrap::plugin_note_off
+                    as fn(&EngineWrap, u8, u8, f64) -> Result<(), WrapError>
+            ),
+            "PluginNoteOff は EngineWrap::plugin_note_off を呼ぶこと"
+        );
     }
 
     // #402 pr-test-analyzer: handle_plugin_note の fn-pointer dispatch（call fn / default_velocity /

--- a/rust/crates/orbit-audio-daemon/tests/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/tests/protocol.rs
@@ -612,6 +612,71 @@ async fn daemon_error_warning_on_clap_process_error() {
     );
 }
 
+/// in-process CLAP event ring への bounded retry が力尽きた（真の event 喪失）回数が増えると
+/// DaemonError (severity=warning, code=PLUGIN_EVENT_RING_OVERFLOW) が発火する（#400/#402）。
+/// LINK_EGRESS_DROP / CLAP_PROCESS_ERROR と同じ 1 Hz ticker + dedup latch 経路。この counter は
+/// producer 側を別スレッドへ outsource しないので `_arc()` 型の注入 seam ではなく
+/// `plugin_event_ring_overflow_inject` で直接加算する（`EngineWrap` 側の doc 参照）。
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn daemon_error_warning_on_plugin_event_ring_overflow() {
+    let daemon = TestDaemon::start().await;
+    let mut ws = daemon.connect().await;
+    let _hs = TestDaemon::recv_handshake(&mut ws).await;
+
+    // 外部から ring overflow を注入（1 Hz ticker が plugin_event_ring_overflow_count の増加を検知
+    // して発火）。
+    daemon.engine.plugin_event_ring_overflow_inject(7);
+
+    advance_and_yield(Duration::from_millis(1_100)).await;
+
+    let mut warning_message: Option<String> = None;
+    for _ in 0..6 {
+        let res = tokio::time::timeout(Duration::from_millis(50), next_json(&mut ws)).await;
+        match res {
+            Ok(msg) => {
+                if msg["event"] == "DaemonError"
+                    && msg["data"]["severity"] == "warning"
+                    && msg["data"]["code"] == "PLUGIN_EVENT_RING_OVERFLOW"
+                {
+                    warning_message =
+                        Some(msg["data"]["message"].as_str().unwrap_or("").to_string());
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    let message = warning_message.expect("PLUGIN_EVENT_RING_OVERFLOW warning event not received");
+    // message は累積 overflow 数（7）を含む = daemon_error_event の format! が壊れていないこと。
+    assert!(
+        message.contains('7'),
+        "PLUGIN_EVENT_RING_OVERFLOW message should carry the running total, got: {message}"
+    );
+
+    // latch: 追加注入なしで次 tick へ進めても **再発火しない**（last_plugin_event_ring_overflow が
+    // 据え置かれること）。再発火すると 1 Hz で warn が溢れる回帰になる。
+    advance_and_yield(Duration::from_millis(1_100)).await;
+    let mut refired = false;
+    for _ in 0..6 {
+        let res = tokio::time::timeout(Duration::from_millis(50), next_json(&mut ws)).await;
+        match res {
+            Ok(msg) => {
+                if msg["event"] == "DaemonError"
+                    && msg["data"]["code"] == "PLUGIN_EVENT_RING_OVERFLOW"
+                {
+                    refired = true;
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    assert!(
+        !refired,
+        "PLUGIN_EVENT_RING_OVERFLOW must not re-fire without additional overflow (latch regression)"
+    );
+}
+
 /// device_lost が記録されると DaemonError (severity=fatal, code=DEVICE_LOST) が発火する。
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn daemon_error_fatal_on_device_lost() {


### PR DESCRIPTION
## Summary

- M2 instrument IPC substrate（#398）の transport 容量設計を検討する過程で、既存の in-process CLAP event ring（`push_plugin_event`・1024 slot）に同種の欠陥（満杯時 drop-newest だが可視化カウンタなし・NoteOff drop で stuck note の可能性）が見つかった。
- producer が RT audio スレッドでないと判明したため、bounded retry（最大200回・1ms間隔・≈200ms上限）だけで安価に lossless 化。真にタイムアウトした場合のみ `plugin_event_ring_overflow_count` を進めてエラーを返す。
- 可視化: `ERROR_CODE_PLUGIN_EVENT_RING_OVERFLOW` を新設し既存の 1Hz ticker パターンに配線。
- bounded retry が最大 ~200ms ブロックしうるため、`PluginNoteOn`/`PluginNoteOff` handler を `LoadPlugin` と同じ `spawn_blocking` パターンで包み、tokio ワーカーを塞がないようにした。

## Test plan

- [x] `cargo build -p orbit-audio-daemon`(default/clap-host/outproc-effect) — 全緑
- [x] `cargo clippy -p orbit-audio-daemon --all-targets -D warnings`(同3構成) — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace` — 全緑（新規 unit test 3本含む）
- [x] `cargo deny check licenses` — ok

Refs #400 #398

https://claude.ai/code/session_01UoMuPtdbm1Zm1mLrEbhCFe