### PR TITLE
fix(engine): surface out-of-process effect frames_clamped counter

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,16 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.222 refactor(engine): outproc_health アクセサ統合 + frames_clamped の test seam 追加（#406） (Jul 12, 2026)
+
+PR #406（6.221 の frames_clamped 可視化）に対する `/simplify` 4並列レビュー（reuse/simplification/efficiency/altitude）が独立に収束した2件を修正。
+
+- **Finding 1（simplification + efficiency の独立一致）**: `EngineWrap::outproc_health()` と新設 `outproc_frames_clamped()` が同一 tick 内で同一 `self.outproc` mutex に対し個別に `try_lock()` + `.snapshot()` していた（冗長ロック・かつ2呼び出しが同一スナップショットを観測する保証が無い＝片方 `WouldBlock` で 0 を返す間にもう片方が非ゼロを観測しうる）。`outproc_health()` の戻り値を `(u64, u64, bool)` → `(u64, u64, bool, u64)` に拡張し、単一の `try_lock` + `snapshot` で4 signal（`child_process_error_count`/`respawn_count`/`measurement_invalid`/`frames_clamped`）を返すよう統合。独立 `outproc_frames_clamped()`（有効/無効ビルド両方の実装）を削除し、`session.rs` のticker loop を4要素destructureに更新（呼び出し箇所は `rg` で `session.rs:163` の1箇所のみと確認済み）。
+- **Finding 2（reuse + altitude の独立一致・履歴根拠あり）**: `link_egress_drops`+`link_egress_drops_arc()`（PR #331）・`clap_process_errors`+`clap_process_errors_arc()`（PR #340）に既に確立していた「counter field + `#[doc(hidden)] *_arc()` injection accessor + `tests/protocol.rs` latch test」パターンが `frames_clamped` には無く（非 outproc-effect ビルドの stub が固定 `return 0`）、default feature build でこの signal を exercise するテストが存在しなかった。altitude レビューが指摘した通り `frames_clamped` は gated 実機テストの現実的な駆動経路も無い（outproc_health の他3 signal は kill-test で強制可能）ため、test seam は「あれば尚良い」ではなく必須。`outproc_frames_clamped: Arc<AtomicU64>` フィールド（unconditional）+ `outproc_frames_clamped_arc()`（`#[doc(hidden)]`・unconditional）を追加し、consolidated `outproc_health()` の frames_clamped を `s.frames_clamped + injected` で合算。`tests/protocol.rs` に `daemon_error_warning_on_outproc_frames_clamped`（`daemon_error_warning_on_link_egress_drop`/`_clap_process_error` と同型・発火 + latch 非再発火を検証）を追加。**scope外**: 既存3 signal（`OUTPROC_EFFECT_ERROR`/`RESPAWN`/`INVALID`）への同種seam retrofit はこのPRの対象外（frames_clamped固有の穴のみ埋める）。
+- **検証**: `cargo build`(default/outproc-effect/clap-host 3構成) / `cargo test --lib`(outproc-effect) / `cargo test --test protocol`(default・20 passed、うち新規1件) / `cargo clippy --workspace --all-targets -D warnings`(default) + 同(outproc-effect) + 同(clap-host) / `cargo fmt --all` すべて green。
+- **役割**: 発見=`/simplify` 4並列レビュー(独立収束) / 実装・検証=Opus main(直接実装)。
+- **状態**: PR #406 への追加コミット。
+
 ### 6.221 fix(engine): out-of-process effect の frames_clamped カウンターを可視化（#404） (Jul 12, 2026)
 
 M2 instrument IPC substrate（#398）の容量設計を検討する過程で、fresh agent（opus）による拡張監査（#400/#401 の Fable 発見を受けた TS層+grepパターン非依存の追加調査）が発見した箇所。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,16 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.221 fix(engine): out-of-process effect の frames_clamped カウンターを可視化（#404） (Jul 12, 2026)
