### PR TITLE
docs(dsl): finalize plugin effect/instrument DSL syntax (Option A decision)

### DIFF
--- a/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
+++ b/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
@@ -648,7 +648,7 @@ s.audio("snare.wav").output("drums")               // kick と snare が同 chan
 
 **Strict mode (v1.2.0+)**: `global.linkAudio()` を宣言したファイル内では、 全ての発音 sequence が `.output(name)` で channel を宣言する必要がある。 `.output()` を持たない sequence が `.play()` した時点で **runtime error** を投げる (`Sequence.resolveDispatchChannel`)。 これは「LinkAudio mode 中は全 sequence が LinkAudio 経由」 という §8.1.1 の宣言と整合させるための strict 制約で、 hardware 出力との silent fallback は行わない (hardware/LinkAudio 混在は不可、 §8.1.1 参照)。 編集時には VS Code 拡張が `analyzeLinkAudioMissingOutput` で同等の error 診断を出す (§11)。
 
-**MIDI 例外**: `seq.midi()` で宣言した MIDI sequence は strict mode の `.output()` 要件から**免除**される。MIDI sequence は SC audio bus ではなく MIDI bus にルーティングされるため、LinkAudio channel binding は不要 (#282)。
+**MIDI 例外**: `seq.midi()` で宣言した MIDI sequence は strict mode の `.output()` 要件から**免除**される。MIDI sequence は SC audio bus ではなく MIDI bus にルーティングされるため、LinkAudio channel binding は不要 (#282)。`seq.instrument()` で宣言した instrument sequence も同様に免除される（plugin 経路にルーティングされるため。ただし v1 では `global.linkAudio()` と plugin hosting の同時使用自体が不可 — Plugin Hosting PH.5 参照）。
 
 `global.linkAudio()` 未宣言で `seq.output()` を呼んだ場合は別経路: channel name は記録されるが hardware path に流れ、 `.output()` 呼び出しのたびに console に警告が出る (LinkAudio mode を有効化し忘れたケースのフェイルセーフ。警告は dedup されず毎回発火する)。 編集時の order-violation 検出は §11 参照。
 
@@ -1123,6 +1123,109 @@ piano.comp([1,3,5], [5,7,2]).voicelead()  // composes with §6.3
   DSL scope (comp C3)**: it belongs to an LLM bandmate skill that live-codes the DSL, keeping the DSL
   a controllable primitive set rather than an auto-composer (philosophy: user/AI control, not autogen).
 
+---
+
+## Plugin Hosting (CLAP effect / instrument)
+
+> ⚠️ **構文確定・未実装 / syntax finalized, not yet implemented**
+>
+> 本節は Issue #425（2026-07-13・owner 設計セッション + Fable 検証）で確定した構文仕様。
+> 実装は #426（effect 疎通）/ #427（instrument 疎通 + Pitch DSL 接続）/ #428（note timing）の
+> スコープであり、本節の記述が実装に先行する（spec-first）。
+> Option A/B/C の比較経緯は `docs/development/POST_2.0_VST3_HOSTING_PLAN.md` §6、
+> 決定の記録は Issue #425 / WORK_LOG を参照。
+
+OrbitScore engine（Rust daemon）は CLAP プラグインをホストする配管を持つ
+（effect = PR #397 / instrument = PR #422）。本節はそれを DSL から消費する構文の正本。
+
+### PH.1 instrument — `seq.instrument(path[, pluginId])`
+
+```js
+var synth = init global.seq
+synth.instrument("~/plugins/Surge XT.clap")   // 種別宣言＝出口宣言
+synth.octave(4).vel(100)
+synth.play(1, 3, 5, 0)                        // 値は度数（Pitch DSL と同じ）
+```
+
+- `.midi(port, ch)` と同型の**シーケンス種別宣言 verb**。宣言したシーケンスは
+  **note シーケンス**となり、`play()` の値は度数として解釈される。
+- `.audio()` / `.midi()` と**相互排他**（同じ throw パターン。1 シーケンス 1 出口）。
+  audio シーケンスの `play()` 意味論には一切影響しない。
+- 度数解釈・リズム木・Pitch DSL §7 realization rules を MIDI シーケンスと共有する
+  （`octave` / `vel` / `gate` / `root`、mode / chord / `[ ]` / tie / voicing 適用可）。
+- **v1 実現マトリクスの例外**: detune `~` は不可（plugin 経路に pitch bend / CC がない
+  ため warn + skip）。`global.midiLatency()` は MIDI 送出専用のため非適用。
+- 出力はエンジン master bus に add-mix され、global gain / master effect insert /
+  capture の対象になる。
+- RUN / LOOP / MUTE / quantize の意味論は MIDI シーケンスと同一。
+
+### PH.2 effect — `global.effect(path[, pluginId])`
+
+```js
+global.effect("~/plugins/TAL-Reverb-4.clap")   // master bus insert
+```
+
+- **master bus への単一 insert**（全シーケンスに掛かる）。global master effects
+  （compressor / limiter / normalizer）と同じ「master バス処理は global スコープ」の
+  役割分担に従う。
+- v1 は 1 基のみ。2 回目の呼び出しはエラー（「v1 は master insert 1 基。チェーンは将来対応」）。
+- 将来拡張（非規範）: 複数回呼び出し = 呼び出し順の直列チェーン（左→右）。
+  per-sequence insert（`seq.effect()`）も将来拡張として予約する — verb 名を共有するため、
+  追加しても構文の非互換は生じない。
+
+### PH.3 プラグイン識別と format 判定
+
+- 第1引数 = path 文字列。相対 path の基準は `.audio()` の path-direct 形
+  （`./` `../` `~/` `/`）と同じ規則。bank 名検索（`global.audioPath()` 相当）はなし。
+- format は**拡張子で判定**: `.clap` → CLAP、`.vst3` → VST3、`.component` → AU。
+  verb は format 非依存（format 別 verb は作らない）。
+  **v1 の受理は `.clap` のみ** — `.vst3` / `.component` は構文上予約し
+  「not yet supported」エラーを返す。未知拡張子はエラー。
+- 第2引数 `pluginId`（optional）: 1 バンドルに複数プラグインが入る場合の指定
+  （daemon `LoadPlugin.plugin_id` に対応）。省略時はバンドル先頭のプラグイン。
+
+### PH.4 ロード・エラー・多重宣言の意味論
+
+- **宣言時 eager ロード**: `.midi()` のポート eager 解決と同型。ロード失敗
+  （ファイル不在・非対応 format・plugin 非対応ビルド）は**宣言時のハードエラー**とし、
+  warn + no-op にしない（instrument の silent failure = 無音を防ぐ。daemon の
+  `CLAP_NOT_LOADED` 正直エラー方針 #405 と整合）。
+- **instrument はエンジン全体で 1 インスタンス**（v1）:
+  - 複数の note シーケンスが**同じ path** を宣言 → 同一インスタンスを共有（note はマージ。
+    v1 は全 note が channel 0 固定。per-sequence channel は将来の非規範拡張）。
+    実装注記: daemon は同 path でも 2 回目の `LoadPlugin` を `AlreadyLoaded` エラーに
+    するため、**共有は TS ブリッジ側の dedup で実現する**（置換ベースで設計しないこと）。
+  - **異なる path** の 2 つ目の宣言 → エラー（daemon が置換非サポート。加えてライブ中の
+    暗黙置換は他シーケンスの音が突然変わる事故になる）。
+  - 同一シーケンスの再宣言: 同一 path は冪等（no-op）。異 path への差し替えはエラー
+    （`.audio()` の置換挙動とは異なることに注意）。
+- **All Notes Off**: plugin 経路に CC はないため、active note を列挙して note-off を
+  逐次送出する。`global.stop()` / LOOP 除外 / MUTE / `play()` 差し替え時の保留 note
+  解放義務は Pitch DSL §7-2 と同一。
+- **underscore 規約**: plugin verb は宣言専用であり `_effect` / `_instrument` 形はない。
+- `.orbslog`: 宣言は他 verb 同様に因果評価ログとして自動記録される（特別扱いなし）。
+
+### PH.5 LinkAudio との関係（v1 制限）
+
+- instrument シーケンスは MIDI シーケンス同様、strict mode の `.output()` 要件から
+  **免除**される（SC audio bus ではなく plugin 経路にルーティングされるため。§8.1.2 参照）。
+- **v1 制限**: `global.linkAudio()` と plugin hosting（effect / instrument）は
+  同時使用不可 — 宣言時エラー（現 engine の compile-time 排他 feature の実態を開示）。
+
+### PH.6 v1 制限（実装事実の開示）
+
+- effect と instrument の同一プロセス同時使用は現配管では不可（compile-time 排他 feature）。
+  解消は #426 / #427 の配線課題であり、**構文はこの制限に依存しない**
+  （制限が解消されても構文は不変）。
+- note 発火は block-head 精度（sample-accurate 化は #428）。
+- ロード確認から audio 反映までの短い race window が残存する（#410）。
+- **param / CC 制御**（EQ-from-DSL 等）は本節のスコープ外 — M2 param path の成熟後に
+  別途構文を確定する（構文未確定。ここで先取りしない）。
+
+---
+
+## Implementation Status
+
 ### Completed Features ✅
 
 #### Core DSL (v3.0)
@@ -1228,12 +1331,17 @@ the two time/pitch axes stay orthogonal and consistent with the chop slice-fit v
 - **delay()**: Per-sequence delay effect
 - **reverb()**: Per-sequence reverb effect
 - **filter()**: Per-sequence filter effects
+- **seq.effect()** (per-sequence plugin insert): reserved as a future extension of the
+  Plugin Hosting section — v1 hosts plugin effects on the master bus only (`global.effect()`)
 
 #### Advanced Features
 - **Composite Meters**: `((3 by 4)(2 by 4))`
 - **Force Modifier**: `.force` for transport commands
 - **Effect Presets**: Named preset system for effect chains
 - **DAW Plugin**: VST/AU plugin development
+- **Plugin Hosting implementation**: the CLAP effect/instrument hosting *syntax* is finalized
+  (#425 — see the Plugin Hosting section above); engine wiring is tracked in #426/#427/#428.
+  `.vst3` / `.component` formats are reserved (not yet supported)
 - **`slice()`**: per-event start/end point selection within a chopped file (#239)
 - **Audio `[ ]` stack / slice layering**: simultaneous audio-layer stacking in the play tree (#238)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,69 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.249 docs(dsl): plugin effect/instrument DSL 構文確定 — #425 Option A 決定 + spec 反映 (Jul 13, 2026)
+
+**Date**: 2026-07-13
+**Status**: ✅ 構文確定・spec 反映済み（実装は #426/#427/#428 のスコープ・本 Issue ではコードを書かない）
+**Branch**: `425-plugin-dsl-syntax`
+**Commit**: `81d65e6`
+
+`POST_2.0_VST3_HOSTING_PLAN.md` §6 で「effect が実機で動いてから owner と確定」と据え置かれていた
+plugin DSL 構文（Option A）を確定した。Epic #424（CLAP plugin DSL wiring）の最初の1手。
+
+**確定した構文（骨子）**:
+- **instrument**: `seq.instrument(path[, pluginId])` — `.midi(port, ch)` と同型の
+  「種別宣言＝出口宣言」verb。`.audio()`/`.midi()` と相互排他。instrument シーケンスは
+  note シーケンス（度数解釈・リズム木・realization rules を MIDI と共有）。
+- **effect**: `global.effect(path[, pluginId])` — master bus 単一 insert（v1）。
+  **§6 素描の `seq.effect()` から意図的に逸れる非対称**を採用: 現配管の seam が
+  master bus 単一 insert のため、per-seq 構文は「全シーケンスに掛かるのに 1 つに
+  紐づいて見える」意味論の乖離になる。`seq.effect()` は将来拡張として予約（verb 名共有・非互換なし）。
+- **format**: 拡張子判定（`.clap`/`.vst3`/`.component`）・verb は format 非依存。
+  v1 受理は `.clap` のみ（`.vst3`/`.component` は予約エラー — #426 が VST3 配線を背負わないため）。
+- **エラー方針**: 宣言時 eager ロード + ハードエラー（warn+no-op にしない。
+  instrument の silent failure 防止・#405 の正直エラー方針と整合）。
+- **多重宣言**: instrument はエンジン全体 1 インスタンス（v1）。同 path 共有は
+  TS ブリッジ側 dedup（daemon は `AlreadyLoaded` エラー）・異 path 2 つ目はエラー。
+- **v1 スコープ外**: param/CC 制御（EQ-from-DSL は M2 param path 成熟後に別途確定）、
+  detune `~`（pitch bend 経路なし・warn+skip）。
+
+**プロセス（役割分担フローどおり）**:
+1. **エビデンス収集**（Sonnet subagent ×2 並行）: ①既存 DSL 構文の慣習
+   （リフレクション dispatch・パーサー変更不要・`.audio()`/`.midi()` の排他パターン、
+   §7 Known Decisions に既決なし = greenfield 確認）②daemon 配管の実 API
+   （`LoadPlugin`/`PluginNoteOn/Off` スキーマ・単一スロット・4-way compile-time 排他・
+   WORK_LOG 6.248 の接続ギャップ 5 点）。
+2. **Fable 検証**: 条件付き GO。修正 5 点 — (1) 「再呼び出しは置換」は事実誤認
+   （実際は `AlreadyLoaded` エラー・`controller.rs:219-225`）(2) 異 path エラーと
+   再宣言の文言矛盾の解消 (3) 「Pitch DSL 全 verb 適用」の過大主張を実現マトリクスに緩和
+   (4) 追加決定点 D7-D10（linkAudio 排他・note-off 意味論・eager ロード・ハードエラー）
+   (5) PITCH_DSL_SPEC への最小 3 変更が必要（core spec :814-817 の権威順位
+   「specs-v2 が勝つ」— 放置すると正本階層が新機能を形式的に否定する）。
+   全て反映済み。確信度: D1/D3/D5/D6 高・D2 中〜高（各判定に反証条件つき）。
+3. **owner 設計セッション**: 3 論点を確認 — instrument = `seq.instrument(path)`（推奨どおり）、
+   effect = `global.effect(path)`（推奨どおり）、エラー方針 = ハードエラー（推奨どおり）。
+   D3-D9 は推奨提示に異論なしで確定。
+
+**spec 反映（spec-first・実装より先）**:
+- `docs/core/INSTRUCTION_ORBITSCORE_DSL.md`: 新セクション「Plugin Hosting
+  (CLAP effect / instrument)」（PH.1-PH.6・構文確定/未実装マーカーつき）+
+  「Not Yet Implemented」2 箇所更新 + `## Implementation Status` 見出しを補い構造明確化。
+- `docs/specs-v2/PITCH_DSL_SPEC_v1.1.html`: §1 に plugin instrument 出力の相互参照、
+  §7 に出力アダプタ適用注記（CC123/120 → note-off 列挙・detune v1 不能・rule 0 適合）、
+  §8 に scope 移管注記（構文の正本 = core spec）。
+
+**反証可能性（この決定が覆りうる条件・Fable 検証より）**:
+- daemon に multi-instance / unload-reload / per-play insert が近期に入る → D4 のエラー意味論は緩められる
+- C1（pitch モデル再設計）が note 発行層を書き換える → D1 の接続点は再検討（Epic #424 反証条件 1）
+- M2 param wire が #426/#427 より先に実装される → D5（param 据え置き）は前倒し可
+
+**レビュー（docs-only 規約に従い advisor 代替 = opus 独立監査で方法を決定）**:
+full pr-review-team / @claude bot は不要（コード 0 行・空振りリスクのみ）と判定し、
+fresh agent 差分監査 + owner 最終確認を採用。監査結果 = ブロッカーなし
+（D1-D10 + 吸収項目の反映漏れなし・相互参照全件正確・§7 rule 番号一致）。
+Low 指摘 1 件（§8.1.2 の MIDI 例外に instrument の鏡写しがない）を反映済み。
+
 ### 6.248 feat(engine): CLAP instrument daemon 縦貫通 — #419 output event 配線 + #420 production 統合 (Jul 13, 2026)
 
 **Date**: 2026-07-13

--- a/docs/specs-v2/PITCH_DSL_SPEC_v1.1.html
+++ b/docs/specs-v2/PITCH_DSL_SPEC_v1.1.html
@@ -356,6 +356,11 @@ diagnostic。不一致時はエラー(利用可能ポート一覧を提示)。</
 との併用はエラー。</li>
 <li><strong>SC オーディオ経路との併走は可</strong>(LinkAudio
 のような排他制約は設けない)。</li>
+<li><strong>Plugin instrument 出力(#425)</strong>: note 出力宣言には
+<code>seq.midi()</code> のほか、ホストされたプラグインを出口にする
+<code>seq.instrument(path)</code> がある(構文の正本: core spec
+<code>INSTRUCTION_ORBITSCORE_DSL.md</code> の Plugin Hosting
+節)。いずれの出口でも <code>play()</code> の値は度数として解釈される。</li>
 </ul>
 <h3 id="sequence-level-parameters">Sequence-level parameters</h3>
 <div class="sourceCode" id="cb2"><pre class="sourceCode js"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>seq<span class="op">.</span><span class="fu">gate</span>(<span class="fl">0.8</span>)      <span class="co">// デフォルトゲート長(スロット長に対する比)。default: 0.8</span></span>
@@ -835,6 +840,13 @@ quantize)に従う。<code>play()</code> 差し替えが quantize
 ピッチベンドで実現。同チャンネル同時発音中の異デチューンは不可(warning)。本格対応は
 MPE(スコープ外)。</li>
 </ol>
+<p><strong>出力アダプタへの適用(#425)</strong>: 本節の realization rules は
+MIDI 出力に限らず、任意の note 出力アダプタ(plugin instrument
+経路を含む)に適用される。plugin 経路の置換規則: CC123/CC120
+は使えないため All Notes Off = active note の列挙 → note-off
+の逐次送出。detune <code>~</code>(rule 5)は pitch bend 経路がないため v1
+では実現不能(warn + skip)。rule 0 のシンボリックピッチ保持は plugin
+出力アダプタにもそのまま適用される。</p>
 <hr />
 <h2 id="out-of-scope-v1.1">8. Out of Scope (v1.1)</h2>
 <ul>
@@ -845,7 +857,10 @@ MPE(スコープ外)。</li>
 <li>CC / Program Change 出力(ROADMAP には記載あり。v1.1.x で追加)</li>
 <li>8音以上のコレクションでの mode テンション規則(当面 root スコープ +
 b/# で書く)</li>
-<li>VST/AU ホスティング(v3.0+ #95)</li>
+<li>VST/AU ホスティング(v3.0+ #95) — <strong>scope 移管(#425)</strong>:
+plugin hosting の DSL 構文(CLAP effect/instrument)は core spec
+<code>INSTRUCTION_ORBITSCORE_DSL.md</code> の Plugin Hosting
+節が正本(本仕様のスコープ外のまま)</li>
 <li>MIDI 入力</li>
 </ul>
 <hr />


### PR DESCRIPTION
Closes #425

## 概要

`POST_2.0_VST3_HOSTING_PLAN.md` §6 で「effect が実機で動いてから owner と確定」と据え置かれていた plugin effect/instrument の DSL 構文（Option A）を確定し、正本 spec に反映した（spec-first・実装は #426/#427/#428 のスコープで本 PR にコードは含まない）。Epic #424 の最初の1手。

## 確定した構文

- **instrument**: `seq.instrument(path[, pluginId])` — `.midi(port, ch)` と同型の「種別宣言＝出口宣言」verb。`.audio()`/`.midi()` と相互排他。instrument シーケンスは note シーケンス（度数解釈・リズム木・realization rules を MIDI と共有）
- **effect**: `global.effect(path[, pluginId])` — master bus 単一 insert（v1）。§6 素描の `seq.effect()` から意図的に逸れる非対称（現配管の seam = master bus 単一 insert と構文の意味論を乖離させない）。`seq.effect()` は将来拡張として予約
- **format**: 拡張子判定・verb は format 非依存。v1 受理は `.clap` のみ（`.vst3`/`.component` は予約エラー）
- **エラー方針**: 宣言時 eager ロード + ハードエラー（instrument の silent failure 防止・#405 と整合）
- **多重宣言**: instrument はエンジン全体 1 インスタンス（v1）。同 path 共有は TS 側 dedup（daemon は `AlreadyLoaded`）・異 path 2 つ目はエラー
- **v1 スコープ外**: param/CC 制御（EQ-from-DSL は M2 param path 成熟後）・detune `~`（warn+skip）

## 変更ファイル

- `docs/core/INSTRUCTION_ORBITSCORE_DSL.md`: 新セクション「Plugin Hosting (CLAP effect / instrument)」（PH.1-PH.6・構文確定/未実装マーカーつき）+ Not Yet Implemented 2 箇所更新 + `## Implementation Status` 見出し補完
- `docs/specs-v2/PITCH_DSL_SPEC_v1.1.html`: §1 plugin instrument 出力の相互参照・§7 出力アダプタ適用注記（CC123/120 → note-off 列挙・detune v1 不能・rule 0 適合）・§8 scope 移管注記
- `docs/development/WORK_LOG.md`: 6.249 エントリ（決定内容・プロセス・反証可能性）

## プロセス

1. エビデンス収集（Sonnet subagent ×2 並行）: DSL 側の慣習（リフレクション dispatch・§7 Known Decisions に既決なし = greenfield）/ daemon 配管の実 API（`LoadPlugin` スキーマ・単一スロット・4-way compile-time 排他）
2. Fable 検証: 条件付き GO → 修正 5 点（`AlreadyLoaded` の事実訂正・実現マトリクス・追加決定点 D7-D10・PITCH_DSL_SPEC 最小 3 変更の必要性）を全て反映。各判定に確信度と反証可能性つき
3. owner 設計セッション: instrument/effect/エラー方針の 3 論点を確定（いずれも Fable 検証済み推奨案どおり）

## 検証

- `npm test` green（pre-commit hook で全テスト実行済み）
- docs のみの変更・実装コードなし・audio シーケンスの `play()` 意味論は不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015R9Km7edyaAgqzVFsUm7uX