### PR TITLE
test(engine): cover load_plugin success flag update (#411)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,15 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.229 refactor(engine): dedupe ClapControl test wiring + flatten match (#412 /simplify) (Jul 12, 2026)
+
+6.228（#411 実装）に対する `/simplify` 4並列レビュー（reuse/simplification/efficiency/altitude）で3本が独立に収束した指摘を修正（PR #412）。
+
+- **reuse/simplification/altitude 独立一致**: `loaded_engine()`/`loadable_engine()` が `ClapControl` 構築（event ring・cmd channel・stats 2種）を個別に重複実装していた。共通セットアップを `wire_clap_control()` に抽出し両ヘルパーから呼ぶよう変更（ヘルパー自体は altitude レビュー指摘の通りマージせず、両者の目的の違い〔`plugin_loaded` 事前セットの有無〕は維持）。
+- **simplification 指摘**: `ClapCommand` は現状 `LoadPlugin` 1バリアントのみなので、`match cmd { ClapCommand::LoadPlugin { .. } => {...} }` を irrefutable `let` pattern に平坦化しネストを1段削除。
+- **simplification 指摘（一部見送り）**: `if let Err(err) = result { panic!(...) }` を `assert!(result.is_ok(), "{result:?}")` に統一する提案は、実際にビルドして確認したところ `LoadedPluginSummary` が `Debug` 未実装のためコンパイルエラーになることが判明。本番コードへの `#[derive(Debug)]` 追加は本 PR のスコープ外（本番コード非変更の制約）のため、元の `if let Err` パターンを維持し、Debug 未実装ゆえの意図的な差異であることをコメントで明記した。
+- **検証**: `cargo build -p orbit-audio-daemon --features clap-host`・`cargo test -p orbit-audio-daemon --features clap-host --lib`（31 passed）・`cargo clippy --features clap-host --all-targets -D warnings`・`cargo fmt --check` すべて green。
+
 ### 6.228 test(engine): cover load_plugin success flag update (#411) (Jul 12, 2026)
 
 `EngineWrap::load_plugin()` の成功分岐が `plugin_loaded` を true にすることを、実際の `LoadPlugin` コマンド送信と reply channel の往復で検証する unit test を追加。従来の `loaded_engine()` はテスト内でフラグを直接注入していたため、成功分岐の `store(true, ...)` が削除・反転されても検出できなかった穴を埋めた。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,10 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.228 test(engine): cover load_plugin success flag update (#411) (Jul 12, 2026)
+
+`EngineWrap::load_plugin()` の成功分岐が `plugin_loaded` を true にすることを、実際の `LoadPlugin` コマンド送信と reply channel の往復で検証する unit test を追加。従来の `loaded_engine()` はテスト内でフラグを直接注入していたため、成功分岐の `store(true, ...)` が削除・反転されても検出できなかった穴を埋めた。
+
 ### 6.227 test(engine): PluginNote load-gate 回帰テストの空洞化を修正 + CLAP_NOT_LOADED error code（#405） (Jul 12, 2026)
 
 6.226（#405 の実装）に対する `/code:pr-review-team` 4並列レビュー（code-reviewer / pr-test-analyzer / silent-failure-hunter / comment-analyzer）で、回帰テストが実は #405 のガードを検証できていないこと等が判明（PR #407）。

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -1490,7 +1490,15 @@ mod plugin_load_gate_tests {
     fn load_plugin_success_sets_plugin_loaded_flag() {
         let (wrap, cmd_rx) = loadable_engine();
         let responder = std::thread::spawn(move || {
-            let cmd = cmd_rx.recv().expect("load_plugin should send LoadPlugin");
+            // `recv_timeout` で fail-fast にする（`clap_host.rs` の専用スレッド pump loop と同じ
+            // パターン）。現状 `load_plugin()` は必ず send 後に待つため無期限 `recv()` でも通るが、
+            // 将来の regression（lock 順序ミス等で send 前に return する等）が入ると無期限ブロックし、
+            // `rust-ci.yml` に `timeout-minutes` 未設定のため CI job が GitHub Actions のデフォルト
+            // 上限（最大6時間）までハングしてから失敗する fail-slow リスクがある
+            // （pr-test-analyzer / silent-failure-hunter 独立指摘・PR #412）。
+            let cmd = cmd_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("load_plugin should send LoadPlugin within 5s");
             // `ClapCommand` は現状 `LoadPlugin` の1バリアントのみなので irrefutable pattern
             // で受けられる（/simplify レビュー #412: match 1本腕は不要なネスト）。
             let crate::clap_host::ClapCommand::LoadPlugin {

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -1458,6 +1458,66 @@ mod plugin_load_gate_tests {
         (wrap, event_rx)
     }
 
+    fn loadable_engine() -> (
+        Arc<EngineWrap>,
+        std::sync::mpsc::Receiver<crate::clap_host::ClapCommand>,
+    ) {
+        let wrap = unstarted_engine();
+        let (event_tx, _event_rx) = orbit_clap_host::make_event_ring(16);
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
+        let stats = orbit_clap_host::ClapProcessorStats::new();
+        let cb_stats = orbit_audio_native::CallbackTimeStats::new();
+        *wrap.clap.lock().expect("clap mutex") = Some(ClapControl {
+            cmd_tx,
+            event_tx,
+            stats,
+            cb_stats,
+        });
+        (wrap, cmd_rx)
+    }
+
+    #[test]
+    fn load_plugin_success_sets_plugin_loaded_flag() {
+        let (wrap, cmd_rx) = loadable_engine();
+        let responder = std::thread::spawn(move || {
+            let cmd = cmd_rx.recv().expect("load_plugin should send LoadPlugin");
+            match cmd {
+                crate::clap_host::ClapCommand::LoadPlugin {
+                    path,
+                    plugin_id,
+                    sample_rate,
+                    channels,
+                    max_frames,
+                    reply,
+                } => {
+                    assert_eq!(path, PathBuf::from("dummy.clap"));
+                    assert_eq!(plugin_id, None);
+                    assert_eq!(sample_rate, 48_000);
+                    assert_eq!(channels, 2);
+                    assert_eq!(max_frames, CLAP_MAX_FRAMES);
+                    reply
+                        .send(Ok(orbit_clap_host::LoadedPluginInfo {
+                            plugin_id: "com.example.dummy".to_string(),
+                            plugin_name: Some("Dummy".to_string()),
+                            note_port_index: 0,
+                        }))
+                        .expect("load_plugin should still be waiting for reply");
+                }
+            }
+        });
+
+        let result = wrap.load_plugin(PathBuf::from("dummy.clap"), None);
+        responder.join().expect("responder thread should not panic");
+
+        if let Err(err) = result {
+            panic!("load_plugin should succeed: {err:?}");
+        }
+        assert!(
+            wrap.plugin_loaded.load(Ordering::Relaxed),
+            "load_plugin success branch must set plugin_loaded"
+        );
+    }
+
     #[test]
     fn note_on_after_load_reaches_ring() {
         let (wrap, mut consumer) = loaded_engine();

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -1438,32 +1438,18 @@ mod plugin_load_gate_tests {
         assert!(!wrap.plugin_loaded.load(Ordering::Relaxed));
     }
 
-    /// `unstarted_engine` に PR #406 の手法（private フィールドへの直接注入）で実 `ClapControl` を
-    /// 構築注入し、`plugin_loaded = true` かつ `clap = Some(...)` な wrap を返す。呼び出し側は
-    /// 返る consumer で event ring への実配送を検証できる（positive-path・#405 finding 3）。
-    /// `cmd_tx` の receiver 側は保持しない（LoadPlugin コマンドは実際には送らないため不要）。
-    fn loaded_engine() -> (Arc<EngineWrap>, orbit_clap_host::PluginEventConsumer) {
-        let wrap = unstarted_engine();
-        let (event_tx, event_rx) = orbit_clap_host::make_event_ring(16);
-        let (cmd_tx, _cmd_rx) = std::sync::mpsc::channel();
-        let stats = orbit_clap_host::ClapProcessorStats::new();
-        let cb_stats = orbit_audio_native::CallbackTimeStats::new();
-        wrap.plugin_loaded.store(true, Ordering::Relaxed);
-        *wrap.clap.lock().expect("clap mutex") = Some(ClapControl {
-            cmd_tx,
-            event_tx,
-            stats,
-            cb_stats,
-        });
-        (wrap, event_rx)
-    }
-
-    fn loadable_engine() -> (
-        Arc<EngineWrap>,
+    /// `wrap.clap` へ実 `ClapControl` を直接注入する共通セットアップ（PR #406 の private
+    /// フィールド直接注入手法）。呼び出し側は event ring の consumer と LoadPlugin コマンドの
+    /// receiver の両方を受け取り、不要な方は `_` で捨てる（`loaded_engine`/`loadable_engine`
+    /// が共有・/simplify レビュー #412: 個別に組み立てると `ClapControl` のフィールド変更が
+    /// 2箇所同時保守になる）。
+    fn wire_clap_control(
+        wrap: &Arc<EngineWrap>,
+    ) -> (
+        orbit_clap_host::PluginEventConsumer,
         std::sync::mpsc::Receiver<crate::clap_host::ClapCommand>,
     ) {
-        let wrap = unstarted_engine();
-        let (event_tx, _event_rx) = orbit_clap_host::make_event_ring(16);
+        let (event_tx, event_rx) = orbit_clap_host::make_event_ring(16);
         let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
         let stats = orbit_clap_host::ClapProcessorStats::new();
         let cb_stats = orbit_audio_native::CallbackTimeStats::new();
@@ -1473,6 +1459,30 @@ mod plugin_load_gate_tests {
             stats,
             cb_stats,
         });
+        (event_rx, cmd_rx)
+    }
+
+    /// `unstarted_engine` に `wire_clap_control` で実 `ClapControl` を構築注入し、
+    /// `plugin_loaded = true` かつ `clap = Some(...)` な wrap を返す。呼び出し側は
+    /// 返る consumer で event ring への実配送を検証できる（positive-path・#405 finding 3）。
+    /// `cmd_rx` は保持しない（LoadPlugin コマンドは実際には送らないため不要）。
+    fn loaded_engine() -> (Arc<EngineWrap>, orbit_clap_host::PluginEventConsumer) {
+        let wrap = unstarted_engine();
+        let (event_rx, _cmd_rx) = wire_clap_control(&wrap);
+        wrap.plugin_loaded.store(true, Ordering::Relaxed);
+        (wrap, event_rx)
+    }
+
+    /// `unstarted_engine` に `wire_clap_control` で実 `ClapControl` を構築注入するが、
+    /// `loaded_engine` と異なり `plugin_loaded` は事前に store しない。呼び出し側は
+    /// `load_plugin()` を実際に呼び、その成功分岐が `plugin_loaded` を true にすることを
+    /// `cmd_rx` 経由の LoadPlugin コマンド応答で検証できる（#411）。
+    fn loadable_engine() -> (
+        Arc<EngineWrap>,
+        std::sync::mpsc::Receiver<crate::clap_host::ClapCommand>,
+    ) {
+        let wrap = unstarted_engine();
+        let (_event_rx, cmd_rx) = wire_clap_control(&wrap);
         (wrap, cmd_rx)
     }
 
@@ -1481,34 +1491,36 @@ mod plugin_load_gate_tests {
         let (wrap, cmd_rx) = loadable_engine();
         let responder = std::thread::spawn(move || {
             let cmd = cmd_rx.recv().expect("load_plugin should send LoadPlugin");
-            match cmd {
-                crate::clap_host::ClapCommand::LoadPlugin {
-                    path,
-                    plugin_id,
-                    sample_rate,
-                    channels,
-                    max_frames,
-                    reply,
-                } => {
-                    assert_eq!(path, PathBuf::from("dummy.clap"));
-                    assert_eq!(plugin_id, None);
-                    assert_eq!(sample_rate, 48_000);
-                    assert_eq!(channels, 2);
-                    assert_eq!(max_frames, CLAP_MAX_FRAMES);
-                    reply
-                        .send(Ok(orbit_clap_host::LoadedPluginInfo {
-                            plugin_id: "com.example.dummy".to_string(),
-                            plugin_name: Some("Dummy".to_string()),
-                            note_port_index: 0,
-                        }))
-                        .expect("load_plugin should still be waiting for reply");
-                }
-            }
+            // `ClapCommand` は現状 `LoadPlugin` の1バリアントのみなので irrefutable pattern
+            // で受けられる（/simplify レビュー #412: match 1本腕は不要なネスト）。
+            let crate::clap_host::ClapCommand::LoadPlugin {
+                path,
+                plugin_id,
+                sample_rate,
+                channels,
+                max_frames,
+                reply,
+            } = cmd;
+            assert_eq!(path, PathBuf::from("dummy.clap"));
+            assert_eq!(plugin_id, None);
+            assert_eq!(sample_rate, 48_000);
+            assert_eq!(channels, 2);
+            assert_eq!(max_frames, CLAP_MAX_FRAMES);
+            reply
+                .send(Ok(orbit_clap_host::LoadedPluginInfo {
+                    plugin_id: "com.example.dummy".to_string(),
+                    plugin_name: Some("Dummy".to_string()),
+                    note_port_index: 0,
+                }))
+                .expect("load_plugin should still be waiting for reply");
         });
 
         let result = wrap.load_plugin(PathBuf::from("dummy.clap"), None);
         responder.join().expect("responder thread should not panic");
 
+        // `LoadedPluginSummary` は Debug 未実装のため `assert!(result.is_ok(), "{result:?}")`
+        // が使えない（sibling の `note_on_after_load_reaches_ring` は `Result<(), WrapError>` で
+        // `()` が Debug のため同型の assert! が効くが、ここは Err 側だけ表示する）。
         if let Err(err) = result {
             panic!("load_plugin should succeed: {err:?}");
         }


### PR DESCRIPTION
## 概要

`EngineWrap::load_plugin()` の成功分岐（`self.plugin_loaded.store(true, Ordering::Relaxed)`）を、実際に `load_plugin()` を呼び出して通過させるユニットテストを追加します。

## 背景

#405/PR #407 のレビュー(iteration 2)で pr-test-analyzer が発見（5/10・non-blocking と判断され Issue #411 として追跡）。既存の `loaded_engine()` ヘルパーは `plugin_loaded` フィールドへの直接注入で「ロード済み」を模擬しており、`load_plugin()` 自体の成功分岐を一度も経由していませんでした。そのため `self.plugin_loaded.store(true, ...)` が削除・反転されても既存テストは全て green のままになる穴がありました。

## 変更内容

- `loadable_engine()` ヘルパー + `load_plugin_success_sets_plugin_loaded_flag` テストを追加（`plugin_load_gate_tests` モジュール内）
- 別スレッドで `ClapCommand::LoadPlugin` を受信し固定の成功応答を返すことで、`load_plugin()` の実際のコード経路（cmd_tx 送信 → reply_rx 受信）を通過させる
- 受信したコマンドの `path`/`plugin_id`/`sample_rate`/`channels`/`max_frames` も併せて pin

## 自己検証

`self.plugin_loaded.store(true, ...)` を一時的にコメントアウトし、新テストが実際に `panic`（fail）することを確認 → 復元して再度 green を確認済み。

## 実装

Codex（`/codex:rescue`）に委譲し、main が diff レビュー + 自己検証（revert→red→restore）を実施。

Closes #411