### PR TITLE
feat(dsl): wire seq.instrument() and Pitch DSL notes to daemon (#427)

### DIFF
--- a/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
+++ b/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
@@ -1127,11 +1127,11 @@ piano.comp([1,3,5], [5,7,2]).voicelead()  // composes with §6.3
 
 ## Plugin Hosting (CLAP effect / instrument)
 
-> ⚠️ **構文確定・未実装 / syntax finalized, not yet implemented**
+> ⚠️ **一部未実装 / partially implemented**
 >
 > 本節は Issue #425（2026-07-13・owner 設計セッション + Fable 検証）で確定した構文仕様。
-> 実装は #426（effect 疎通）/ #427（instrument 疎通 + Pitch DSL 接続）/ #428（note timing）の
-> スコープであり、本節の記述が実装に先行する（spec-first）。
+> DSL 疎通は #426（effect・PR #432）/ #427（instrument + Pitch DSL 接続）ともに実装済み。
+> 残るスコープは #428（note timing のサンプル精度化）のみ。
 > Option A/B/C の比較経緯は `docs/development/POST_2.0_VST3_HOSTING_PLAN.md` §6、
 > 決定の記録は Issue #425 / WORK_LOG を参照。
 
@@ -1343,7 +1343,8 @@ the two time/pitch axes stay orthogonal and consistent with the chop slice-fit v
 - **Effect Presets**: Named preset system for effect chains
 - **DAW Plugin**: VST/AU plugin development
 - **Plugin Hosting implementation**: the CLAP effect/instrument hosting *syntax* is finalized
-  (#425 — see the Plugin Hosting section above); engine wiring is tracked in #426/#427/#428.
+  (#425 — see the Plugin Hosting section above); DSL wiring for effect (#426) and instrument
+  (#427) is implemented. Only sample-accurate note timing (#428) remains outstanding.
   `.vst3` / `.component` formats are reserved (not yet supported)
 - **`slice()`**: per-event start/end point selection within a chopped file (#239)
 - **Audio `[ ]` stack / slice layering**: simultaneous audio-layer stacking in the play tree (#238)

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -45,7 +45,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
   #431 本文に追記済み）・linkAudio 双方向・`loadedPlugin` キャッシュに role 保存
   （respawn 後に effect として復元される事故の芽を排除）
 
-**実装（Codex 委譲・罠7点 🔴 明示）**: 21ファイル・+784/-45・新規3モジュール
+**実装（Codex 委譲・罠7点 🔴 明示）**: 21 files changed, 784 insertions(+), 45 deletions(-)・新規3モジュール
 （plugin-note-output / plugin-instrument-manager / 各テスト）+ VS Code 診断免除。
 逸脱なしと報告され、監査で全遵守を確認。
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,89 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.252 feat(dsl): seq.instrument() — Pitch DSL note の daemon 配線 #427 (Jul 14, 2026)
+
+**Date**: 2026-07-14
+**Status**: ✅ 実装・受け入れ監査 GO・実機 E2E で DoD 達成（PR 作成・レビューフローへ）
+**Branch**: `427-clap-instrument-dsl-wiring`
+**Commit**: `3d5aa7e`
+
+#425 確定構文の instrument 側を実装。Pitch DSL v1.1 の note 出力を daemon の
+`PluginNoteOn`/`PluginNoteOff` へ振り向け、「DSL の度数から CLAP instrument が鳴る」を
+初めて成立させた。Epic #424 Stage 1 の後半。
+
+**設計（Fable 実装前相談 GO・統合点7つを事前特定）**:
+- **`MidiOutput` interface が seam**: `PluginNoteOutput implements MidiOutput` により
+  度数解決・gate/tie/legato・voicelead・スケジューラを既存 MIDI 経路と完全共有
+  （新規実装は出力アダプタのみ）
+- `isNoteSequence()` 新設（= isMidi ∨ isInstrument）: 意味論6箇所を置換・出力先4箇所は
+  明示分岐。`isMidi()` の意味（RtMidi 出力）は不変
+- `scheduleMidiEvents` は fork せず `resolveNoteTarget()` でパラメータ化
+  （instrument = plugin scheduler・channel 1→wire 0・**sendDelay 0 = midiLatency 非適用**）
+- 第2 `MidiScheduler`（plugin 用）を MidiManager が保持し **start/stop/panic の既存連鎖に
+  組み込み**（global.stop() で instrument も止まる = PH.4）
+- detune warn+skip は Stage A の per-sequence once-flag + ゼロ潰し（pitchBend 非 enqueue）
+- 順序保証: `pluginNoteOn/Off` は **ws.send 前に await を置かない契約**（daemon read loop の
+  逐次性と合わせ「同期 send 順 = 演奏順」・コメントで明文化）・未接続 drop は ❌ log
+- effect⇔instrument の双方向早期エラー（同一 path 含む・#431 で撤去のチェック項目を
+  #431 本文に追記済み）・linkAudio 双方向・`loadedPlugin` キャッシュに role 保存
+  （respawn 後に effect として復元される事故の芽を排除）
+
+**実装（Codex 委譲・罠7点 🔴 明示）**: 21ファイル・+784/-45・新規3モジュール
+（plugin-note-output / plugin-instrument-manager / 各テスト）+ VS Code 診断免除。
+逸脱なしと報告され、監査で全遵守を確認。
+
+**受け入れ監査（Fable・GO）**: PH.1-PH.6 全項目適合・罠7点全遵守・
+**既存 MIDI 経路は bit-equivalent 判定**（instrument 未宣言時 isNoteSequence は恒等・
+effect wire は同一バイト列・751 テスト再実行 green）・await-before-send 契約を独立再検証。
+Minor 4 件（detune の直接スパイ検証等）は非ブロッカーとして PR レビューへ。
+
+**検証**: `npm test` **1327 passed / 0 failed / 29 skipped**（+22 新規・main 環境）。
+
+**実機 gated E2E（DoD 達成・self-run 許可の範囲）**:
+`global.key("C")` + `seq.instrument("CLAPTestSynth.clap")`（**バンドルディレクトリ・
+#433 修正入り daemon**）+ `play(1, 3, 5, 8)` → 実発音。capture 計測
+**peak = 0.2500（厳密一致）** = clap-test-synth の既知振幅で PR #422 実機検証と同一
+シグネチャ。DSL → LoadPlugin(role=instrument) → PluginNoteOn/Off → CLAP synth →
+master bus の全経路を客観実証。eager 検証も実地確認（key 未宣言で宣言時ハードエラー）。
+
+**/simplify（4観点並行・2エージェントが API stall で1回失敗し再実行・適用4件/スキップ多数）**:
+- 適用: ①**effect⇔instrument 排他 guard を Global に集約**（altitude 指摘・
+  `Global.linkAudio()` と同型のパターンに揃え、相互コンストラクタクロージャの
+  前方参照脆弱性を解消。fixer 自身が実装中に「自分の宣言も誤検査する」バグを
+  発見し「相手 manager のみ検査」に修正）②`isNoteSequence()` の使い漏らし3箇所
+  （activeScheduler/scheduleEventsFromTime/scheduleEvents）を統合（reuse+simplification
+  一致）③`PluginNoteOutput.noteOff` の送信ロジック重複を `sendTrackedNoteOff` に統合
+  （reuse+simplification 一致）④`daemon-client.ts` の余剰 `.then(() => undefined)` 除去
+- スキップ（理由つき）: PluginEffectManager/PluginInstrumentManager の共通基底化
+  （#431/#434 で作り直される層への過剰投資 — altitude 自身が「正しい抑制」と評価）／
+  MidiManager・ActiveNoteTracker の共通化（同理由）／テストヘルパー共通化（既存慣習・別課題）
+- 適用後検証: `npm test` 1327 passed / 0 failed・lint 変更ファイル新規指摘ゼロ
+
+**/code:pr-review-team round 1（4レビュアー並行 + CI）**:
+- code-reviewer PASS（レース窓・7分岐すべて独立追跡）
+- silent-failure-hunter: HIGH 2件（drop ログのレート制限なし・respawn 失敗後も
+  pluginActive 未確認で送信継続）+ MEDIUM 3件（interface メソッド欠如時の完全サイレント
+  経路・guard バイパス可能な public getter・detune once-flag のリセット契約未文書化）
+- pr-test-analyzer: Important 1件（`clearEvents` の instrument 分岐 = PH.4 の note 解放
+  義務そのものが未テスト）+ Minor 5件
+- comment-analyzer: doc 更新漏れ4件（`linkAudio()`/`midi()` JSDoc・spec バナーの
+  「未実装」放置・WORK_LOG diffstat 誤り）
+- fixer 適用: 既存 `warnOnce`/`GapKind` 機構に乗せてレート制限（HIGH×2 解消）・
+  `getPluginInstrumentManager()` 削除しテストを Global 経由に統一（guard バイパス解消）・
+  `clearEvents` instrument 分岐のテスト追加・interface メソッド欠如時の console.error 追加・
+  doc 更新4件（spec バナー = #426/#427 実装済みに更新・#428 のみ残と明記）
+- 検証: `npm test` **1330 passed / 0 failed / 29 skipped**（+3）・lint 変更ファイル新規指摘ゼロ
+
+**round 2（silent-failure-hunter 再検証）**: HIGH 2件・MEDIUM 2件とも解消を確認
+（機能面まで検証・guard バイパス経路が repo 全体で 0 件であることを grep で確認）。
+新規は LOW 1件のみ（`warned` ラッチのリセットが `stopAll()` のみで respawn 時に
+再アームしない — ただし他の unconditional ログが episode レベルの可観測性を
+既に担保しており non-blocking と評価・**#437 起票**）。**Critical/Important = 0・
+CI 4/4 pass**。silent-failure-hunter round1 の MEDIUM Finding5（detune once-flag の
+リセット契約未文書化）は **#438 起票**（複数レビュアーが独立指摘・実害なしの
+ドキュメント/テスト債務として follow-up 化）
+
 ### 6.251 fix(daemon): discovery の macOS .clap バンドルディレクトリ解決 #433 (Jul 14, 2026)
 
 **Date**: 2026-07-14

--- a/packages/engine/src/audio/engine-backend.ts
+++ b/packages/engine/src/audio/engine-backend.ts
@@ -31,7 +31,13 @@ export interface AudioEngineBackend extends Scheduler {
   setAvailableDevices?(devices: AudioDevice[]): void
   registerLinkAudioChannel?(channelName: string): Promise<void>
   setLinkTempo?(bpm: number): Promise<void>
-  loadPlugin?(filePath: string, pluginId?: string): Promise<PluginLoadResult>
+  loadPlugin?(
+    filePath: string,
+    pluginId: string | undefined,
+    role: 'effect' | 'instrument',
+  ): Promise<PluginLoadResult>
+  pluginNoteOn?(key: number, channel: number, velocity: number): Promise<void>
+  pluginNoteOff?(key: number, channel: number, velocity?: number): Promise<void>
   isPluginActive?(): boolean
 }
 

--- a/packages/engine/src/audio/rust-engine/daemon-client.ts
+++ b/packages/engine/src/audio/rust-engine/daemon-client.ts
@@ -352,20 +352,36 @@ export class DaemonClient extends EventEmitter {
    * Loads a `.clap` plugin into the daemon. Rejects with `DaemonProtocolError` —
    * notably `CLAP_UNAVAILABLE` when the daemon was built without `--features
    * clap-host` — which `RustEnginePlayer.loadPlugin()` converts into an
-   * operator-actionable message. `role` is hardcoded to `'effect'` until #427
-   * threads it through as an argument (e.g. for `seq.instrument()`).
+   * operator-actionable message. The role is forwarded for effect/instrument
+   * restoration compatibility even while older daemons ignore it.
    */
-  async loadPlugin(filePath: string, pluginId?: string): Promise<PluginLoadResult> {
+  async loadPlugin(
+    filePath: string,
+    pluginId: string | undefined,
+    role: 'effect' | 'instrument',
+  ): Promise<PluginLoadResult> {
     const result = await this.request('LoadPlugin', {
       path: filePath,
       ...(pluginId === undefined ? {} : { plugin_id: pluginId }),
-      role: 'effect',
+      role,
     })
     return {
       pluginId: String(result.plugin_id),
       pluginName: String(result.plugin_name),
       notePortIndex: Number(result.note_port_index),
     }
+  }
+
+  pluginNoteOn(key: number, channel: number, velocity: number): Promise<void> {
+    return this.request('PluginNoteOn', { key, channel, velocity }).then(() => undefined)
+  }
+
+  pluginNoteOff(key: number, channel: number, velocity?: number): Promise<void> {
+    return this.request('PluginNoteOff', {
+      key,
+      channel,
+      ...(velocity === undefined ? {} : { velocity }),
+    }).then(() => undefined)
   }
 
   async getStatus(): Promise<Record<string, unknown>> {

--- a/packages/engine/src/audio/rust-engine/daemon-client.ts
+++ b/packages/engine/src/audio/rust-engine/daemon-client.ts
@@ -373,7 +373,7 @@ export class DaemonClient extends EventEmitter {
   }
 
   pluginNoteOn(key: number, channel: number, velocity: number): Promise<void> {
-    return this.request('PluginNoteOn', { key, channel, velocity }).then(() => undefined)
+    return this.request('PluginNoteOn', { key, channel, velocity }) as unknown as Promise<void>
   }
 
   pluginNoteOff(key: number, channel: number, velocity?: number): Promise<void> {
@@ -381,7 +381,7 @@ export class DaemonClient extends EventEmitter {
       key,
       channel,
       ...(velocity === undefined ? {} : { velocity }),
-    }).then(() => undefined)
+    }) as unknown as Promise<void>
   }
 
   async getStatus(): Promise<Record<string, unknown>> {

--- a/packages/engine/src/audio/rust-engine/protocol-types.ts
+++ b/packages/engine/src/audio/rust-engine/protocol-types.ts
@@ -18,6 +18,8 @@ export interface HandshakeFrame {
 export type CommandMethod =
   | 'LoadSample'
   | 'LoadPlugin'
+  | 'PluginNoteOn'
+  | 'PluginNoteOff'
   | 'UnloadSample'
   | 'PlayAt'
   | 'Stop'

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -50,9 +50,12 @@ import { DaemonConnectionError, DaemonProtocolError, DaemonQuitError } from './e
  * boundary で明示する未対応 feature gap の種別（A4 era）。
  * - `outputChannel`(LinkAudio) / `masterEffect`: 未対応 feature gap。
  * - `linkTempo`: Link テンポリード（#283・A4-PR3）。daemon が feature 無効ビルドなら warn-once。
+ * - `pluginNoteDrop`: daemon 未接続時に plugin note-on/off が silent drop される gap（#427 レビュー C1）。
+ * - `pluginInactive`: respawn 後の instrument 復元失敗（`pluginActive===false`）で note が
+ *   silent drop される gap（#427 レビュー C2）。
  * pan / slice 領域 / slice varispeed（rate≠1.0）は実装済みのため gap ではない。
  */
-type GapKind = 'outputChannel' | 'masterEffect' | 'linkTempo'
+type GapKind = 'outputChannel' | 'masterEffect' | 'linkTempo' | 'pluginNoteDrop' | 'pluginInactive'
 
 /** chop slice 情報。`scheduleSliceEvent` 由来。発火時に領域（offset/duration）へ解決する。 */
 export interface SliceSpec {
@@ -234,6 +237,8 @@ const freshWarned = (): Record<GapKind, boolean> => ({
   outputChannel: false,
   masterEffect: false,
   linkTempo: false,
+  pluginNoteDrop: false,
+  pluginInactive: false,
 })
 
 export class RustEnginePlayer implements AudioEngineBackend {
@@ -631,7 +636,17 @@ export class RustEnginePlayer implements AudioEngineBackend {
 
   pluginNoteOn(key: number, channel: number, velocity: number): Promise<void> {
     if (!this.daemon.isRunning()) {
-      console.error('❌ [rust-engine] plugin note-on dropped: daemon is not connected', { key })
+      this.warnOnce(
+        'pluginNoteDrop',
+        '⚠️  [rust-engine] plugin note-on/off dropped: daemon is not connected (notes will be silently dropped until reconnect)',
+      )
+      return Promise.resolve()
+    }
+    if (!this.pluginActive) {
+      this.warnOnce(
+        'pluginInactive',
+        '⚠️  [rust-engine] plugin note-on/off dropped: instrument was not restored after the last daemon respawn — re-run seq.instrument(...) to restore it',
+      )
       return Promise.resolve()
     }
     // Ordering contract: do not insert an await before this call. Daemon requests are
@@ -641,7 +656,17 @@ export class RustEnginePlayer implements AudioEngineBackend {
 
   pluginNoteOff(key: number, channel: number, velocity?: number): Promise<void> {
     if (!this.daemon.isRunning()) {
-      console.error('❌ [rust-engine] plugin note-off dropped: daemon is not connected', { key })
+      this.warnOnce(
+        'pluginNoteDrop',
+        '⚠️  [rust-engine] plugin note-on/off dropped: daemon is not connected (notes will be silently dropped until reconnect)',
+      )
+      return Promise.resolve()
+    }
+    if (!this.pluginActive) {
+      this.warnOnce(
+        'pluginInactive',
+        '⚠️  [rust-engine] plugin note-on/off dropped: instrument was not restored after the last daemon respawn — re-run seq.instrument(...) to restore it',
+      )
       return Promise.resolve()
     }
     // Keep the synchronous send ordering contract documented above: no await here.

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -259,10 +259,14 @@ export class RustEnginePlayer implements AudioEngineBackend {
   /** 同一 filepath の並行ロードを直列化する single-flight。 */
   private readonly inflightLoads = new Map<string, Promise<string>>()
   /**
-   * v1 は単一 master insert（PluginEffectManager が上流で保証）。daemon crash 後に
-   * replay する宣言 intent。
+   * v1 は effect / instrument 共通の単一 plugin slot（各 manager が上流で保証）。
+   * daemon crash 後に同じ role で replay する宣言 intent。
    */
-  private loadedPlugin?: { filePath: string; pluginId?: string }
+  private loadedPlugin?: {
+    filePath: string
+    pluginId?: string
+    role: 'effect' | 'instrument'
+  }
   /**
    * Whether `loadedPlugin` is actually loaded in the daemon right now (silent-failure
    * guard). Set true on a successful `loadPlugin()`/reload, false when a post-respawn
@@ -600,10 +604,14 @@ export class RustEnginePlayer implements AudioEngineBackend {
    * build hint, other codes → generic wrap); non-protocol errors pass through
    * unchanged.
    */
-  async loadPlugin(filePath: string, pluginId?: string): Promise<PluginLoadResult> {
+  async loadPlugin(
+    filePath: string,
+    pluginId: string | undefined,
+    role: 'effect' | 'instrument',
+  ): Promise<PluginLoadResult> {
     try {
-      const result = await this.daemon.loadPlugin(filePath, pluginId)
-      this.loadedPlugin = { filePath, pluginId }
+      const result = await this.daemon.loadPlugin(filePath, pluginId, role)
+      this.loadedPlugin = { filePath, pluginId, role }
       this.pluginActive = true
       return result
     } catch (err) {
@@ -621,6 +629,25 @@ export class RustEnginePlayer implements AudioEngineBackend {
     }
   }
 
+  pluginNoteOn(key: number, channel: number, velocity: number): Promise<void> {
+    if (!this.daemon.isRunning()) {
+      console.error('❌ [rust-engine] plugin note-on dropped: daemon is not connected', { key })
+      return Promise.resolve()
+    }
+    // Ordering contract: do not insert an await before this call. Daemon requests are
+    // processed sequentially, so synchronous WebSocket send order is musical note order.
+    return this.daemon.pluginNoteOn(key, channel, velocity)
+  }
+
+  pluginNoteOff(key: number, channel: number, velocity?: number): Promise<void> {
+    if (!this.daemon.isRunning()) {
+      console.error('❌ [rust-engine] plugin note-off dropped: daemon is not connected', { key })
+      return Promise.resolve()
+    }
+    // Keep the synchronous send ordering contract documented above: no await here.
+    return this.daemon.pluginNoteOff(key, channel, velocity)
+  }
+
   /**
    * Re-issues the last successful plugin declaration after a daemon respawn (the
    * new daemon process starts with no plugins loaded). Broad catch is intentional:
@@ -632,9 +659,9 @@ export class RustEnginePlayer implements AudioEngineBackend {
    */
   private async reloadPluginsAfterRespawn(): Promise<void> {
     if (!this.loadedPlugin) return
-    const { filePath, pluginId } = this.loadedPlugin
+    const { filePath, pluginId, role } = this.loadedPlugin
     try {
-      await this.daemon.loadPlugin(filePath, pluginId)
+      await this.daemon.loadPlugin(filePath, pluginId, role)
       this.pluginActive = true
     } catch (err) {
       this.pluginActive = false

--- a/packages/engine/src/audio/types.ts
+++ b/packages/engine/src/audio/types.ts
@@ -62,7 +62,14 @@ export interface AudioEngine {
   setLinkTempo?(bpm: number): Promise<void>
 
   /** Eagerly load a plugin into the engine's master effect insert. */
-  loadPlugin?(filePath: string, pluginId?: string): Promise<PluginLoadResult>
+  loadPlugin?(
+    filePath: string,
+    pluginId: string | undefined,
+    role: 'effect' | 'instrument',
+  ): Promise<PluginLoadResult>
+
+  pluginNoteOn?(key: number, channel: number, velocity: number): Promise<void>
+  pluginNoteOff?(key: number, channel: number, velocity?: number): Promise<void>
 
   /**
    * Whether a previously-declared plugin is currently active in the engine

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -8,6 +8,7 @@ import { StackElement, PlayElement } from '../parser/types'
 import { BoundValue, ChordVoice } from '../midi/chord/types'
 import { evaluateChordDefinition } from '../midi/chord/resolve-chords'
 import { PREDEFINED_CHORDS } from '../midi/chord/predefined-chords'
+import { PluginNoteOutput } from '../midi/plugin-note-output'
 
 import { Sequence } from './sequence'
 import { Scheduler, GlobalState } from './global/types'
@@ -22,6 +23,7 @@ import { MidiManager } from './global/midi-manager'
 import { TransportClock } from './global/transport-clock'
 import { MidiTransportScheduler } from './global/midi-transport-scheduler'
 import { PluginEffectManager } from './global/plugin-effect-manager'
+import { PluginInstrumentManager } from './global/plugin-instrument-manager'
 
 export class Global {
   // Manager instances for different responsibilities
@@ -34,6 +36,7 @@ export class Global {
   private quantizeManager: QuantizeManager
   private midiManager: MidiManager
   private pluginEffectManager: PluginEffectManager
+  private pluginInstrumentManager: PluginInstrumentManager
 
   // Shared transport clock — the single Date.now() origin for both the audio
   // scheduler and the MIDI scheduler, so they stay in sync (§1). MIDI sequences
@@ -65,9 +68,17 @@ export class Global {
       audioEngine,
       this.audioManager,
       this.linkAudioManager,
+      () => this.pluginInstrumentManager.hasDeclaration(),
     )
     this.quantizeManager = new QuantizeManager()
     this.midiManager = midiManager ?? new MidiManager()
+    this.midiManager.setPluginOutputFactory(() => new PluginNoteOutput(audioEngine))
+    this.pluginInstrumentManager = new PluginInstrumentManager(
+      audioEngine,
+      this.audioManager,
+      this.linkAudioManager,
+      () => this.pluginEffectManager.hasDeclaration(),
+    )
     this.sequenceRegistry = new SequenceRegistry(audioEngine, this)
     this.effectsManager = new EffectsManager(
       this.globalScheduler,
@@ -136,6 +147,10 @@ export class Global {
   /** Accessor for the shared MIDI manager (used by Sequence MIDI dispatch). */
   getMidiManager(): MidiManager {
     return this.midiManager
+  }
+
+  getPluginInstrumentManager(): PluginInstrumentManager {
+    return this.pluginInstrumentManager
   }
 
   // ─── Chord namespace (§6) ──────────────────────────────────────────────────
@@ -235,7 +250,10 @@ export class Global {
    *                         omitted.
    */
   linkAudio(targetSampleRate?: number): this {
-    if (this.pluginEffectManager.hasDeclaration()) {
+    if (
+      this.pluginEffectManager.hasDeclaration() ||
+      this.pluginInstrumentManager.hasDeclaration()
+    ) {
       throw new Error(
         'global.linkAudio() cannot be used after plugin hosting has been declared in v1.',
       )

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -68,7 +68,6 @@ export class Global {
       audioEngine,
       this.audioManager,
       this.linkAudioManager,
-      () => this.pluginInstrumentManager.hasDeclaration(),
     )
     this.quantizeManager = new QuantizeManager()
     this.midiManager = midiManager ?? new MidiManager()
@@ -77,7 +76,6 @@ export class Global {
       audioEngine,
       this.audioManager,
       this.linkAudioManager,
-      () => this.pluginEffectManager.hasDeclaration(),
     )
     this.sequenceRegistry = new SequenceRegistry(audioEngine, this)
     this.effectsManager = new EffectsManager(
@@ -269,9 +267,36 @@ export class Global {
     return this.linkAudioManager.isEnabled()
   }
 
+  /**
+   * v1 mutual exclusion between `global.effect()` and `seq.instrument()`
+   * (daemon single-plugin slot limitation; planned for #431). Checked here —
+   * rather than inside each manager — so neither manager needs a closure over
+   * the other (mirrors the `linkAudio()` cross-manager check above). Each
+   * caller passes the *other* manager, so a repeat call declaring the same
+   * plugin again (idempotent path, handled inside the manager itself) is
+   * unaffected.
+   */
+  private assertNoCrossPluginDeclaration(
+    other: PluginEffectManager | PluginInstrumentManager,
+  ): void {
+    if (other.hasDeclaration()) {
+      throw new Error(
+        'v1 does not support simultaneous effect and instrument use (daemon single-plugin slot limitation; planned for #431).',
+      )
+    }
+  }
+
   /** Eagerly load the v1 single master-insert plugin. */
   async effect(path: string, pluginId?: string): Promise<this> {
+    this.assertNoCrossPluginDeclaration(this.pluginInstrumentManager)
     await this.pluginEffectManager.effect(path, pluginId)
+    return this
+  }
+
+  /** Eagerly load the v1 single hosted instrument plugin (shared by note sequences). */
+  async instrument(path: string, pluginId?: string): Promise<this> {
+    this.assertNoCrossPluginDeclaration(this.pluginEffectManager)
+    await this.pluginInstrumentManager.instrument(path, pluginId)
     return this
   }
 

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -147,10 +147,6 @@ export class Global {
     return this.midiManager
   }
 
-  getPluginInstrumentManager(): PluginInstrumentManager {
-    return this.pluginInstrumentManager
-  }
-
   // ─── Chord namespace (§6) ──────────────────────────────────────────────────
   // A program-global table of chord values, read by Sequence.play to spread chord
   // refs (§6, 評価時値渡し). Lives here — like global.key() — so the interpreter
@@ -240,8 +236,8 @@ export class Global {
    * Ableton Link Audio instead of the hardware bus. Hardware output and
    * LinkAudio cannot coexist within the same .orbs file.
    *
-   * Rejected once plugin hosting (`global.effect()`) has already been
-   * declared — v1 mutual exclusion (PH.5).
+   * Rejected once plugin hosting (`global.effect()` or `seq.instrument()`) has
+   * already been declared — v1 mutual exclusion (PH.5).
    *
    * @param targetSampleRate Optional explicit target SR for plugin-side
    *                         resampling. Auto-detect with 48000 fallback when

--- a/packages/engine/src/core/global/midi-manager.ts
+++ b/packages/engine/src/core/global/midi-manager.ts
@@ -18,8 +18,11 @@ import { RtMidiOutput } from '../../midi/rtmidi-output'
 
 export class MidiManager {
   private readonly outputFactory: () => MidiOutput
+  private pluginOutputFactory?: () => MidiOutput
   private output?: MidiOutput
   private scheduler?: MidiScheduler
+  private pluginOutput?: MidiOutput
+  private pluginScheduler?: MidiScheduler
 
   /** Global key pitch class (0..11), undefined until `global.key()` is called. */
   private keyPitchClass?: number
@@ -48,6 +51,21 @@ export class MidiManager {
       this.scheduler = new MidiScheduler(this.getOutput())
     }
     return this.scheduler
+  }
+
+  setPluginOutputFactory(factory: () => MidiOutput): void {
+    this.pluginOutputFactory = factory
+  }
+
+  getPluginScheduler(): MidiScheduler {
+    if (!this.pluginScheduler) {
+      if (!this.pluginOutputFactory) {
+        throw new Error('Plugin note output has not been configured.')
+      }
+      this.pluginOutput = this.pluginOutputFactory()
+      this.pluginScheduler = new MidiScheduler(this.pluginOutput)
+    }
+    return this.pluginScheduler
   }
 
   /** True once any MIDI scheduler has been created (a MIDI sequence ran). */
@@ -111,15 +129,18 @@ export class MidiManager {
   /** Start the scheduler loop if MIDI is active. */
   start(): void {
     this.scheduler?.start()
+    this.pluginScheduler?.start()
   }
 
   /** Stop the scheduler (panics the output) if MIDI is active. */
   stop(): void {
     this.scheduler?.stop()
+    this.pluginScheduler?.stop()
   }
 
   /** Panic the output directly (CC123/CC120 all channels) if it exists. */
   panic(): void {
     this.output?.panic()
+    this.pluginOutput?.panic()
   }
 }

--- a/packages/engine/src/core/global/plugin-effect-manager.ts
+++ b/packages/engine/src/core/global/plugin-effect-manager.ts
@@ -18,7 +18,6 @@ export class PluginEffectManager {
     private readonly audioEngine: AudioEngine,
     private readonly audioManager: AudioManager,
     private readonly linkAudioManager: LinkAudioManager,
-    private readonly hasInstrumentDeclaration: () => boolean = () => false,
   ) {}
 
   hasDeclaration(): boolean {
@@ -35,12 +34,6 @@ export class PluginEffectManager {
 
     if (this.linkAudioManager.isEnabled()) {
       throw new Error('global.effect() cannot be used while LinkAudio is enabled in v1.')
-    }
-
-    if (this.hasInstrumentDeclaration()) {
-      throw new Error(
-        'v1 does not support simultaneous effect and instrument use (daemon single-plugin slot limitation; planned for #431).',
-      )
     }
 
     const resolvedPath = resolvePluginPath(

--- a/packages/engine/src/core/global/plugin-instrument-manager.ts
+++ b/packages/engine/src/core/global/plugin-instrument-manager.ts
@@ -18,7 +18,6 @@ export class PluginInstrumentManager {
     private readonly audioEngine: AudioEngine,
     private readonly audioManager: AudioManager,
     private readonly linkAudioManager: LinkAudioManager,
-    private readonly hasEffectDeclaration: () => boolean,
   ) {}
 
   hasDeclaration(): boolean {
@@ -29,11 +28,6 @@ export class PluginInstrumentManager {
     validatePluginExtension(spec)
     if (this.linkAudioManager.isEnabled()) {
       throw new Error('seq.instrument() cannot be used while LinkAudio is enabled in v1.')
-    }
-    if (this.hasEffectDeclaration()) {
-      throw new Error(
-        'v1 does not support simultaneous effect and instrument use (daemon single-plugin slot limitation; planned for #431).',
-      )
     }
 
     const resolvedPath = resolvePluginPath(

--- a/packages/engine/src/core/global/plugin-instrument-manager.ts
+++ b/packages/engine/src/core/global/plugin-instrument-manager.ts
@@ -4,40 +4,33 @@ import { AudioManager } from './audio-manager'
 import { LinkAudioManager } from './link-audio-manager'
 import { resolvePluginPath, validatePluginExtension } from './plugin-resolver'
 
-interface EffectDeclaration {
+interface InstrumentDeclaration {
   resolvedPath: string
   pluginId?: string
   load: Promise<void>
 }
 
-/** Owns the single v1 master-insert plugin declaration and eager load. */
-export class PluginEffectManager {
-  private declaration?: EffectDeclaration
+/** Owns the single v1 daemon instrument declaration shared by note sequences. */
+export class PluginInstrumentManager {
+  private declaration?: InstrumentDeclaration
 
   constructor(
     private readonly audioEngine: AudioEngine,
     private readonly audioManager: AudioManager,
     private readonly linkAudioManager: LinkAudioManager,
-    private readonly hasInstrumentDeclaration: () => boolean = () => false,
+    private readonly hasEffectDeclaration: () => boolean,
   ) {}
 
   hasDeclaration(): boolean {
     return this.declaration !== undefined
   }
 
-  async effect(spec: string, pluginId?: string): Promise<void> {
-    // Order is load-bearing: validate the spec, then gate on LinkAudio, and
-    // only then resolve the path. A relative spec with no document context
-    // yet (unsaved file) makes `resolvePluginPath` throw a "cannot resolve"
-    // error; if that ran before the LinkAudio gate, it would mask the more
-    // relevant LinkAudio-conflict error with a confusing resolve failure.
+  async instrument(spec: string, pluginId?: string): Promise<void> {
     validatePluginExtension(spec)
-
     if (this.linkAudioManager.isEnabled()) {
-      throw new Error('global.effect() cannot be used while LinkAudio is enabled in v1.')
+      throw new Error('seq.instrument() cannot be used while LinkAudio is enabled in v1.')
     }
-
-    if (this.hasInstrumentDeclaration()) {
+    if (this.hasEffectDeclaration()) {
       throw new Error(
         'v1 does not support simultaneous effect and instrument use (daemon single-plugin slot limitation; planned for #431).',
       )
@@ -48,38 +41,28 @@ export class PluginEffectManager {
       this.audioManager.getAudioPaths(),
       this.audioManager.getDocumentDirectory(),
     )
-
     const existing = this.declaration
     if (existing) {
       if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
         await existing.load
-        // Self-heal: `isPluginActive() === false` means a prior daemon respawn
-        // failed to restore this plugin in the engine even though our cache
-        // still thinks it succeeded (silent-failure guard). Re-issue the load
-        // instead of returning a false "success". Engines without
-        // `isPluginActive` (SC backend / plain mocks) keep the old no-op
-        // idempotent behavior.
         if (this.audioEngine.isPluginActive?.() === false) {
           await this.issueLoad(resolvedPath, pluginId)
         }
         return
       }
-      throw new Error(
-        'global.effect() supports one master insert in v1; effect chains are reserved for future support.',
-      )
+      throw new Error('seq.instrument() supports one instrument instance in v1.')
     }
-
     await this.issueLoad(resolvedPath, pluginId)
   }
 
-  /** Issues (or re-issues) the load, installing the declaration and clearing it on failure. */
   private async issueLoad(resolvedPath: string, pluginId: string | undefined): Promise<void> {
     if (!this.audioEngine.loadPlugin) {
       throw new Error('Plugin hosting requires the Rust engine backend.')
     }
-
-    const load = this.audioEngine.loadPlugin(resolvedPath, pluginId, 'effect').then(() => undefined)
-    const declaration: EffectDeclaration = { resolvedPath, pluginId, load }
+    const load = this.audioEngine
+      .loadPlugin(resolvedPath, pluginId, 'instrument')
+      .then(() => undefined)
+    const declaration = { resolvedPath, pluginId, load }
     this.declaration = declaration
     try {
       await load

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -13,6 +13,7 @@ import { resolveChords, cloneElement } from '../midi/chord/resolve-chords'
 import { voiceLeadOctaves } from '../midi/voice-leading'
 import { cellToGrid } from '../midi/comp-rhythm'
 import { RootContext, SymbolicPitch } from '../midi/types'
+import { MidiScheduler } from '../midi/midi-scheduler'
 import { TimedEvent, TimedEventScope } from '../timing/calculation/types'
 
 import { Global } from './global'
@@ -97,6 +98,8 @@ export class Sequence {
   // A MIDI sequence interprets play() values as degrees, not slice numbers.
   private _midiPort?: string // resolved actual port name
   private _midiChannel?: number // 1..16
+  private _instrumentDeclared = false
+  private _instrumentDetuneWarned = false
   private _gate = 0.8 // default gate length (fraction of slot). spec §1
   private _vel = 96 // default velocity 1..127. spec §1
   private _hold = false // §5.3: auto common-tone tie between consecutive stacks
@@ -358,6 +361,9 @@ export class Sequence {
    */
   midi(portName: string, channel: number): this {
     const name = this.stateManager.getName() || 'sequence'
+    if (this.isInstrument()) {
+      throw new Error(`Sequence '${name}': midi() cannot be combined with instrument().`)
+    }
     if (this._audioFilePath !== undefined) {
       throw new Error(`Sequence '${name}': midi() cannot be combined with audio()/chop().`)
     }
@@ -375,6 +381,26 @@ export class Sequence {
   /** True when this sequence outputs MIDI (declared via `seq.midi()`). */
   isMidi(): boolean {
     return this._midiPort !== undefined
+  }
+
+  async instrument(pluginPath: string, pluginId?: string): Promise<this> {
+    const name = this.stateManager.getName() || 'sequence'
+    if (this._audioFilePath !== undefined || this._chopDivisions !== undefined || this.isMidi()) {
+      throw new Error(
+        `Sequence '${name}': instrument() cannot be combined with audio()/chop()/midi().`,
+      )
+    }
+    await this.global.getPluginInstrumentManager().instrument(pluginPath, pluginId)
+    this._instrumentDeclared = true
+    return this
+  }
+
+  isInstrument(): boolean {
+    return this._instrumentDeclared
+  }
+
+  isNoteSequence(): boolean {
+    return this.isMidi() || this.isInstrument()
   }
 
   /**
@@ -522,8 +548,8 @@ export class Sequence {
 
   audio(filepath: string): this {
     const name = this.stateManager.getName() || 'sequence'
-    if (this.isMidi()) {
-      throw new Error(`Sequence '${name}': audio() cannot be combined with midi().`)
+    if (this.isNoteSequence()) {
+      throw new Error(`Sequence '${name}': audio() cannot be combined with midi()/instrument().`)
     }
     // Resolve to absolute path. Supports path-direct forms (./, ../, ~/, /,
     // contains '/') and bare bank names like "bd" or "bd:2" via the global
@@ -544,9 +570,9 @@ export class Sequence {
   }
 
   chop(divisions: number): this {
-    if (this.isMidi()) {
+    if (this.isNoteSequence()) {
       throw new Error(
-        `Sequence '${this.stateManager.getName() || 'sequence'}': chop() cannot be combined with midi().`,
+        `Sequence '${this.stateManager.getName() || 'sequence'}': chop() cannot be combined with midi()/instrument().`,
       )
     }
     this._chopDivisions = divisions
@@ -606,7 +632,9 @@ export class Sequence {
    * MIDI stay in sync (§1).
    */
   private activeScheduler(): Scheduler {
-    return this.isMidi() ? this.global.getMidiTransport() : this.global.getScheduler()
+    return this.isMidi() || this.isInstrument()
+      ? this.global.getMidiTransport()
+      : this.global.getScheduler()
   }
 
   /**
@@ -617,6 +645,8 @@ export class Sequence {
   private clearEvents(name: string): void {
     if (this.isMidi()) {
       this.global.getMidiManager().getScheduler().clearOwner(name)
+    } else if (this.isInstrument()) {
+      this.global.getMidiManager().getPluginScheduler().clearOwner(name)
     } else {
       this.global.getScheduler().clearSequenceEvents(name)
     }
@@ -737,7 +767,7 @@ export class Sequence {
    * recomputes them with the running pitch range (§2.4).
    */
   private validateMidiDispatch(): void {
-    if (!this.isMidi()) return
+    if (!this.isNoteSequence()) return
     const timedEvents = this.stateManager.getTimedEvents()
     if (!timedEvents) return
     let seqDefault: RootContext | undefined
@@ -769,7 +799,7 @@ export class Sequence {
    * VL sees the full chord regardless.
    */
   private applyVoiceLeading(): void {
-    if (!this.isMidi()) return
+    if (!this.isNoteSequence()) return
     const timedEvents = this.stateManager.getTimedEvents()
     if (!timedEvents) return
     const seqVl = this._voicelead
@@ -840,7 +870,7 @@ export class Sequence {
    * the throw reaches the caller rather than becoming an unhandled rejection.
    */
   private validateNonMidiDispatch(): void {
-    if (this.isMidi()) return
+    if (this.isNoteSequence()) return
     const pattern = this.stateManager.getPlayPattern()
     if (pattern && this.containsStack(pattern)) {
       throw new Error(
@@ -887,18 +917,14 @@ export class Sequence {
       return
     }
 
-    const midi = this.global.getMidiManager()
-    const scheduler = midi.getScheduler()
+    const { scheduler, port, channel, sendDelay } = this.resolveNoteTarget()
     scheduler.start() // idempotent — ensure the lookahead loop is running
 
     const owner = this.stateManager.getName()
-    const port = this._midiPort!
-    const channel = this._midiChannel!
     // Sequence-default context, computed lazily (only if some event falls back
     // to it — a note-name-rooted-only sequence needs no key, §2.3).
     let seqDefault: RootContext | undefined
     const getSeqDefault = (): RootContext => (seqDefault ??= this.resolveRootContext())
-    const sendDelay = midi.sendDelayFor(port)
 
     // ── Stage A: resolve each event to a PlannedNote (§7-0 output stage) ──
     // §2.4 sticky pitch range: a note/rest with an explicit `^N` (rangeSet) sets
@@ -940,7 +966,7 @@ export class Sequence {
         onTime,
         slotDur: ev.duration,
         note, // null = rest (degree 0) or a random-suppressed voice this cycle
-        detune: resolved ? resolved.detune : 0,
+        detune: this.resolveOutputDetune(resolved?.detune ?? 0),
         tie: false,
         legato: !!ev.legato,
         voiceTie: !!ev.voiceTie,
@@ -983,6 +1009,41 @@ export class Sequence {
     }
 
     this.stateManager.setPlaying(true)
+  }
+
+  private resolveNoteTarget(): {
+    scheduler: MidiScheduler
+    port: string
+    channel: number
+    sendDelay: number
+  } {
+    const midi = this.global.getMidiManager()
+    if (this.isInstrument()) {
+      return {
+        scheduler: midi.getPluginScheduler(),
+        port: `plugin:${this.stateManager.getName() || 'sequence'}`,
+        channel: 1,
+        sendDelay: 0,
+      }
+    }
+    const port = this._midiPort!
+    return {
+      scheduler: midi.getScheduler(),
+      port,
+      channel: this._midiChannel!,
+      sendDelay: midi.sendDelayFor(port),
+    }
+  }
+
+  private resolveOutputDetune(detune: number): number {
+    if (!this.isInstrument() || detune === 0) return detune
+    if (!this._instrumentDetuneWarned) {
+      console.warn(
+        `⚠️  Sequence '${this.stateManager.getName() || 'sequence'}': detune is not supported for plugin instruments in v1; skipping detune.`,
+      )
+      this._instrumentDetuneWarned = true
+    }
+    return 0
   }
 
   /** A `_` event-tie PlannedNote: no pitch, never emits — absorbed in Stage B1. */
@@ -1088,6 +1149,10 @@ export class Sequence {
       this.scheduleMidiEvents(scheduler.startTime, fromTime)
       return
     }
+    if (this.isInstrument()) {
+      this.scheduleMidiEvents(scheduler.startTime, fromTime)
+      return
+    }
 
     const timedEvents = this.stateManager.getTimedEvents()
     if (!timedEvents || !this._audioFilePath) {
@@ -1142,7 +1207,7 @@ export class Sequence {
     // "発音 (sounding) sequences". Without this, run()/loop() (which call this
     // eagerly, unlike the schedule paths that early-return for MIDI) wrongly
     // throw for a `.midi()` sequence in a `global.linkAudio()` file (#282).
-    if (this.isMidi()) {
+    if (this.isNoteSequence()) {
       return undefined
     }
     if (!this.global.isLinkAudioEnabled()) {
@@ -1166,6 +1231,10 @@ export class Sequence {
     baseTime: number = 0,
   ): Promise<void> {
     if (this.isMidi()) {
+      this.scheduleMidiEvents(scheduler.startTime, baseTime)
+      return
+    }
+    if (this.isInstrument()) {
       this.scheduleMidiEvents(scheduler.startTime, baseTime)
       return
     }

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -351,8 +351,8 @@ export class Sequence {
   /**
    * Declare this sequence as a MIDI output (§1). `play()` values are then
    * interpreted as degrees, not slice numbers. Cannot be combined with
-   * `audio()` / `chop()`. Coexists with the SuperCollider audio path (no
-   * LinkAudio-style exclusion).
+   * `audio()` / `chop()` / `instrument()`. Coexists with the SuperCollider
+   * audio path (no LinkAudio-style exclusion).
    *
    * @param portName CoreMIDI output port (case-insensitive substring, e.g.
    *                 "iac" matches "IACドライバ バス1"). Resolved eagerly so an

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -390,7 +390,7 @@ export class Sequence {
         `Sequence '${name}': instrument() cannot be combined with audio()/chop()/midi().`,
       )
     }
-    await this.global.getPluginInstrumentManager().instrument(pluginPath, pluginId)
+    await this.global.instrument(pluginPath, pluginId)
     this._instrumentDeclared = true
     return this
   }
@@ -632,9 +632,7 @@ export class Sequence {
    * MIDI stay in sync (§1).
    */
   private activeScheduler(): Scheduler {
-    return this.isMidi() || this.isInstrument()
-      ? this.global.getMidiTransport()
-      : this.global.getScheduler()
+    return this.isNoteSequence() ? this.global.getMidiTransport() : this.global.getScheduler()
   }
 
   /**
@@ -1145,11 +1143,7 @@ export class Sequence {
 
   // Schedule events from a specific time onwards (for seamless parameter changes)
   private scheduleEventsFromTime(scheduler: Scheduler, fromTime: number): void {
-    if (this.isMidi()) {
-      this.scheduleMidiEvents(scheduler.startTime, fromTime)
-      return
-    }
-    if (this.isInstrument()) {
+    if (this.isNoteSequence()) {
       this.scheduleMidiEvents(scheduler.startTime, fromTime)
       return
     }
@@ -1230,11 +1224,7 @@ export class Sequence {
     loopIteration: number = 0,
     baseTime: number = 0,
   ): Promise<void> {
-    if (this.isMidi()) {
-      this.scheduleMidiEvents(scheduler.startTime, baseTime)
-      return
-    }
-    if (this.isInstrument()) {
+    if (this.isNoteSequence()) {
       this.scheduleMidiEvents(scheduler.startTime, baseTime)
       return
     }

--- a/packages/engine/src/midi/plugin-note-output.ts
+++ b/packages/engine/src/midi/plugin-note-output.ts
@@ -23,9 +23,7 @@ export class PluginNoteOutput implements MidiOutput {
 
   noteOff(port: string, channel: number, note: number, owner: string): void {
     const key = Math.max(0, Math.min(127, Math.round(note)))
-    void this.engine
-      .pluginNoteOff?.(key, channel - 1)
-      ?.catch((err) => console.error('❌ PluginNoteOff failed', { key, err }))
+    this.sendTrackedNoteOff({ port, channel, note: key, owner })
     const index = this.activeNotes.findIndex(
       (active) =>
         active.port === port &&

--- a/packages/engine/src/midi/plugin-note-output.ts
+++ b/packages/engine/src/midi/plugin-note-output.ts
@@ -15,9 +15,13 @@ export class PluginNoteOutput implements MidiOutput {
   noteOn(port: string, channel: number, note: number, velocity: number, owner: string): void {
     const key = Math.max(0, Math.min(127, Math.round(note)))
     const normalizedVelocity = Math.max(1, Math.min(127, Math.round(velocity))) / 127
-    void this.engine
-      .pluginNoteOn?.(key, channel - 1, normalizedVelocity)
-      ?.catch((err) => console.error('❌ PluginNoteOn failed', { key, err }))
+    if (this.engine.pluginNoteOn) {
+      void this.engine
+        .pluginNoteOn(key, channel - 1, normalizedVelocity)
+        .catch((err) => console.error('❌ PluginNoteOn failed', { key, err }))
+    } else {
+      console.error('❌ PluginNoteOn unavailable: engine.pluginNoteOn is not implemented', { key })
+    }
     this.activeNotes.push({ port, channel, note: key, owner })
   }
 
@@ -62,8 +66,14 @@ export class PluginNoteOutput implements MidiOutput {
 
   private sendTrackedNoteOff(note: ActiveNote): void {
     const key = note.note
-    void this.engine
-      .pluginNoteOff?.(key, note.channel - 1)
-      ?.catch((err) => console.error('❌ PluginNoteOff failed', { key, err }))
+    if (this.engine.pluginNoteOff) {
+      void this.engine
+        .pluginNoteOff(key, note.channel - 1)
+        .catch((err) => console.error('❌ PluginNoteOff failed', { key, err }))
+    } else {
+      console.error('❌ PluginNoteOff unavailable: engine.pluginNoteOff is not implemented', {
+        key,
+      })
+    }
   }
 }

--- a/packages/engine/src/midi/plugin-note-output.ts
+++ b/packages/engine/src/midi/plugin-note-output.ts
@@ -1,0 +1,71 @@
+import type { AudioEngine } from '../audio/types'
+
+import type { ActiveNote, MidiOutput } from './midi-output'
+
+/** MidiScheduler output adapter for the daemon's single hosted instrument. */
+export class PluginNoteOutput implements MidiOutput {
+  private activeNotes: ActiveNote[] = []
+
+  constructor(private readonly engine: AudioEngine) {}
+
+  ensurePort(portName: string): string {
+    return portName
+  }
+
+  noteOn(port: string, channel: number, note: number, velocity: number, owner: string): void {
+    const key = Math.max(0, Math.min(127, Math.round(note)))
+    const normalizedVelocity = Math.max(1, Math.min(127, Math.round(velocity))) / 127
+    void this.engine
+      .pluginNoteOn?.(key, channel - 1, normalizedVelocity)
+      ?.catch((err) => console.error('❌ PluginNoteOn failed', { key, err }))
+    this.activeNotes.push({ port, channel, note: key, owner })
+  }
+
+  noteOff(port: string, channel: number, note: number, owner: string): void {
+    const key = Math.max(0, Math.min(127, Math.round(note)))
+    void this.engine
+      .pluginNoteOff?.(key, channel - 1)
+      ?.catch((err) => console.error('❌ PluginNoteOff failed', { key, err }))
+    const index = this.activeNotes.findIndex(
+      (active) =>
+        active.port === port &&
+        active.channel === channel &&
+        active.note === key &&
+        active.owner === owner,
+    )
+    if (index !== -1) this.activeNotes.splice(index, 1)
+  }
+
+  pitchBend(_port: string, _channel: number, _semitones: number): void {}
+
+  releaseOwner(owner: string): void {
+    for (const note of this.activeNotes.filter((active) => active.owner === owner)) {
+      this.sendTrackedNoteOff(note)
+    }
+    this.activeNotes = this.activeNotes.filter((active) => active.owner !== owner)
+  }
+
+  panic(): void {
+    for (const note of this.activeNotes) this.sendTrackedNoteOff(note)
+    this.activeNotes = []
+  }
+
+  getActiveNotes(): ReadonlyArray<ActiveNote> {
+    return [...this.activeNotes]
+  }
+
+  listPorts(): string[] {
+    return []
+  }
+
+  closeAll(): void {
+    this.panic()
+  }
+
+  private sendTrackedNoteOff(note: ActiveNote): void {
+    const key = note.note
+    void this.engine
+      .pluginNoteOff?.(key, note.channel - 1)
+      ?.catch((err) => console.error('❌ PluginNoteOff failed', { key, err }))
+  }
+}

--- a/packages/vscode-extension/src/diagnostics-analysis.ts
+++ b/packages/vscode-extension/src/diagnostics-analysis.ts
@@ -327,13 +327,16 @@ export function analyzeLinkAudioMissingOutput(text: string): DiagnosticIssue[] {
   // runtime exemption をミラー、#282) を、ドキュメント1パスで同時に分類する。
   const outputPatterns = new Map<string, RegExp>()
   const midiPatterns = new Map<string, RegExp>()
+  const instrumentPatterns = new Map<string, RegExp>()
   for (const name of sequenceNames) {
     outputPatterns.set(name, new RegExp(`\\b${name}\\b[^\\n]*\\.output\\s*\\(`))
     midiPatterns.set(name, new RegExp(`\\b${name}\\b[^\\n]*\\.midi\\s*\\(`))
+    instrumentPatterns.set(name, new RegExp(`\\b${name}\\b[^\\n]*\\.instrument\\s*\\(`))
   }
 
   const namesWithOutput = new Set<string>()
   const namesWithMidi = new Set<string>()
+  const namesWithInstrument = new Set<string>()
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i]
     if (!raw || raw.trim().startsWith('//')) continue
@@ -344,11 +347,16 @@ export function analyzeLinkAudioMissingOutput(text: string): DiagnosticIssue[] {
     for (const [name, pattern] of midiPatterns) {
       if (pattern.test(line)) namesWithMidi.add(name)
     }
+    for (const [name, pattern] of instrumentPatterns) {
+      if (pattern.test(line)) namesWithInstrument.add(name)
+    }
   }
 
   const orphans = new Set<string>()
   for (const name of sequenceNames) {
-    if (!namesWithOutput.has(name) && !namesWithMidi.has(name)) orphans.add(name)
+    if (!namesWithOutput.has(name) && !namesWithMidi.has(name) && !namesWithInstrument.has(name)) {
+      orphans.add(name)
+    }
   }
   if (orphans.size === 0) return issues
 

--- a/tests/audio/rust-engine/daemon-client.spec.ts
+++ b/tests/audio/rust-engine/daemon-client.spec.ts
@@ -73,7 +73,9 @@ describe('DaemonClient with mock server', () => {
       }),
     })
     await client.start({ wsUrlOverride: url })
-    await expect(client.loadPlugin('/tmp/echo.clap', 'com.example.echo')).resolves.toEqual({
+    await expect(
+      client.loadPlugin('/tmp/echo.clap', 'com.example.echo', 'effect'),
+    ).resolves.toEqual({
       pluginId: 'com.example.echo',
       pluginName: 'Example Echo',
       notePortIndex: 2,
@@ -95,9 +97,35 @@ describe('DaemonClient with mock server', () => {
       },
     })
     await client.start({ wsUrlOverride: url })
-    await expect(client.loadPlugin('/tmp/echo.clap')).rejects.toBeInstanceOf(DaemonProtocolError)
-    await expect(client.loadPlugin('/tmp/echo.clap')).rejects.toMatchObject({
+    await expect(client.loadPlugin('/tmp/echo.clap', undefined, 'effect')).rejects.toBeInstanceOf(
+      DaemonProtocolError,
+    )
+    await expect(client.loadPlugin('/tmp/echo.clap', undefined, 'effect')).rejects.toMatchObject({
       code: 'CLAP_UNAVAILABLE',
+    })
+  })
+
+  it('LoadPlugin sends instrument role and PluginNoteOn/Off wire params', async () => {
+    const url = await server.start({
+      LoadPlugin: () => ({ plugin_id: 'synth', plugin_name: 'Synth', note_port_index: 0 }),
+      PluginNoteOn: () => ({}),
+      PluginNoteOff: () => ({}),
+    })
+    await client.start({ wsUrlOverride: url })
+    await client.loadPlugin('/tmp/synth.clap', undefined, 'instrument')
+    await client.pluginNoteOn(60, 0, 0.75)
+    await client.pluginNoteOff(60, 0, 0.25)
+
+    expect(server.received.find((r) => r.method === 'LoadPlugin')?.params.role).toBe('instrument')
+    expect(server.received.find((r) => r.method === 'PluginNoteOn')?.params).toEqual({
+      key: 60,
+      channel: 0,
+      velocity: 0.75,
+    })
+    expect(server.received.find((r) => r.method === 'PluginNoteOff')?.params).toEqual({
+      key: 60,
+      channel: 0,
+      velocity: 0.25,
     })
   })
 

--- a/tests/audio/rust-engine/mock-daemon-server.ts
+++ b/tests/audio/rust-engine/mock-daemon-server.ts
@@ -25,6 +25,8 @@ type MockHandler = (
 export interface MockDaemonHandlers {
   LoadSample?: MockHandler
   LoadPlugin?: MockHandler
+  PluginNoteOn?: MockHandler
+  PluginNoteOff?: MockHandler
   PlayAt?: MockHandler
   Stop?: MockHandler
   StopAll?: MockHandler

--- a/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
+++ b/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
@@ -39,8 +39,11 @@ function createHarness() {
 }
 
 describe('RustEnginePlayer plugin note ordering', () => {
-  it('issues note sends synchronously with no await boundary before the daemon call', () => {
+  it('issues note sends synchronously with no await boundary before the daemon call', async () => {
     const { player, daemon } = createHarness()
+    // pluginActive only flips true after a successful loadPlugin() — mirrors
+    // the real seq.instrument() -> daemon.loadPlugin() -> note dispatch order.
+    await player.loadPlugin('/plugins/echo.clap', 'echo-id', 'instrument')
     const on = player.pluginNoteOn(60, 0, 0.75)
     const off = player.pluginNoteOff(60, 0)
     expect(daemon.pluginNoteOn).toHaveBeenCalledWith(60, 0, 0.75)
@@ -48,13 +51,30 @@ describe('RustEnginePlayer plugin note ordering', () => {
     return Promise.all([on, off])
   })
 
-  it('logs a visible drop when the daemon is disconnected', async () => {
+  it('warns once and drops the note when the daemon is disconnected (C1)', async () => {
     const { player, daemon } = createHarness()
     daemon.isRunning.mockReturnValue(false)
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     await player.pluginNoteOn(60, 0, 1)
+    await player.pluginNoteOff(60, 0)
     expect(daemon.pluginNoteOn).not.toHaveBeenCalled()
-    expect(error).toHaveBeenCalledWith(expect.stringContaining('❌'), { key: 60 })
+    expect(daemon.pluginNoteOff).not.toHaveBeenCalled()
+    // warn-once: two drops, one warning.
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('daemon is not connected'))
+  })
+
+  it('warns once and drops the note when pluginActive is false (C2 — respawn restore failed)', async () => {
+    const { player, daemon } = createHarness()
+    // Daemon is connected, but no successful loadPlugin() has happened, so
+    // pluginActive is still false (e.g. after a failed post-respawn reload).
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await player.pluginNoteOn(60, 0, 1)
+    await player.pluginNoteOff(60, 0)
+    expect(daemon.pluginNoteOn).not.toHaveBeenCalled()
+    expect(daemon.pluginNoteOff).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('was not restored'))
   })
 })
 

--- a/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
+++ b/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
@@ -10,6 +10,8 @@ interface FakeDaemon {
   off: ReturnType<typeof vi.fn>
   on: ReturnType<typeof vi.fn>
   loadPlugin: ReturnType<typeof vi.fn>
+  pluginNoteOn: ReturnType<typeof vi.fn>
+  pluginNoteOff: ReturnType<typeof vi.fn>
   quit: ReturnType<typeof vi.fn>
 }
 
@@ -28,11 +30,33 @@ function createHarness() {
     off: vi.fn(),
     on: vi.fn(),
     loadPlugin: vi.fn().mockResolvedValue(ECHO_LOAD_RESULT),
+    pluginNoteOn: vi.fn().mockResolvedValue(undefined),
+    pluginNoteOff: vi.fn().mockResolvedValue(undefined),
     quit: vi.fn().mockResolvedValue(undefined),
   }
   Object.defineProperty(player, 'daemon', { value: daemon })
   return { player, daemon }
 }
+
+describe('RustEnginePlayer plugin note ordering', () => {
+  it('issues note sends synchronously with no await boundary before the daemon call', () => {
+    const { player, daemon } = createHarness()
+    const on = player.pluginNoteOn(60, 0, 0.75)
+    const off = player.pluginNoteOff(60, 0)
+    expect(daemon.pluginNoteOn).toHaveBeenCalledWith(60, 0, 0.75)
+    expect(daemon.pluginNoteOff).toHaveBeenCalledWith(60, 0, undefined)
+    return Promise.all([on, off])
+  })
+
+  it('logs a visible drop when the daemon is disconnected', async () => {
+    const { player, daemon } = createHarness()
+    daemon.isRunning.mockReturnValue(false)
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await player.pluginNoteOn(60, 0, 1)
+    expect(daemon.pluginNoteOn).not.toHaveBeenCalled()
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('❌'), { key: 60 })
+  })
+})
 
 describe('RustEnginePlayer plugin recovery after daemon respawn', () => {
   const players: RustEnginePlayer[] = []
@@ -45,13 +69,13 @@ describe('RustEnginePlayer plugin recovery after daemon respawn', () => {
   it('reissues every successfully loaded plugin after respawn', async () => {
     const { player, daemon } = createHarness()
     players.push(player)
-    await player.loadPlugin('/plugins/echo.clap', 'echo-id')
+    await player.loadPlugin('/plugins/echo.clap', 'echo-id', 'effect')
     daemon.loadPlugin.mockClear()
     vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     await (player as any).respawnLoop()
 
-    expect(daemon.loadPlugin).toHaveBeenCalledWith('/plugins/echo.clap', 'echo-id')
+    expect(daemon.loadPlugin).toHaveBeenCalledWith('/plugins/echo.clap', 'echo-id', 'effect')
     // C1: a successful reload must flip pluginActive back to true, so
     // PluginEffectManager's self-heal check doesn't mistake this recovery
     // for a still-stale cache.
@@ -61,7 +85,7 @@ describe('RustEnginePlayer plugin recovery after daemon respawn', () => {
   it('logs a reload failure and retains the plugin for the next respawn retry', async () => {
     const { player, daemon } = createHarness()
     players.push(player)
-    await player.loadPlugin('/plugins/echo.clap', 'echo-id')
+    await player.loadPlugin('/plugins/echo.clap', 'echo-id', 'instrument')
     daemon.loadPlugin.mockClear()
     daemon.loadPlugin
       .mockRejectedValueOnce(new Error('reload failed'))
@@ -80,7 +104,11 @@ describe('RustEnginePlayer plugin recovery after daemon respawn', () => {
 
     await (player as any).respawnLoop()
     expect(daemon.loadPlugin).toHaveBeenCalledTimes(2)
-    expect(daemon.loadPlugin).toHaveBeenLastCalledWith('/plugins/echo.clap', 'echo-id')
+    expect(daemon.loadPlugin).toHaveBeenLastCalledWith(
+      '/plugins/echo.clap',
+      'echo-id',
+      'instrument',
+    )
     expect(player.isPluginActive()).toBe(true)
   })
 })
@@ -100,7 +128,7 @@ describe('RustEnginePlayer.loadPlugin() error conversion', () => {
       new DaemonProtocolError('CLAP_UNAVAILABLE', 'clap host is unavailable'),
     )
 
-    await expect(player.loadPlugin('/plugins/echo.clap', 'echo-id')).rejects.toThrow(
+    await expect(player.loadPlugin('/plugins/echo.clap', 'echo-id', 'effect')).rejects.toThrow(
       '--features clap-host',
     )
   })
@@ -112,7 +140,7 @@ describe('RustEnginePlayer.loadPlugin() error conversion', () => {
       new DaemonProtocolError('PLUGIN_LOAD_FAILED', 'the plugin crashed on init'),
     )
 
-    await expect(player.loadPlugin('/plugins/echo.clap', 'echo-id')).rejects.toThrow(
+    await expect(player.loadPlugin('/plugins/echo.clap', 'echo-id', 'effect')).rejects.toThrow(
       /^Failed to load plugin:/,
     )
   })
@@ -123,18 +151,20 @@ describe('RustEnginePlayer.loadPlugin() error conversion', () => {
     const original = new Error('unexpected transport failure')
     daemon.loadPlugin.mockRejectedValueOnce(original)
 
-    await expect(player.loadPlugin('/plugins/echo.clap', 'echo-id')).rejects.toBe(original)
+    await expect(player.loadPlugin('/plugins/echo.clap', 'echo-id', 'effect')).rejects.toBe(
+      original,
+    )
   })
 
   it('flips pluginActive to false when a subsequent loadPlugin call fails', async () => {
     const { player, daemon } = createHarness()
     players.push(player)
-    await player.loadPlugin('/plugins/echo.clap', 'echo-id')
+    await player.loadPlugin('/plugins/echo.clap', 'echo-id', 'effect')
     expect(player.isPluginActive()).toBe(true)
 
     daemon.loadPlugin.mockRejectedValueOnce(new Error('daemon transport failure'))
 
-    await expect(player.loadPlugin('/plugins/echo.clap', 'echo-id')).rejects.toThrow(
+    await expect(player.loadPlugin('/plugins/echo.clap', 'echo-id', 'effect')).rejects.toThrow(
       'daemon transport failure',
     )
     // The catch block must not rely on callers guaranteeing false-on-entry —

--- a/tests/core/global-plugin-effect.spec.ts
+++ b/tests/core/global-plugin-effect.spec.ts
@@ -44,7 +44,11 @@ describe('Global.effect()', () => {
     await expect(global.effect('./echo.clap', 'echo-id')).resolves.toBe(global)
     await global.effect('./echo.clap', 'echo-id')
     expect(loadPlugin).toHaveBeenCalledTimes(1)
-    expect(loadPlugin).toHaveBeenCalledWith(path.resolve('/songs/session', 'echo.clap'), 'echo-id')
+    expect(loadPlugin).toHaveBeenCalledWith(
+      path.resolve('/songs/session', 'echo.clap'),
+      'echo-id',
+      'effect',
+    )
   })
 
   it('treats different spec spellings that resolve to the same path as idempotent', async () => {
@@ -133,6 +137,7 @@ describe('Global.effect()', () => {
         2,
         path.resolve('/songs/session', 'echo.clap'),
         'echo-id',
+        'effect',
       )
     })
 

--- a/tests/core/plugin-instrument.spec.ts
+++ b/tests/core/plugin-instrument.spec.ts
@@ -25,9 +25,8 @@ describe('PluginInstrumentManager', () => {
     const pending = new Promise<void>((r) => (resolve = r))
     const loadPlugin = vi.fn(() => pending)
     const { global } = makeGlobal(loadPlugin)
-    const manager = global.getPluginInstrumentManager()
-    const first = manager.instrument('./synth.clap', 'synth-id')
-    const second = manager.instrument('synth.clap', 'synth-id')
+    const first = global.instrument('./synth.clap', 'synth-id')
+    const second = global.instrument('synth.clap', 'synth-id')
     resolve()
     await Promise.all([first, second])
     expect(loadPlugin).toHaveBeenCalledTimes(1)
@@ -40,10 +39,9 @@ describe('PluginInstrumentManager', () => {
 
   it('rejects a different path or plugin id after declaration', async () => {
     const { global, loadPlugin } = makeGlobal()
-    const manager = global.getPluginInstrumentManager()
-    await manager.instrument('synth.clap', 'one')
-    await expect(manager.instrument('other.clap', 'one')).rejects.toThrow('one instrument')
-    await expect(manager.instrument('synth.clap', 'two')).rejects.toThrow('one instrument')
+    await global.instrument('synth.clap', 'one')
+    await expect(global.instrument('other.clap', 'one')).rejects.toThrow('one instrument')
+    await expect(global.instrument('synth.clap', 'two')).rejects.toThrow('one instrument')
     expect(loadPlugin).toHaveBeenCalledTimes(1)
   })
 
@@ -51,17 +49,15 @@ describe('PluginInstrumentManager', () => {
     const failure = new Error('load failed')
     const loadPlugin = vi.fn().mockRejectedValueOnce(failure).mockResolvedValueOnce({})
     const { global } = makeGlobal(loadPlugin)
-    const manager = global.getPluginInstrumentManager()
-    await expect(manager.instrument('synth.clap')).rejects.toBe(failure)
-    await expect(manager.instrument('synth.clap')).resolves.toBeUndefined()
+    await expect(global.instrument('synth.clap')).rejects.toBe(failure)
+    await expect(global.instrument('synth.clap')).resolves.toBe(global)
     expect(loadPlugin).toHaveBeenCalledTimes(2)
   })
 
   it('self-heals an inactive idempotent declaration', async () => {
     const { global, loadPlugin } = makeGlobal(vi.fn().mockResolvedValue({}), false)
-    const manager = global.getPluginInstrumentManager()
-    await manager.instrument('synth.clap')
-    await manager.instrument('synth.clap')
+    await global.instrument('synth.clap')
+    await global.instrument('synth.clap')
     expect(loadPlugin).toHaveBeenCalledTimes(2)
   })
 
@@ -78,12 +74,10 @@ describe('PluginInstrumentManager', () => {
   it('rejects LinkAudio in both declaration orders', async () => {
     const first = makeGlobal().global
     first.linkAudio()
-    await expect(first.getPluginInstrumentManager().instrument('synth.clap')).rejects.toThrow(
-      'LinkAudio',
-    )
+    await expect(first.instrument('synth.clap')).rejects.toThrow('LinkAudio')
 
     const second = makeGlobal().global
-    await second.getPluginInstrumentManager().instrument('synth.clap')
+    await second.instrument('synth.clap')
     expect(() => second.linkAudio()).toThrow('plugin hosting')
   })
 })

--- a/tests/core/plugin-instrument.spec.ts
+++ b/tests/core/plugin-instrument.spec.ts
@@ -1,0 +1,91 @@
+import path from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { Global } from '../../packages/engine/src/core/global'
+
+function makeGlobal(loadPlugin = vi.fn().mockResolvedValue({}), active?: boolean) {
+  const engine = {
+    loadPlugin,
+    pluginNoteOn: vi.fn().mockResolvedValue(undefined),
+    pluginNoteOff: vi.fn().mockResolvedValue(undefined),
+    ...(active === undefined ? {} : { isPluginActive: vi.fn(() => active) }),
+    boot: vi.fn(),
+    quit: vi.fn(),
+    isRunning: true,
+  } as any
+  const global = new Global(engine)
+  global.setDocumentDirectory('/songs/session')
+  return { global, loadPlugin }
+}
+
+describe('PluginInstrumentManager', () => {
+  it('eagerly loads once and shares concurrent identical declarations', async () => {
+    let resolve!: () => void
+    const pending = new Promise<void>((r) => (resolve = r))
+    const loadPlugin = vi.fn(() => pending)
+    const { global } = makeGlobal(loadPlugin)
+    const manager = global.getPluginInstrumentManager()
+    const first = manager.instrument('./synth.clap', 'synth-id')
+    const second = manager.instrument('synth.clap', 'synth-id')
+    resolve()
+    await Promise.all([first, second])
+    expect(loadPlugin).toHaveBeenCalledTimes(1)
+    expect(loadPlugin).toHaveBeenCalledWith(
+      path.resolve('/songs/session', 'synth.clap'),
+      'synth-id',
+      'instrument',
+    )
+  })
+
+  it('rejects a different path or plugin id after declaration', async () => {
+    const { global, loadPlugin } = makeGlobal()
+    const manager = global.getPluginInstrumentManager()
+    await manager.instrument('synth.clap', 'one')
+    await expect(manager.instrument('other.clap', 'one')).rejects.toThrow('one instrument')
+    await expect(manager.instrument('synth.clap', 'two')).rejects.toThrow('one instrument')
+    expect(loadPlugin).toHaveBeenCalledTimes(1)
+  })
+
+  it('rolls back a failed eager load and permits retry', async () => {
+    const failure = new Error('load failed')
+    const loadPlugin = vi.fn().mockRejectedValueOnce(failure).mockResolvedValueOnce({})
+    const { global } = makeGlobal(loadPlugin)
+    const manager = global.getPluginInstrumentManager()
+    await expect(manager.instrument('synth.clap')).rejects.toBe(failure)
+    await expect(manager.instrument('synth.clap')).resolves.toBeUndefined()
+    expect(loadPlugin).toHaveBeenCalledTimes(2)
+  })
+
+  it('self-heals an inactive idempotent declaration', async () => {
+    const { global, loadPlugin } = makeGlobal(vi.fn().mockResolvedValue({}), false)
+    const manager = global.getPluginInstrumentManager()
+    await manager.instrument('synth.clap')
+    await manager.instrument('synth.clap')
+    expect(loadPlugin).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects effect and instrument in both declaration orders, including the same path', async () => {
+    const first = makeGlobal().global
+    await first.effect('shared.clap')
+    await expect(first.getPluginInstrumentManager().instrument('shared.clap')).rejects.toThrow(
+      '#431',
+    )
+
+    const second = makeGlobal().global
+    await second.getPluginInstrumentManager().instrument('shared.clap')
+    await expect(second.effect('shared.clap')).rejects.toThrow('#431')
+  })
+
+  it('rejects LinkAudio in both declaration orders', async () => {
+    const first = makeGlobal().global
+    first.linkAudio()
+    await expect(first.getPluginInstrumentManager().instrument('synth.clap')).rejects.toThrow(
+      'LinkAudio',
+    )
+
+    const second = makeGlobal().global
+    await second.getPluginInstrumentManager().instrument('synth.clap')
+    expect(() => second.linkAudio()).toThrow('plugin hosting')
+  })
+})

--- a/tests/core/plugin-instrument.spec.ts
+++ b/tests/core/plugin-instrument.spec.ts
@@ -68,12 +68,10 @@ describe('PluginInstrumentManager', () => {
   it('rejects effect and instrument in both declaration orders, including the same path', async () => {
     const first = makeGlobal().global
     await first.effect('shared.clap')
-    await expect(first.getPluginInstrumentManager().instrument('shared.clap')).rejects.toThrow(
-      '#431',
-    )
+    await expect(first.instrument('shared.clap')).rejects.toThrow('#431')
 
     const second = makeGlobal().global
-    await second.getPluginInstrumentManager().instrument('shared.clap')
+    await second.instrument('shared.clap')
     await expect(second.effect('shared.clap')).rejects.toThrow('#431')
   })
 

--- a/tests/core/sequence-instrument.spec.ts
+++ b/tests/core/sequence-instrument.spec.ts
@@ -129,4 +129,34 @@ describe('Sequence instrument dispatch', () => {
     global.stop()
     expect(audio.pluginNoteOff).toHaveBeenCalledWith(60, 0)
   })
+
+  it('gain() during LOOP clears pending notes via the plugin scheduler (clearOwner)', async () => {
+    const { global, seq } = harness()
+    await seq.instrument('synth.clap')
+    global.quantize('off')
+    global.start()
+    seq.play(1, 3, 5, 0)
+    await seq.loop()
+
+    const clearOwnerSpy = vi.spyOn(global.getMidiManager().getPluginScheduler(), 'clearOwner')
+
+    seq.gain(-6)
+
+    expect(clearOwnerSpy).toHaveBeenCalledWith('synth')
+  })
+
+  it('play() replacement during LOOP defers to the next cycle (no immediate clearOwner)', async () => {
+    const { global, seq } = harness()
+    await seq.instrument('synth.clap')
+    global.quantize('off')
+    global.start()
+    seq.play(1, 3, 5, 0)
+    await seq.loop()
+
+    const clearOwnerSpy = vi.spyOn(global.getMidiManager().getPluginScheduler(), 'clearOwner')
+
+    seq.play(1, 1, 1, 1)
+
+    expect(clearOwnerSpy).not.toHaveBeenCalled()
+  })
 })

--- a/tests/core/sequence-instrument.spec.ts
+++ b/tests/core/sequence-instrument.spec.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Global } from '../../packages/engine/src/core/global'
+import { Sequence } from '../../packages/engine/src/core/sequence'
+import { MidiManager } from '../../packages/engine/src/core/global/midi-manager'
+import type { MidiOutput } from '../../packages/engine/src/midi/midi-output'
+
+const T0 = 1_000_000
+
+function scheduler() {
+  return {
+    isRunning: true,
+    startTime: T0,
+    getCurrentTime: () => 0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(),
+    clearSequenceEvents: vi.fn(),
+    reinitializeSequenceTracking: vi.fn(),
+    getMasterGainDb: () => 0,
+  } as never
+}
+
+function harness() {
+  const audio = scheduler() as any
+  audio.loadPlugin = vi.fn().mockResolvedValue({})
+  audio.pluginNoteOn = vi.fn().mockResolvedValue(undefined)
+  audio.pluginNoteOff = vi.fn().mockResolvedValue(undefined)
+  const midiOutput: MidiOutput = {
+    ensurePort: vi.fn(() => 'IAC'),
+    noteOn: vi.fn(),
+    noteOff: vi.fn(),
+    pitchBend: vi.fn(),
+    releaseOwner: vi.fn(),
+    panic: vi.fn(),
+    getActiveNotes: vi.fn(() => []),
+    listPorts: vi.fn(() => ['IAC']),
+    closeAll: vi.fn(),
+  }
+  const global = new Global(audio, new MidiManager(() => midiOutput))
+  global.setDocumentDirectory('/songs')
+  global.key('C')
+  const seq = new Sequence(global, audio)
+  seq.setName('synth')
+  return { audio, global, seq }
+}
+
+describe('Sequence instrument dispatch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(T0)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('awaits eager declaration, marks note mode, and resolves degrees to plugin notes', async () => {
+    const { audio, global, seq } = harness()
+    const chained = await seq.instrument('synth.clap')
+    chained.octave(4)
+    expect(seq.isInstrument()).toBe(true)
+    expect(seq.isMidi()).toBe(false)
+    expect(seq.isNoteSequence()).toBe(true)
+    expect(seq.resolveDispatchChannel()).toBeUndefined()
+
+    global.start()
+    seq.play(1, 0, 3)
+    await seq.run()
+    await vi.advanceTimersByTimeAsync(2100)
+
+    expect(audio.pluginNoteOn.mock.calls.map((call: unknown[]) => call[0])).toEqual([60, 64])
+    expect(audio.pluginNoteOn).toHaveBeenCalledWith(60, 0, 96 / 127)
+  })
+
+  it('enforces instrument/midi/audio/chop exclusion in both directions', async () => {
+    const first = harness()
+    await first.seq.instrument('synth.clap')
+    expect(() => first.seq.midi('iac', 1)).toThrow('instrument')
+    expect(() => first.seq.audio('kick.wav')).toThrow('instrument')
+    expect(() => first.seq.chop(4)).toThrow('instrument')
+
+    const midi = harness()
+    midi.seq.midi('iac', 1)
+    await expect(midi.seq.instrument('synth.clap')).rejects.toThrow('midi')
+
+    const audio = harness()
+    vi.spyOn(audio.global, 'resolveAudioSpec').mockReturnValue('/songs/kick.wav')
+    audio.seq.audio('kick.wav')
+    await expect(audio.seq.instrument('synth.clap')).rejects.toThrow('audio')
+
+    const chopped = harness()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    chopped.seq.chop(4)
+    await expect(chopped.seq.instrument('synth.clap')).rejects.toThrow('chop')
+  })
+
+  it('warns once for detune and never enqueues pitch bend', async () => {
+    const { audio, global, seq } = harness()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await seq.instrument('synth.clap')
+    global.start()
+    const detuned = {
+      type: 'pitch',
+      degree: 1,
+      alteration: 0,
+      octaveShift: 0,
+      rangeSet: false,
+      detune: 0.5,
+    }
+    seq.play(detuned as never, detuned as never)
+    await seq.run()
+    await vi.advanceTimersByTimeAsync(2100)
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(audio.pluginNoteOn).toHaveBeenCalledTimes(2)
+  })
+
+  it('global.stop panics the plugin scheduler by enumerating active notes', async () => {
+    const { audio, global, seq } = harness()
+    await seq.instrument('synth.clap')
+    global.quantize('off')
+    global.start()
+    seq.play(1)
+    await seq.run()
+    await vi.advanceTimersByTimeAsync(105)
+    expect(audio.pluginNoteOn).toHaveBeenCalledTimes(1)
+    expect(audio.pluginNoteOff).not.toHaveBeenCalled()
+    global.stop()
+    expect(audio.pluginNoteOff).toHaveBeenCalledWith(60, 0)
+  })
+})

--- a/tests/midi/plugin-note-output.spec.ts
+++ b/tests/midi/plugin-note-output.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { PluginNoteOutput } from '../../packages/engine/src/midi/plugin-note-output'
+
+function harness() {
+  const engine = {
+    pluginNoteOn: vi.fn().mockResolvedValue(undefined),
+    pluginNoteOff: vi.fn().mockResolvedValue(undefined),
+  } as any
+  return { engine, output: new PluginNoteOutput(engine) }
+}
+
+describe('PluginNoteOutput', () => {
+  it.each([
+    [1, 1 / 127],
+    [127, 1],
+    [-10, 1 / 127],
+    [200, 1],
+  ])('normalizes and clamps velocity %s', (velocity, normalized) => {
+    const { engine, output } = harness()
+    output.noteOn('plugin', 1, 60, velocity, 'lead')
+    expect(engine.pluginNoteOn).toHaveBeenCalledWith(60, 0, normalized)
+  })
+
+  it('tracks noteOn/Off and maps scheduler channel 1 to wire channel 0', () => {
+    const { engine, output } = harness()
+    output.noteOn('plugin', 1, 60, 96, 'lead')
+    expect(output.getActiveNotes()).toEqual([
+      { port: 'plugin', channel: 1, note: 60, owner: 'lead' },
+    ])
+    output.noteOff('plugin', 1, 60, 'lead')
+    expect(engine.pluginNoteOff).toHaveBeenCalledWith(60, 0)
+    expect(output.getActiveNotes()).toEqual([])
+  })
+
+  it('panic enumerates active notes and clears tracking', () => {
+    const { engine, output } = harness()
+    output.noteOn('a', 1, 60, 96, 'lead')
+    output.noteOn('b', 2, 64, 96, 'pad')
+    output.panic()
+    expect(engine.pluginNoteOff.mock.calls).toEqual([
+      [60, 0],
+      [64, 1],
+    ])
+    expect(output.getActiveNotes()).toEqual([])
+  })
+
+  it('releaseOwner releases only that owner and pitchBend is a silent no-op', () => {
+    const { engine, output } = harness()
+    output.noteOn('plugin', 1, 60, 96, 'lead')
+    output.noteOn('plugin', 1, 64, 96, 'pad')
+    output.pitchBend('plugin', 1, 1)
+    output.releaseOwner('lead')
+    expect(engine.pluginNoteOff).toHaveBeenCalledTimes(1)
+    expect(output.getActiveNotes()).toEqual([
+      { port: 'plugin', channel: 1, note: 64, owner: 'pad' },
+    ])
+  })
+
+  it('accepts virtual ports, lists no hardware ports, and closeAll panics', () => {
+    const { engine, output } = harness()
+    expect(output.ensurePort('anything')).toBe('anything')
+    expect(output.listPorts()).toEqual([])
+    output.noteOn('plugin', 1, 60, 96, 'lead')
+    output.closeAll()
+    expect(engine.pluginNoteOff).toHaveBeenCalledWith(60, 0)
+  })
+})

--- a/tests/vscode-extension/diagnostics-analysis.spec.ts
+++ b/tests/vscode-extension/diagnostics-analysis.spec.ts
@@ -460,6 +460,17 @@ describe('analyzeLinkAudioMissingOutput', () => {
     expect(analyzeLinkAudioMissingOutput(text)).toEqual([])
   })
 
+  it('does not flag an instrument sequence with no .output() under linkAudio mode', () => {
+    const text = [
+      'global.linkAudio()',
+      'var synth = init global.seq',
+      'synth.instrument("synth.clap").octave(4)',
+      'synth.play(1, 3, 5)',
+    ].join('\n')
+
+    expect(analyzeLinkAudioMissingOutput(text)).toEqual([])
+  })
+
   it('flags only the orphan AUDIO sequence in a mixed MIDI + LinkAudio file (#282 coexistence)', () => {
     // Mirrors examples/19_iac_linkaudio_coexist.orbs: MIDI voices (no .output(),
     // exempt) coexisting with audio channels. Only the audio sequence missing


### PR DESCRIPTION
Closes #427

## 概要

#425 で確定した `seq.instrument(path[, pluginId])` を実装し、Pitch DSL v1.1 の note 出力を daemon の `PluginNoteOn`/`PluginNoteOff` へ配線した。**「DSL の度数から CLAP instrument が鳴る」を初めて成立させた**（Epic #424 Stage 1 後半・#426 effect と対）。TS のみ・Rust 変更なし。

## 設計の要（Fable 実装前相談 GO・統合点7つを事前特定）

- **`MidiOutput` interface が seam**: `PluginNoteOutput implements MidiOutput` により、度数解決・gate/tie/legato・voicelead・lookahead スケジューラを既存 MIDI 経路と**完全共有**。新規実装は出力アダプタのみ
- `isNoteSequence()` 新設（= isMidi ∨ isInstrument）: 意味論6箇所を置換・出力先4箇所は明示分岐（`isMidi()` = RtMidi 出力の意味は不変）
- `scheduleMidiEvents` は fork せず `resolveNoteTarget()` でパラメータ化（instrument = plugin scheduler・channel 1→wire 0・sendDelay 0 = `midiLatency` 非適用）
- plugin 用第2 `MidiScheduler` を MidiManager の **start/stop/panic 連鎖に組み込み**（`global.stop()` で instrument も停止 = PH.4 の All Notes Off 列挙）
- **順序保証契約**: `pluginNoteOn/Off` は ws.send 前に await を置かない（daemon read loop の逐次性と合わせ「同期 send 順 = 演奏順」・コード内に明文化）。未接続 drop は ❌ log（silent drop なし）
- detune `~` は warn+skip（sequence 層 once-flag + ゼロ潰し）・effect⇔instrument 双方向早期エラー（同一 path 含む・撤去項目は #431 チェックリストに追記済み）・`loadedPlugin` キャッシュに role 保存（respawn 復元の事故防止）

## 検証

- `npm test`: **1327 passed / 0 failed / 29 skipped**（+22 新規・main 環境で再実行確認）
- **Fable 受け入れ監査 GO**: PH.1-PH.6 全項目適合・ブリーフの罠7点全遵守・**既存 MIDI 経路は bit-equivalent 判定**（751 テスト再実行 + 全 hunk 読解）・await-before-send 契約の独立再検証
- **実機 gated E2E（DoD 達成）**: `global.key("C")` + `seq.instrument("CLAPTestSynth.clap")`（バンドルディレクトリ・#433 修正入り daemon）+ `play(1, 3, 5, 8)` → 実発音。**capture peak = 0.2500（厳密一致）** = clap-test-synth の既知振幅で PR #422 実機検証と同一シグネチャ。eager 検証も実地確認（key 未宣言は宣言時ハードエラー）

## 残作業・関連

- 監査 Minor 4件（detune の直接スパイ検証等）はレビューフェーズで対応判断
- #431: OOP post-boot attach + effect/instrument 同時使用（Epic #424 DoD「同時演奏」はここ）
- WORK_LOG は PR #435（#433）とエントリ挿入位置が競合するため、#435 マージ後に rebase 予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015R9Km7edyaAgqzVFsUm7uX