### PR TITLE
fix(engine): surface Engine lock-contention silent zero-fill

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,18 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.222 fix(engine): ENGINE_LOCK_CONTENTION の WouldBlock/Poisoned 混同を修正（PR #403） (Jul 12, 2026)
+
+PR #403（#401 の実装）に対する `/simplify` 4並列レビュー（reuse/simplification/efficiency/altitude）で altitude レビュアーが発見し、コード直接確認で確定した実バグ。`orbit-audio-core::Engine::with_scheduler`/`render_multi` の `Err(_)` ワイルドカードが `std::sync::Mutex::try_lock()` の `WouldBlock`（一時競合・次ブロックで自己修復）と `Poisoned`（別スレッド panic による永続破損・`clear_poison()` 呼び出し箇所なしで恒久化）を同一カウンタ・同一 fallback に混ぜていた。poison すると `contention_count` が以後ずっと増え続け、daemon の WARNING メッセージ「this self-heals next block」が実際には二度と真にならない状態のまま無限に再発火する欠陥だった。
+
+- **実装**: `Engine` に `poisoned: Arc<AtomicBool>` を追加し `with_scheduler`/`render_multi` の match 節を `Err(TryLockError::WouldBlock)`（`contention_count` 増分のみ）と `Err(TryLockError::Poisoned(_))`（`poisoned.store(true, Relaxed)` のみ）に分離。両分岐とも RT スレッドのため `tracing::warn!` 等のブロッキング処理は行わない（非ブロッキング atomic write のみ）。`is_lock_poisoned()` accessor を追加。
+- **daemon 配線**: `ERROR_CODE_ENGINE_LOCK_POISONED`（新設・**FATAL** severity）を追加し、`EngineWrap::engine_lock_poisoned()` → 1Hz ticker で `device_lost` と同じ fire-once latch パターンで発火。FATAL 選定根拠: このコードベースの FATAL は session を終了しない（`device_lost_reported=true` 後も ticker は StreamStats を出し続ける）ため「恒久障害だが daemon 生存」を表す severity として一貫する。poison は render 全体 + `schedule`/`stop`/`stop_all`/`set_global_gain` の制御系 API も道連れにする点で `OUTPROC_EFFECT_INVALID`（effect 経路のみ凍結・WARNING）より重く、`device_lost` に近いため FATAL とした。
+- **テスト seam**: `Engine::contention_count_arc()`/`poisoned_arc()`（`#[doc(hidden)]`、`StreamStats::record_xrun` と同形の直接注入 — 生の atomic なので link/clap のような additive 分離 counter は不要）を追加し `EngineWrap` に delegate。`tests/protocol.rs` に `daemon_error_warning_on_engine_lock_contention`/`daemon_error_fatal_on_engine_lock_poisoned` を追加（latch 検証込み）。加えて `orbit-audio-core::engine::tests` に、別スレッドで実際に panic させ Mutex を genuine-poison する unit test を追加し、`poisoned` フラグが `contention_count` を汚染しないことを実際の poison で確認。
+- **ドキュメント cleanup**: field doc とアクセサ doc の重複を解消（simplification レビュー指摘）、`render_multi_routes_by_channel_tag` テストの「決定論的に競合を起こせない」という古いコメントを削除（後続テストで実際に決定論的検証済みのため矛盾していた）。
+- **検証**: `cargo build`(core / daemon default / daemon clap-host)・`cargo test`(core --lib 45件・daemon --lib 13件・daemon --test protocol 21件、全緑)・`cargo clippy --workspace --all-targets -D warnings`・`cargo fmt --check` を確認。
+- **役割**: 発見=`/simplify` 4並列レビュー（altitude が主犯、reuse/simplification が付随指摘）/ 実装・検証=Opus subagent（advisor で設計レビュー後に commit）。
+- **状態**: PR #403 に追加コミットとして push 済み。
+
 ### 6.221 fix(engine): Engine lock 競合の silent zero-fill を可視化（#401） (Jul 12, 2026)
 
 M2 instrument IPC substrate（#398）の容量設計を検討する過程で、Fable の拡張レビューが新たに発見した箇所。`orbit-audio-core::Engine::with_scheduler`/`render_multi` は RT 競合（`try_lock` 失敗）時に出力バッファを silent zero-fill する既存設計（lock-free 化は別 Issue で defer 済み・自己修復する障害）だったが、発生を可視化する仕組みが一切なかった。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,17 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.221 fix(engine): Engine lock 競合の silent zero-fill を可視化（#401） (Jul 12, 2026)
