### PR TITLE
feat(dsl): wire global.effect() to daemon LoadPlugin (#426)

### DIFF
--- a/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
+++ b/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
@@ -1168,7 +1168,10 @@ global.effect("~/plugins/TAL-Reverb-4.clap")   // master bus insert
 - **master bus への単一 insert**（全シーケンスに掛かる）。global master effects
   （compressor / limiter / normalizer）と同じ「master バス処理は global スコープ」の
   役割分担に従う。
-- v1 は 1 基のみ。2 回目の呼び出しはエラー（「v1 は master insert 1 基。チェーンは将来対応」）。
+- v1 は 1 基のみ。**同一 path + pluginId の再宣言は冪等（no-op）** — ライブコーディングの
+  ファイル全体再評価を壊さないため（PH.4 の instrument 冪等と同じ原理）。
+  **異なる path / pluginId での 2 回目の呼び出しはエラー**
+  （「v1 は master insert 1 基。チェーンは将来対応」）。
 - 将来拡張（非規範）: 複数回呼び出し = 呼び出し順の直列チェーン（左→右）。
   per-sequence insert（`seq.effect()`）も将来拡張として予約する — verb 名を共有するため、
   追加しても構文の非互換は生じない。
@@ -1215,8 +1218,8 @@ global.effect("~/plugins/TAL-Reverb-4.clap")   // master bus insert
 ### PH.6 v1 制限（実装事実の開示）
 
 - effect と instrument の同一プロセス同時使用は現配管では不可（compile-time 排他 feature）。
-  解消は #426 / #427 の配線課題であり、**構文はこの制限に依存しない**
-  （制限が解消されても構文は不変）。
+  解消は #431（daemon の OOP post-boot attach + 排他解消・Epic #424 Stage 2）のスコープであり、
+  **構文はこの制限に依存しない**（制限が解消されても構文は不変）。
 - note 発火は block-head 精度（sample-accurate 化は #428）。
 - ロード確認から audio 反映までの短い race window が残存する（#410）。
 - **param / CC 制御**（EQ-from-DSL 等）は本節のスコープ外 — M2 param path の成熟後に

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,66 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.250 feat(dsl): global.effect() — CLAP effect の DSL 疎通 #426 Stage 1 (Jul 14, 2026)
+
+**Date**: 2026-07-14
+**Status**: ✅ 実装・受け入れ監査済み（実機 gated DoD = 可聴確認は後続。#431 起票・Epic #424 段階化）
+**Branch**: `426-clap-effect-dsl-wiring`
+**Commit**: `86a9574`
+
+#425 で確定した `global.effect(path[, pluginId])` を TS 側に実装し、daemon の実行時
+`LoadPlugin`（in-process clap-host 経路）へ配線した。Epic #424 Stage 1 の前半。
+
+**グラウンディングで判明した構造ギャップ（plan-affecting）**:
+- daemon に OOP effect/instrument の実行時ロードコマンドが無い（`outproc-*` は起動時 env のみ・
+  `main.rs` が WS サーバー開始前に `EngineWrap::start()` を同期実行）。実行時 `LoadPlugin` は
+  in-process `clap-host` feature 専用
+- 4-way pairwise `compile_error!` により effect+instrument の同時使用不可 → **Epic #424 DoD は
+  daemon 側作業なしに達成不能**
+- release build は plugin feature 全て無効（`--features` なし）
+
+**Fable 一発判断（2026-07-14・確信度 高・案A/B/C 比較）**:
+- **案C ハイブリッド採用**: #426/#427 は in-process `clap-host` 経路で単体 DoD を通す
+  （今日の daemon で唯一の DSL 駆動実行時ロード経路・PH.4 の AlreadyLoaded 意味論は
+  この経路の実装そのもの）。wire 契約（`LoadPlugin`/`PluginNoteOn/Off`）は backend 中立で、
+  OOP 化後も TS/DSL 層は不変（`plugin_note_on/off` が既に両 backend に配線済みの実績）
+- 案B（env 注入）棄却: REPL 再宣言不能・「宣言時 eager ロード」が boot 時 config に退化
+- **`role: "effect"` param を初回から送る**（将来の OOP attach での child 選択に必須の wire を
+  先行確定。daemon は `params.get` 方式で未知 field を無視 = コスト 0）
+- **#431 起票**（OOP post-boot attach + 排他解消 + 配布 feature 方針 = Epic #424 Stage 2。
+  **Epic DoD「effect+instrument 同時演奏」は #431 で達成**）・Epic #424 body に段階化注記を追記
+
+**spec 追従（spec-first・同ブランチ）**:
+- PH.2 に「同一 path+pluginId の再宣言は冪等」を明確化（ライブコーディングのファイル全体
+  再評価を壊さないため。PH.4 instrument 冪等と同じ原理。owner 承認済みの「2回目エラー」は
+  チェーン防止の意図であり、異なる path/pluginId のみエラーとする精緻化）
+- PH.6 の排他解消ポインタを #426/#427 → #431 に更新
+
+**実装（Codex 委譲・2 ラウンド）**:
+- Round 1: `PluginEffectManager`（拡張子検証→linkAudio 排他→resolvePathDirect 解決→
+  冪等/エラー→eager load・失敗ロールバック・並行呼び出しは load Promise 共有）、
+  `Global.effect()` chainable、`DaemonClient.loadPlugin()`（camelCase 変換・role: "effect"）、
+  `RustEnginePlayer.loadPlugin()`（CLAP_UNAVAILABLE → 「--features clap-host build が必要」
+  マッピング）、LinkAudioManager 逆方向排他（callback 注入）、`resolvePathDirect` export、
+  テスト 13 件（global 11 + daemon-client 2 + mock server ハンドラ）
+- Round 2（受け入れ監査 Important 指摘 B-1 の fix）: **daemon crash→respawn 後に plugin
+  master insert が黙って消える silent failure** を修正 — `loadedPlugins` キャッシュ +
+  `respawnLoop` の `sampleIds.clear()` 直後に再発行・失敗は ❌ ERROR で observable・
+  キャッシュ保持で次回 respawn 再試行。**fail-before/pass-after 実証**（修正 revert で
+  2 テスト red「Number of calls: 0」→ 復元で green）
+
+**受け入れ監査（Fable・条件付き GO → fix 反映で解消）**:
+- spec 適合全項目 ✅・wire 正しさ（session.rs 突合・role 無害）✅・並行/ロールバック/
+  コンストラクション順 by construction 安全 ✅・スコープ外変更なし ✅
+- 逸脱メモ: `daemon-client.loadPlugin` の role 固定は #427 で引数化が必要（既知・許容）
+
+**検証（main 環境・非サンドボックス）**: `npm test` 1294+ passed / 0 failed（Codex sandbox の
+73 failures は loopback listen EPERM の偽陰性と確認）・`npm run lint` の 10 errors は
+未変更の SC SDK submodule 翻訳 .ts（既存）のみ。
+
+**残作業**: 実機 gated DoD（可聴変化の確認・要 clap-host build + 実 CLAP effect）→
+PR レビューフロー後に実施。#427（instrument + Pitch DSL 接続）が次。
+
 ### 6.249 docs(dsl): plugin effect/instrument DSL 構文確定 — #425 Option A 決定 + spec 反映 (Jul 13, 2026)
 
 **Date**: 2026-07-13

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -74,6 +74,18 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 73 failures は loopback listen EPERM の偽陰性と確認）・`npm run lint` の 10 errors は
 未変更の SC SDK submodule 翻訳 .ts（既存）のみ。
 
+**/simplify（4観点並行・適用6件/スキップ3件）**:
+- 適用: ①`daemon-client.loadPlugin` 戻り値型を `PluginLoadResult` に統一 ②console.error を
+  ファイル慣行 `❌ [rust-engine]` に統一 ③`loadedPlugins` Map → 単一 `loadedPlugin?` フィールド
+  （v1 単一 insert 保証により Map は常に 0/1 エントリ・JSON.stringify キー削除）
+  ④linkAudio 排他 guard を `Global.linkAudio()` に移動し `LinkAudioManager` を zero-arg に復元
+  （callback 注入の前方参照の脆さを解消）⑤テスト fixture 定数化 ⑥拡張子検証+path 解決を
+  `plugin-resolver.ts`（`resolvePluginPath`）に切り出し — **#427 の `seq.instrument()` が再利用**
+- スキップ（理由つき）: respawn テストの MockDaemonServer 経由書き直し（fail-before/pass-after の
+  実証由来を保全・#427 で再訪）／backend replay seam の全面再設計（#431 が daemon 層を作り直す
+  ため過剰投資）／effect 側 linkAudio チェックの Global 移動（エラー順序の挙動変更になるため）
+- 適用後検証: `npm test` 1296 passed / 0 failed・lint 変更ファイル新規指摘ゼロ
+
 **残作業**: 実機 gated DoD（可聴変化の確認・要 clap-host build + 実 CLAP effect）→
 PR レビューフロー後に実施。#427（instrument + Pitch DSL 接続）が次。
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -99,8 +99,20 @@ A design and implementation project for a new music DSL (Domain Specific Languag
   I1 = catch 3分岐のテスト追加 / I3 + Minor 群 = JSDoc・コメント整備
 - 適用後: `npm test` **1304 passed / 0 failed**（テスト 16+5 件に増強）・lint 新規指摘ゼロ
 
+**/code:pr-review-team round 2（収束確認）**:
+- comment-analyzer = **CONVERGED**（全指摘解消・新 docstring/コメントの実挙動一致・
+  回帰テストの非空虚性まで確認）
+- silent-failure-hunter = Critical 2 件とも解消を **fail-before/pass-after で再実証**
+  （修正前コミット 0bdb35b に新テストを移植して red 5 件 → 修正後 21/21 green）。
+  新規 LOW 1 件（`loadPlugin()` catch の `pluginActive` 明示リセット漏れ —
+  現状無害だが非局所的不変条件が脆弱）→ 1 行 + 回帰テスト 1 件で即時適用
+- **収束: Critical/Important = 0**・CI 4/4 pass・最終 `npm test` **1305 passed / 0 failed**
+- セキュリティ面: 新規依存なし・secrets なし・network surface 変更なし・
+  license/dependency gate CI pass
+
 **残作業**: 実機 gated DoD（可聴変化の確認・要 clap-host build + 実 CLAP effect）→
-PR レビューフロー後に実施。#427（instrument + Pitch DSL 接続）が次。
+レビュー通過済みのため owner 判断でマージ前後いずれでも実施可。#427（instrument +
+Pitch DSL 接続）が次。
 
 ### 6.249 docs(dsl): plugin effect/instrument DSL 構文確定 — #425 Option A 決定 + spec 反映 (Jul 13, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -22,7 +22,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 **Date**: 2026-07-14
 **Status**: ✅ 実装・受け入れ監査済み（実機 gated DoD = 可聴確認は後続。#431 起票・Epic #424 段階化）
 **Branch**: `426-clap-effect-dsl-wiring`
-**Commit**: `86a9574`
+**Commit**: `5d8e1ba`（feat 本体）+ `0bdb35b`（/simplify 適用）
 
 #425 で確定した `global.effect(path[, pluginId])` を TS 側に実装し、daemon の実行時
 `LoadPlugin`（in-process clap-host 経路）へ配線した。Epic #424 Stage 1 の前半。
@@ -85,6 +85,19 @@ A design and implementation project for a new music DSL (Domain Specific Languag
   実証由来を保全・#427 で再訪）／backend replay seam の全面再設計（#431 が daemon 層を作り直す
   ため過剰投資）／effect 側 linkAudio チェックの Global 移動（エラー順序の挙動変更になるため）
 - 適用後検証: `npm test` 1296 passed / 0 failed・lint 変更ファイル新規指摘ゼロ
+
+**/code:pr-review-team round 1（4レビュアー並行 + CI）**:
+- CI 4/4 pass。code-reviewer = PASS。指摘: Critical 2（silent-failure-hunter:
+  respawn 再ロード失敗後に冪等キャッシュが幻の成功を返す残存経路 / comment-analyzer:
+  /simplify で resolve が linkAudio チェックより前に移動しエラー順序が変化 —
+  両 commit の実挙動差を実証しての検出）・Important 3（エラー変換 catch 3分岐未テスト×2
+  レビュアー一致・WORK_LOG の dangling hash・linkAudio JSDoc 記載漏れ）・Minor 5
+- fixer round 1 適用: C1 = `pluginActive` フラグ + optional `isPluginActive?()` +
+  冪等キャッシュヒット時の self-healing 再発行（`issueLoad` 共通化・エンジン未対応時は
+  従来 no-op で後方互換）/ C2 = validate → linkAudio gate → resolve の順序復元
+  （load-bearing コメント + `validatePluginExtension` export + 回帰テスト）/
+  I1 = catch 3分岐のテスト追加 / I3 + Minor 群 = JSDoc・コメント整備
+- 適用後: `npm test` **1304 passed / 0 failed**（テスト 16+5 件に増強）・lint 新規指摘ゼロ
 
 **残作業**: 実機 gated DoD（可聴変化の確認・要 clap-host build + 実 CLAP effect）→
 PR レビューフロー後に実施。#427（instrument + Pitch DSL 接続）が次。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -110,9 +110,27 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 - セキュリティ面: 新規依存なし・secrets なし・network surface 変更なし・
   license/dependency gate CI pass
 
-**残作業**: 実機 gated DoD（可聴変化の確認・要 clap-host build + 実 CLAP effect）→
-レビュー通過済みのため owner 判断でマージ前後いずれでも実施可。#427（instrument +
-Pitch DSL 接続）が次。
+**実機 gated E2E（DoD 達成・2026-07-14・self-run は owner 常時許可の範囲）**:
+- advisor 判断: bot レビュー不要（独立視点 5 系統済み・残余リスクは静的レビューで
+  捕捉不能な実機 E2E ギャップ）+ **effect 経路の E2E は #426 クローズのゲート**
+  （#427 は PluginNoteOn/Off の別経路のため束ねられない）→ マージ前に self-run 実施
+- 手順: `cargo build --release -p orbit-audio-daemon --features clap-host` +
+  `clap-test-effect`（固定 gain 0.5・挙動既知の oracle プラグイン）を flat-file
+  `.clap` 化 → `ORBIT_AUDIO_DAEMON_PATH` + `ORBIT_CAPTURE_WAV` で
+  `cli-audio.js play` を baseline / `global.effect()` あり の 2 回実行し capture 比較
+- **結果: peak ratio = 0.5000（厳密一致・gain 0.5 の closed-form signature）**。
+  RMS 比 0.566（−4.94dB・前後無音の希釈込み）。DSL → daemon LoadPlugin →
+  in-process CLAP host → master insert の全経路が実機で音を処理したことを客観実証。
+  スピーカー実再生も両 run で確認。**Issue #426 の DoD 達成**
+- **副産物の発見 → #433 起票**: daemon discovery は path をそのまま dlopen するため
+  macOS 標準の `.clap` バンドル**ディレクトリ**を解決できない（市販プラグインは
+  全てバンドル形式）。E2E は flat-file 形式で回避。mock では捕捉不能な
+  統合ギャップの実物（advisor の予測どおり）。実プラグイン運用前に要対応
+- 注記: `rust/target/release/orbit-audio-daemon` は E2E 用に clap-host feature 付きで
+  上書きビルドした状態（plain 構成が要る場合は再ビルド）
+
+**残作業**: なし（#426 スコープ完了・マージはユーザー指示待ち）。次 = #427（instrument +
+Pitch DSL 接続。`daemon-client.loadPlugin` の role 引数化・#433 の bundle 解決を含む）。
 
 ### 6.249 docs(dsl): plugin effect/instrument DSL 構文確定 — #425 Option A 決定 + spec 反映 (Jul 13, 2026)
 

--- a/packages/engine/src/audio/engine-backend.ts
+++ b/packages/engine/src/audio/engine-backend.ts
@@ -14,6 +14,7 @@
 import type { Scheduler } from '../core/global/types'
 
 import type { AudioDevice } from './supercollider/types'
+import type { PluginLoadResult } from './types'
 
 /**
  * interpreter（`InterpreterState.audioEngine`）/ Global が依存する音声バックエンド契約。
@@ -30,6 +31,7 @@ export interface AudioEngineBackend extends Scheduler {
   setAvailableDevices?(devices: AudioDevice[]): void
   registerLinkAudioChannel?(channelName: string): Promise<void>
   setLinkTempo?(bpm: number): Promise<void>
+  loadPlugin?(filePath: string, pluginId?: string): Promise<PluginLoadResult>
 }
 
 /** バックエンド選択 env。既定（未設定）は Rust daemon 経路。`sc` / `supercollider` で SC に opt-out。 */

--- a/packages/engine/src/audio/engine-backend.ts
+++ b/packages/engine/src/audio/engine-backend.ts
@@ -32,6 +32,7 @@ export interface AudioEngineBackend extends Scheduler {
   registerLinkAudioChannel?(channelName: string): Promise<void>
   setLinkTempo?(bpm: number): Promise<void>
   loadPlugin?(filePath: string, pluginId?: string): Promise<PluginLoadResult>
+  isPluginActive?(): boolean
 }
 
 /** バックエンド選択 env。既定（未設定）は Rust daemon 経路。`sc` / `supercollider` で SC に opt-out。 */

--- a/packages/engine/src/audio/rust-engine/daemon-client.ts
+++ b/packages/engine/src/audio/rust-engine/daemon-client.ts
@@ -21,6 +21,8 @@ import * as path from 'path'
 import { v4 as uuidv4 } from 'uuid'
 import WebSocket from 'ws'
 
+import type { PluginLoadResult } from '../types'
+
 import {
   DaemonConnectionError,
   DaemonNotFoundError,
@@ -346,10 +348,7 @@ export class DaemonClient extends EventEmitter {
     await this.request('SetLinkTempo', { bpm })
   }
 
-  async loadPlugin(
-    filePath: string,
-    pluginId?: string,
-  ): Promise<{ pluginId: string; pluginName: string; notePortIndex: number }> {
+  async loadPlugin(filePath: string, pluginId?: string): Promise<PluginLoadResult> {
     const result = await this.request('LoadPlugin', {
       path: filePath,
       ...(pluginId === undefined ? {} : { plugin_id: pluginId }),

--- a/packages/engine/src/audio/rust-engine/daemon-client.ts
+++ b/packages/engine/src/audio/rust-engine/daemon-client.ts
@@ -348,6 +348,13 @@ export class DaemonClient extends EventEmitter {
     await this.request('SetLinkTempo', { bpm })
   }
 
+  /**
+   * Loads a `.clap` plugin into the daemon. Rejects with `DaemonProtocolError` —
+   * notably `CLAP_UNAVAILABLE` when the daemon was built without `--features
+   * clap-host` — which `RustEnginePlayer.loadPlugin()` converts into an
+   * operator-actionable message. `role` is hardcoded to `'effect'` until #427
+   * threads it through as an argument (e.g. for `seq.instrument()`).
+   */
   async loadPlugin(filePath: string, pluginId?: string): Promise<PluginLoadResult> {
     const result = await this.request('LoadPlugin', {
       path: filePath,

--- a/packages/engine/src/audio/rust-engine/daemon-client.ts
+++ b/packages/engine/src/audio/rust-engine/daemon-client.ts
@@ -346,6 +346,22 @@ export class DaemonClient extends EventEmitter {
     await this.request('SetLinkTempo', { bpm })
   }
 
+  async loadPlugin(
+    filePath: string,
+    pluginId?: string,
+  ): Promise<{ pluginId: string; pluginName: string; notePortIndex: number }> {
+    const result = await this.request('LoadPlugin', {
+      path: filePath,
+      ...(pluginId === undefined ? {} : { plugin_id: pluginId }),
+      role: 'effect',
+    })
+    return {
+      pluginId: String(result.plugin_id),
+      pluginName: String(result.plugin_name),
+      notePortIndex: Number(result.note_port_index),
+    }
+  }
+
   async getStatus(): Promise<Record<string, unknown>> {
     return this.request('GetStatus', {})
   }

--- a/packages/engine/src/audio/rust-engine/protocol-types.ts
+++ b/packages/engine/src/audio/rust-engine/protocol-types.ts
@@ -17,6 +17,7 @@ export interface HandshakeFrame {
 /** Protocol v0.1 で daemon が受け付ける method 名。 */
 export type CommandMethod =
   | 'LoadSample'
+  | 'LoadPlugin'
   | 'UnloadSample'
   | 'PlayAt'
   | 'Stop'

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -607,6 +607,8 @@ export class RustEnginePlayer implements AudioEngineBackend {
       this.pluginActive = true
       return result
     } catch (err) {
+      // 失敗時は必ず false（呼び出し元の false-on-entry 保証に依存しない）
+      this.pluginActive = false
       if (err instanceof DaemonProtocolError) {
         if (err.code === 'CLAP_UNAVAILABLE') {
           throw new Error(

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -41,6 +41,7 @@
 import { gainDbToAmplitude } from '../audio-gain-utils'
 import type { AudioEngineBackend } from '../engine-backend'
 import type { AudioDevice } from '../supercollider/types'
+import type { PluginLoadResult } from '../types'
 
 import { DaemonClient } from './daemon-client'
 import { DaemonConnectionError, DaemonProtocolError, DaemonQuitError } from './errors'
@@ -257,6 +258,8 @@ export class RustEnginePlayer implements AudioEngineBackend {
   private readonly durations = new Map<string, number>()
   /** 同一 filepath の並行ロードを直列化する single-flight。 */
   private readonly inflightLoads = new Map<string, Promise<string>>()
+  /** daemon crash 後に master insert を復元する、成功済み plugin 宣言のキャッシュ。 */
+  private readonly loadedPlugins = new Map<string, { filePath: string; pluginId?: string }>()
   private clockAnchor: ClockAnchor = { tsMs: 0, daemonSec: 0 }
   /**
    * 直近の StreamStats anchor サンプル列（#389 機構 B・ANCHOR_WINDOW 参照）。
@@ -481,6 +484,7 @@ export class RustEnginePlayer implements AudioEngineBackend {
           // （durations は file 由来で不変なので保持し slice 領域解決に使う）。inflightLoads の旧
           // エントリは ws close の reject で各自の .finally が既に delete 済み。
           this.sampleIds.clear()
+          await this.reloadPluginsAfterRespawn()
           console.warn(
             `✅ [rust-engine] daemon respawned and session re-established (attempt ${attempt}/${MAX_RESPAWN_ATTEMPTS}).`,
           )
@@ -576,6 +580,38 @@ export class RustEnginePlayer implements AudioEngineBackend {
         return
       }
       throw err
+    }
+  }
+
+  async loadPlugin(filePath: string, pluginId?: string): Promise<PluginLoadResult> {
+    try {
+      const result = await this.daemon.loadPlugin(filePath, pluginId)
+      this.loadedPlugins.set(JSON.stringify([filePath, pluginId ?? null]), { filePath, pluginId })
+      return result
+    } catch (err) {
+      if (err instanceof DaemonProtocolError) {
+        if (err.code === 'CLAP_UNAVAILABLE') {
+          throw new Error(
+            `Plugin hosting is unavailable in this daemon build; a --features clap-host build is required: ${err.message}`,
+          )
+        }
+        throw new Error(`Failed to load plugin: ${err.message}`)
+      }
+      throw err
+    }
+  }
+
+  private async reloadPluginsAfterRespawn(): Promise<void> {
+    for (const { filePath, pluginId } of this.loadedPlugins.values()) {
+      try {
+        await this.daemon.loadPlugin(filePath, pluginId)
+      } catch (err) {
+        // Cache entry intentionally remains: a later daemon respawn retries restoration.
+        console.error(
+          `❌ ERROR [rust-engine] failed to reload plugin after daemon respawn: ${filePath}`,
+          err,
+        )
+      }
     }
   }
 

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -263,6 +263,14 @@ export class RustEnginePlayer implements AudioEngineBackend {
    * replay する宣言 intent。
    */
   private loadedPlugin?: { filePath: string; pluginId?: string }
+  /**
+   * Whether `loadedPlugin` is actually loaded in the daemon right now (silent-failure
+   * guard). Set true on a successful `loadPlugin()`/reload, false when a post-respawn
+   * reload fails — surfaced via `isPluginActive()` so `PluginEffectManager`'s idempotent
+   * cache-hit path can detect a stale "success" and re-issue the load instead of
+   * silently returning as if the plugin were still active.
+   */
+  private pluginActive = false
   private clockAnchor: ClockAnchor = { tsMs: 0, daemonSec: 0 }
   /**
    * 直近の StreamStats anchor サンプル列（#389 機構 B・ANCHOR_WINDOW 参照）。
@@ -586,10 +594,17 @@ export class RustEnginePlayer implements AudioEngineBackend {
     }
   }
 
+  /**
+   * Loads a plugin into the daemon's master effect insert. Converts daemon-side
+   * `DaemonProtocolError`s into operator-actionable messages (CLAP_UNAVAILABLE →
+   * build hint, other codes → generic wrap); non-protocol errors pass through
+   * unchanged.
+   */
   async loadPlugin(filePath: string, pluginId?: string): Promise<PluginLoadResult> {
     try {
       const result = await this.daemon.loadPlugin(filePath, pluginId)
       this.loadedPlugin = { filePath, pluginId }
+      this.pluginActive = true
       return result
     } catch (err) {
       if (err instanceof DaemonProtocolError) {
@@ -604,18 +619,34 @@ export class RustEnginePlayer implements AudioEngineBackend {
     }
   }
 
+  /**
+   * Re-issues the last successful plugin declaration after a daemon respawn (the
+   * new daemon process starts with no plugins loaded). Broad catch is intentional:
+   * a reload failure is this plugin's own concern, not the respawn's — it must not
+   * make `respawnLoop` treat an otherwise-successful respawn as failed. Cache entry
+   * intentionally remains on failure so a later respawn retries restoration, and
+   * `pluginActive` flips false so `PluginEffectManager` can detect the stale cache
+   * (see `pluginActive` field doc) and self-heal on the next `effect()` call.
+   */
   private async reloadPluginsAfterRespawn(): Promise<void> {
     if (!this.loadedPlugin) return
     const { filePath, pluginId } = this.loadedPlugin
     try {
       await this.daemon.loadPlugin(filePath, pluginId)
+      this.pluginActive = true
     } catch (err) {
+      this.pluginActive = false
       // Cache entry intentionally remains: a later daemon respawn retries restoration.
       console.error(
         `❌ [rust-engine] failed to reload plugin after daemon respawn: ${filePath}`,
         err,
       )
     }
+  }
+
+  /** Whether `loadedPlugin` is actually active in the daemon right now (see field doc). */
+  isPluginActive(): boolean {
+    return this.pluginActive
   }
 
   /**

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -258,8 +258,11 @@ export class RustEnginePlayer implements AudioEngineBackend {
   private readonly durations = new Map<string, number>()
   /** 同一 filepath の並行ロードを直列化する single-flight。 */
   private readonly inflightLoads = new Map<string, Promise<string>>()
-  /** daemon crash 後に master insert を復元する、成功済み plugin 宣言のキャッシュ。 */
-  private readonly loadedPlugins = new Map<string, { filePath: string; pluginId?: string }>()
+  /**
+   * v1 は単一 master insert（PluginEffectManager が上流で保証）。daemon crash 後に
+   * replay する宣言 intent。
+   */
+  private loadedPlugin?: { filePath: string; pluginId?: string }
   private clockAnchor: ClockAnchor = { tsMs: 0, daemonSec: 0 }
   /**
    * 直近の StreamStats anchor サンプル列（#389 機構 B・ANCHOR_WINDOW 参照）。
@@ -586,7 +589,7 @@ export class RustEnginePlayer implements AudioEngineBackend {
   async loadPlugin(filePath: string, pluginId?: string): Promise<PluginLoadResult> {
     try {
       const result = await this.daemon.loadPlugin(filePath, pluginId)
-      this.loadedPlugins.set(JSON.stringify([filePath, pluginId ?? null]), { filePath, pluginId })
+      this.loadedPlugin = { filePath, pluginId }
       return result
     } catch (err) {
       if (err instanceof DaemonProtocolError) {
@@ -602,16 +605,16 @@ export class RustEnginePlayer implements AudioEngineBackend {
   }
 
   private async reloadPluginsAfterRespawn(): Promise<void> {
-    for (const { filePath, pluginId } of this.loadedPlugins.values()) {
-      try {
-        await this.daemon.loadPlugin(filePath, pluginId)
-      } catch (err) {
-        // Cache entry intentionally remains: a later daemon respawn retries restoration.
-        console.error(
-          `❌ ERROR [rust-engine] failed to reload plugin after daemon respawn: ${filePath}`,
-          err,
-        )
-      }
+    if (!this.loadedPlugin) return
+    const { filePath, pluginId } = this.loadedPlugin
+    try {
+      await this.daemon.loadPlugin(filePath, pluginId)
+    } catch (err) {
+      // Cache entry intentionally remains: a later daemon respawn retries restoration.
+      console.error(
+        `❌ [rust-engine] failed to reload plugin after daemon respawn: ${filePath}`,
+        err,
+      )
     }
   }
 

--- a/packages/engine/src/audio/types.ts
+++ b/packages/engine/src/audio/types.ts
@@ -63,6 +63,15 @@ export interface AudioEngine {
 
   /** Eagerly load a plugin into the engine's master effect insert. */
   loadPlugin?(filePath: string, pluginId?: string): Promise<PluginLoadResult>
+
+  /**
+   * Whether a previously-declared plugin is currently active in the engine
+   * (optional). Lets callers detect a stale idempotent cache after a daemon
+   * respawn silently failed to restore the plugin, so they can re-issue the
+   * load instead of returning a false "success". Engines without this method
+   * are treated as always-active (no self-heal check performed).
+   */
+  isPluginActive?(): boolean
 }
 
 /**

--- a/packages/engine/src/audio/types.ts
+++ b/packages/engine/src/audio/types.ts
@@ -5,6 +5,12 @@
 
 import type { AudioDevice } from './supercollider/types'
 
+export interface PluginLoadResult {
+  pluginId: string
+  pluginName: string
+  notePortIndex: number
+}
+
 /**
  * Audio engine interface
  * Defines the common interface for audio engines (currently SuperCollider)
@@ -54,6 +60,9 @@ export interface AudioEngine {
    * Best-effort. No-op on engines without LinkAudio (optional).
    */
   setLinkTempo?(bpm: number): Promise<void>
+
+  /** Eagerly load a plugin into the engine's master effect insert. */
+  loadPlugin?(filePath: string, pluginId?: string): Promise<PluginLoadResult>
 }
 
 /**

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -227,6 +227,9 @@ export class Global {
    * Ableton Link Audio instead of the hardware bus. Hardware output and
    * LinkAudio cannot coexist within the same .orbs file.
    *
+   * Rejected once plugin hosting (`global.effect()`) has already been
+   * declared — v1 mutual exclusion (PH.5).
+   *
    * @param targetSampleRate Optional explicit target SR for plugin-side
    *                         resampling. Auto-detect with 48000 fallback when
    *                         omitted.

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -60,7 +60,7 @@ export class Global {
     // Initialize managers
     this.tempoManager = new TempoManager()
     this.audioManager = new AudioManager(audioEngine)
-    this.linkAudioManager = new LinkAudioManager(() => this.pluginEffectManager.hasDeclaration())
+    this.linkAudioManager = new LinkAudioManager()
     this.pluginEffectManager = new PluginEffectManager(
       audioEngine,
       this.audioManager,
@@ -232,6 +232,11 @@ export class Global {
    *                         omitted.
    */
   linkAudio(targetSampleRate?: number): this {
+    if (this.pluginEffectManager.hasDeclaration()) {
+      throw new Error(
+        'global.linkAudio() cannot be used after plugin hosting has been declared in v1.',
+      )
+    }
     this.linkAudioManager.linkAudio(targetSampleRate)
     // #283: assert leadership for a tempo set before this call (usual order is
     // global.tempo() then global.linkAudio()).

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -21,6 +21,7 @@ import { QuantizeManager, QuantizeValue, nextQuantizedTime } from './global/quan
 import { MidiManager } from './global/midi-manager'
 import { TransportClock } from './global/transport-clock'
 import { MidiTransportScheduler } from './global/midi-transport-scheduler'
+import { PluginEffectManager } from './global/plugin-effect-manager'
 
 export class Global {
   // Manager instances for different responsibilities
@@ -32,6 +33,7 @@ export class Global {
   private linkAudioManager: LinkAudioManager
   private quantizeManager: QuantizeManager
   private midiManager: MidiManager
+  private pluginEffectManager: PluginEffectManager
 
   // Shared transport clock — the single Date.now() origin for both the audio
   // scheduler and the MIDI scheduler, so they stay in sync (§1). MIDI sequences
@@ -58,7 +60,12 @@ export class Global {
     // Initialize managers
     this.tempoManager = new TempoManager()
     this.audioManager = new AudioManager(audioEngine)
-    this.linkAudioManager = new LinkAudioManager()
+    this.linkAudioManager = new LinkAudioManager(() => this.pluginEffectManager.hasDeclaration())
+    this.pluginEffectManager = new PluginEffectManager(
+      audioEngine,
+      this.audioManager,
+      this.linkAudioManager,
+    )
     this.quantizeManager = new QuantizeManager()
     this.midiManager = midiManager ?? new MidiManager()
     this.sequenceRegistry = new SequenceRegistry(audioEngine, this)
@@ -234,6 +241,12 @@ export class Global {
 
   isLinkAudioEnabled(): boolean {
     return this.linkAudioManager.isEnabled()
+  }
+
+  /** Eagerly load the v1 single master-insert plugin. */
+  async effect(path: string, pluginId?: string): Promise<this> {
+    await this.pluginEffectManager.effect(path, pluginId)
+    return this
   }
 
   /**

--- a/packages/engine/src/core/global/audio-manager.ts
+++ b/packages/engine/src/core/global/audio-manager.ts
@@ -99,6 +99,10 @@ export class AudioManager {
     return this._audioPaths
   }
 
+  getDocumentDirectory(): string {
+    return this._documentDirectory
+  }
+
   /**
    * Resolve a sample spec to an absolute file path using the configured
    * audioPath(s) and document directory. Throws on resolution failure.

--- a/packages/engine/src/core/global/audio-resolver.ts
+++ b/packages/engine/src/core/global/audio-resolver.ts
@@ -64,7 +64,7 @@ export function resolveAudio(options: ResolveAudioOptions): string {
   return result
 }
 
-function resolvePathDirect(
+export function resolvePathDirect(
   spec: string,
   audioPaths: readonly string[],
   documentDirectory: string,

--- a/packages/engine/src/core/global/link-audio-manager.ts
+++ b/packages/engine/src/core/global/link-audio-manager.ts
@@ -17,8 +17,6 @@ export class LinkAudioManager {
   // undefined = auto-detect (fallback 48000), 数値指定で明示 override
   private _targetSampleRate?: number
 
-  constructor(private readonly isPluginHostingDeclared: () => boolean = () => false) {}
-
   /**
    * Enable LinkAudio mode and optionally specify the target sample rate
    * for plugin-side resampling.
@@ -35,11 +33,6 @@ export class LinkAudioManager {
    *                         48000 as the documented fallback.
    */
   linkAudio(targetSampleRate?: number): void {
-    if (this.isPluginHostingDeclared()) {
-      throw new Error(
-        'global.linkAudio() cannot be used after plugin hosting has been declared in v1.',
-      )
-    }
     this._enabled = true
     if (targetSampleRate === undefined) {
       this._targetSampleRate = undefined

--- a/packages/engine/src/core/global/link-audio-manager.ts
+++ b/packages/engine/src/core/global/link-audio-manager.ts
@@ -17,6 +17,8 @@ export class LinkAudioManager {
   // undefined = auto-detect (fallback 48000), 数値指定で明示 override
   private _targetSampleRate?: number
 
+  constructor(private readonly isPluginHostingDeclared: () => boolean = () => false) {}
+
   /**
    * Enable LinkAudio mode and optionally specify the target sample rate
    * for plugin-side resampling.
@@ -33,6 +35,11 @@ export class LinkAudioManager {
    *                         48000 as the documented fallback.
    */
   linkAudio(targetSampleRate?: number): void {
+    if (this.isPluginHostingDeclared()) {
+      throw new Error(
+        'global.linkAudio() cannot be used after plugin hosting has been declared in v1.',
+      )
+    }
     this._enabled = true
     if (targetSampleRate === undefined) {
       this._targetSampleRate = undefined

--- a/packages/engine/src/core/global/plugin-effect-manager.ts
+++ b/packages/engine/src/core/global/plugin-effect-manager.ts
@@ -2,7 +2,7 @@ import type { AudioEngine } from '../../audio/types'
 
 import { AudioManager } from './audio-manager'
 import { LinkAudioManager } from './link-audio-manager'
-import { resolvePluginPath } from './plugin-resolver'
+import { resolvePluginPath, validatePluginExtension } from './plugin-resolver'
 
 interface EffectDeclaration {
   resolvedPath: string
@@ -25,20 +25,36 @@ export class PluginEffectManager {
   }
 
   async effect(spec: string, pluginId?: string): Promise<void> {
+    // Order is load-bearing: validate the spec, then gate on LinkAudio, and
+    // only then resolve the path. A relative spec with no document context
+    // yet (unsaved file) makes `resolvePluginPath` throw a "cannot resolve"
+    // error; if that ran before the LinkAudio gate, it would mask the more
+    // relevant LinkAudio-conflict error with a confusing resolve failure.
+    validatePluginExtension(spec)
+
+    if (this.linkAudioManager.isEnabled()) {
+      throw new Error('global.effect() cannot be used while LinkAudio is enabled in v1.')
+    }
+
     const resolvedPath = resolvePluginPath(
       spec,
       this.audioManager.getAudioPaths(),
       this.audioManager.getDocumentDirectory(),
     )
 
-    if (this.linkAudioManager.isEnabled()) {
-      throw new Error('global.effect() cannot be used while LinkAudio is enabled in v1.')
-    }
-
     const existing = this.declaration
     if (existing) {
       if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
         await existing.load
+        // Self-heal: `isPluginActive() === false` means a prior daemon respawn
+        // failed to restore this plugin in the engine even though our cache
+        // still thinks it succeeded (silent-failure guard). Re-issue the load
+        // instead of returning a false "success". Engines without
+        // `isPluginActive` (SC backend / plain mocks) keep the old no-op
+        // idempotent behavior.
+        if (this.audioEngine.isPluginActive?.() === false) {
+          await this.issueLoad(resolvedPath, pluginId)
+        }
         return
       }
       throw new Error(
@@ -46,6 +62,11 @@ export class PluginEffectManager {
       )
     }
 
+    await this.issueLoad(resolvedPath, pluginId)
+  }
+
+  /** Issues (or re-issues) the load, installing the declaration and clearing it on failure. */
+  private async issueLoad(resolvedPath: string, pluginId: string | undefined): Promise<void> {
     if (!this.audioEngine.loadPlugin) {
       throw new Error('Plugin hosting requires the Rust engine backend.')
     }

--- a/packages/engine/src/core/global/plugin-effect-manager.ts
+++ b/packages/engine/src/core/global/plugin-effect-manager.ts
@@ -1,10 +1,8 @@
-import path from 'node:path'
-
 import type { AudioEngine } from '../../audio/types'
 
 import { AudioManager } from './audio-manager'
-import { resolvePathDirect } from './audio-resolver'
 import { LinkAudioManager } from './link-audio-manager'
+import { resolvePluginPath } from './plugin-resolver'
 
 interface EffectDeclaration {
   resolvedPath: string
@@ -27,17 +25,16 @@ export class PluginEffectManager {
   }
 
   async effect(spec: string, pluginId?: string): Promise<void> {
-    this.validateExtension(spec)
+    const resolvedPath = resolvePluginPath(
+      spec,
+      this.audioManager.getAudioPaths(),
+      this.audioManager.getDocumentDirectory(),
+    )
 
     if (this.linkAudioManager.isEnabled()) {
       throw new Error('global.effect() cannot be used while LinkAudio is enabled in v1.')
     }
 
-    const resolvedPath = resolvePathDirect(
-      spec,
-      this.audioManager.getAudioPaths(),
-      this.audioManager.getDocumentDirectory(),
-    )
     const existing = this.declaration
     if (existing) {
       if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
@@ -62,16 +59,5 @@ export class PluginEffectManager {
       if (this.declaration === declaration) this.declaration = undefined
       throw err
     }
-  }
-
-  private validateExtension(spec: string): void {
-    const extension = path.extname(spec).toLowerCase()
-    if (extension === '.clap') return
-    if (extension === '.vst3' || extension === '.component') {
-      throw new Error(
-        `${extension} plugins are not yet supported (reserved for future VST3/AU support).`,
-      )
-    }
-    throw new Error(`Unknown plugin extension "${extension || '(none)'}"; expected .clap.`)
   }
 }

--- a/packages/engine/src/core/global/plugin-effect-manager.ts
+++ b/packages/engine/src/core/global/plugin-effect-manager.ts
@@ -1,0 +1,77 @@
+import path from 'node:path'
+
+import type { AudioEngine } from '../../audio/types'
+
+import { AudioManager } from './audio-manager'
+import { resolvePathDirect } from './audio-resolver'
+import { LinkAudioManager } from './link-audio-manager'
+
+interface EffectDeclaration {
+  resolvedPath: string
+  pluginId?: string
+  load: Promise<void>
+}
+
+/** Owns the single v1 master-insert plugin declaration and eager load. */
+export class PluginEffectManager {
+  private declaration?: EffectDeclaration
+
+  constructor(
+    private readonly audioEngine: AudioEngine,
+    private readonly audioManager: AudioManager,
+    private readonly linkAudioManager: LinkAudioManager,
+  ) {}
+
+  hasDeclaration(): boolean {
+    return this.declaration !== undefined
+  }
+
+  async effect(spec: string, pluginId?: string): Promise<void> {
+    this.validateExtension(spec)
+
+    if (this.linkAudioManager.isEnabled()) {
+      throw new Error('global.effect() cannot be used while LinkAudio is enabled in v1.')
+    }
+
+    const resolvedPath = resolvePathDirect(
+      spec,
+      this.audioManager.getAudioPaths(),
+      this.audioManager.getDocumentDirectory(),
+    )
+    const existing = this.declaration
+    if (existing) {
+      if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
+        await existing.load
+        return
+      }
+      throw new Error(
+        'global.effect() supports one master insert in v1; effect chains are reserved for future support.',
+      )
+    }
+
+    if (!this.audioEngine.loadPlugin) {
+      throw new Error('Plugin hosting requires the Rust engine backend.')
+    }
+
+    const load = this.audioEngine.loadPlugin(resolvedPath, pluginId).then(() => undefined)
+    const declaration: EffectDeclaration = { resolvedPath, pluginId, load }
+    this.declaration = declaration
+    try {
+      await load
+    } catch (err) {
+      if (this.declaration === declaration) this.declaration = undefined
+      throw err
+    }
+  }
+
+  private validateExtension(spec: string): void {
+    const extension = path.extname(spec).toLowerCase()
+    if (extension === '.clap') return
+    if (extension === '.vst3' || extension === '.component') {
+      throw new Error(
+        `${extension} plugins are not yet supported (reserved for future VST3/AU support).`,
+      )
+    }
+    throw new Error(`Unknown plugin extension "${extension || '(none)'}"; expected .clap.`)
+  }
+}

--- a/packages/engine/src/core/global/plugin-resolver.ts
+++ b/packages/engine/src/core/global/plugin-resolver.ts
@@ -1,0 +1,35 @@
+/**
+ * Plugin path resolver.
+ *
+ * Shared extension-validation + path-resolution logic for `.clap` plugin
+ * specs. Extracted from `PluginEffectManager` (`global.effect()`) so #427's
+ * `seq.instrument()` can reuse the same validation + resolution without
+ * duplicating it.
+ *
+ * Order (unchanged from the previous inline implementation): extension
+ * validation first, then `resolvePathDirect`. Error messages are identical.
+ */
+
+import path from 'node:path'
+
+import { resolvePathDirect } from './audio-resolver'
+
+export function resolvePluginPath(
+  spec: string,
+  audioPaths: readonly string[],
+  documentDirectory: string,
+): string {
+  validateExtension(spec)
+  return resolvePathDirect(spec, audioPaths, documentDirectory)
+}
+
+function validateExtension(spec: string): void {
+  const extension = path.extname(spec).toLowerCase()
+  if (extension === '.clap') return
+  if (extension === '.vst3' || extension === '.component') {
+    throw new Error(
+      `${extension} plugins are not yet supported (reserved for future VST3/AU support).`,
+    )
+  }
+  throw new Error(`Unknown plugin extension "${extension || '(none)'}"; expected .clap.`)
+}

--- a/packages/engine/src/core/global/plugin-resolver.ts
+++ b/packages/engine/src/core/global/plugin-resolver.ts
@@ -6,8 +6,14 @@
  * `seq.instrument()` can reuse the same validation + resolution without
  * duplicating it.
  *
- * Order (unchanged from the previous inline implementation): extension
- * validation first, then `resolvePathDirect`. Error messages are identical.
+ * `resolvePluginPath` validates the extension first, then resolves the path
+ * (`resolvePathDirect`) — this single entry point always does both, in that
+ * order, so callers can't accidentally skip validation. Callers that also
+ * need to gate on other state (e.g. `PluginEffectManager.effect()` rejecting
+ * while LinkAudio is enabled) should run that check *between* validation and
+ * resolution — call `validatePluginExtension(spec)` directly first, do the
+ * gating check, then call `resolvePluginPath` (which re-validates; the
+ * function is pure so the repeat call is harmless).
  */
 
 import path from 'node:path'
@@ -19,11 +25,11 @@ export function resolvePluginPath(
   audioPaths: readonly string[],
   documentDirectory: string,
 ): string {
-  validateExtension(spec)
+  validatePluginExtension(spec)
   return resolvePathDirect(spec, audioPaths, documentDirectory)
 }
 
-function validateExtension(spec: string): void {
+export function validatePluginExtension(spec: string): void {
   const extension = path.extname(spec).toLowerCase()
   if (extension === '.clap') return
   if (extension === '.vst3' || extension === '.component') {

--- a/tests/audio/rust-engine/daemon-client.spec.ts
+++ b/tests/audio/rust-engine/daemon-client.spec.ts
@@ -64,6 +64,43 @@ describe('DaemonClient with mock server', () => {
     expect(record?.params.path).toBe('/tmp/kick.wav')
   })
 
+  it('LoadPlugin は response を camelCase に変換し effect role と plugin_id を送る', async () => {
+    const url = await server.start({
+      LoadPlugin: () => ({
+        plugin_id: 'com.example.echo',
+        plugin_name: 'Example Echo',
+        note_port_index: 2,
+      }),
+    })
+    await client.start({ wsUrlOverride: url })
+    await expect(client.loadPlugin('/tmp/echo.clap', 'com.example.echo')).resolves.toEqual({
+      pluginId: 'com.example.echo',
+      pluginName: 'Example Echo',
+      notePortIndex: 2,
+    })
+    const record = server.received.find((r) => r.method === 'LoadPlugin')
+    expect(record?.params).toEqual({
+      path: '/tmp/echo.clap',
+      plugin_id: 'com.example.echo',
+      role: 'effect',
+    })
+  })
+
+  it('LoadPlugin error は code を保持した DaemonProtocolError に変換する', async () => {
+    const url = await server.start({
+      LoadPlugin: () => {
+        const error = new Error('clap host is unavailable') as Error & { code?: string }
+        error.code = 'CLAP_UNAVAILABLE'
+        throw error
+      },
+    })
+    await client.start({ wsUrlOverride: url })
+    await expect(client.loadPlugin('/tmp/echo.clap')).rejects.toBeInstanceOf(DaemonProtocolError)
+    await expect(client.loadPlugin('/tmp/echo.clap')).rejects.toMatchObject({
+      code: 'CLAP_UNAVAILABLE',
+    })
+  })
+
   it('PlayAt は playId を返す', async () => {
     const url = await server.start({
       PlayAt: () => ({ play_id: 'p-mock-1' }),

--- a/tests/audio/rust-engine/mock-daemon-server.ts
+++ b/tests/audio/rust-engine/mock-daemon-server.ts
@@ -24,6 +24,7 @@ type MockHandler = (
 
 export interface MockDaemonHandlers {
   LoadSample?: MockHandler
+  LoadPlugin?: MockHandler
   PlayAt?: MockHandler
   Stop?: MockHandler
   StopAll?: MockHandler

--- a/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
+++ b/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
@@ -12,6 +12,12 @@ interface FakeDaemon {
   quit: ReturnType<typeof vi.fn>
 }
 
+const ECHO_LOAD_RESULT = {
+  pluginId: 'echo-id',
+  pluginName: 'Echo',
+  notePortIndex: 0,
+}
+
 function createHarness() {
   const player = new RustEnginePlayer()
   const daemon: FakeDaemon = {
@@ -20,11 +26,7 @@ function createHarness() {
     isRunning: vi.fn().mockReturnValue(true),
     off: vi.fn(),
     on: vi.fn(),
-    loadPlugin: vi.fn().mockResolvedValue({
-      pluginId: 'echo-id',
-      pluginName: 'Echo',
-      notePortIndex: 0,
-    }),
+    loadPlugin: vi.fn().mockResolvedValue(ECHO_LOAD_RESULT),
     quit: vi.fn().mockResolvedValue(undefined),
   }
   Object.defineProperty(player, 'daemon', { value: daemon })
@@ -56,16 +58,17 @@ describe('RustEnginePlayer plugin recovery after daemon respawn', () => {
     players.push(player)
     await player.loadPlugin('/plugins/echo.clap', 'echo-id')
     daemon.loadPlugin.mockClear()
-    daemon.loadPlugin.mockRejectedValueOnce(new Error('reload failed')).mockResolvedValueOnce({
-      pluginId: 'echo-id',
-      pluginName: 'Echo',
-      notePortIndex: 0,
-    })
+    daemon.loadPlugin
+      .mockRejectedValueOnce(new Error('reload failed'))
+      .mockResolvedValueOnce(ECHO_LOAD_RESULT)
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     await (player as any).respawnLoop()
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('ERROR'), expect.any(Error))
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('❌ [rust-engine] failed to reload plugin'),
+      expect.any(Error),
+    )
 
     await (player as any).respawnLoop()
     expect(daemon.loadPlugin).toHaveBeenCalledTimes(2)

--- a/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
+++ b/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
@@ -125,4 +125,20 @@ describe('RustEnginePlayer.loadPlugin() error conversion', () => {
 
     await expect(player.loadPlugin('/plugins/echo.clap', 'echo-id')).rejects.toBe(original)
   })
+
+  it('flips pluginActive to false when a subsequent loadPlugin call fails', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    await player.loadPlugin('/plugins/echo.clap', 'echo-id')
+    expect(player.isPluginActive()).toBe(true)
+
+    daemon.loadPlugin.mockRejectedValueOnce(new Error('daemon transport failure'))
+
+    await expect(player.loadPlugin('/plugins/echo.clap', 'echo-id')).rejects.toThrow(
+      'daemon transport failure',
+    )
+    // The catch block must not rely on callers guaranteeing false-on-entry —
+    // it must flip pluginActive to false itself on every failure path.
+    expect(player.isPluginActive()).toBe(false)
+  })
 })

--- a/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
+++ b/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { DaemonProtocolError } from '../../../packages/engine/src/audio/rust-engine/errors'
 import { RustEnginePlayer } from '../../../packages/engine/src/audio/rust-engine/rust-engine-player'
 
 interface FakeDaemon {
@@ -51,6 +52,10 @@ describe('RustEnginePlayer plugin recovery after daemon respawn', () => {
     await (player as any).respawnLoop()
 
     expect(daemon.loadPlugin).toHaveBeenCalledWith('/plugins/echo.clap', 'echo-id')
+    // C1: a successful reload must flip pluginActive back to true, so
+    // PluginEffectManager's self-heal check doesn't mistake this recovery
+    // for a still-stale cache.
+    expect(player.isPluginActive()).toBe(true)
   })
 
   it('logs a reload failure and retains the plugin for the next respawn retry', async () => {
@@ -69,9 +74,55 @@ describe('RustEnginePlayer plugin recovery after daemon respawn', () => {
       expect.stringContaining('❌ [rust-engine] failed to reload plugin'),
       expect.any(Error),
     )
+    // C1: a failed reload must flip pluginActive to false — this is the
+    // signal PluginEffectManager uses to detect the silent-failure cache.
+    expect(player.isPluginActive()).toBe(false)
 
     await (player as any).respawnLoop()
     expect(daemon.loadPlugin).toHaveBeenCalledTimes(2)
     expect(daemon.loadPlugin).toHaveBeenLastCalledWith('/plugins/echo.clap', 'echo-id')
+    expect(player.isPluginActive()).toBe(true)
+  })
+})
+
+describe('RustEnginePlayer.loadPlugin() error conversion', () => {
+  const players: RustEnginePlayer[] = []
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await Promise.all(players.splice(0).map((player) => player.quit()))
+  })
+
+  it('converts CLAP_UNAVAILABLE into a build-hint error', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    daemon.loadPlugin.mockRejectedValueOnce(
+      new DaemonProtocolError('CLAP_UNAVAILABLE', 'clap host is unavailable'),
+    )
+
+    await expect(player.loadPlugin('/plugins/echo.clap', 'echo-id')).rejects.toThrow(
+      '--features clap-host',
+    )
+  })
+
+  it('wraps other DaemonProtocolError codes with a generic "Failed to load plugin" message', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    daemon.loadPlugin.mockRejectedValueOnce(
+      new DaemonProtocolError('PLUGIN_LOAD_FAILED', 'the plugin crashed on init'),
+    )
+
+    await expect(player.loadPlugin('/plugins/echo.clap', 'echo-id')).rejects.toThrow(
+      /^Failed to load plugin:/,
+    )
+  })
+
+  it('passes through non-DaemonProtocolError failures unchanged', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    const original = new Error('unexpected transport failure')
+    daemon.loadPlugin.mockRejectedValueOnce(original)
+
+    await expect(player.loadPlugin('/plugins/echo.clap', 'echo-id')).rejects.toBe(original)
   })
 })

--- a/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
+++ b/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { RustEnginePlayer } from '../../../packages/engine/src/audio/rust-engine/rust-engine-player'
+
+interface FakeDaemon {
+  start: ReturnType<typeof vi.fn>
+  getStatus: ReturnType<typeof vi.fn>
+  isRunning: ReturnType<typeof vi.fn>
+  off: ReturnType<typeof vi.fn>
+  on: ReturnType<typeof vi.fn>
+  loadPlugin: ReturnType<typeof vi.fn>
+  quit: ReturnType<typeof vi.fn>
+}
+
+function createHarness() {
+  const player = new RustEnginePlayer()
+  const daemon: FakeDaemon = {
+    start: vi.fn().mockResolvedValue(undefined),
+    getStatus: vi.fn().mockResolvedValue({ uptime_sec: 0 }),
+    isRunning: vi.fn().mockReturnValue(true),
+    off: vi.fn(),
+    on: vi.fn(),
+    loadPlugin: vi.fn().mockResolvedValue({
+      pluginId: 'echo-id',
+      pluginName: 'Echo',
+      notePortIndex: 0,
+    }),
+    quit: vi.fn().mockResolvedValue(undefined),
+  }
+  Object.defineProperty(player, 'daemon', { value: daemon })
+  return { player, daemon }
+}
+
+describe('RustEnginePlayer plugin recovery after daemon respawn', () => {
+  const players: RustEnginePlayer[] = []
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await Promise.all(players.splice(0).map((player) => player.quit()))
+  })
+
+  it('reissues every successfully loaded plugin after respawn', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    await player.loadPlugin('/plugins/echo.clap', 'echo-id')
+    daemon.loadPlugin.mockClear()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await (player as any).respawnLoop()
+
+    expect(daemon.loadPlugin).toHaveBeenCalledWith('/plugins/echo.clap', 'echo-id')
+  })
+
+  it('logs a reload failure and retains the plugin for the next respawn retry', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    await player.loadPlugin('/plugins/echo.clap', 'echo-id')
+    daemon.loadPlugin.mockClear()
+    daemon.loadPlugin.mockRejectedValueOnce(new Error('reload failed')).mockResolvedValueOnce({
+      pluginId: 'echo-id',
+      pluginName: 'Echo',
+      notePortIndex: 0,
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await (player as any).respawnLoop()
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('ERROR'), expect.any(Error))
+
+    await (player as any).respawnLoop()
+    expect(daemon.loadPlugin).toHaveBeenCalledTimes(2)
+    expect(daemon.loadPlugin).toHaveBeenLastCalledWith('/plugins/echo.clap', 'echo-id')
+  })
+})

--- a/tests/core/global-plugin-effect.spec.ts
+++ b/tests/core/global-plugin-effect.spec.ts
@@ -47,6 +47,16 @@ describe('Global.effect()', () => {
     expect(loadPlugin).toHaveBeenCalledWith(path.resolve('/songs/session', 'echo.clap'), 'echo-id')
   })
 
+  it('treats different spec spellings that resolve to the same path as idempotent', async () => {
+    // Regression guard: the idempotent cache-hit compares `resolvedPath`, not the raw
+    // spec string, so a spelling change alone (leading `./` vs bare name) must not
+    // trigger a second load.
+    const { global, loadPlugin } = makeGlobal()
+    await global.effect('./echo.clap', 'echo-id')
+    await global.effect('echo.clap', 'echo-id')
+    expect(loadPlugin).toHaveBeenCalledTimes(1)
+  })
+
   it('rejects a second, different effect declaration', async () => {
     const { global, loadPlugin } = makeGlobal()
     await global.effect('echo.clap')
@@ -79,5 +89,79 @@ describe('Global.effect()', () => {
     await expect(global.effect('echo.clap')).rejects.toBe(failure)
     await expect(global.effect('echo.clap')).resolves.toBe(global)
     expect(loadPlugin).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects with a LinkAudio error, not a resolve error, when no document context is set', async () => {
+    // C2 regression: a relative spec with no documentDirectory/audioPath makes
+    // resolvePluginPath throw "cannot resolve"; the LinkAudio gate must run
+    // before resolution so this scenario surfaces the more relevant LinkAudio
+    // conflict instead of a confusing resolve failure.
+    const engine = {
+      loadPlugin: vi.fn().mockResolvedValue({}),
+      boot: vi.fn(),
+      quit: vi.fn(),
+      isRunning: true,
+    } as any
+    const global = new Global(engine)
+    global.linkAudio()
+    await expect(global.effect('rel.clap')).rejects.toThrow('LinkAudio')
+  })
+
+  describe('self-heal after a stale idempotent cache', () => {
+    function makeSelfHealingGlobal(loadPlugin: ReturnType<typeof vi.fn>, isPluginActive: boolean) {
+      const engine = {
+        loadPlugin,
+        isPluginActive: vi.fn().mockReturnValue(isPluginActive),
+        boot: vi.fn(),
+        quit: vi.fn(),
+        isRunning: true,
+      } as any
+      const global = new Global(engine)
+      global.setDocumentDirectory('/songs/session')
+      return global
+    }
+
+    it('re-issues the load when the engine reports the plugin inactive', async () => {
+      const loadPlugin = vi.fn().mockResolvedValue({})
+      const global = makeSelfHealingGlobal(loadPlugin, false)
+
+      await global.effect('./echo.clap', 'echo-id')
+      await expect(global.effect('./echo.clap', 'echo-id')).resolves.toBe(global)
+
+      expect(loadPlugin).toHaveBeenCalledTimes(2)
+      expect(loadPlugin).toHaveBeenNthCalledWith(
+        2,
+        path.resolve('/songs/session', 'echo.clap'),
+        'echo-id',
+      )
+    })
+
+    it('throws and clears the declaration when the re-issue itself fails, permitting a further retry', async () => {
+      const failure = new Error('daemon rejected the reissue')
+      const loadPlugin = vi
+        .fn()
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(failure)
+        .mockResolvedValueOnce({})
+      const global = makeSelfHealingGlobal(loadPlugin, false)
+
+      await global.effect('echo.clap', 'echo-id')
+      await expect(global.effect('echo.clap', 'echo-id')).rejects.toBe(failure)
+      // Declaration was cleared on failure, so a further call retries the load
+      // (same semantics as an initial-load failure) rather than being treated
+      // as a "different declaration" conflict.
+      await expect(global.effect('echo.clap', 'echo-id')).resolves.toBe(global)
+      expect(loadPlugin).toHaveBeenCalledTimes(3)
+    })
+
+    it('stays a no-op idempotent cache hit when isPluginActive is undefined (back-compat)', async () => {
+      // Covered structurally by the existing "eagerly loads once..." test above
+      // (its mock engine has no isPluginActive), asserted again here to make the
+      // back-compat guarantee explicit for this describe block.
+      const { global, loadPlugin } = makeGlobal()
+      await global.effect('./echo.clap', 'echo-id')
+      await global.effect('./echo.clap', 'echo-id')
+      expect(loadPlugin).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/tests/core/global-plugin-effect.spec.ts
+++ b/tests/core/global-plugin-effect.spec.ts
@@ -1,0 +1,83 @@
+import path from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { Global } from '../../packages/engine/src/core/global'
+
+function makeGlobal(loadPlugin = vi.fn().mockResolvedValue({})) {
+  const engine = {
+    loadPlugin,
+    boot: vi.fn(),
+    quit: vi.fn(),
+    isRunning: true,
+  } as any
+  const global = new Global(engine)
+  global.setDocumentDirectory('/songs/session')
+  return { global, loadPlugin }
+}
+
+describe('Global.effect()', () => {
+  it.each(['synth.vst3', 'synth.component'])('rejects reserved format %s', async (spec) => {
+    const { global } = makeGlobal()
+    await expect(global.effect(spec)).rejects.toThrow('not yet supported')
+  })
+
+  it.each(['effect.wav', 'effect'])('rejects unknown extension %s', async (spec) => {
+    const { global } = makeGlobal()
+    await expect(global.effect(spec)).rejects.toThrow('Unknown plugin extension')
+  })
+
+  it('rejects effect while LinkAudio is enabled', async () => {
+    const { global } = makeGlobal()
+    global.linkAudio()
+    await expect(global.effect('echo.clap')).rejects.toThrow('LinkAudio')
+  })
+
+  it('rejects LinkAudio after an effect declaration', async () => {
+    const { global } = makeGlobal()
+    await global.effect('echo.clap')
+    expect(() => global.linkAudio()).toThrow('plugin hosting')
+  })
+
+  it('eagerly loads once and treats the same resolved path and plugin id as idempotent', async () => {
+    const { global, loadPlugin } = makeGlobal()
+    await expect(global.effect('./echo.clap', 'echo-id')).resolves.toBe(global)
+    await global.effect('./echo.clap', 'echo-id')
+    expect(loadPlugin).toHaveBeenCalledTimes(1)
+    expect(loadPlugin).toHaveBeenCalledWith(path.resolve('/songs/session', 'echo.clap'), 'echo-id')
+  })
+
+  it('rejects a second, different effect declaration', async () => {
+    const { global, loadPlugin } = makeGlobal()
+    await global.effect('echo.clap')
+    await expect(global.effect('reverb.clap')).rejects.toThrow('one master insert in v1')
+    expect(loadPlugin).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects the same path with a different plugin id', async () => {
+    const { global, loadPlugin } = makeGlobal()
+    await global.effect('bundle.clap', 'first-id')
+    await expect(global.effect('bundle.clap', 'second-id')).rejects.toThrow(
+      'one master insert in v1',
+    )
+    expect(loadPlugin).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a backend without plugin hosting support', async () => {
+    const engine = { boot: vi.fn(), quit: vi.fn(), isRunning: true } as any
+    const global = new Global(engine)
+    global.setDocumentDirectory('/songs/session')
+    await expect(global.effect('echo.clap')).rejects.toThrow(
+      'Plugin hosting requires the Rust engine backend',
+    )
+  })
+
+  it('propagates eager load failures and permits a retry', async () => {
+    const failure = new Error('daemon rejected the plugin')
+    const loadPlugin = vi.fn().mockRejectedValueOnce(failure).mockResolvedValueOnce({})
+    const { global } = makeGlobal(loadPlugin)
+    await expect(global.effect('echo.clap')).rejects.toBe(failure)
+    await expect(global.effect('echo.clap')).resolves.toBe(global)
+    expect(loadPlugin).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
Closes #426

## 概要

#425 で確定した `global.effect(path[, pluginId])` を TypeScript 側に実装し、daemon の実行時 `LoadPlugin`（in-process clap-host 経路）へ配線した。Epic #424 Stage 1 の前半（instrument 側の #427 が後半）。Rust 側の変更はなし。

## 判断経緯（Fable 一発判断・2026-07-14）

グラウンディングで「daemon に OOP effect の実行時ロードコマンドが無い（outproc-* は起動時 env のみ）・4-way compile-time 排他で effect+instrument 同時使用不可・release build は plugin feature 全て無効」という構造ギャップが確定。3案比較の結果:

- **案C ハイブリッド採用**: #426/#427 は in-process `clap-host` 経路（今日の daemon で唯一の DSL 駆動実行時ロード経路）で単体 DoD を通す。wire 契約は backend 中立で、OOP 化後も TS/DSL 層は不変
- **`role: "effect"` を初回から送信**（将来の OOP attach での child 選択 wire を先行確定。daemon は未知 field を無視 = コスト0）
- **#431 起票 + Epic #424 段階化**: OOP post-boot attach・排他解消・配布 feature 方針は Stage 2（#431）。Epic DoD「effect+instrument 同時演奏」は #431 で達成

## 実装内容

- `PluginEffectManager`（新規）: 拡張子検証（`.clap` のみ・`.vst3`/`.component` 予約エラー）→ linkAudio 排他 → `resolvePathDirect` 解決（bank 検索なし）→ 冪等/エラー判定 → eager load（失敗ロールバック・並行呼び出しは load Promise 共有）
- `Global.effect()`: chainable async verb（リフレクション dispatch でパーサー変更不要）
- `DaemonClient.loadPlugin()`: camelCase 変換・`role: "effect"` 送信
- `RustEnginePlayer.loadPlugin()`: `CLAP_UNAVAILABLE` → 「--features clap-host build が必要」のエラーマッピング + **respawn 後の plugin 再ロード**（受け入れ監査 Important 指摘: crash→respawn で master insert が黙って消える silent failure を修正。fail-before/pass-after 実証済み — 修正 revert で 2 テスト red「Number of calls: 0」→ 復元で green）
- 逆方向排他: effect 宣言後の `linkAudio()` を `Global.linkAudio()` 内の guard で拒否（/simplify で callback 注入から Global 直接チェックに変更。`LinkAudioManager` は zero-arg constructor のまま main と無差分）
- spec 追従: PH.2 に同一 path+pluginId 再宣言の冪等を明確化・PH.6 のポインタを #431 に更新

## プロセス

1. グラウンディング（Sonnet subagent: TS 配線点の地図）
2. Fable 実装前相談（案A/B/C の一発判断・確信度 高・反証条件つき）
3. Codex 委譲（2 ラウンド: 本体 + 監査指摘 fix）
4. Fable 受け入れ監査: spec 適合全項目 ✅・wire 正しさ（session.rs 突合）✅・並行/ロールバック安全 ✅・条件付き GO → B-1 fix 反映で解消

## 検証

- `npm test`: **1305 passed / 0 failed / 29 skipped**（レビューフロー完了後の最終値・main 環境で再実行確認）
- `npm run lint`: 変更ファイル 0 problems（既存 SC SDK submodule 由来の 10 errors は本 PR と無関係）
- **実機 gated E2E 達成（2026-07-14）**: `--features clap-host` build + `clap-test-effect`（固定 gain 0.5・挙動既知の oracle）で baseline / `global.effect()` あり の capture WAV を比較 → **peak ratio = 0.5000（厳密一致）**。DSL → daemon LoadPlugin → CLAP host → master insert の全経路を実機で実証（詳細は WORK_LOG 6.250）
- レビュー: /simplify（4観点・6適用）→ /code:pr-review-team 2 ラウンド収束（Critical/Important = 0・round 2 は修正前コミットへのテスト移植による fail-before/pass-after 再実証つき）・CI 4/4 pass・bot レビューは advisor 判断で省略

## 残作業・関連

- #427: instrument + Pitch DSL v1.1 接続（`daemon-client.loadPlugin` の role 引数化を含む）
- #431: OOP post-boot attach + 排他解消 + 配布 feature（Stage 2）
- #433: daemon discovery の macOS `.clap` バンドルディレクトリ解決（E2E で発見した統合ギャップ・市販プラグイン対応に必須）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015R9Km7edyaAgqzVFsUm7uX

