### PR TITLE
fix(daemon): resolve macOS .clap bundle directories in plugin discovery (#433)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -61,6 +61,17 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 - ゴール再確認: 「CLAP effect + instrument が完全に動く」まで横展開に入らない
   （#433 → #427 → #431 → Epic #424 DoD 実機実証）
 
+**/simplify（4観点・適用2件/スキップ2件）**:
+- 適用: ①**ubuntu CI fail の実修復** — テスト fixture（TempDir 等）が Linux で dead code
+  になり clippy --all-targets -D warnings が fail していた → `mod tests` 全体への単一
+  `#[cfg(target_os = "macos")]` で cfg 重複7箇所の解消と CI 修復を同時に達成
+  ②orbit-clap-spike（移植元・凍結）の `open_bundle` に「#433 で上流 API に置換済み」の
+  パンくずコメント（将来のコピペによるバグ再導入防止）
+- スキップ: TempDir 手組み（workspace 慣行4例目・tempfile 依存なし・rule-of-five 待ち）／
+  bundle-macos.sh のテンプレート化（spike 2例のみ・rule-of-three 前）
+- reuse / efficiency は clean（上流 API 置換で entry cache 経路は不変・追加コストは
+  control plane の stat 1回のみ）
+
 ### 6.250 feat(dsl): global.effect() — CLAP effect の DSL 疎通 #426 Stage 1 (Jul 14, 2026)
 
 **Date**: 2026-07-14

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -22,7 +22,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 **Date**: 2026-07-14
 **Status**: ✅ 実装・実機 E2E 済み（PR 作成・レビューフローへ）
 **Branch**: `433-clap-bundle-dir-discovery`
-**Commit**: `0575e98`
+**Commit**: `610bef4`
 
 #426 実機 E2E で発見した統合ギャップ（discovery が `.clap` バンドルディレクトリを
 そのまま dlopen して失敗）の修正。市販 CLAP プラグイン（Surge XT / FabFilter 等）は
@@ -43,7 +43,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
   削除（約40行減）。テストを plist つき4系統に再構成: stem 一致 /
   **CFBundleExecutable ≠ stem（NSBundle 正規解決の検証・手組み版より強い保証）** /
   実行体不在エラー / flat-file 後方互換。plist 無しバンドルも NSBundle が stem から
-  推定してロード成功することを実測
+  推定してロード成功することを手動確認（自動テスト対象外）
 
 **検証（main 環境・非サンドボックス）**:
 - `cargo test --workspace` 全 green（failed 0・orbit-clap-host 24 件・daemon protocol 28 件含む）
@@ -71,6 +71,19 @@ A design and implementation project for a new music DSL (Domain Specific Languag
   bundle-macos.sh のテンプレート化（spike 2例のみ・rule-of-three 前）
 - reuse / efficiency は clean（上流 API 置換で entry cache 経路は不変・追加コストは
   control plane の stat 1回のみ）
+
+**/code:pr-review-team round 1（4レビュアー + CI）**:
+- CI 4/4 pass（cfg ゲート修正で ubuntu clippy 回復）。comment-analyzer ≈ PASS
+  （全 claim を pinned ソース + 本家 entry.h で裏取り）。エラー経路も PASS
+  （NullBundlePath 削除で失われた failure mode なし・DSL への observability 不変）
+- **3レビュアーが同一 Important に収束**: fixture 依存の3テストがサイレント skip で
+  偽 PASS になる（dylib 未ビルド時に assertion ゼロで green・CI は macOS ゲートで
+  未実行のため回帰検知が実質ゼロ）
+- fixer 適用: リポジトリ既存の gated 慣行に準拠 — `#[ignore = "needs a built test CLAP
+  dylib..."]` + 未ビルド時は build 手順つき panic（loud fail を fixture 退避で実測）。
+  `cargo test -p orbit-clap-host --lib` = 21 passed / 3 ignored（正直な表示）・
+  `-- --ignored` = 3 passed。WORK_LOG の hash/文言補正・TESTING_GUIDE に
+  fixture 事前ビルド手順を追加
 
 ### 6.250 feat(dsl): global.effect() — CLAP effect の DSL 疎通 #426 Stage 1 (Jul 14, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,50 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.251 fix(daemon): discovery の macOS .clap バンドルディレクトリ解決 #433 (Jul 14, 2026)
+
+**Date**: 2026-07-14
+**Status**: ✅ 実装・実機 E2E 済み（PR 作成・レビューフローへ）
+**Branch**: `433-clap-bundle-dir-discovery`
+**Commit**: `0575e98`
+
+#426 実機 E2E で発見した統合ギャップ（discovery が `.clap` バンドルディレクトリを
+そのまま dlopen して失敗）の修正。市販 CLAP プラグイン（Surge XT / FabFilter 等）は
+全てバンドル形式のため、実プラグイン対応の前提。
+
+**実装の経緯（2ラウンド・監査が上流資産を発見）**:
+- Round 1（Codex）: 手組みの `resolve_dylib_path`（stem 候補 → 単一ファイル fallback →
+  0/複数エラー）+ `BundleExecutableNotFound` variant。テスト4件・全検証 green
+- **Fable 受け入れ監査（GO + Important 発見）**: pinned clack-host（rev `f874e858`）に
+  **`PluginEntry::load(path)` が既存**で、NSBundle（Info.plist の CFBundleExecutable）に
+  よる正規の macOS 解決を上流実装済みと一次ソースで確認（`host/src/entry/library.rs:120-148`）。
+  CLAP 契約（dlopen = 実行体・entry init = 元バンドルパス。本家 entry.h L93 で確認）も
+  手組み実装は正しかったが、手組みには CFBundleExecutable ≠ stem + `.DS_Store` 混入で
+  誤エラーになる実運用上の穴。監査は follow-up 化も可としたが、
+  **#433 の目的そのもの（実プラグインが完全に動く）+ 資産再利用の観点で即リワークを選択**
+- Round 2（Codex resume）: `open_bundle` を `PluginEntry::load(path)` に置換（実質1行 +
+  契約コメント）。手組み解決・`BundleExecutableNotFound`・`NullBundlePath`・CString 処理を
+  削除（約40行減）。テストを plist つき4系統に再構成: stem 一致 /
+  **CFBundleExecutable ≠ stem（NSBundle 正規解決の検証・手組み版より強い保証）** /
+  実行体不在エラー / flat-file 後方互換。plist 無しバンドルも NSBundle が stem から
+  推定してロード成功することを実測
+
+**検証（main 環境・非サンドボックス）**:
+- `cargo test --workspace` 全 green（failed 0・orbit-clap-host 24 件・daemon protocol 28 件含む）
+- fmt / clippy / deny 全 green
+- **実機 E2E（fail-before/pass-after）**: fail-before = #426 E2E での
+  `dlopen(<bundle dir>): not a file` エラー（WORK_LOG 6.250 記録済み）→ pass-after =
+  同じバンドルディレクトリ path で `global.effect()` → LoadPlugin 成功・
+  **peak ratio = 0.5000（厳密一致・gain 0.5 の closed-form signature）**
+- 監査も fail-before を独立実測（旧挙動へ一時復元で新テスト 2 件が #426 と同一症状で red）
+
+**owner 対応（同日）**:
+- **#434 起票**: `seq.effect()`（per-track insert）— owner 要望「正直 seq でのエフェクトは
+  入れて欲しかった」を受け、Epic #424 DoD 達成後の最初の CLAP 深掘り項目として明文化
+  （前提 = #431 の部品・新規部分 = per-sequence バスのタップ）
+- ゴール再確認: 「CLAP effect + instrument が完全に動く」まで横展開に入らない
+  （#433 → #427 → #431 → Epic #424 DoD 実機実証）
+
 ### 6.250 feat(dsl): global.effect() — CLAP effect の DSL 疎通 #426 Stage 1 (Jul 14, 2026)
 
 **Date**: 2026-07-14

--- a/docs/testing/TESTING_GUIDE.md
+++ b/docs/testing/TESTING_GUIDE.md
@@ -83,6 +83,27 @@ npm test -- unidirectional-toggle
 - SuperCollider environment-specific tests
 - Some interpreter tests
 
+### Rust: CLAP Host Gated Fixture Tests
+
+`orbit-clap-host` の discovery テスト（.clap バンドルディレクトリ解決など）は、
+実ビルド済みの CLAP テストプラグイン dylib（`rust-spike/clap-test-effect` または
+`rust-spike/clap-test-synth`）を前提とする `#[ignore]` 付き gated テスト。
+
+**事前ビルド**:
+```bash
+cargo build --release --manifest-path rust-spike/clap-test-effect/Cargo.toml
+# または
+cargo build --release --manifest-path rust-spike/clap-test-synth/Cargo.toml
+```
+
+**実行**:
+```bash
+cargo test -p orbit-clap-host --lib -- --ignored
+```
+
+fixture dylib が見つからない場合、これらのテストはサイレント skip せず `panic!` で
+loud fail する（build 手順を含むメッセージ付き）。
+
 ---
 
 ## 🎵 IDE Integration Testing (VS Code / Cursor / Claude Code)

--- a/rust-spike/clap-test-effect/bundle-macos.sh
+++ b/rust-spike/clap-test-effect/bundle-macos.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# bundle-macos.sh — build the dylib and assemble the macOS .clap bundle.
+# Usage: ./bundle-macos.sh [--release]
+#
+# The bundle is created at:
+#   target/<profile>/CLAPTestEffect.clap/Contents/MacOS/CLAPTestEffect
+
+set -euo pipefail
+
+export PATH="$HOME/.cargo/bin:$PATH"
+
+PROFILE="debug"
+CARGO_FLAGS=""
+if [[ "${1:-}" == "--release" ]]; then
+  PROFILE="release"
+  CARGO_FLAGS="--release"
+fi
+
+echo "==> cargo build $CARGO_FLAGS"
+cargo build $CARGO_FLAGS
+
+DYLIB="target/$PROFILE/libclap_test_effect.dylib"
+BUNDLE="target/$PROFILE/CLAPTestEffect.clap"
+
+echo "==> Assembling bundle: $BUNDLE"
+mkdir -p "$BUNDLE/Contents/MacOS"
+cp "$DYLIB" "$BUNDLE/Contents/MacOS/CLAPTestEffect"
+
+cat > "$BUNDLE/Contents/Info.plist" << 'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>CLAPTestEffect</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.signalcompose.clap-test-effect</string>
+    <key>CFBundleName</key>
+    <string>CLAP Test Effect</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>0.1.0</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+</dict>
+</plist>
+PLIST
+
+echo "==> Verifying clap_entry export:"
+nm -gU "$BUNDLE/Contents/MacOS/CLAPTestEffect" | grep clap_entry
+
+echo ""
+echo "Bundle: $(pwd)/$BUNDLE"
+echo "Plugin ID: com.signalcompose.clap-test-effect"

--- a/rust/crates/orbit-clap-host/src/discovery.rs
+++ b/rust/crates/orbit-clap-host/src/discovery.rs
@@ -6,9 +6,8 @@
 // プラグインバンドルのロードには unsafe FFI が必要。
 #![allow(unsafe_code)]
 
-use clack_host::entry::{LibraryEntry, PluginEntryError};
+use clack_host::entry::PluginEntryError;
 use clack_host::prelude::PluginEntry;
-use std::ffi::CString;
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -75,8 +74,6 @@ pub enum DiscoveryError {
     LoadError(PluginEntryError),
     #[error("ファイルにプラグインファクトリがない")]
     MissingPluginFactory,
-    #[error("バンドルパスに null バイトが含まれる")]
-    NullBundlePath,
 }
 
 impl From<PluginEntryError> for DiscoveryError {
@@ -89,11 +86,10 @@ impl From<PluginEntryError> for DiscoveryError {
 /// `PluginFactory` は `PluginEntry` を借用するため、エントリの方を返す（factory は caller
 /// のスタックフレームで使う）。
 fn open_bundle(path: &Path) -> Result<PluginEntry, DiscoveryError> {
-    let bundle_path = CString::new(path.to_string_lossy().as_bytes())
-        .map_err(|_| DiscoveryError::NullBundlePath)?;
+    // clack-host が macOS の NSBundle / CFBundleExecutable 解決と、CLAP entry init に
+    // 渡す元の .clap バンドルパスの保持を一括して行う。flat-file にも対応する。
     // SAFETY: ネイティブライブラリのロードは本質的に unsafe。
-    let library = unsafe { LibraryEntry::load_from_path(path) }?;
-    Ok(unsafe { PluginEntry::load_from(library, &bundle_path) }?)
+    Ok(unsafe { PluginEntry::load(path) }?)
 }
 
 /// `path` の .clap バンドルに含まれる全プラグインをロードする。
@@ -133,4 +129,125 @@ pub fn load_plugin_id_from_path(
             path: path.to_path_buf(),
             plugin,
         }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new() -> Self {
+            let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "orbit-clap-discovery-{}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).expect("create temporary test directory");
+            Self(path)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn make_bundle(executable_name: &str) -> (TempDir, PathBuf) {
+        let temp = TempDir::new();
+        let bundle = temp.0.join("TestBundle.clap");
+        let executable_dir = bundle.join("Contents/MacOS");
+        fs::create_dir_all(&executable_dir).expect("create bundle executable directory");
+        let plist = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>{executable_name}</string>
+</dict>
+</plist>
+"#
+        );
+        fs::write(bundle.join("Contents/Info.plist"), plist).expect("write bundle Info.plist");
+        (temp, bundle)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn built_test_plugin() -> Option<PathBuf> {
+        let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..");
+        [
+            "rust-spike/clap-test-effect/target/release/libclap_test_effect.dylib",
+            "rust-spike/clap-test-effect/target/debug/libclap_test_effect.dylib",
+            "rust-spike/clap-test-synth/target/release/libclap_test_synth.dylib",
+            "rust-spike/clap-test-synth/target/debug/libclap_test_synth.dylib",
+        ]
+        .into_iter()
+        .map(|relative| repo.join(relative))
+        .find(|candidate| candidate.is_file())
+    }
+
+    #[cfg(target_os = "macos")]
+    fn copy_test_plugin(destination: &Path) -> bool {
+        let Some(plugin) = built_test_plugin() else {
+            eprintln!(
+                "skip: test CLAP dylib が無い — rust-spike/clap-test-effect または clap-test-synth を build してください"
+            );
+            return false;
+        };
+        fs::copy(&plugin, destination).expect("copy test plugin");
+        true
+    }
+
+    #[cfg(target_os = "macos")]
+    fn assert_bundle_loads(executable_name: &str) {
+        let (_temp, bundle) = make_bundle(executable_name);
+        if !copy_test_plugin(&bundle.join("Contents/MacOS").join(executable_name)) {
+            return;
+        }
+
+        let plugins = list_plugins_in_file(&bundle).expect("load plugin from .clap bundle");
+        assert!(!plugins.is_empty(), "bundle must expose a plugin");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn loads_stem_named_executable_from_bundle_directory() {
+        assert_bundle_loads("TestBundle");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn loads_cf_bundle_executable_with_different_name() {
+        assert_bundle_loads("DifferentExecutableName");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn bundle_with_missing_executable_is_an_error() {
+        let (_temp, bundle) = make_bundle("MissingExecutable");
+        assert!(matches!(
+            list_plugins_in_file(&bundle),
+            Err(DiscoveryError::LoadError(_))
+        ));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn loads_flat_file_clap() {
+        let temp = TempDir::new();
+        let flat_file = temp.0.join("FlatFile.clap");
+        if !copy_test_plugin(&flat_file) {
+            return;
+        }
+
+        let plugins = list_plugins_in_file(&flat_file).expect("load flat-file .clap plugin");
+        assert!(!plugins.is_empty(), "flat-file must expose a plugin");
+    }
 }

--- a/rust/crates/orbit-clap-host/src/discovery.rs
+++ b/rust/crates/orbit-clap-host/src/discovery.rs
@@ -132,6 +132,7 @@ pub fn load_plugin_id_from_path(
 }
 
 #[cfg(test)]
+#[cfg(target_os = "macos")]
 mod tests {
     use super::*;
     use std::fs;
@@ -179,7 +180,6 @@ mod tests {
         (temp, bundle)
     }
 
-    #[cfg(target_os = "macos")]
     fn built_test_plugin() -> Option<PathBuf> {
         let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..");
         [
@@ -193,7 +193,6 @@ mod tests {
         .find(|candidate| candidate.is_file())
     }
 
-    #[cfg(target_os = "macos")]
     fn copy_test_plugin(destination: &Path) -> bool {
         let Some(plugin) = built_test_plugin() else {
             eprintln!(
@@ -205,7 +204,6 @@ mod tests {
         true
     }
 
-    #[cfg(target_os = "macos")]
     fn assert_bundle_loads(executable_name: &str) {
         let (_temp, bundle) = make_bundle(executable_name);
         if !copy_test_plugin(&bundle.join("Contents/MacOS").join(executable_name)) {
@@ -216,19 +214,16 @@ mod tests {
         assert!(!plugins.is_empty(), "bundle must expose a plugin");
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
     fn loads_stem_named_executable_from_bundle_directory() {
         assert_bundle_loads("TestBundle");
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
     fn loads_cf_bundle_executable_with_different_name() {
         assert_bundle_loads("DifferentExecutableName");
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
     fn bundle_with_missing_executable_is_an_error() {
         let (_temp, bundle) = make_bundle("MissingExecutable");
@@ -238,7 +233,6 @@ mod tests {
         ));
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
     fn loads_flat_file_clap() {
         let temp = TempDir::new();

--- a/rust/crates/orbit-clap-host/src/discovery.rs
+++ b/rust/crates/orbit-clap-host/src/discovery.rs
@@ -180,7 +180,9 @@ mod tests {
         (temp, bundle)
     }
 
-    fn built_test_plugin() -> Option<PathBuf> {
+    /// ビルド済みの test CLAP dylib を探す。無ければ build 手順を示して loud fail する
+    /// （サイレント skip は偽 green を招くため禁止 — PR #433 レビュー指摘）。
+    fn built_test_plugin() -> PathBuf {
         let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..");
         [
             "rust-spike/clap-test-effect/target/release/libclap_test_effect.dylib",
@@ -191,35 +193,35 @@ mod tests {
         .into_iter()
         .map(|relative| repo.join(relative))
         .find(|candidate| candidate.is_file())
+        .unwrap_or_else(|| {
+            panic!(
+                "test CLAP dylib が無い — 先に `cargo build --manifest-path rust-spike/clap-test-effect/Cargo.toml`\
+                 （または clap-test-synth）を実行してください"
+            )
+        })
     }
 
-    fn copy_test_plugin(destination: &Path) -> bool {
-        let Some(plugin) = built_test_plugin() else {
-            eprintln!(
-                "skip: test CLAP dylib が無い — rust-spike/clap-test-effect または clap-test-synth を build してください"
-            );
-            return false;
-        };
+    fn copy_test_plugin(destination: &Path) {
+        let plugin = built_test_plugin();
         fs::copy(&plugin, destination).expect("copy test plugin");
-        true
     }
 
     fn assert_bundle_loads(executable_name: &str) {
         let (_temp, bundle) = make_bundle(executable_name);
-        if !copy_test_plugin(&bundle.join("Contents/MacOS").join(executable_name)) {
-            return;
-        }
+        copy_test_plugin(&bundle.join("Contents/MacOS").join(executable_name));
 
         let plugins = list_plugins_in_file(&bundle).expect("load plugin from .clap bundle");
         assert!(!plugins.is_empty(), "bundle must expose a plugin");
     }
 
     #[test]
+    #[ignore = "needs a built test CLAP dylib (rust-spike/clap-test-effect or clap-test-synth, local only)"]
     fn loads_stem_named_executable_from_bundle_directory() {
         assert_bundle_loads("TestBundle");
     }
 
     #[test]
+    #[ignore = "needs a built test CLAP dylib (rust-spike/clap-test-effect or clap-test-synth, local only)"]
     fn loads_cf_bundle_executable_with_different_name() {
         assert_bundle_loads("DifferentExecutableName");
     }
@@ -234,12 +236,11 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "needs a built test CLAP dylib (rust-spike/clap-test-effect or clap-test-synth, local only)"]
     fn loads_flat_file_clap() {
         let temp = TempDir::new();
         let flat_file = temp.0.join("FlatFile.clap");
-        if !copy_test_plugin(&flat_file) {
-            return;
-        }
+        copy_test_plugin(&flat_file);
 
         let plugins = list_plugins_in_file(&flat_file).expect("load flat-file .clap plugin");
         assert!(!plugins.is_empty(), "flat-file must expose a plugin");

--- a/rust/crates/orbit-clap-spike/src/discovery.rs
+++ b/rust/crates/orbit-clap-spike/src/discovery.rs
@@ -96,6 +96,8 @@ impl std::error::Error for DiscoveryError {}
 /// Load a .clap bundle's entry — the unsafe FFI shared by both lookups below.
 /// (The `PluginFactory` borrows from the `PluginEntry`, so the entry must outlive the
 /// factory in the caller's stack frame; that's why this returns the entry, not the factory.)
+// 注: この手組み実装は .clap バンドルディレクトリを解決できない既知の制限がある。production 側
+// （orbit-clap-host）は #433 で上流 `PluginEntry::load` に置換済み。この spike は凍結されたまま修正しない。
 fn open_bundle(path: &Path) -> Result<PluginEntry, DiscoveryError> {
     let bundle_path = CString::new(path.to_string_lossy().as_bytes())
         .map_err(|_| DiscoveryError::NullBundlePath)?;


### PR DESCRIPTION
Closes #433

## 概要

#426 実機 E2E で発見した統合ギャップの修正: discovery が `.clap` バンドル**ディレクトリ**をそのまま dlopen して `not a file` で失敗していた。市販 CLAP プラグイン（Surge XT / FabFilter 等）は全てバンドル形式のため、実プラグインを DSL からロードするための前提修正。

## 実装（2ラウンド・監査が上流資産を発見）

- **最終形**: `open_bundle` を pinned clack-host（rev `f874e858`）の上流 API **`PluginEntry::load(path)`** に置換（実質1行 + 契約コメント）。macOS では NSBundle（Info.plist の `CFBundleExecutable`）による正規解決が行われ、CLAP entry init には元のバンドルパスが渡る — 本家 `entry.h` L93 の契約（macOS では bundle path を init に渡す）を受け入れ監査が一次ソース3段追跡で裏取り済み
- Round 1 は手組み解決（stem 候補 → 単一ファイル fallback）だったが、Fable 受け入れ監査が上流 API の存在と手組みの実運用上の穴（`CFBundleExecutable` ≠ stem + `.DS_Store` 混入で誤エラー）を発見 → **即リワークを選択**（約40行 + error variant 2個削減・資産の再利用）
- テスト4系統: stem 一致 / **`CFBundleExecutable` ≠ stem**（NSBundle 正規解決の検証）/ 実行体不在エラー / flat-file `.clap` 後方互換。plist 無しバンドルも NSBundle が stem から推定してロード成功することを実測
- `rust-spike/clap-test-effect/bundle-macos.sh` 追加（synth 版と対称・dev 用バンドル生成）

## 検証

- `cargo test --workspace` 全 green（orbit-clap-host 24 件・daemon protocol 28 件含む・非サンドボックス環境で確認）
- `cargo fmt` / `clippy -D warnings` / `cargo deny check` green
- **実機 E2E fail-before/pass-after**: fail-before = #426 E2E で記録済みの `dlopen(<bundle dir>): not a file`（WORK_LOG 6.250）→ pass-after = 同一バンドルディレクトリ path が `global.effect()` から LoadPlugin 成功・**peak ratio = 0.5000（gain 0.5 effect の closed-form signature・厳密一致）**
- 監査も独立に fail-before を実測（旧挙動へ一時復元で新テスト2件が #426 と同一症状で red → 復元で green）

## 関連

- 発見元: #426（PR #432）実機 E2E / 親: Epic #424
- 消費者: #427（instrument も同じ discovery を通る）・実プラグイン運用全般

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015R9Km7edyaAgqzVFsUm7uX