+
+M2 instrument IPC substrate（#398）の容量設計を検討する過程で、Fable の拡張レビューが新たに発見した箇所。`orbit-audio-core::Engine::with_scheduler`/`render_multi` は RT 競合（`try_lock` 失敗）時に出力バッファを silent zero-fill する既存設計（lock-free 化は別 Issue で defer 済み・自己修復する障害）だったが、発生を可視化する仕組みが一切なかった。
+
+- **実装**: `Engine` に `contention_count: Arc<AtomicU64>` を追加し、`with_scheduler`/`render_multi` 両方の `Err(_)`（try_lock 失敗）分岐で増分。`lock_contention_count()` accessor を追加。
+- **daemon 配線**: `EngineWrap::engine_lock_contention_count()` → `ERROR_CODE_ENGINE_LOCK_CONTENTION`（新設）→ 既存の 1Hz ticker パターンに配線。
+- **検証**: 新規 unit test 2本（`inner` は同一モジュール内テストから直接 lock 可能な private field のため、同一スレッドで guard を保持したまま `render`/`render_multi` を呼び、try_lock 失敗を人工的に発生させて検証。std::sync::Mutex は非再入なので別スレッド spawn 不要）。`cargo build`(default/clap-host/outproc-effect)・`cargo clippy --all-targets -D warnings`(orbit-audio-core含む4構成)・`cargo fmt --check`・`cargo test --workspace`(全緑)・`cargo deny check licenses`(ok)を確認。
+- **付随調査**: 同セッションで fresh agent(opus)による拡張監査（TS層+grepパターン非依存のRust手書きqueue探索）を実施し、TS層には同種欠陥なし・新たに2件発見（`orbit-audio-sandbox`の`frames_clamped`カウンター未配線／プラグイン未ロード時のNoteOn/NoteOffが嘘の成功応答を返す）→ 別途 issue化予定。LinkAudio側の`MAX_LINK_CHANNELS`(64)の debug_assert は、control側(`register_channel`)が同じ上限を既に error として強制しているため構造上到達不能と判断し見送り。
+- **役割**: 発見=Fable(実コード確認込みレビュー) / 実装・検証=Opus main(直接実装)。
+- **状態**: M2(#398)とは独立スコープ。PR 作成 → owner マージ待ち。
+
 ### 6.220 fix(engine): VST3 host unsafe memory-safety 監査 + hardening 3件（#397） (Jul 11, 2026)
 
 中核の手書き unsafe COM FFI（`orbit-vst3-host/src/lib.rs`・80 unsafe blocks）に対し、`/code:pr-review-team`（汎用 correctness）が構造的に狙わない **memory-safety/UB 次元**の外部第二意見を実施。@claude bot は pr-review-team と同一モデルファミリで盲点が相関するため除外し、**codex（cross-family）+ fresh Opus（非著者）を並列 adversarial 監査 → advisor で tie-break**（[[consult-layering-by-error-type]] の分担）。

--- a/rust/crates/orbit-audio-core/src/engine.rs
+++ b/rust/crates/orbit-audio-core/src/engine.rs
@@ -3,6 +3,7 @@
 //! Phase 2 以降で DSL interpreter と接続する想定。PoC では
 //! 「サンプルをロードして、時刻指定でスケジュールする」だけを提供する。
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use thiserror::Error;
@@ -27,12 +28,19 @@ pub enum EngineError {
 #[derive(Clone)]
 pub struct Engine {
     inner: Arc<Mutex<Scheduler>>,
+    /// `with_scheduler` / `render_multi` が RT 競合（`try_lock` 失敗）で silent zero-fill に
+    /// フォールバックした回数（health signal）。この経路自体は既存の設計判断（lock-free 化は
+    /// 別 Issue で defer 済み）だが、発生を可視化する仕組みが無かったため追加した（#401）。
+    /// 自己修復する障害（次のブロックで復帰）なので stuck しないが、32/64f 小バッファ性能ゴール下
+    /// ではライブコマンド頻度に比例して発生確率が上がるため、operator が気づける形にする。
+    contention_count: Arc<AtomicU64>,
 }
 
 impl Engine {
     pub fn new(sample_rate: u32, channels: u16) -> Self {
         Self {
             inner: Arc::new(Mutex::new(Scheduler::new(sample_rate, channels))),
+            contention_count: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -122,6 +130,7 @@ impl Engine {
             // MutexGuard を DerefMut で &mut Scheduler に再借用して closure に渡す。
             Ok(mut s) => f(&mut s, out),
             Err(_) => {
+                self.contention_count.fetch_add(1, Ordering::Relaxed);
                 for x in out.iter_mut() {
                     *x = 0.0;
                 }
@@ -152,12 +161,20 @@ impl Engine {
         match self.inner.try_lock() {
             Ok(mut s) => s.render_multi(hardware_out, channels),
             Err(_) => {
+                self.contention_count.fetch_add(1, Ordering::Relaxed);
                 hardware_out.fill(0.0);
                 for (_, buf) in channels.iter_mut() {
                     buf.fill(0.0);
                 }
             }
         }
+    }
+
+    /// `with_scheduler` / `render_multi` が RT 競合で silent zero-fill にフォールバックした
+    /// 累積回数（#401）。daemon の 1 Hz ticker が polling して増加を surface する
+    /// health signal。通常は 0 のまま推移する想定。
+    pub fn lock_contention_count(&self) -> u64 {
+        self.contention_count.load(Ordering::Relaxed)
     }
 
     /// 現在の出力ストリーム時刻（秒）を返す。
@@ -187,6 +204,48 @@ mod tests {
     fn now_sec_returns_some_zero_at_start() {
         let engine = Engine::new(48_000, 2);
         assert_eq!(engine.now_sec(), Some(0.0));
+    }
+
+    // try_lock 競合時の silent zero-fill フォールバック（#401）を、同一スレッドで `inner` を
+    // 直接 lock して人工的に競合させ検証する（std::sync::Mutex は非再入なので、同一スレッド内で
+    // guard を保持したまま try_lock しても Err になる — 別スレッドを spawn する必要がない）。
+    #[test]
+    fn contention_count_increments_on_render_lock_conflict() {
+        let engine = Engine::new(48_000, 2);
+        assert_eq!(engine.lock_contention_count(), 0);
+
+        let mut buf = vec![1.0f32; 8]; // 非ゼロで初期化し zero-fill を検証できるようにする
+        {
+            let _guard = engine.inner.lock().expect("lock for contention setup");
+            engine.render(&mut buf);
+        }
+
+        assert!(
+            buf.iter().all(|&x| x == 0.0),
+            "lock 競合時は silent zero-fill されるべき"
+        );
+        assert_eq!(
+            engine.lock_contention_count(),
+            1,
+            "render の try_lock 失敗で contention_count が増分されるべき"
+        );
+    }
+
+    #[test]
+    fn contention_count_increments_on_render_multi_lock_conflict() {
+        let engine = Engine::new(48_000, 2);
+
+        let mut hw = vec![1.0f32; 4];
+        let mut ch_buf = vec![1.0f32; 4];
+        {
+            let _guard = engine.inner.lock().expect("lock for contention setup");
+            let mut chans: [(&str, &mut [f32]); 1] = [("fx", &mut ch_buf)];
+            engine.render_multi(&mut hw, &mut chans);
+        }
+
+        assert!(hw.iter().all(|&x| x == 0.0));
+        assert!(ch_buf.iter().all(|&x| x == 0.0));
+        assert_eq!(engine.lock_contention_count(), 1);
     }
 
     // render_multi の Engine ラッパが channel タグで出力先を分離することを CI で検証する

--- a/rust/crates/orbit-audio-core/src/engine.rs
+++ b/rust/crates/orbit-audio-core/src/engine.rs
@@ -281,6 +281,10 @@ mod tests {
             1,
             "render の try_lock 失敗で contention_count が増分されるべき"
         );
+        assert!(
+            !engine.is_lock_poisoned(),
+            "WouldBlock contention must not also set the poisoned flag"
+        );
     }
 
     #[test]
@@ -298,6 +302,10 @@ mod tests {
         assert!(hw.iter().all(|&x| x == 0.0));
         assert!(ch_buf.iter().all(|&x| x == 0.0));
         assert_eq!(engine.lock_contention_count(), 1);
+        assert!(
+            !engine.is_lock_poisoned(),
+            "WouldBlock contention must not also set the poisoned flag"
+        );
     }
 
     // `WouldBlock`（上の2テスト・同一スレッドで guard を保持したまま try_lock）とは別に、
@@ -337,6 +345,84 @@ mod tests {
             engine.lock_contention_count(),
             0,
             "poison は WouldBlock 専用の contention_count に混ぜてはいけない"
+        );
+    }
+
+    // render_multi は with_scheduler を経由せず try_lock を直接ハンドリングする別実装
+    // （#401 で Poisoned 分岐を手動で複製した）ため、render() 側の genuine-poison テストとは
+    // 独立して render_multi() 側も同じ経路を検証する。
+    #[test]
+    fn poisoned_flag_sets_on_render_multi_lock_poison_distinct_from_contention_count() {
+        let engine = Engine::new(48_000, 2);
+        assert!(!engine.is_lock_poisoned());
+        assert_eq!(engine.lock_contention_count(), 0);
+
+        let engine_clone = engine.clone();
+        let panicked = std::thread::spawn(move || {
+            let _guard = engine_clone.inner.lock().expect("lock for poison setup");
+            panic!("intentional poison for poisoned_flag_sets_on_render_multi_lock_poison test");
+        })
+        .join()
+        .is_err();
+        assert!(
+            panicked,
+            "spawned thread should have panicked while holding the lock"
+        );
+
+        let mut hw = vec![1.0f32; 8];
+        let mut ch_buf = vec![1.0f32; 4];
+        let mut chans: [(&str, &mut [f32]); 1] = [("fx", &mut ch_buf)];
+        engine.render_multi(&mut hw, &mut chans);
+
+        assert!(
+            hw.iter().all(|&x| x == 0.0),
+            "poisoned lock 時も hardware_out は silent zero-fill されるべき"
+        );
+        assert!(
+            ch_buf.iter().all(|&x| x == 0.0),
+            "poisoned lock 時も channel buffer は silent zero-fill されるべき"
+        );
+        assert!(
+            engine.is_lock_poisoned(),
+            "render_multi の try_lock Poisoned 失敗で poisoned フラグが立つべき"
+        );
+        assert_eq!(
+            engine.lock_contention_count(),
+            0,
+            "poison は WouldBlock 専用の contention_count に混ぜてはいけない"
+        );
+    }
+
+    // 制御系 API（schedule/stop/stop_all/set_global_gain）は既に `self.inner.lock().map_err(|_|
+    // EngineError::Poisoned)?` を実装しているが（#401 以前からの既存コード）、実際に mutex を
+    // panic-poison させて `Err(EngineError::Poisoned)` を返すことを検証するテストが無かった。
+    // render 系と同じ poison 手法（別スレッドで panic させて join）を流用する。
+    #[test]
+    fn control_plane_methods_return_poisoned_error_after_genuine_poison() {
+        let engine = Engine::new(48_000, 2);
+
+        let engine_clone = engine.clone();
+        let panicked = std::thread::spawn(move || {
+            let _guard = engine_clone.inner.lock().expect("lock for poison setup");
+            panic!("intentional poison for control_plane_methods_return_poisoned_error test");
+        })
+        .join()
+        .is_err();
+        assert!(
+            panicked,
+            "spawned thread should have panicked while holding the lock"
+        );
+
+        assert!(
+            matches!(engine.stop_all(), Err(EngineError::Poisoned)),
+            "stop_all() should surface EngineError::Poisoned instead of panicking after genuine poison"
+        );
+        assert!(
+            matches!(
+                engine.schedule(0.0, Sample::new(vec![0.5f32; 8], 48_000, 2)),
+                Err(EngineError::Poisoned)
+            ),
+            "schedule() should surface EngineError::Poisoned instead of panicking after genuine poison"
         );
     }
 

--- a/rust/crates/orbit-audio-core/src/engine.rs
+++ b/rust/crates/orbit-audio-core/src/engine.rs
@@ -3,7 +3,7 @@
 //! Phase 2 以降で DSL interpreter と接続する想定。PoC では
 //! 「サンプルをロードして、時刻指定でスケジュールする」だけを提供する。
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use thiserror::Error;
@@ -28,12 +28,22 @@ pub enum EngineError {
 #[derive(Clone)]
 pub struct Engine {
     inner: Arc<Mutex<Scheduler>>,
-    /// `with_scheduler` / `render_multi` が RT 競合（`try_lock` 失敗）で silent zero-fill に
-    /// フォールバックした回数（health signal）。この経路自体は既存の設計判断（lock-free 化は
-    /// 別 Issue で defer 済み）だが、発生を可視化する仕組みが無かったため追加した（#401）。
-    /// 自己修復する障害（次のブロックで復帰）なので stuck しないが、32/64f 小バッファ性能ゴール下
-    /// ではライブコマンド頻度に比例して発生確率が上がるため、operator が気づける形にする。
+    /// `with_scheduler` / `render_multi` が RT 競合で `try_lock` が **`WouldBlock`** を返し
+    /// silent zero-fill にフォールバックした回数（health signal）。この経路自体は既存の設計判断
+    /// （lock-free 化は別 Issue で defer 済み）だが、発生を可視化する仕組みが無かったため追加した
+    /// （#401）。`WouldBlock` は自己修復する障害（次のブロックでロックが空けば復帰）なので stuck
+    /// しないが、32/64f 小バッファ性能ゴール下ではライブコマンド頻度に比例して発生確率が上がるため、
+    /// operator が気づける形にする。**`Poisoned`（恒久障害）はこのカウンタに含めない** — 別スレッドの
+    /// panic で一度 poison すると `clear_poison()` を呼ぶ箇所が無く同一プロセス内で永続するため、
+    /// 一時的な競合と同列に数えると「次のブロックで自己修復する」という意味が壊れる。poison は
+    /// `poisoned` フラグで区別する。
     contention_count: Arc<AtomicU64>,
+    /// scheduler Mutex が RT `try_lock` で **`Poisoned`** と判定されたかどうか（#401）。
+    /// 一度 `true` になると `clear_poison()` が呼ばれないため、同一プロセス生存中は戻らない
+    /// （render 系は恒久的に zero-fill、`schedule`/`stop`/`stop_all`/`set_global_gain` などの
+    /// 制御系 API も以降ずっと `EngineError::Poisoned` を返す）。`contention_count` の
+    /// `WouldBlock` とは異なり自己修復しない。
+    poisoned: Arc<AtomicBool>,
 }
 
 impl Engine {
@@ -41,6 +51,7 @@ impl Engine {
         Self {
             inner: Arc::new(Mutex::new(Scheduler::new(sample_rate, channels))),
             contention_count: Arc::new(AtomicU64::new(0)),
+            poisoned: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -125,12 +136,24 @@ impl Engine {
     /// `try_lock` で Scheduler を借りて `f` を実行する。RT スレッドから呼ばれるため、ロック
     /// 競合時は無音（silent drop）で即時 return する（将来 lock-free ringbuffer 化の余地あり・
     /// Phase 2）。`render` / `render_channel` がこの try-lock + silent-drop 規約を共有する。
+    ///
+    /// `try_lock` の失敗理由を区別する（#401）: **`WouldBlock`**（一時的競合）は
+    /// `contention_count` に積むだけ — 次のブロックで自己修復する。**`Poisoned`**（別スレッドの
+    /// panic で永続破損）は `poisoned` フラグを立てるだけに留める。RT コールバック内なので
+    /// どちらの分岐も `tracing::warn!` 等のブロッキング/アロケーションを伴う処理は行わない
+    /// （非ブロッキングな atomic write のみ）。
     fn with_scheduler(&self, out: &mut [f32], f: impl FnOnce(&mut Scheduler, &mut [f32])) {
         match self.inner.try_lock() {
             // MutexGuard を DerefMut で &mut Scheduler に再借用して closure に渡す。
             Ok(mut s) => f(&mut s, out),
-            Err(_) => {
+            Err(std::sync::TryLockError::WouldBlock) => {
                 self.contention_count.fetch_add(1, Ordering::Relaxed);
+                for x in out.iter_mut() {
+                    *x = 0.0;
+                }
+            }
+            Err(std::sync::TryLockError::Poisoned(_)) => {
+                self.poisoned.store(true, Ordering::Relaxed);
                 for x in out.iter_mut() {
                     *x = 0.0;
                 }
@@ -154,14 +177,22 @@ impl Engine {
 
     /// 本番 RT 用の single-pass multi-buffer render（A4-2b-2）。`hardware_out`（channel=None）と
     /// 各 named channel buffer を 1 パスで埋め transport を 1 回だけ進める
-    /// （[`Scheduler::render_multi`]）。RT 競合（try_lock 失敗）時は `render` の silent-drop 規約を
-    /// multi-buffer に拡張し、**hardware と全 channel buffer を無音**にする（ramp を多重に進めないため
-    /// 単一の try_lock で一括処理する）。
+    /// （[`Scheduler::render_multi`]）。RT 競合時は `render` の silent-drop 規約を multi-buffer に
+    /// 拡張し、**hardware と全 channel buffer を無音**にする（ramp を多重に進めないため単一の
+    /// try_lock で一括処理する）。`try_lock` 失敗理由（`WouldBlock` / `Poisoned`）の区別と RT-safety
+    /// 制約は `with_scheduler` と同じ（#401）。
     pub fn render_multi(&self, hardware_out: &mut [f32], channels: &mut [(&str, &mut [f32])]) {
         match self.inner.try_lock() {
             Ok(mut s) => s.render_multi(hardware_out, channels),
-            Err(_) => {
+            Err(std::sync::TryLockError::WouldBlock) => {
                 self.contention_count.fetch_add(1, Ordering::Relaxed);
+                hardware_out.fill(0.0);
+                for (_, buf) in channels.iter_mut() {
+                    buf.fill(0.0);
+                }
+            }
+            Err(std::sync::TryLockError::Poisoned(_)) => {
+                self.poisoned.store(true, Ordering::Relaxed);
                 hardware_out.fill(0.0);
                 for (_, buf) in channels.iter_mut() {
                     buf.fill(0.0);
@@ -170,11 +201,32 @@ impl Engine {
         }
     }
 
-    /// `with_scheduler` / `render_multi` が RT 競合で silent zero-fill にフォールバックした
-    /// 累積回数（#401）。daemon の 1 Hz ticker が polling して増加を surface する
-    /// health signal。通常は 0 のまま推移する想定。
+    /// `contention_count`（`WouldBlock` 由来の累積 zero-fill 回数）を返す。詳細な意味論は
+    /// field doc 参照。daemon の 1 Hz ticker が polling して増加を surface する。
     pub fn lock_contention_count(&self) -> u64 {
         self.contention_count.load(Ordering::Relaxed)
+    }
+
+    /// scheduler Mutex が RT `try_lock` で poisoned と判定されたか。詳細な意味論は `poisoned`
+    /// field doc 参照。daemon の 1 Hz ticker が polling して fire-once の FATAL event を出す。
+    pub fn is_lock_poisoned(&self) -> bool {
+        self.poisoned.load(Ordering::Relaxed)
+    }
+
+    /// test harness 用: `contention_count` の `Arc` を取得し、外部から `WouldBlock` 競合を
+    /// 決定論的に注入できるようにする（`StreamStats::record_xrun` と同形 — 本番と同一 counter に
+    /// 直接書く injection seam）。`#[doc(hidden)]` で公開 API としては扱わない。
+    #[doc(hidden)]
+    pub fn contention_count_arc(&self) -> Arc<AtomicU64> {
+        self.contention_count.clone()
+    }
+
+    /// test harness 用: `poisoned` の `Arc` を取得し、外部から poison 状態を決定論的に注入できる
+    /// ようにする（`contention_count_arc` と同形）。実際に Mutex を panic-poison させずに
+    /// daemon 側の FATAL event 経路を検証するための seam。`#[doc(hidden)]`。
+    #[doc(hidden)]
+    pub fn poisoned_arc(&self) -> Arc<AtomicBool> {
+        self.poisoned.clone()
     }
 
     /// 現在の出力ストリーム時刻（秒）を返す。
@@ -248,10 +300,50 @@ mod tests {
         assert_eq!(engine.lock_contention_count(), 1);
     }
 
+    // `WouldBlock`（上の2テスト・同一スレッドで guard を保持したまま try_lock）とは別に、
+    // 別スレッドで実際に panic させて Mutex を poison し、`Poisoned` 分岐が `contention_count`
+    // ではなく専用の `poisoned` フラグを立てることを検証する（#401 の主眼: 一時競合と恒久障害を
+    // 同一カウンタに混ぜない）。
+    #[test]
+    fn poisoned_flag_sets_on_render_lock_poison_distinct_from_contention_count() {
+        let engine = Engine::new(48_000, 2);
+        assert!(!engine.is_lock_poisoned());
+        assert_eq!(engine.lock_contention_count(), 0);
+
+        let engine_clone = engine.clone();
+        let panicked = std::thread::spawn(move || {
+            let _guard = engine_clone.inner.lock().expect("lock for poison setup");
+            panic!("intentional poison for poisoned_flag_sets_on_render_lock_poison test");
+        })
+        .join()
+        .is_err();
+        assert!(
+            panicked,
+            "spawned thread should have panicked while holding the lock"
+        );
+
+        let mut buf = vec![1.0f32; 8];
+        engine.render(&mut buf);
+
+        assert!(
+            buf.iter().all(|&x| x == 0.0),
+            "poisoned lock 時も silent zero-fill されるべき"
+        );
+        assert!(
+            engine.is_lock_poisoned(),
+            "render の try_lock Poisoned 失敗で poisoned フラグが立つべき"
+        );
+        assert_eq!(
+            engine.lock_contention_count(),
+            0,
+            "poison は WouldBlock 専用の contention_count に混ぜてはいけない"
+        );
+    }
+
     // render_multi の Engine ラッパが channel タグで出力先を分離することを CI で検証する
     // （ルーティング本体の網羅は Scheduler::render_multi 側のテスト群・ここは Engine の委譲を pin）。
-    // try_lock 競合時の全バッファ zero-fill 経路は `render` と同一の with_scheduler 規約
-    // （inner Mutex は非公開で決定論的に競合を起こせない）。
+    // try_lock 競合時（WouldBlock）の全バッファ zero-fill 経路は `render` と同一の with_scheduler
+    // 規約（決定論的な再現は `contention_count_increments_on_render_multi_lock_conflict` 参照）。
     #[test]
     fn render_multi_routes_by_channel_tag() {
         let engine = Engine::new(48_000, 2);

--- a/rust/crates/orbit-audio-core/src/engine.rs
+++ b/rust/crates/orbit-audio-core/src/engine.rs
@@ -145,19 +145,16 @@ impl Engine {
     fn with_scheduler(&self, out: &mut [f32], f: impl FnOnce(&mut Scheduler, &mut [f32])) {
         match self.inner.try_lock() {
             // MutexGuard を DerefMut で &mut Scheduler に再借用して closure に渡す。
-            Ok(mut s) => f(&mut s, out),
+            Ok(mut s) => return f(&mut s, out),
             Err(std::sync::TryLockError::WouldBlock) => {
                 self.contention_count.fetch_add(1, Ordering::Relaxed);
-                for x in out.iter_mut() {
-                    *x = 0.0;
-                }
             }
             Err(std::sync::TryLockError::Poisoned(_)) => {
                 self.poisoned.store(true, Ordering::Relaxed);
-                for x in out.iter_mut() {
-                    *x = 0.0;
-                }
             }
+        }
+        for x in out.iter_mut() {
+            *x = 0.0;
         }
     }
 
@@ -183,21 +180,17 @@ impl Engine {
     /// 制約は `with_scheduler` と同じ（#401）。
     pub fn render_multi(&self, hardware_out: &mut [f32], channels: &mut [(&str, &mut [f32])]) {
         match self.inner.try_lock() {
-            Ok(mut s) => s.render_multi(hardware_out, channels),
+            Ok(mut s) => return s.render_multi(hardware_out, channels),
             Err(std::sync::TryLockError::WouldBlock) => {
                 self.contention_count.fetch_add(1, Ordering::Relaxed);
-                hardware_out.fill(0.0);
-                for (_, buf) in channels.iter_mut() {
-                    buf.fill(0.0);
-                }
             }
             Err(std::sync::TryLockError::Poisoned(_)) => {
                 self.poisoned.store(true, Ordering::Relaxed);
-                hardware_out.fill(0.0);
-                for (_, buf) in channels.iter_mut() {
-                    buf.fill(0.0);
-                }
             }
+        }
+        hardware_out.fill(0.0);
+        for (_, buf) in channels.iter_mut() {
+            buf.fill(0.0);
         }
     }
 

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use orbit_audio_core::{resolve_slice_region, sanitize_rate, Engine, Sample};
@@ -913,10 +913,32 @@ impl EngineWrap {
         self.engine.now_sec()
     }
 
-    /// `Engine::with_scheduler`/`render_multi` が RT 競合で silent zero-fill にフォールバック
-    /// した累積回数（#401）。daemon の 1 Hz ticker が polling して増加を surface する health signal。
+    /// `Engine::lock_contention_count` の delegate（詳細はそちら参照）。daemon の 1 Hz ticker が
+    /// polling する（#401）。
     pub fn engine_lock_contention_count(&self) -> u64 {
         self.engine.lock_contention_count()
+    }
+
+    /// `Engine::is_lock_poisoned` の delegate（詳細はそちら参照）。daemon の 1 Hz ticker が
+    /// polling して fire-once の FATAL event を出す（#401）。
+    pub fn engine_lock_poisoned(&self) -> bool {
+        self.engine.is_lock_poisoned()
+    }
+
+    /// test harness 用: `Engine::contention_count_arc` の delegate。integration test から
+    /// `fetch_add` して 1 Hz ticker の `ENGINE_LOCK_CONTENTION` WARNING 発火を駆動する
+    /// （`link_egress_drops_arc` と同様の注入 seam・`#[doc(hidden)]`）。
+    #[doc(hidden)]
+    pub fn engine_lock_contention_arc(&self) -> Arc<AtomicU64> {
+        self.engine.contention_count_arc()
+    }
+
+    /// test harness 用: `Engine::poisoned_arc` の delegate。integration test から `store(true, ..)`
+    /// して 1 Hz ticker の `ENGINE_LOCK_POISONED` FATAL 発火を、実際に Mutex を panic-poison させずに
+    /// 駆動する（`#[doc(hidden)]`）。
+    #[doc(hidden)]
+    pub fn engine_lock_poisoned_arc(&self) -> Arc<AtomicBool> {
+        self.engine.poisoned_arc()
     }
 
     pub fn output_channels(&self) -> u16 {

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -913,6 +913,12 @@ impl EngineWrap {
         self.engine.now_sec()
     }
 
+    /// `Engine::with_scheduler`/`render_multi` が RT 競合で silent zero-fill にフォールバック
+    /// した累積回数（#401）。daemon の 1 Hz ticker が polling して増加を surface する health signal。
+    pub fn engine_lock_contention_count(&self) -> u64 {
+        self.engine.lock_contention_count()
+    }
+
     pub fn output_channels(&self) -> u16 {
         self.channels
     }

--- a/rust/crates/orbit-audio-daemon/src/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/src/protocol.rs
@@ -101,11 +101,18 @@ pub const ERROR_CODE_OUTPROC_EFFECT_RESPAWN: &str = "OUTPROC_EFFECT_RESPAWN";
 /// repeat-previous が出続ける = effect 経路のみ恒久停止）。daemon が 1 Hz ticker で `measurement_invalid`
 /// を検知して一度だけ発火する（fire-once・γ M1 PR-C）。
 pub const ERROR_CODE_OUTPROC_EFFECT_INVALID: &str = "OUTPROC_EFFECT_INVALID";
-/// `Engine` の内部 Mutex が RT 競合（`try_lock` 失敗）で silent zero-fill にフォールバックした。
-/// WARNING severity。この経路自体は既存の設計判断（lock-free 化は別 Issue で defer 済み・自己修復
-/// する障害で次のブロックで復帰する）だが、発生を可視化する仕組みが無かったため追加した（#401）。
-/// daemon が 1 Hz ticker で累積カウンタの増加を検知して発火する。
+/// `Engine` の内部 Mutex が RT `try_lock` で `WouldBlock`（一時競合）を返し silent zero-fill に
+/// フォールバックした。WARNING severity。この経路自体は既存の設計判断（lock-free 化は別 Issue で
+/// defer 済み）だが、発生を可視化する仕組みが無かったため追加した（#401）。`WouldBlock` は自己修復
+/// する障害（次のブロックで復帰）。daemon が 1 Hz ticker で累積カウンタの増加を検知して発火する。
 pub const ERROR_CODE_ENGINE_LOCK_CONTENTION: &str = "ENGINE_LOCK_CONTENTION";
+/// `Engine` の内部 Mutex が RT `try_lock` で `Poisoned`（別スレッドの panic による永続破損）と
+/// 判定された。**FATAL** severity — `DEVICE_LOST` と同様、`clear_poison()` を呼ぶ箇所が無いため
+/// 同一プロセス生存中は回復せず、以降の render は恒久的に zero-fill・制御系 API
+/// （schedule/stop/stop_all/set_global_gain）も `EngineError::Poisoned` を返し続ける（#401）。
+/// `ENGINE_LOCK_CONTENTION`（自己修復する `WouldBlock`）とは意味論が異なるため別コードにする。
+/// daemon が 1 Hz ticker でフラグを検知し、`device_lost` と同様 fire-once で発火する。
+pub const ERROR_CODE_ENGINE_LOCK_POISONED: &str = "ENGINE_LOCK_POISONED";
 
 /// Daemon → Client の event（通知、id なし）。
 #[derive(Debug, Serialize)]

--- a/rust/crates/orbit-audio-daemon/src/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/src/protocol.rs
@@ -101,6 +101,11 @@ pub const ERROR_CODE_OUTPROC_EFFECT_RESPAWN: &str = "OUTPROC_EFFECT_RESPAWN";
 /// repeat-previous が出続ける = effect 経路のみ恒久停止）。daemon が 1 Hz ticker で `measurement_invalid`
 /// を検知して一度だけ発火する（fire-once・γ M1 PR-C）。
 pub const ERROR_CODE_OUTPROC_EFFECT_INVALID: &str = "OUTPROC_EFFECT_INVALID";
+/// `Engine` の内部 Mutex が RT 競合（`try_lock` 失敗）で silent zero-fill にフォールバックした。
+/// WARNING severity。この経路自体は既存の設計判断（lock-free 化は別 Issue で defer 済み・自己修復
+/// する障害で次のブロックで復帰する）だが、発生を可視化する仕組みが無かったため追加した（#401）。
+/// daemon が 1 Hz ticker で累積カウンタの増加を検知して発火する。
+pub const ERROR_CODE_ENGINE_LOCK_CONTENTION: &str = "ENGINE_LOCK_CONTENTION";
 
 /// Daemon → Client の event（通知、id なし）。
 #[derive(Debug, Serialize)]

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -19,11 +19,11 @@ use tracing::warn;
 use crate::engine_wrap::{EngineWrap, WrapError};
 use crate::protocol::{
     Command, ErrorResponse, Event, Handshake, OkResponse, ProtocolError,
-    ERROR_CODE_CLAP_PROCESS_ERROR, ERROR_CODE_DEVICE_LOST, ERROR_CODE_LINK_EGRESS_DROP,
-    ERROR_CODE_OUTPROC_EFFECT_ERROR, ERROR_CODE_OUTPROC_EFFECT_INVALID,
-    ERROR_CODE_OUTPROC_EFFECT_RESPAWN, ERROR_CODE_STREAM_XRUN, ERROR_SEVERITY_FATAL,
-    ERROR_SEVERITY_WARNING, EVENT_DAEMON_ERROR, EVENT_PLAY_ENDED, EVENT_PLAY_STARTED,
-    EVENT_STREAM_STATS,
+    ERROR_CODE_CLAP_PROCESS_ERROR, ERROR_CODE_DEVICE_LOST, ERROR_CODE_ENGINE_LOCK_CONTENTION,
+    ERROR_CODE_LINK_EGRESS_DROP, ERROR_CODE_OUTPROC_EFFECT_ERROR,
+    ERROR_CODE_OUTPROC_EFFECT_INVALID, ERROR_CODE_OUTPROC_EFFECT_RESPAWN, ERROR_CODE_STREAM_XRUN,
+    ERROR_SEVERITY_FATAL, ERROR_SEVERITY_WARNING, EVENT_DAEMON_ERROR, EVENT_PLAY_ENDED,
+    EVENT_PLAY_STARTED, EVENT_STREAM_STATS,
 };
 
 /// writer task のキュー容量。過大に積まれると back pressure をかける。
@@ -82,6 +82,7 @@ pub async fn run(
             let mut last_clap_errors: u64 = 0;
             let mut last_outproc_errors: u64 = 0;
             let mut last_outproc_respawns: u64 = 0;
+            let mut last_engine_lock_contention: u64 = 0;
             let mut outproc_invalid_reported = false;
             let mut device_lost_reported = false;
             loop {
@@ -154,6 +155,26 @@ pub async fn run(
                         break;
                     }
                     last_clap_errors = clap_errors;
+                }
+
+                // Engine 内部 Mutex の RT 競合（try_lock 失敗 → silent zero-fill）を非 RT で
+                // surface（#401）。lock-free 化は別 Issue で defer 済みの既存判断のまま、発生の
+                // 可視化のみ追加。自己修復する障害（次のブロックで復帰）だが 32/64f 小バッファ
+                // 性能ゴール下ではライブコマンド頻度に比例して発生確率が上がる。
+                let engine_lock_contention = engine.engine_lock_contention_count();
+                if engine_lock_contention > last_engine_lock_contention {
+                    let evt = daemon_error_event(
+                        ERROR_SEVERITY_WARNING,
+                        ERROR_CODE_ENGINE_LOCK_CONTENTION,
+                        format!(
+                            "engine lock contention ({engine_lock_contention} total); a block \
+                             was silently zero-filled — this self-heals next block",
+                        ),
+                    );
+                    if tx.send(to_json_or_fallback(&evt)).await.is_err() {
+                        break;
+                    }
+                    last_engine_lock_contention = engine_lock_contention;
                 }
 
                 // out-of-process effect の health（γ M1 PR-C）を非 RT で surface。child の process() エラー

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -20,7 +20,7 @@ use crate::engine_wrap::{EngineWrap, WrapError};
 use crate::protocol::{
     Command, ErrorResponse, Event, Handshake, OkResponse, ProtocolError,
     ERROR_CODE_CLAP_PROCESS_ERROR, ERROR_CODE_DEVICE_LOST, ERROR_CODE_ENGINE_LOCK_CONTENTION,
-    ERROR_CODE_LINK_EGRESS_DROP, ERROR_CODE_OUTPROC_EFFECT_ERROR,
+    ERROR_CODE_ENGINE_LOCK_POISONED, ERROR_CODE_LINK_EGRESS_DROP, ERROR_CODE_OUTPROC_EFFECT_ERROR,
     ERROR_CODE_OUTPROC_EFFECT_INVALID, ERROR_CODE_OUTPROC_EFFECT_RESPAWN, ERROR_CODE_STREAM_XRUN,
     ERROR_SEVERITY_FATAL, ERROR_SEVERITY_WARNING, EVENT_DAEMON_ERROR, EVENT_PLAY_ENDED,
     EVENT_PLAY_STARTED, EVENT_STREAM_STATS,
@@ -85,6 +85,7 @@ pub async fn run(
             let mut last_engine_lock_contention: u64 = 0;
             let mut outproc_invalid_reported = false;
             let mut device_lost_reported = false;
+            let mut engine_lock_poisoned_reported = false;
             loop {
                 ticker.tick().await;
                 let snapshot = engine.stream_stats_snapshot();
@@ -101,6 +102,25 @@ pub async fn run(
                         break;
                     }
                     device_lost_reported = true;
+                }
+
+                // Engine 内部 Mutex が RT 競合で poisoned と判定された（#401）。`device_lost` と同じ
+                // 恒久障害クラス（`clear_poison()` を呼ぶ箇所が無く同一プロセス生存中は回復しない —
+                // render は恒久 zero-fill、schedule/stop 等の制御系 API も以降ずっとエラーを返す）
+                // なので FATAL・fire-once。"self-heals" と言い切る `ENGINE_LOCK_CONTENTION` の
+                // WARNING メッセージとは異なり、poisoned は自己修復しないことを明示する。
+                if engine.engine_lock_poisoned() && !engine_lock_poisoned_reported {
+                    let fatal_evt = daemon_error_event(
+                        ERROR_SEVERITY_FATAL,
+                        ERROR_CODE_ENGINE_LOCK_POISONED,
+                        "engine scheduler mutex poisoned by a panicking thread; audio output is \
+                         permanently down until daemon restart"
+                            .to_string(),
+                    );
+                    if tx.send(to_json_or_fallback(&fatal_evt)).await.is_err() {
+                        break;
+                    }
+                    engine_lock_poisoned_reported = true;
                 }
 
                 if snapshot.xruns > last_xruns {
@@ -157,10 +177,11 @@ pub async fn run(
                     last_clap_errors = clap_errors;
                 }
 
-                // Engine 内部 Mutex の RT 競合（try_lock 失敗 → silent zero-fill）を非 RT で
+                // Engine 内部 Mutex の RT 競合（try_lock が WouldBlock → silent zero-fill）を非 RT で
                 // surface（#401）。lock-free 化は別 Issue で defer 済みの既存判断のまま、発生の
-                // 可視化のみ追加。自己修復する障害（次のブロックで復帰）だが 32/64f 小バッファ
-                // 性能ゴール下ではライブコマンド頻度に比例して発生確率が上がる。
+                // 可視化のみ追加。WouldBlock は自己修復する障害（次のブロックで復帰）だが 32/64f
+                // 小バッファ性能ゴール下ではライブコマンド頻度に比例して発生確率が上がる。
+                // 恒久障害（Poisoned）はこのカウンタに含めない — 上の ENGINE_LOCK_POISONED FATAL 参照。
                 let engine_lock_contention = engine.engine_lock_contention_count();
                 if engine_lock_contention > last_engine_lock_contention {
                     let evt = daemon_error_event(

--- a/rust/crates/orbit-audio-daemon/tests/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/tests/protocol.rs
@@ -612,6 +612,144 @@ async fn daemon_error_warning_on_clap_process_error() {
     );
 }
 
+/// engine lock contention（try_lock の WouldBlock）が増えると
+/// DaemonError (severity=warning, code=ENGINE_LOCK_CONTENTION) が発火する（#401）。
+/// LINK_EGRESS_DROP/CLAP_PROCESS_ERROR と同じ 1 Hz ticker 経路。`engine_lock_contention_arc` の
+/// **本番と同一 counter に直接書く注入 seam**（`Engine::contention_count_arc` の delegate）で
+/// この event を driver する。
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn daemon_error_warning_on_engine_lock_contention() {
+    let daemon = TestDaemon::start().await;
+    let mut ws = daemon.connect().await;
+    let _hs = TestDaemon::recv_handshake(&mut ws).await;
+
+    // 外部から lock contention を注入（1 Hz ticker が engine_lock_contention_count の増加を検知）。
+    daemon
+        .engine
+        .engine_lock_contention_arc()
+        .fetch_add(7, std::sync::atomic::Ordering::Relaxed);
+
+    advance_and_yield(Duration::from_millis(1_100)).await;
+
+    let mut warning_message: Option<String> = None;
+    for _ in 0..6 {
+        let res = tokio::time::timeout(Duration::from_millis(50), next_json(&mut ws)).await;
+        match res {
+            Ok(msg) => {
+                if msg["event"] == "DaemonError"
+                    && msg["data"]["severity"] == "warning"
+                    && msg["data"]["code"] == "ENGINE_LOCK_CONTENTION"
+                {
+                    warning_message =
+                        Some(msg["data"]["message"].as_str().unwrap_or("").to_string());
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    let message = warning_message.expect("ENGINE_LOCK_CONTENTION warning event not received");
+    // message は累積カウント（7）と self-heals の説明を含む = WouldBlock（一時競合）専用の
+    // メッセージであり、恒久障害（poisoned）のメッセージと混同していないこと。
+    assert!(
+        message.contains('7'),
+        "ENGINE_LOCK_CONTENTION message should carry the running total, got: {message}"
+    );
+    assert!(
+        message.contains("self-heals"),
+        "WouldBlock contention message should claim self-healing, got: {message}"
+    );
+
+    // latch: 追加注入なしで次 tick へ進めても再発火しない。
+    advance_and_yield(Duration::from_millis(1_100)).await;
+    let mut refired = false;
+    for _ in 0..6 {
+        let res = tokio::time::timeout(Duration::from_millis(50), next_json(&mut ws)).await;
+        match res {
+            Ok(msg) => {
+                if msg["event"] == "DaemonError" && msg["data"]["code"] == "ENGINE_LOCK_CONTENTION"
+                {
+                    refired = true;
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    assert!(
+        !refired,
+        "ENGINE_LOCK_CONTENTION must not re-fire without additional contention (latch regression)"
+    );
+}
+
+/// engine の scheduler mutex が poisoned と判定されると
+/// DaemonError (severity=fatal, code=ENGINE_LOCK_POISONED) が発火する（#401）。DEVICE_LOST と同じ
+/// fire-once の恒久障害クラス。実際に Mutex を panic で poison させる代わりに、
+/// `engine_lock_poisoned_arc`（`Engine::poisoned_arc` の delegate）で直接フラグを注入する
+/// （`Engine` 側の genuine-poison 検証は `orbit-audio-core::engine::tests` の
+/// `poisoned_flag_sets_on_render_lock_poison_distinct_from_contention_count` が担う）。
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn daemon_error_fatal_on_engine_lock_poisoned() {
+    let daemon = TestDaemon::start().await;
+    let mut ws = daemon.connect().await;
+    let _hs = TestDaemon::recv_handshake(&mut ws).await;
+
+    daemon
+        .engine
+        .engine_lock_poisoned_arc()
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+
+    advance_and_yield(Duration::from_millis(1_100)).await;
+
+    let mut fatal_message: Option<String> = None;
+    for _ in 0..6 {
+        let res = tokio::time::timeout(Duration::from_millis(50), next_json(&mut ws)).await;
+        match res {
+            Ok(msg) => {
+                if msg["event"] == "DaemonError"
+                    && msg["data"]["severity"] == "fatal"
+                    && msg["data"]["code"] == "ENGINE_LOCK_POISONED"
+                {
+                    fatal_message = Some(msg["data"]["message"].as_str().unwrap_or("").to_string());
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    let message = fatal_message.expect("ENGINE_LOCK_POISONED fatal event not received");
+    // poisoned は恒久障害なので "self-heals" を名乗ってはいけない
+    // （ENGINE_LOCK_CONTENTION の WARNING メッセージと取り違えていないこと）。
+    assert!(
+        !message.contains("self-heals"),
+        "poisoned message must not claim self-healing, got: {message}"
+    );
+    assert!(
+        message.contains("restart"),
+        "poisoned message should say audio is down until restart, got: {message}"
+    );
+
+    // fire-once: フラグを立てたまま次 tick へ進めても再発火しない（device_lost_reported と同じ latch）。
+    advance_and_yield(Duration::from_millis(1_100)).await;
+    let mut refired = false;
+    for _ in 0..6 {
+        let res = tokio::time::timeout(Duration::from_millis(50), next_json(&mut ws)).await;
+        match res {
+            Ok(msg) => {
+                if msg["event"] == "DaemonError" && msg["data"]["code"] == "ENGINE_LOCK_POISONED" {
+                    refired = true;
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    assert!(
+        !refired,
+        "ENGINE_LOCK_POISONED must not re-fire once latched (fire-once regression)"
+    );
+}
+
 /// device_lost が記録されると DaemonError (severity=fatal, code=DEVICE_LOST) が発火する。
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn daemon_error_fatal_on_device_lost() {

--- a/rust/crates/orbit-audio-daemon/tests/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/tests/protocol.rs
@@ -750,6 +750,62 @@ async fn daemon_error_fatal_on_engine_lock_poisoned() {
     );
 }
 
+/// contention（WouldBlock）と poisoned が同一 tick で両方成立した場合、
+/// ENGINE_LOCK_CONTENTION (warning) と ENGINE_LOCK_POISONED (fatal) の両方が配信され、
+/// かつ `session.rs` のティッカーループが poisoned/FATAL チェックを contention/WARNING
+/// チェックより先に実行する実装順序（#401）どおり、FATAL が先に届くことを検証する
+/// （WS client がイベントを順番に処理する前提のため、存在確認だけでなく到着順も pin する）。
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn daemon_error_both_contention_and_poisoned_fire_same_tick_fatal_first() {
+    let daemon = TestDaemon::start().await;
+    let mut ws = daemon.connect().await;
+    let _hs = TestDaemon::recv_handshake(&mut ws).await;
+
+    // 同一 tick 内で両方の条件を成立させる。
+    daemon
+        .engine
+        .engine_lock_contention_arc()
+        .fetch_add(3, std::sync::atomic::Ordering::Relaxed);
+    daemon
+        .engine
+        .engine_lock_poisoned_arc()
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+
+    advance_and_yield(Duration::from_millis(1_100)).await;
+
+    // StreamStats 等の他イベントを読み飛ばしつつ、ENGINE_LOCK_POISONED と
+    // ENGINE_LOCK_CONTENTION の DaemonError が届いた順序を記録する。
+    let mut order: Vec<String> = Vec::new();
+    for _ in 0..12 {
+        let res = tokio::time::timeout(Duration::from_millis(50), next_json(&mut ws)).await;
+        match res {
+            Ok(msg) => {
+                if msg["event"] == "DaemonError" {
+                    if let Some(code) = msg["data"]["code"].as_str() {
+                        if code == "ENGINE_LOCK_POISONED" || code == "ENGINE_LOCK_CONTENTION" {
+                            order.push(code.to_string());
+                        }
+                    }
+                }
+                if order.len() == 2 {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+
+    assert_eq!(
+        order,
+        vec![
+            "ENGINE_LOCK_POISONED".to_string(),
+            "ENGINE_LOCK_CONTENTION".to_string(),
+        ],
+        "both events must be delivered, with FATAL (poisoned) arriving before WARNING \
+         (contention) — session.rs's ticker checks poisoned before contention, got: {order:?}"
+    );
+}
+
 /// device_lost が記録されると DaemonError (severity=fatal, code=DEVICE_LOST) が発火する。
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn daemon_error_fatal_on_device_lost() {


### PR DESCRIPTION
## Summary

- M2 instrument IPC substrate（#398）の容量設計を検討する過程で、Fable の拡張レビューが新たに発見した箇所。`orbit-audio-core::Engine::with_scheduler`/`render_multi` は RT 競合（`try_lock` 失敗）時に出力バッファを silent zero-fill する既存設計（lock-free 化は別 Issue で defer 済み・自己修復する障害）だったが、発生を可視化する仕組みが一切なかった。
- `Engine` に `contention_count` を追加し、両 silent-drop 分岐で増分。daemon 側は `ERROR_CODE_ENGINE_LOCK_CONTENTION` を新設し既存の 1Hz ticker パターンに配線。

## Test plan

- [x] `cargo build -p orbit-audio-daemon`(default/clap-host/outproc-effect) — 全緑
- [x] `cargo clippy --all-targets -D warnings`(orbit-audio-core含む4構成) — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace` — 全緑（新規 unit test 2本含む）
- [x] `cargo deny check licenses` — ok

Refs #401 #398

https://claude.ai/code/session_01UoMuPtdbm1Zm1mLrEbhCFe