+
+M2 instrument IPC substrate（#398）の容量設計を検討する過程で、fresh agent（opus）による拡張監査（#400/#401 の Fable 発見を受けた TS層+grepパターン非依存の追加調査）が発見した箇所。
+
+- **問題**: `orbit-audio-sandbox`（out-of-process effect transport・`MAX_FRAMES=4096`）で、1ブロックがこれを超えると末尾を無音化し `frames_clamped` カウンターに記録する仕組みは既に実装済み（`OutProcEffectStats::frames_clamped`・`snapshot()` にも含まれる）だったが、`EngineWrap::outproc_health()` が返すタプルに含まれておらず、他の兄弟カウンター（`CLAP_PROCESS_ERROR`・`OUTPROC_EFFECT_ERROR`等）と違って daemon の 1Hz ticker に一度も配線されていなかった。
+- **修正**: 既存タプルを変更せず、新規 `EngineWrap::outproc_frames_clamped()` accessor（`outproc_health` と同じ try_lock 規約）を追加し、`ERROR_CODE_OUTPROC_EFFECT_FRAMES_CLAMPED`（新設）で 1Hz ticker に配線。カウント自体のロジックは `orbit-audio-sandbox` 側で既にテスト済みのため、今回は plumbing のみ（新規 unit test は追加せず、既存の `outproc_health()` と同型の untested accessor パターンに合わせた）。
+- **検証**: `cargo build`(default/outproc-effect/clap-host)・`cargo clippy --all-targets -D warnings`(同3構成)・`cargo fmt --check`・`cargo test --workspace`(全緑)・`cargo deny check licenses`(ok)を確認。
+- **役割**: 発見=fresh agent(opus) / 実装・検証=Opus main(直接実装)。
+- **状態**: M2(#398)とは独立スコープ。PR 作成 → owner マージ待ち。
+
 ### 6.220 fix(engine): VST3 host unsafe memory-safety 監査 + hardening 3件（#397） (Jul 11, 2026)
 
 中核の手書き unsafe COM FFI（`orbit-vst3-host/src/lib.rs`・80 unsafe blocks）に対し、`/code:pr-review-team`（汎用 correctness）が構造的に狙わない **memory-safety/UB 次元**の外部第二意見を実施。@claude bot は pr-review-team と同一モデルファミリで盲点が相関するため除外し、**codex（cross-family）+ fresh Opus（非著者）を並列 adversarial 監査 → advisor で tie-break**（[[consult-layering-by-error-type]] の分担）。

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -836,6 +836,35 @@ impl EngineWrap {
         (0, 0, false)
     }
 
+    /// OOP effect の block が `MAX_FRAMES`（`orbit-audio-sandbox`）を超えて clamp された累積回数
+    /// （#404）。既に `OutProcEffectStats::frames_clamped` として計測されていたが、`outproc_health`
+    /// が返すタプルに含まれておらず daemon の 1 Hz ticker に一度も配線されていなかった。通常は 0 の
+    /// まま推移する health signal（32/64f 小バッファ運用では実質到達不能・大バッファ/変則デバイス
+    /// 構成でのみ意味を持つ）。`outproc_health` と同じ `try_lock` 規約に従う。
+    #[cfg(feature = "outproc-effect")]
+    pub fn outproc_frames_clamped(&self) -> u64 {
+        match self.outproc.try_lock() {
+            Ok(g) => g
+                .as_ref()
+                .map(|c| c.stats.snapshot().frames_clamped)
+                .unwrap_or(0),
+            Err(std::sync::TryLockError::WouldBlock) => 0,
+            Err(std::sync::TryLockError::Poisoned(_)) => {
+                tracing::warn!(
+                    "outproc mutex poisoned; outproc_frames_clamped reporting 0 \
+                     (OUTPROC_EFFECT_FRAMES_CLAMPED suppressed until daemon restart)"
+                );
+                0
+            }
+        }
+    }
+
+    /// feature `outproc-effect` 無効ビルド用の stub。本番は常に 0（control が無い）。
+    #[cfg(not(feature = "outproc-effect"))]
+    pub fn outproc_frames_clamped(&self) -> u64 {
+        0
+    }
+
     /// 全 LinkAudio channel の ring overflow drop（interleaved サンプル数）の累積合計（A4-2b-2b）。
     /// daemon の 1 Hz ticker が polling して増加を WARNING event で surface する（非 RT observability）。
     /// link 未初期化（test backend）時は control 分が 0。test 注入分（本番 0）を必ず加える。

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -84,6 +84,13 @@ pub struct EngineWrap {
     /// 本番の error は clap mutex 内の `ClapProcessorStats::process_error_count` が供給するので、
     /// production read-path ではこの addend は常に 0（`link_egress_drops` と同設計）。
     clap_process_errors: Arc<AtomicU64>,
+    /// OOP effect `frames_clamped` の **test 注入用** カウンタ（本番は常に 0）。`outproc_health` が
+    /// これを加算する。integration test は child process を spawn しない（= 実 clamp 源が無い）ため、
+    /// この counter が outproc-effect feature の有無に依らず 1 Hz ticker の
+    /// OUTPROC_EFFECT_FRAMES_CLAMPED 発火を駆動する唯一の seam になる（[`Self::outproc_frames_clamped_arc`]）。
+    /// `link_egress_drops` / `clap_process_errors` と同設計（#406 /simplify: 専用 seam が無いと
+    /// この signal はどのテストからも exercise できなかった）。
+    outproc_frames_clamped: Arc<AtomicU64>,
     /// LinkAudio egress の control-side ハンドル（feature `link-audio` 専用・A4-2b-2）。
     /// reg-ring push / mpsc send が内部可変性（`&mut LinkAudioControl`）を要する一方、`EngineWrap`
     /// は `Arc` 共有で `&self` しか持てない。`Mutex` で内包することで `register_link_audio_channel`
@@ -484,6 +491,7 @@ impl EngineWrap {
             stopped_play_ids: Mutex::new(HashSet::new()),
             link_egress_drops: Arc::new(AtomicU64::new(0)),
             clap_process_errors: Arc::new(AtomicU64::new(0)),
+            outproc_frames_clamped: Arc::new(AtomicU64::new(0)),
             // 本番 `start()`（feature 時）が spawn 後に Some を注入する。test backend 経路は None。
             #[cfg(feature = "link-audio")]
             link: Mutex::new(None),
@@ -800,13 +808,21 @@ impl EngineWrap {
         }
     }
 
-    /// OOP effect の health signal を `(child_process_error_count, respawn_count, measurement_invalid)` で
-    /// 返す（daemon の 1 Hz ticker が polling して WARNING/FATAL event で surface する非 RT observability）。
-    /// `clap_process_error_count` と同様 `try_lock` で ticker をブロックしない（**WouldBlock** は cumulative
-    /// なので次 tick が全累積を報告・**Poisoned** は warn して 0 を返し post-mortem の根拠を残す）。
-    /// plugin 未起動 / outproc 無効時は `(0, 0, false)`。
+    /// OOP effect の health signal を `(child_process_error_count, respawn_count, measurement_invalid,
+    /// frames_clamped)` で返す（daemon の 1 Hz ticker が polling して WARNING/FATAL event で surface する
+    /// 非 RT observability）。`clap_process_error_count` と同様 `try_lock` で ticker をブロックしない
+    /// （**WouldBlock** は cumulative なので次 tick が全累積を報告・**Poisoned** は warn して 0 を返し
+    /// post-mortem の根拠を残す）。plugin 未起動 / outproc 無効時は `(0, 0, false, <injected>)`。
+    ///
+    /// `frames_clamped` は #404 で `OutProcEffectStats` から追加した 4 つ目の signal（block が
+    /// `MAX_FRAMES` を超えて clamp された累積回数）。当初は独立した `outproc_frames_clamped()`
+    /// accessor だったが、同一 tick 内で同一 `self.outproc` mutex を 2 回 `try_lock` + `snapshot` する
+    /// ことになり（(a) 無駄な二重ロック (b) 4 signal が同一スナップショットである保証が消える —
+    /// 片方が `WouldBlock` で 0 を返す間にもう片方が非ゼロを観測しうる）、#406 /simplify レビューで
+    /// この 1 accessor に統合した。
     #[cfg(feature = "outproc-effect")]
-    pub fn outproc_health(&self) -> (u64, u64, bool) {
+    pub fn outproc_health(&self) -> (u64, u64, bool, u64) {
+        let injected = self.outproc_frames_clamped.load(Ordering::Relaxed);
         match self.outproc.try_lock() {
             Ok(g) => g
                 .as_ref()
@@ -816,53 +832,32 @@ impl EngineWrap {
                         s.child_process_error_count,
                         s.respawn_count,
                         s.measurement_invalid,
+                        s.frames_clamped + injected,
                     )
                 })
-                .unwrap_or((0, 0, false)),
-            Err(std::sync::TryLockError::WouldBlock) => (0, 0, false),
+                .unwrap_or((0, 0, false, injected)),
+            Err(std::sync::TryLockError::WouldBlock) => (0, 0, false, injected),
             Err(std::sync::TryLockError::Poisoned(_)) => {
                 tracing::warn!(
                     "outproc mutex poisoned; outproc_health reporting zeros \
                      (OUTPROC_EFFECT events suppressed until daemon restart)"
                 );
-                (0, 0, false)
+                (0, 0, false, injected)
             }
         }
     }
 
-    /// feature `outproc-effect` 無効ビルド用の stub。本番は常に `(0, 0, false)`（control が無い）。
+    /// feature `outproc-effect` 無効ビルド用の stub。本番は常に `(0, 0, false, ...)`（control が無い）。
+    /// `frames_clamped` は test 注入分のみ反映（`link_egress_ring_drops` / `clap_process_error_count`
+    /// の無効ビルド stub と同設計）。
     #[cfg(not(feature = "outproc-effect"))]
-    pub fn outproc_health(&self) -> (u64, u64, bool) {
-        (0, 0, false)
-    }
-
-    /// OOP effect の block が `MAX_FRAMES`（`orbit-audio-sandbox`）を超えて clamp された累積回数
-    /// （#404）。既に `OutProcEffectStats::frames_clamped` として計測されていたが、`outproc_health`
-    /// が返すタプルに含まれておらず daemon の 1 Hz ticker に一度も配線されていなかった。通常は 0 の
-    /// まま推移する health signal（32/64f 小バッファ運用では実質到達不能・大バッファ/変則デバイス
-    /// 構成でのみ意味を持つ）。`outproc_health` と同じ `try_lock` 規約に従う。
-    #[cfg(feature = "outproc-effect")]
-    pub fn outproc_frames_clamped(&self) -> u64 {
-        match self.outproc.try_lock() {
-            Ok(g) => g
-                .as_ref()
-                .map(|c| c.stats.snapshot().frames_clamped)
-                .unwrap_or(0),
-            Err(std::sync::TryLockError::WouldBlock) => 0,
-            Err(std::sync::TryLockError::Poisoned(_)) => {
-                tracing::warn!(
-                    "outproc mutex poisoned; outproc_frames_clamped reporting 0 \
-                     (OUTPROC_EFFECT_FRAMES_CLAMPED suppressed until daemon restart)"
-                );
-                0
-            }
-        }
-    }
-
-    /// feature `outproc-effect` 無効ビルド用の stub。本番は常に 0（control が無い）。
-    #[cfg(not(feature = "outproc-effect"))]
-    pub fn outproc_frames_clamped(&self) -> u64 {
-        0
+    pub fn outproc_health(&self) -> (u64, u64, bool, u64) {
+        (
+            0,
+            0,
+            false,
+            self.outproc_frames_clamped.load(Ordering::Relaxed),
+        )
     }
 
     /// 全 LinkAudio channel の ring overflow drop（interleaved サンプル数）の累積合計（A4-2b-2b）。
@@ -910,6 +905,15 @@ impl EngineWrap {
     #[doc(hidden)]
     pub fn clap_process_errors_arc(&self) -> Arc<AtomicU64> {
         self.clap_process_errors.clone()
+    }
+
+    /// test harness 用: OOP effect `frames_clamped` の注入カウンタを取得する。`link_egress_drops_arc` /
+    /// `clap_process_errors_arc` と同形で、下層 counter は本番経路から分離した注入専用（本番 0）。
+    /// integration test から `fetch_add` して 1 Hz ticker の OUTPROC_EFFECT_FRAMES_CLAMPED 発火を
+    /// 駆動する（child process 不要・#406）。`#[doc(hidden)]`。
+    #[doc(hidden)]
+    pub fn outproc_frames_clamped_arc(&self) -> Arc<AtomicU64> {
+        self.outproc_frames_clamped.clone()
     }
 
     /// test harness 用: `StreamStats` への参照を取得し、外部から

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -1249,3 +1249,118 @@ mod capture_path_tests {
         );
     }
 }
+
+/// `outproc_health()` の real body（`#[cfg(feature = "outproc-effect")]`）を直接叩く unit test。
+///
+/// `tests/protocol.rs` の統合テストは default feature build（`outproc-effect` 無効）で走るため、
+/// stub（`(0, 0, false, injected)`）しか exercise できず、この real body の match arm は
+/// どのテストからも一度も compile even されていなかった（#406 pr-test-analyzer 指摘）。
+/// ここは同一 crate 内の `#[cfg(test)]` submodule なので `EngineWrap::outproc`（private field）
+/// と `OutProcControl`（private struct）へ直接アクセスできる（親モジュールの private item は子
+/// module から可視）。`OutProcEffectStats::new()` / `CallbackTimeStats::new()` はどちらも
+/// child process 不要の cheap constructor（plain atomic のみ）なので、`StubBackend` で起動した
+/// `EngineWrap` に対して real child を spawn せず `Some(OutProcControl)` を注入できる。
+#[cfg(all(test, feature = "outproc-effect"))]
+mod outproc_health_tests {
+    use super::{EngineWrap, OutProcControl};
+    use crate::backend::StubBackend;
+    use crate::outproc_effect::OutProcEffectStats;
+    use orbit_audio_native::CallbackTimeStats;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    /// `StubBackend` で `EngineWrap` を起動し、real child なしで組み立てた `OutProcControl` を
+    /// `self.outproc` に注入する。返す `Arc<OutProcEffectStats>` はテスト側から直接
+    /// `store`/`load` して `Ok(Some(c))` real-value summing 経路を駆動するのに使う。
+    fn wrap_with_outproc_stats() -> (Arc<EngineWrap>, Arc<OutProcEffectStats>) {
+        let (wrap, _guard) =
+            EngineWrap::start_with(StubBackend::default()).expect("stub backend start");
+        let stats = OutProcEffectStats::new();
+        *wrap.outproc.lock().expect("lock outproc for injection") = Some(OutProcControl {
+            stats: stats.clone(),
+            cb_stats: CallbackTimeStats::new(),
+        });
+        (wrap, stats)
+    }
+
+    #[test]
+    fn ok_none_reports_only_injected_frames_clamped() {
+        // outproc 未注入（build() 直後の初期値）= Ok(None) 分岐。
+        let (wrap, _guard) =
+            EngineWrap::start_with(StubBackend::default()).expect("stub backend start");
+        wrap.outproc_frames_clamped_arc()
+            .fetch_add(7, Ordering::Relaxed);
+        assert_eq!(wrap.outproc_health(), (0, 0, false, 7));
+    }
+
+    #[test]
+    fn ok_some_sums_real_stats_with_injected_counter() {
+        // Ok(Some(c)) 分岐: 実 OutProcEffectStats スナップショットと injected カウンタを両方
+        // 合算して返すこと（finding 3: 実 stats の summing が一度も exercise されていなかった）。
+        let (wrap, stats) = wrap_with_outproc_stats();
+        stats.child_process_error_count.store(3, Ordering::Relaxed);
+        stats.respawn_count.store(2, Ordering::Relaxed);
+        stats.measurement_invalid.store(true, Ordering::Relaxed);
+        stats.frames_clamped.store(5, Ordering::Relaxed);
+        wrap.outproc_frames_clamped_arc()
+            .fetch_add(9, Ordering::Relaxed);
+
+        assert_eq!(wrap.outproc_health(), (3, 2, true, 14));
+    }
+
+    #[test]
+    fn would_block_ignores_real_stats_and_reports_only_injected() {
+        // WouldBlock 分岐: 別スレッドが outproc mutex を保持している間は real stats を読まず
+        // injected カウンタのみ返すこと（cumulative なので次 tick で real 分も取り戻せる設計）。
+        let (wrap, stats) = wrap_with_outproc_stats();
+        stats.frames_clamped.store(100, Ordering::Relaxed);
+        wrap.outproc_frames_clamped_arc()
+            .fetch_add(1, Ordering::Relaxed);
+
+        let wrap_clone = wrap.clone();
+        let (holding_tx, holding_rx) = std::sync::mpsc::channel::<()>();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let holder = std::thread::spawn(move || {
+            let _guard = wrap_clone
+                .outproc
+                .lock()
+                .expect("lock outproc for contention setup");
+            holding_tx.send(()).expect("signal lock held");
+            release_rx.recv().expect("wait for release signal");
+        });
+        holding_rx.recv().expect("holder thread signaled lock held");
+
+        assert_eq!(wrap.outproc_health(), (0, 0, false, 1));
+
+        release_tx.send(()).expect("signal release");
+        holder.join().expect("holder thread should not panic");
+    }
+
+    #[test]
+    fn poisoned_still_reports_injected_frames_clamped_not_lost() {
+        // Poisoned 分岐: real stats は 0 に丸めるが、injected の frames_clamped は黙って
+        // 失わず返すこと（finding 2: silent-failure-hunter が指摘した「値が消えないこと」の
+        // 直接検証。手法は PR #403 の genuine-poison パターン（別スレッドで panic → join）を流用）。
+        let (wrap, stats) = wrap_with_outproc_stats();
+        stats.frames_clamped.store(42, Ordering::Relaxed);
+        wrap.outproc_frames_clamped_arc()
+            .fetch_add(3, Ordering::Relaxed);
+
+        let wrap_clone = wrap.clone();
+        let panicked = std::thread::spawn(move || {
+            let _guard = wrap_clone
+                .outproc
+                .lock()
+                .expect("lock outproc for poison setup");
+            panic!("intentional poison for outproc_health poisoned test");
+        })
+        .join()
+        .is_err();
+        assert!(
+            panicked,
+            "spawned thread should have panicked while holding the lock"
+        );
+
+        assert_eq!(wrap.outproc_health(), (0, 0, false, 3));
+    }
+}

--- a/rust/crates/orbit-audio-daemon/src/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/src/protocol.rs
@@ -101,6 +101,11 @@ pub const ERROR_CODE_OUTPROC_EFFECT_RESPAWN: &str = "OUTPROC_EFFECT_RESPAWN";
 /// repeat-previous が出続ける = effect 経路のみ恒久停止）。daemon が 1 Hz ticker で `measurement_invalid`
 /// を検知して一度だけ発火する（fire-once・γ M1 PR-C）。
 pub const ERROR_CODE_OUTPROC_EFFECT_INVALID: &str = "OUTPROC_EFFECT_INVALID";
+/// OOP effect の block が `MAX_FRAMES`（`orbit-audio-sandbox`）を超えて clamp され、末尾が
+/// 無音化された。WARNING severity。カウンタ自体は既に計測されていたが、1 Hz ticker への配線が
+/// 欠けていたため追加した（#404）。通常は 0 のまま推移する想定（32/64f 小バッファ運用では
+/// 実質到達不能）。
+pub const ERROR_CODE_OUTPROC_EFFECT_FRAMES_CLAMPED: &str = "OUTPROC_EFFECT_FRAMES_CLAMPED";
 
 /// Daemon → Client の event（通知、id なし）。
 #[derive(Debug, Serialize)]

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -158,9 +158,13 @@ pub async fn run(
                 }
 
                 // out-of-process effect の health（γ M1 PR-C）を非 RT で surface。child の process() エラー
-                // / crash→respawn / supervise 不能（計測無効）を 1 Hz ticker で検知して event を出す（CLAP
-                // 経路と同設計。outproc 無効 / 異常なしは (0,0,false) のまま発火しない）。
-                let (outproc_errors, outproc_respawns, outproc_invalid) = engine.outproc_health();
+                // / crash→respawn / supervise 不能（計測無効）/ frames_clamped（#404）を 1 Hz ticker で
+                // 検知して event を出す（CLAP 経路と同設計。outproc 無効 / 異常なしは (0,0,false,0) のまま
+                // 発火しない）。4 signal を 1 回の try_lock + snapshot にまとめて読む（#406 /simplify:
+                // 個別 accessor だと同一 mutex を同一 tick 内で複数回 lock し、かつ同一スナップショットを
+                // 観測する保証がなくなる）。
+                let (outproc_errors, outproc_respawns, outproc_invalid, outproc_frames_clamped) =
+                    engine.outproc_health();
                 if outproc_errors > last_outproc_errors {
                     let evt = daemon_error_event(
                         ERROR_SEVERITY_WARNING,
@@ -205,8 +209,8 @@ pub async fn run(
                 }
 
                 // OOP effect の block が MAX_FRAMES を超えて clamp された累積回数を非 RT で
-                // surface（#404）。カウンタ自体は既存だったが ticker 未配線だったため追加。
-                let outproc_frames_clamped = engine.outproc_frames_clamped();
+                // surface（#404）。カウンタ自体は既存だったが ticker 未配線だったため追加。#406 で
+                // outproc_health() に統合済み（上で destructure 済みの値をそのまま使う）。
                 if outproc_frames_clamped > last_outproc_frames_clamped {
                     let evt = daemon_error_event(
                         ERROR_SEVERITY_WARNING,

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -20,10 +20,10 @@ use crate::engine_wrap::{EngineWrap, WrapError};
 use crate::protocol::{
     Command, ErrorResponse, Event, Handshake, OkResponse, ProtocolError,
     ERROR_CODE_CLAP_PROCESS_ERROR, ERROR_CODE_DEVICE_LOST, ERROR_CODE_LINK_EGRESS_DROP,
-    ERROR_CODE_OUTPROC_EFFECT_ERROR, ERROR_CODE_OUTPROC_EFFECT_INVALID,
-    ERROR_CODE_OUTPROC_EFFECT_RESPAWN, ERROR_CODE_STREAM_XRUN, ERROR_SEVERITY_FATAL,
-    ERROR_SEVERITY_WARNING, EVENT_DAEMON_ERROR, EVENT_PLAY_ENDED, EVENT_PLAY_STARTED,
-    EVENT_STREAM_STATS,
+    ERROR_CODE_OUTPROC_EFFECT_ERROR, ERROR_CODE_OUTPROC_EFFECT_FRAMES_CLAMPED,
+    ERROR_CODE_OUTPROC_EFFECT_INVALID, ERROR_CODE_OUTPROC_EFFECT_RESPAWN, ERROR_CODE_STREAM_XRUN,
+    ERROR_SEVERITY_FATAL, ERROR_SEVERITY_WARNING, EVENT_DAEMON_ERROR, EVENT_PLAY_ENDED,
+    EVENT_PLAY_STARTED, EVENT_STREAM_STATS,
 };
 
 /// writer task のキュー容量。過大に積まれると back pressure をかける。
@@ -82,6 +82,7 @@ pub async fn run(
             let mut last_clap_errors: u64 = 0;
             let mut last_outproc_errors: u64 = 0;
             let mut last_outproc_respawns: u64 = 0;
+            let mut last_outproc_frames_clamped: u64 = 0;
             let mut outproc_invalid_reported = false;
             let mut device_lost_reported = false;
             loop {
@@ -201,6 +202,25 @@ pub async fn run(
                         break;
                     }
                     outproc_invalid_reported = true;
+                }
+
+                // OOP effect の block が MAX_FRAMES を超えて clamp された累積回数を非 RT で
+                // surface（#404）。カウンタ自体は既存だったが ticker 未配線だったため追加。
+                let outproc_frames_clamped = engine.outproc_frames_clamped();
+                if outproc_frames_clamped > last_outproc_frames_clamped {
+                    let evt = daemon_error_event(
+                        ERROR_SEVERITY_WARNING,
+                        ERROR_CODE_OUTPROC_EFFECT_FRAMES_CLAMPED,
+                        format!(
+                            "out-of-process effect block exceeded MAX_FRAMES and was clamped \
+                             ({outproc_frames_clamped} total); tail of an oversized block was \
+                             silenced",
+                        ),
+                    );
+                    if tx.send(to_json_or_fallback(&evt)).await.is_err() {
+                        break;
+                    }
+                    last_outproc_frames_clamped = outproc_frames_clamped;
                 }
 
                 let stats_evt = Event::new(

--- a/rust/crates/orbit-audio-daemon/tests/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/tests/protocol.rs
@@ -679,6 +679,38 @@ async fn daemon_error_warning_on_outproc_frames_clamped() {
         !refired,
         "OUTPROC_EFFECT_FRAMES_CLAMPED must not re-fire without additional clamps (latch regression)"
     );
+
+    // re-arm: 追加注入されると latch が再度開き、更新済みの累積値（7+5=12）で再発火すること
+    // （#406 pr-test-analyzer finding 4: 「fire-once + no-refire」だけでなく「2 回目の注入で
+    // 再発火し累積が更新されること」も検証する）。
+    daemon
+        .engine
+        .outproc_frames_clamped_arc()
+        .fetch_add(5, std::sync::atomic::Ordering::Relaxed);
+    advance_and_yield(Duration::from_millis(1_100)).await;
+    let mut rearmed_message: Option<String> = None;
+    for _ in 0..6 {
+        let res = tokio::time::timeout(Duration::from_millis(50), next_json(&mut ws)).await;
+        match res {
+            Ok(msg) => {
+                if msg["event"] == "DaemonError"
+                    && msg["data"]["severity"] == "warning"
+                    && msg["data"]["code"] == "OUTPROC_EFFECT_FRAMES_CLAMPED"
+                {
+                    rearmed_message =
+                        Some(msg["data"]["message"].as_str().unwrap_or("").to_string());
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    let rearmed_message = rearmed_message
+        .expect("OUTPROC_EFFECT_FRAMES_CLAMPED did not re-fire after second injection");
+    assert!(
+        rearmed_message.contains("12"),
+        "re-armed OUTPROC_EFFECT_FRAMES_CLAMPED message should carry the updated cumulative total (12), got: {rearmed_message}"
+    );
 }
 
 /// device_lost が記録されると DaemonError (severity=fatal, code=DEVICE_LOST) が発火する。

--- a/rust/crates/orbit-audio-daemon/tests/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/tests/protocol.rs
@@ -612,6 +612,75 @@ async fn daemon_error_warning_on_clap_process_error() {
     );
 }
 
+/// OOP effect の frames_clamped が増えると DaemonError (severity=warning,
+/// code=OUTPROC_EFFECT_FRAMES_CLAMPED) が発火する（#404 / #406）。LINK_EGRESS_DROP・
+/// CLAP_PROCESS_ERROR と同じ 1 Hz ticker 経路。integration test は outproc child process を spawn
+/// しない（default feature build には `outproc-effect` が無い）ため、`outproc_frames_clamped_arc`
+/// の **本番経路から分離した注入 seam**（本番常に 0）でこの event を driver する（`outproc_health`
+/// が consolidated accessor としてこの注入分を frames_clamped に合算する・#406 /simplify）。
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn daemon_error_warning_on_outproc_frames_clamped() {
+    let daemon = TestDaemon::start().await;
+    let mut ws = daemon.connect().await;
+    let _hs = TestDaemon::recv_handshake(&mut ws).await;
+
+    // 外部から frames_clamped を注入（1 Hz ticker が outproc_health() の増加を検知して発火）。
+    daemon
+        .engine
+        .outproc_frames_clamped_arc()
+        .fetch_add(7, std::sync::atomic::Ordering::Relaxed);
+
+    advance_and_yield(Duration::from_millis(1_100)).await;
+
+    let mut warning_message: Option<String> = None;
+    for _ in 0..6 {
+        let res = tokio::time::timeout(Duration::from_millis(50), next_json(&mut ws)).await;
+        match res {
+            Ok(msg) => {
+                if msg["event"] == "DaemonError"
+                    && msg["data"]["severity"] == "warning"
+                    && msg["data"]["code"] == "OUTPROC_EFFECT_FRAMES_CLAMPED"
+                {
+                    warning_message =
+                        Some(msg["data"]["message"].as_str().unwrap_or("").to_string());
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    let message =
+        warning_message.expect("OUTPROC_EFFECT_FRAMES_CLAMPED warning event not received");
+    // message は累積 clamp 数（7）を含む = daemon_error_event の format! が壊れていないこと。
+    assert!(
+        message.contains('7'),
+        "OUTPROC_EFFECT_FRAMES_CLAMPED message should carry the running total, got: {message}"
+    );
+
+    // latch: 追加注入なしで次 tick へ進めても **再発火しない**
+    // （last_outproc_frames_clamped が据え置かれること）。
+    advance_and_yield(Duration::from_millis(1_100)).await;
+    let mut refired = false;
+    for _ in 0..6 {
+        let res = tokio::time::timeout(Duration::from_millis(50), next_json(&mut ws)).await;
+        match res {
+            Ok(msg) => {
+                if msg["event"] == "DaemonError"
+                    && msg["data"]["code"] == "OUTPROC_EFFECT_FRAMES_CLAMPED"
+                {
+                    refired = true;
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    assert!(
+        !refired,
+        "OUTPROC_EFFECT_FRAMES_CLAMPED must not re-fire without additional clamps (latch regression)"
+    );
+}
+
 /// device_lost が記録されると DaemonError (severity=fatal, code=DEVICE_LOST) が発火する。
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn daemon_error_fatal_on_device_lost() {


### PR DESCRIPTION
## Summary

- M2 instrument IPC substrate（#398）の容量設計を検討する過程で、fresh agent（opus）による拡張監査が発見した箇所。
- `orbit-audio-sandbox`（out-of-process effect transport・`MAX_FRAMES=4096`）で、1ブロックがこれを超えると末尾を無音化し `frames_clamped` カウンターに記録する仕組みは既に実装済みだったが、`EngineWrap::outproc_health()` が返すタプルに含まれておらず、他の兄弟カウンターと違って daemon の 1Hz ticker に一度も配線されていなかった。
- 既存タプルを変更せず、新規 `outproc_frames_clamped()` accessor を追加し、`ERROR_CODE_OUTPROC_EFFECT_FRAMES_CLAMPED`（新設）で 1Hz ticker に配線。

## Test plan

- [x] `cargo build -p orbit-audio-daemon`(default/outproc-effect/clap-host) — 全緑
- [x] `cargo clippy --all-targets -D warnings`(同3構成) — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace` — 全緑
- [x] `cargo deny check licenses` — ok

Refs #404 #398

https://claude.ai/code/session_01UoMuPtdbm1Zm1mLrEbhCFe