### PR TITLE
feat(daemon): extend SharedRegion + add engaged gate (#431 PR-1a)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -145,6 +145,30 @@ fmt/clippy（両 feature）green・`cargo deny --offline check` green。
 - CI 3/3 pass 継続。Critical=0・Important=0・CI green で `/code:pr-review-team`
   の収束条件を満たした
 
+**flake watch item の実証（advisor 指摘: 不在証明は机上でなく実証で確定・PR#417
+教訓の適用）**:
+- advisor に相談: 複数レビュアーが round 1/2 を通じて別々に観測した異常（作業ツリーの
+  一時的な engaged ゲート除去・`eprintln!` 混入・`publish_child_ready` テストの
+  初回 FAILED→`cargo clean` で green・disengaged テストの120回中1 flake）は
+  互いに無関係ではなく、**4レビュアーを同一 working tree 上で並行実行し、各自が
+  mutation テスト（ソース書き換え→cargo→revert）を行ったことによる交差汚染**が
+  根本原因という指摘。bot レビューに出す前に「隔離環境での再現」を実証すべきとの
+  助言
+- 実証: `cargo test -p orbit-audio-daemon --features outproc-instrument --lib`
+  を単体フィルタで120回・フル `--lib` スイート（並行テスト有効・silent-failure-
+  hunter が flake を観測した条件と同一）で60回、計180回連続実行 → **全 green
+  （fail 0件）**。加えて別途200回ループも試行したが、確認できた「失敗」は全て
+  `if cargo test ...; then rm -f ...; else echo FAIL; fi` という repro スクリプト
+  自身の実装上、**pass した run のログファイルが `rm -f` される直前の一瞬を
+  観測しただけ**（実際にファイル内容を読むと該当テストも含め全て `ok`）と判明
+  ——本物の test failure ではなく repro スクリプトの race だった
+- 結論: 該当 flake は**隔離再現せず**。silent-failure-hunter の元の1回の観測も、
+  advisor の仮説どおり並行 cargo プロセス間の競合（build lock 待ち・target dir
+  共有）による環境ノイズであった可能性が高いと判断し、watch item を「解決
+  （環境ノイズと確定・コード側の対応不要）」にクローズ。methodology の申し送り:
+  今後レビューエージェントに mutation テストをさせる場合は `isolation: "worktree"`
+  を必須にする（共有 tree だと reviewer 自身が偽シグナルに振り回される）
+
 ### 6.252 feat(dsl): seq.instrument() — Pitch DSL note の daemon 配線 #427 (Jul 14, 2026)
 
 **Date**: 2026-07-14

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -22,7 +22,7 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 **Date**: 2026-07-14
 **Status**: ✅ 実装・受け入れ監査 GO（PR 作成・レビューフローへ）
 **Branch**: `431-oop-plugin-coexistence`
-**Commit**: `5eebf16`
+**Commit**: `e68e746`
 
 Epic #424 の DoD「1 effect + 1 instrument を DSL から同時にロードして演奏」を達成する
 最後のピース #431（OOP post-boot attach + effect/instrument 同時使用）の第一段。
@@ -52,7 +52,7 @@ PR-1 をさらに 2 段階（1a: 非侵襲的準備・1b: 実際の post-boot at
 - **見落とし発見**: TS ガード撤去だけでは不十分——in-process daemon にも cross-role reject が
   必要（撤去のみだと silent plugin 置換が起きる）。PR-3 に反映
 
-**PR-1a 実装（Codex 委譲・8ファイル・+164/-4・非侵襲的）**:
+**PR-1a 実装（Codex 委譲・8ファイル・+167/-4・非侵襲的）**:
 - `SharedRegion`（`transport.rs`）に `child_status`/`child_flags`（`AtomicU32`）を
   **既存フィールド末尾に追記**（ABI 互換保持）。child readiness handshake の定義のみ
 - effect/instrument 両 child binary: load 成功直後に `child_flags`（has_audio_input 判定）→
@@ -92,6 +92,40 @@ fmt/clippy（両 feature）green・`cargo deny --offline check` green。
   に抽出し、child 側は1行呼び出しに簡素化（重複2箇所→共通関数）
 - 挙動変更なし（named local 化・helper 抽出・関数抽出のみ）。再検証（cargo build/test
   両 feature・fmt --check・clippy -D warnings 両 feature・cargo deny check）全 green
+
+**/code:pr-review-team round 1（4レビュアー + CI・Critical 1件/Important 4件→全適用）**:
+- CI 3/3 pass（code-review・fmt/clippy/test・license/dependency gate）
+- **Critical**（comment-analyzer）: WORK_LOG の `**Commit**: \`5eebf16\`` が
+  到達不能な孤立コミット（自己参照ハッシュ埋め込みの手順ミスの残骸）を指していた。
+  実際の初回実装コミット `e68e746` に修正
+- **Important**（code-reviewer・pr-test-analyzer・silent-failure-hunter が独立に
+  同一の核心へ収束）: 新規関数 `publish_child_ready`（transport.rs）に直接のユニット
+  テストが無く、`has_audio_input` の true/false 分岐が未検証だった → 両分岐を
+  直接検証するテストを追加
+- **Important**（pr-test-analyzer）: instrument 版 `disengaged_passes_dry_without_
+  updating_stats` テストが event ring を空のまま検証しており、この PR の設計動機
+  そのもの（engaged=false 中は note event を drain せず data-loss race を防ぐ）を
+  一度も踏んでいなかった → note を1件 push し、process() 後も未消費のまま残ることを
+  assert する形に強化
+- **Important**（comment-analyzer）: `OutProcEffectPostProcessor::new` の doc が
+  新規引数 `engaged` を列挙していなかった → 追記（`OutProcInstrumentPostProcessor::new`
+  は doc 自体が無かったため新設）
+- **Important**（silent-failure-hunter）: `CHILD_STATUS_LOAD_FAILED` の doc が
+  「host は `child_status == STARTING` のまま child が消えたことで判別する」という
+  前提を述べていたが、これは初回起動でのみ成立する。respawn は shm を再 truncate
+  しないため、一度 READY に達した後の respawn 失敗では前 incarnation の READY が
+  残留する — doc 自身が防ごうとしていた silent failure の芽を doc 自身が見落として
+  いた（PR-1a の受け入れ監査が「Minor: doc 追記」として済ませていた項目の中身が
+  不完全だった）→ respawn 注意文を追記
+- Minor 4件（engaged docの予言的記述の重複緩和・engine_wrap.rs のステップコメント
+  漏れ・WORK_LOG 差分行数の実測補正 `+164/-4`→`+167/-4`・doc 語順整理）も全て適用
+- fixer が新規テスト2件それぞれで fail-before/pass-after 実証: `publish_child_ready`
+  の `child_flags` store を一時除去 → red（`left: 0 / right: 1`）→ 復元で green。
+  instrument disengaged テストは `!engaged` 分岐に一時的な ring drain を追加 →
+  red（`left: Err(Empty) / right: Ok(NoteOn {..})`）→ 復元で green
+- main が独立再検証: 両新規テストを個別実行して pass を確認（sandbox 外実行含む）・
+  cargo build/test 両 feature（0 failed）・fmt --check・clippy -D warnings 両
+  feature・cargo deny check 全 green
 
 ### 6.252 feat(dsl): seq.instrument() — Pitch DSL note の daemon 配線 #427 (Jul 14, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,68 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.253 feat(daemon): SharedRegion 拡張 + engaged ゲート導入 #431 PR-1a (Jul 14, 2026)
+
+**Date**: 2026-07-14
+**Status**: ✅ 実装・受け入れ監査 GO（PR 作成・レビューフローへ）
+**Branch**: `431-oop-plugin-coexistence`
+**Commit**: `5eebf16`
+
+Epic #424 の DoD「1 effect + 1 instrument を DSL から同時にロードして演奏」を達成する
+最後のピース #431（OOP post-boot attach + effect/instrument 同時使用）の第一段。
+実装規模が大きいため 3 PR に段階分割（PR-1: substrate → PR-2: 共存 → PR-3: DoD 配線）し、
+PR-1 をさらに 2 段階（1a: 非侵襲的準備・1b: 実際の post-boot attach）に分割した前半。
+
+**グラウンディングの核心発見（Sonnet subagent・path:line 裏取り済み）**:
+- transport 層（`SharedRegion`）は各 child が専用 shm ファイルを持つため既に N-child 対応
+  （構造変更不要）
+- 真のギャップ = `PostProcessor` に engaged ゲートが無いこと。child 不在時
+  `PipelinedEffectHost::process_block` の READ 分岐は `seq_tag` 一致が一度も無いため
+  `primed` が永久 false のまま `0.0` で埋める（**恒久的無音**。単なる起動時の一時的事象ではない）
+- 合成順序は構造的に確定: instrument = add-mix・effect = overwrite。
+  `instrument → effect` の順で 1 つの `CompositePostProcessor` に包めば
+  `output.rs` は変更不要（単一 `Box<dyn PostProcessor>` スロットのまま）
+- `role` は Rust 側に概念ごと存在しない（greenfield）。`LoadPlugin` の OOP 実行時受け口も
+  存在しない（起動時 env のみ）
+
+**Fable 実装前相談（GO・D1-D7 一発判断・全判断根拠は path:line で裏取り済み）**:
+- engaged ゲートは processor 側（`teardown_requested` と同じ既存イディオム。host は
+  cross-thread atomic を持ち込まず純状態機械のまま）
+- 遅延 supervisor は `Arc<Mutex<ChildSlot>>` 共有 + StreamGuard 側 takeover guard
+  （PR-1b で実装）
+- ready ack は「child ready + role 検証通過」を control thread が確認してから Ok
+  （note ring drain を engaged 内に置くことで #410 型の data-loss race を構造的に排除）
+- 冪等性: 同一 path+role の再送は冪等 Ok・異なる path のみ reject
+- **見落とし発見**: TS ガード撤去だけでは不十分——in-process daemon にも cross-role reject が
+  必要（撤去のみだと silent plugin 置換が起きる）。PR-3 に反映
+
+**PR-1a 実装（Codex 委譲・8ファイル・+164/-4・非侵襲的）**:
+- `SharedRegion`（`transport.rs`）に `child_status`/`child_flags`（`AtomicU32`）を
+  **既存フィールド末尾に追記**（ABI 互換保持）。child readiness handshake の定義のみ
+- effect/instrument 両 child binary: load 成功直後に `child_flags`（has_audio_input 判定）→
+  `child_status = READY` の順で Release store
+- `ClapEffectProcessor`/`ClapInstrumentProcessor` に `has_audio_input()` accessor 追加
+  （in-process 経路の既存判定関数 `HostAudioBuffers::has_audio_input()` への単純委譲）
+- `OutProcEffectPostProcessor`/`OutProcInstrumentPostProcessor` に `engaged: Arc<AtomicBool>`
+  ゲート追加（`teardown_requested` チェックの後・処理委譲の前）。
+  **本 PR では全既存起動経路が `engaged=true` で構築するため挙動は1bitも変わらない**
+
+**受け入れ監査（Fable・GO・Minor 1件）**:
+- ABI 互換性・Release/Acquire 順序・engaged ゲート配置・`has_audio_input` 委譲を全て
+  一次コード精読で確認
+- **mutation による fail-before/pass-after 実証**: engaged ゲートを一時除去して実行 →
+  新規 disengaged テスト 2 件が red（effect: data 不変アサート失敗・instrument:
+  callback_count アサート失敗）→ 復元（shasum で byte-identical 確認）で green
+- Minor 1件（`CHILD_STATUS_LOAD_FAILED` が未使用の予約値であることの doc 追記）を適用
+- **PR-1b への申し送り2点**: ①respawn は同一 shm 再利用のため前 incarnation の READY が
+  残留する（poll ロジックは spawn 前 STARTING リセット or try_wait 併用が必須）
+  ②`engine_wrap.rs` は engaged の Arc を保持しておらず、LoadPlugin から flip するには
+  `ChildSlot` 構造に clone を持たせる変更が必要
+
+**検証**: `cargo test --workspace --features outproc-effect`（protocol 28件含む）・
+`--features outproc-instrument` 全 green・`cargo build --features clap-host` green・
+fmt/clippy（両 feature）green・`cargo deny --offline check` green。
+
 ### 6.252 feat(dsl): seq.instrument() — Pitch DSL note の daemon 配線 #427 (Jul 14, 2026)
 
 **Date**: 2026-07-14

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -127,6 +127,24 @@ fmt/clippy（両 feature）green・`cargo deny --offline check` green。
   cargo build/test 両 feature（0 failed）・fmt --check・clippy -D warnings 両
   feature・cargo deny check 全 green
 
+**/code:pr-review-team round 2（4レビュアー・round 1 修正の検証）— Critical/Important 0件で収束**:
+- 4レビュアー全員が round 1 の6修正（Critical 1件・Important 4件・Minor 4件）の
+  適用内容を実ファイル精読・mutation 注入・実行確認で検証し、**新規の Critical/
+  Important 指摘なし**
+- pr-test-analyzer: 両新規テストに意図的な回帰を注入（`has_audio_input` 分岐反転・
+  engaged チェック順序入れ替え）→ 両方とも red を確認 → 復元で green。tautological
+  でない有効な回帰ガードであることを実証
+- silent-failure-hunter: 自身の round 1 指摘2点（respawn 注意文・engaged 不可視性）
+  が「コード修正」「記録のみで妥当」とそれぞれ適切に扱われたことを確認。**non-
+  blocking watch item**: `disengaged_passes_dry_without_updating_stats`
+  （outproc_instrument.rs）を120回試行中1回だけ flake を観測（同一バイナリ内の
+  他テスト（実子プロセス+watchdog スレッドを使う `supervisor_respawns_child_on_
+  unexpected_exit` 等）との干渉が疑われるが未特定・再現不可）。本 round の修正が
+  原因ではなくブロッカーでもないため、PR-1b 以降で再現した場合のフォローアップ
+  として `cargo nextest`（プロセス単位分離）での切り分けを申し送り
+- CI 3/3 pass 継続。Critical=0・Important=0・CI green で `/code:pr-review-team`
+  の収束条件を満たした
+
 ### 6.252 feat(dsl): seq.instrument() — Pitch DSL note の daemon 配線 #427 (Jul 14, 2026)
 
 **Date**: 2026-07-14

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -79,6 +79,20 @@ PR-1 をさらに 2 段階（1a: 非侵襲的準備・1b: 実際の post-boot at
 `--features outproc-instrument` 全 green・`cargo build --features clap-host` green・
 fmt/clippy（両 feature）green・`cargo deny --offline check` green。
 
+**/simplify（4観点並行レビュー→dedup→3件適用・スキップなし）**:
+- `engine_wrap.rs`: `start_outproc_effect`/`start_outproc_instrument` の3連続
+  `Arc<AtomicBool>` 引数のうち `engaged` をインライン `Arc::new(...)` から named local
+  （`let engaged = ...`）化。3引数が同型のため取り違えリスクを軽減
+- `outproc_instrument.rs` の `mod tests`: `outproc_effect.rs` に既にある
+  `engaged(value: bool) -> Arc<AtomicBool>` helper と対称の関数を追加し、4箇所の
+  `Arc::new(AtomicBool::new(...))` 直書きを置換（reuse・両ファイルのテスト記法を統一）
+- `transport.rs`: effect/instrument 両 child binary で重複していた
+  「flags 判定 → `child_flags` store → `child_status` store」の unsafe ブロックを
+  `pub unsafe fn publish_child_ready(region: *mut SharedRegion, has_audio_input: bool)`
+  に抽出し、child 側は1行呼び出しに簡素化（重複2箇所→共通関数）
+- 挙動変更なし（named local 化・helper 抽出・関数抽出のみ）。再検証（cargo build/test
+  両 feature・fmt --check・clippy -D warnings 両 feature・cargo deny check）全 green
+
 ### 6.252 feat(dsl): seq.instrument() — Pitch DSL note の daemon 配線 #427 (Jul 14, 2026)
 
 **Date**: 2026-07-14

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -543,12 +543,13 @@ impl EngineWrap {
         let host = orbit_audio_sandbox::PipelinedEffectHost::from_mmap(host_mmap);
 
         // 2. teardown flags + 観測 stats + adapter。
+        let engaged = Arc::new(AtomicBool::new(true));
         let teardown_requested = Arc::new(AtomicBool::new(false));
         let teardown_done = Arc::new(AtomicBool::new(false));
         let stats = OutProcEffectStats::new();
         let processor = Box::new(OutProcEffectPostProcessor::new(
             host,
-            Arc::new(AtomicBool::new(true)),
+            engaged,
             teardown_requested.clone(),
             teardown_done.clone(),
             stats.clone(),
@@ -656,6 +657,7 @@ impl EngineWrap {
         })?;
         let host = orbit_audio_sandbox::PipelinedInstrumentHost::from_mmap(host_mmap);
         let (event_tx, event_rx) = rtrb::RingBuffer::new(NOTE_RING_CAPACITY);
+        let engaged = Arc::new(AtomicBool::new(true));
         let teardown_requested = Arc::new(AtomicBool::new(false));
         let teardown_done = Arc::new(AtomicBool::new(false));
         let stats = OutProcInstrumentStats::new();
@@ -663,7 +665,7 @@ impl EngineWrap {
             host,
             event_rx,
             NOTE_RING_CAPACITY,
-            Arc::new(AtomicBool::new(true)),
+            engaged,
             teardown_requested.clone(),
             teardown_done.clone(),
             stats.clone(),

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -548,6 +548,7 @@ impl EngineWrap {
         let stats = OutProcEffectStats::new();
         let processor = Box::new(OutProcEffectPostProcessor::new(
             host,
+            Arc::new(AtomicBool::new(true)),
             teardown_requested.clone(),
             teardown_done.clone(),
             stats.clone(),
@@ -662,6 +663,7 @@ impl EngineWrap {
             host,
             event_rx,
             NOTE_RING_CAPACITY,
+            Arc::new(AtomicBool::new(true)),
             teardown_requested.clone(),
             teardown_done.clone(),
             stats.clone(),

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -542,7 +542,7 @@ impl EngineWrap {
             .map_err(|e| WrapError::OutProcEffect(format!("create shm {shm_path:?}: {e}")))?;
         let host = orbit_audio_sandbox::PipelinedEffectHost::from_mmap(host_mmap);
 
-        // 2. teardown flags + 観測 stats + adapter。
+        // 2. engaged ゲート + teardown flags + 観測 stats + adapter。
         let engaged = Arc::new(AtomicBool::new(true));
         let teardown_requested = Arc::new(AtomicBool::new(false));
         let teardown_done = Arc::new(AtomicBool::new(false));

--- a/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
@@ -263,6 +263,10 @@ pub struct OutProcEffectSnapshot {
 /// （atomic store のみ・RT 安全）。
 pub struct OutProcEffectPostProcessor {
     host: PipelinedEffectHost,
+    /// PR-431: child が未 attach（post-boot attach 待ち）の間は音を素通しする安全弁。
+    /// **本 PR では常に true で構築される**（既存起動経路は eager attach のまま無変更）。
+    /// PR-1b で post-boot attach 経路がこれを false スタートにし、child ready 確認後に true へ遷移する。
+    engaged: Arc<AtomicBool>,
     /// teardown 要求（daemon supervisor → audio thread）。立つと transport への submit を止め、`data` を
     /// dry のまま素通しする。control 側が child へ QUIT を送って reap・shm unlink する前に audio thread が
     /// transport を触らなくなる（in-process clap の handshake を踏襲・設計 §4.5）。
@@ -278,12 +282,14 @@ impl OutProcEffectPostProcessor {
     /// `teardown_requested` / `teardown_done` = supervisor と共有する協調フラグ、`stats` = 観測ミラー。
     pub fn new(
         host: PipelinedEffectHost,
+        engaged: Arc<AtomicBool>,
         teardown_requested: Arc<AtomicBool>,
         teardown_done: Arc<AtomicBool>,
         stats: Arc<OutProcEffectStats>,
     ) -> Self {
         Self {
             host,
+            engaged,
             teardown_requested,
             teardown_done,
             stats,
@@ -301,6 +307,9 @@ impl PostProcessor for OutProcEffectPostProcessor {
         if self.teardown_requested.load(Ordering::Acquire) {
             // quiesce: 以降 transport（shm）を触らない。data は engine の dry 出力のまま流れる。
             self.teardown_done.store(true, Ordering::Release);
+            return;
+        }
+        if !self.engaged.load(Ordering::Acquire) {
             return;
         }
         // dry（effect 適用前）の abs ピークを記録（gated parity の baseline）。
@@ -634,13 +643,23 @@ mod tests {
         )
     }
 
+    fn engaged(value: bool) -> Arc<AtomicBool> {
+        Arc::new(AtomicBool::new(value))
+    }
+
     // 通常経路: adapter は host.process_block に委譲し counter を stats へミラーする。child が未処理
     // （mmap zero-init）なので初回は prime silence（host が data を無音化）= 委譲が起きた証拠。
     #[test]
     fn delegates_to_host_first_block_primes_silence_and_mirrors_stats() {
         let (tr, td) = flags();
         let stats = OutProcEffectStats::new();
-        let mut pp = OutProcEffectPostProcessor::new(temp_host(), tr, td.clone(), stats.clone());
+        let mut pp = OutProcEffectPostProcessor::new(
+            temp_host(),
+            engaged(true),
+            tr,
+            td.clone(),
+            stats.clone(),
+        );
         let mut data = vec![0.7f32; 64 * 2];
         pp.process(&mut data);
         assert!(
@@ -662,8 +681,13 @@ mod tests {
     fn teardown_passes_dry_and_acks() {
         let (tr, td) = flags();
         let stats = OutProcEffectStats::new();
-        let mut pp =
-            OutProcEffectPostProcessor::new(temp_host(), tr.clone(), td.clone(), stats.clone());
+        let mut pp = OutProcEffectPostProcessor::new(
+            temp_host(),
+            engaged(true),
+            tr.clone(),
+            td.clone(),
+            stats.clone(),
+        );
         tr.store(true, Ordering::Release);
 
         let mut data = vec![0.7f32; 64 * 2];
@@ -690,6 +714,20 @@ mod tests {
             "冪等に dry 素通し"
         );
         assert!(td.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn disengaged_passes_dry_without_updating_stats() {
+        let (tr, td) = flags();
+        let stats = OutProcEffectStats::new();
+        let mut pp =
+            OutProcEffectPostProcessor::new(temp_host(), engaged(false), tr, td, stats.clone());
+
+        let mut data = vec![0.7f32; 64 * 2];
+        pp.process(&mut data);
+
+        assert!(data.iter().all(|&sample| sample == 0.7));
+        assert_eq!(stats.snapshot().callback_count, 0);
     }
 
     // OutProcEffectStats のスナップショットは全フィールドを反映する（observability の回帰ガード）。
@@ -888,7 +926,13 @@ mod tests {
     fn teardown_handshake_acked_under_concurrent_process() {
         let (tr, td) = flags();
         let stats = OutProcEffectStats::new();
-        let mut pp = OutProcEffectPostProcessor::new(temp_host(), tr.clone(), td.clone(), stats);
+        let mut pp = OutProcEffectPostProcessor::new(
+            temp_host(),
+            engaged(true),
+            tr.clone(),
+            td.clone(),
+            stats,
+        );
         let stop = Arc::new(AtomicBool::new(false));
         let stop_t = stop.clone();
         let handle = std::thread::spawn(move || {

--- a/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
@@ -265,7 +265,7 @@ pub struct OutProcEffectPostProcessor {
     host: PipelinedEffectHost,
     /// PR-431: child が未 attach（post-boot attach 待ち）の間は音を素通しする安全弁。
     /// **本 PR では常に true で構築される**（既存起動経路は eager attach のまま無変更）。
-    /// PR-1b で post-boot attach 経路がこれを false スタートにし、child ready 確認後に true へ遷移する。
+    /// PR-1b で post-boot attach 実装時に false スタートさせる想定（詳細は Issue #431 参照）。
     engaged: Arc<AtomicBool>,
     /// teardown 要求（daemon supervisor → audio thread）。立つと transport への submit を止め、`data` を
     /// dry のまま素通しする。control 側が child へ QUIT を送って reap・shm unlink する前に audio thread が
@@ -279,6 +279,7 @@ pub struct OutProcEffectPostProcessor {
 
 impl OutProcEffectPostProcessor {
     /// `host` = mmap を所有する production 構築子（`PipelinedEffectHost::from_mmap`）で作った host、
+    /// `engaged` = child の post-boot attach 完了までの安全弁（本 PR では常に `true` で渡される）、
     /// `teardown_requested` / `teardown_done` = supervisor と共有する協調フラグ、`stats` = 観測ミラー。
     pub fn new(
         host: PipelinedEffectHost,

--- a/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
@@ -554,6 +554,10 @@ mod tests {
     use super::*;
     use orbit_audio_sandbox::{slot_index, VoiceAddr, VoiceKey, CHANNELS};
 
+    fn engaged(value: bool) -> Arc<AtomicBool> {
+        Arc::new(AtomicBool::new(value))
+    }
+
     // pr-test-analyzer (item 7, PR #422 review): `OutProcInstrumentConfig::from_env`'s
     // `ORBIT_INSTRUMENT_BUFFER_FRAMES` parsing boundaries had no coverage. Test the extracted pure
     // helper directly rather than `std::env::set_var` (parallel-test flakiness trap; mirrors
@@ -617,7 +621,7 @@ mod tests {
             host,
             event_rx,
             NOTE_RING_CAPACITY,
-            Arc::new(AtomicBool::new(true)),
+            engaged(true),
             requested,
             done,
             stats.clone(),
@@ -684,7 +688,7 @@ mod tests {
             host,
             event_rx,
             NOTE_RING_CAPACITY,
-            Arc::new(AtomicBool::new(true)),
+            engaged(true),
             Arc::new(AtomicBool::new(false)),
             Arc::new(AtomicBool::new(false)),
             stats.clone(),
@@ -757,7 +761,7 @@ mod tests {
             host,
             event_rx,
             NOTE_RING_CAPACITY,
-            Arc::new(AtomicBool::new(true)),
+            engaged(true),
             requested,
             done.clone(),
             stats.clone(),
@@ -796,7 +800,7 @@ mod tests {
             host,
             event_rx,
             NOTE_RING_CAPACITY,
-            Arc::new(AtomicBool::new(false)),
+            engaged(false),
             Arc::new(AtomicBool::new(false)),
             Arc::new(AtomicBool::new(false)),
             stats.clone(),

--- a/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
@@ -189,7 +189,7 @@ pub struct OutProcInstrumentPostProcessor {
     audio_scratch: Vec<f32>,
     /// PR-431: child が未 attach（post-boot attach 待ち）の間は音を素通しする安全弁。
     /// **本 PR では常に true で構築される**（既存起動経路は eager attach のまま無変更）。
-    /// PR-1b で post-boot attach 経路がこれを false スタートにし、child ready 確認後に true へ遷移する。
+    /// PR-1b で post-boot attach 実装時に false スタートさせる想定（詳細は Issue #431 参照）。
     engaged: Arc<AtomicBool>,
     teardown_requested: Arc<AtomicBool>,
     teardown_done: Arc<AtomicBool>,
@@ -200,6 +200,10 @@ pub struct OutProcInstrumentPostProcessor {
 }
 
 impl OutProcInstrumentPostProcessor {
+    /// `host` = mmap を所有する production 構築子（`PipelinedInstrumentHost::from_mmap`）で作った
+    /// host、`event_rx` = note event の受け側（`event_capacity` はその scratch buffer 分の容量）、
+    /// `engaged` = child の post-boot attach 完了までの安全弁（本 PR では常に `true` で渡される）、
+    /// `teardown_requested` / `teardown_done` = supervisor と共有する協調フラグ、`stats` = 観測ミラー。
     pub fn new(
         host: PipelinedInstrumentHost,
         event_rx: rtrb::Consumer<NeutralEvent>,
@@ -789,13 +793,34 @@ mod tests {
         std::fs::remove_file(path).expect("remove shared memory");
     }
 
+    // disengaged (engaged=false) の間は event ring を drain してはいけない: drain してしまうと
+    // engaged になった後の最初の process() でその note を再び読めず、note-on が消える data-loss
+    // race になる。以前の版はイベントを1件も積まずに空の ring を検証していたため、この drain-vs-
+    // no-drain の分岐を実際には踏んでいなかった（空の ring は pop() が常に Err なので、drain して
+    // もしなくても外から見た結果は同じ）。note を1件積んでから process() を呼び、process() 後も
+    // 同じ note が event_rx から pop できる（= 消費されていない）ことを直接検証する。
     #[test]
     fn disengaged_passes_dry_without_updating_stats() {
         let path = unique_shm_path();
         let host_mmap = orbit_audio_sandbox::create_shared(&path).expect("create shared memory");
         let host = PipelinedInstrumentHost::from_mmap(host_mmap);
-        let (_event_tx, event_rx) = rtrb::RingBuffer::new(NOTE_RING_CAPACITY);
+        let (mut event_tx, event_rx) = rtrb::RingBuffer::new(NOTE_RING_CAPACITY);
         let stats = OutProcInstrumentStats::new();
+        let addr = VoiceAddr {
+            note_id: -1,
+            port_index: 0,
+            channel: PROBE_KEY.channel,
+            key: PROBE_KEY.key,
+            _pad: 0,
+        };
+        let note = NeutralEvent::NoteOn {
+            sample_offset: 0,
+            addr,
+            velocity: 0.8,
+            tuning_cents: 0.0,
+            length_frames: 0,
+        };
+        event_tx.push(note).expect("push note to control ring");
         let mut processor = OutProcInstrumentPostProcessor::new(
             host,
             event_rx,
@@ -811,6 +836,11 @@ mod tests {
 
         assert!(data.iter().all(|sample| *sample == 0.42));
         assert_eq!(stats.callback_count.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            processor.event_rx.pop(),
+            Ok(note),
+            "disengaged 中は event ring を drain せず、note がそのまま残っている"
+        );
 
         drop(processor);
         std::fs::remove_file(path).expect("remove shared memory");

--- a/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
@@ -187,6 +187,10 @@ pub struct OutProcInstrumentPostProcessor {
     event_rx: rtrb::Consumer<NeutralEvent>,
     event_scratch: Vec<NeutralEvent>,
     audio_scratch: Vec<f32>,
+    /// PR-431: child が未 attach（post-boot attach 待ち）の間は音を素通しする安全弁。
+    /// **本 PR では常に true で構築される**（既存起動経路は eager attach のまま無変更）。
+    /// PR-1b で post-boot attach 経路がこれを false スタートにし、child ready 確認後に true へ遷移する。
+    engaged: Arc<AtomicBool>,
     teardown_requested: Arc<AtomicBool>,
     teardown_done: Arc<AtomicBool>,
     stats: Arc<OutProcInstrumentStats>,
@@ -200,6 +204,7 @@ impl OutProcInstrumentPostProcessor {
         host: PipelinedInstrumentHost,
         event_rx: rtrb::Consumer<NeutralEvent>,
         event_capacity: usize,
+        engaged: Arc<AtomicBool>,
         teardown_requested: Arc<AtomicBool>,
         teardown_done: Arc<AtomicBool>,
         stats: Arc<OutProcInstrumentStats>,
@@ -209,6 +214,7 @@ impl OutProcInstrumentPostProcessor {
             event_rx,
             event_scratch: Vec::with_capacity(event_capacity),
             audio_scratch: vec![0.0; BUF_LEN],
+            engaged,
             teardown_requested,
             teardown_done,
             stats,
@@ -221,6 +227,9 @@ impl PostProcessor for OutProcInstrumentPostProcessor {
     fn process(&mut self, data: &mut [f32]) {
         if self.teardown_requested.load(Ordering::Acquire) {
             self.teardown_done.store(true, Ordering::Release);
+            return;
+        }
+        if !self.engaged.load(Ordering::Acquire) {
             return;
         }
 
@@ -608,6 +617,7 @@ mod tests {
             host,
             event_rx,
             NOTE_RING_CAPACITY,
+            Arc::new(AtomicBool::new(true)),
             requested,
             done,
             stats.clone(),
@@ -674,6 +684,7 @@ mod tests {
             host,
             event_rx,
             NOTE_RING_CAPACITY,
+            Arc::new(AtomicBool::new(true)),
             Arc::new(AtomicBool::new(false)),
             Arc::new(AtomicBool::new(false)),
             stats.clone(),
@@ -746,6 +757,7 @@ mod tests {
             host,
             event_rx,
             NOTE_RING_CAPACITY,
+            Arc::new(AtomicBool::new(true)),
             requested,
             done.clone(),
             stats.clone(),
@@ -770,6 +782,33 @@ mod tests {
 
         drop(processor);
         drop(ctl_mmap);
+        std::fs::remove_file(path).expect("remove shared memory");
+    }
+
+    #[test]
+    fn disengaged_passes_dry_without_updating_stats() {
+        let path = unique_shm_path();
+        let host_mmap = orbit_audio_sandbox::create_shared(&path).expect("create shared memory");
+        let host = PipelinedInstrumentHost::from_mmap(host_mmap);
+        let (_event_tx, event_rx) = rtrb::RingBuffer::new(NOTE_RING_CAPACITY);
+        let stats = OutProcInstrumentStats::new();
+        let mut processor = OutProcInstrumentPostProcessor::new(
+            host,
+            event_rx,
+            NOTE_RING_CAPACITY,
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+            stats.clone(),
+        );
+
+        let mut data = vec![0.42; 8 * CHANNELS];
+        processor.process(&mut data);
+
+        assert!(data.iter().all(|sample| *sample == 0.42));
+        assert_eq!(stats.callback_count.load(Ordering::Relaxed), 0);
+
+        drop(processor);
         std::fs::remove_file(path).expect("remove shared memory");
     }
 

--- a/rust/crates/orbit-audio-sandbox/src/transport.rs
+++ b/rust/crates/orbit-audio-sandbox/src/transport.rs
@@ -33,7 +33,7 @@
 use std::fs::OpenOptions;
 use std::io;
 use std::path::Path;
-use std::sync::atomic::{AtomicU32, AtomicU64};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
 use memmap2::MmapMut;
 
@@ -245,6 +245,27 @@ pub fn open_shared(path: &Path) -> io::Result<MmapMut> {
 /// ページ境界整列)でなければならない。返したポインタは `mmap` の生存期間を超えて使ってはならない。
 pub fn region_ptr(mmap: &MmapMut) -> *mut SharedRegion {
     mmap.as_ptr() as *mut SharedRegion
+}
+
+/// child が plugin load 成功後に呼ぶ readiness 公開ヘルパ（PR-431）。`child_flags` を先に
+/// Release store してから `child_status = CHILD_STATUS_READY` を Release store する
+/// （host が status を Acquire で観測すれば flags も必ず可視という happens-before を
+/// この1箇所に集約する）。
+///
+/// # Safety
+/// `region` は呼び出し元が map 済みの生存 SharedRegion を指していること。
+pub unsafe fn publish_child_ready(region: *mut SharedRegion, has_audio_input: bool) {
+    let flags = if has_audio_input {
+        CHILD_FLAG_HAS_AUDIO_INPUT
+    } else {
+        0
+    };
+    unsafe {
+        (*region).child_flags.store(flags, Ordering::Release);
+        (*region)
+            .child_status
+            .store(CHILD_STATUS_READY, Ordering::Release);
+    }
 }
 
 #[cfg(test)]

--- a/rust/crates/orbit-audio-sandbox/src/transport.rs
+++ b/rust/crates/orbit-audio-sandbox/src/transport.rs
@@ -8,6 +8,9 @@
 //! - **child**: `seq_request` を Acquire で読む(前回より進んだら)→ n_frames/input が可視 → `output[slot]` を書く → `seq_tag[slot] = seq` を Release(その slot の出力 publish)→ `seq_done = seq` を Release(submit guard 用の最新処理 seq)で store。
 //! - **host READ**: `seq_tag[slot(target)]` を Acquire で読み `== target` なら output が可視 → 出力にコピー。global monotone な `seq_done` でなく per-slot `seq_tag` で判定するのは、child が「latest 処理」で中間 seq を skip しても、その slot の tag が target に一致せず false-fresh を防げるから(seq_done では skip を検知できない)。
 //! - **host SUBMIT guard**: `seq_done` を Acquire で読み slot 再利用可否(下記不変条件)を判定する。
+//! - **child readiness**: child は `ClapEffectProcessor::load` / `ClapInstrumentProcessor::load`
+//!   成功直後に `child_flags` → `child_status` の順で Release store する。host は起動時にこれを poll
+//!   する（本 PR では poll する呼び出し元は未実装・PR-1b で追加）。
 //!
 //! **ping-pong バッファ**: `input` / `output` は各 [`SLOTS`] 個の slot を持ち、seq を [`slot_offset`]
 //! で割り当てて交替する。slot を分けることで「host が seq s の slot を書く」のと「child が seq s-k の
@@ -78,6 +81,22 @@ pub fn slot_offset(seq: u64) -> usize {
 pub const CONTROL_RUN: u32 = 0;
 /// `control` の値: host が child に spin loop を抜けて正常終了するよう要求する。
 pub const CONTROL_QUIT: u32 = 1;
+
+/// child が実際にロードした CLAP plugin の readiness（PR-431・child→host handshake）。
+/// 0 = starting（child がまだ load 中）。
+pub const CHILD_STATUS_STARTING: u32 = 0;
+/// child が load に成功し、以降 process loop に入る状態。
+pub const CHILD_STATUS_READY: u32 = 1;
+/// child が load に失敗して終了する直前の状態。**PR-1a 時点では未使用の予約値**（child は load
+/// 失敗時 `?` の早期 return でこの値を書かずにそのままプロセス終了する。host は
+/// `child_status == STARTING` のまま child が消えたことを `try_wait` で判別する前提。PR-1b で
+/// この値を実際に書く経路を追加する場合、host 側の判定ロジックとセットで設計すること）。
+pub const CHILD_STATUS_LOAD_FAILED: u32 = 2;
+
+/// child のロード結果を表す bit flags（PR-431）。bit0 = has_audio_input
+/// （`orbit_clap_host::buffers::HostAudioBuffers::has_audio_input()` 相当）。effect/instrument の
+/// 実体判定に使い、PR-1b で role 不一致検証に使う予定（本 PR では書き込みのみ）。
+pub const CHILD_FLAG_HAS_AUDIO_INPUT: u32 = 1 << 0;
 
 /// per-block の演奏文脈(event ではなく block header・設計 doc §4.5)。CLAP/VST3/AU が process
 /// 呼び出しのたびに共通して消費する transport metadata の superset。host -> child のみ(child から
@@ -173,6 +192,11 @@ pub struct SharedRegion {
     pub event_decode_error_count: AtomicU64,
     /// **per-slot**: host -> child の per-block 演奏文脈(§4.5)。child からの逆方向は無い。
     pub transport_context: [TransportContext; SLOTS],
+    /// **child -> host readiness signal**（PR-431）。child は load 成功後、[`SharedRegion::child_flags`]
+    /// を先に Release store してから本 field を [`CHILD_STATUS_READY`] に Release store する。
+    pub child_status: AtomicU32,
+    /// child が実際にロードした plugin の role 判定用 bit flags（[`CHILD_FLAG_HAS_AUDIO_INPUT`]）。
+    pub child_flags: AtomicU32,
 }
 
 /// 共有領域のバイトサイズ(mmap ファイルサイズ)。
@@ -272,6 +296,25 @@ mod tests {
             assert_eq!((*region).child_process_error_count.load(Relaxed), 0);
             (*region).child_process_error_count.fetch_add(3, Relaxed);
             assert_eq!((*region).child_process_error_count.load(Relaxed), 3);
+        }
+        drop(mmap);
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn child_readiness_defaults_to_starting_with_no_flags() {
+        use std::sync::atomic::Ordering::Relaxed;
+        let p = std::env::temp_dir().join(format!(
+            "orbit-sbx-child-readiness-{}.shm",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&p);
+        let mmap = create_shared(&p).expect("create");
+        let region = region_ptr(&mmap);
+        // SAFETY: create_shared が返した生存 mapping を指す。truncate 直後で 0 初期化。
+        unsafe {
+            assert_eq!((*region).child_status.load(Relaxed), CHILD_STATUS_STARTING);
+            assert_eq!((*region).child_flags.load(Relaxed), 0);
         }
         drop(mmap);
         let _ = std::fs::remove_file(&p);

--- a/rust/crates/orbit-audio-sandbox/src/transport.rs
+++ b/rust/crates/orbit-audio-sandbox/src/transport.rs
@@ -87,10 +87,17 @@ pub const CONTROL_QUIT: u32 = 1;
 pub const CHILD_STATUS_STARTING: u32 = 0;
 /// child が load に成功し、以降 process loop に入る状態。
 pub const CHILD_STATUS_READY: u32 = 1;
-/// child が load に失敗して終了する直前の状態。**PR-1a 時点では未使用の予約値**（child は load
-/// 失敗時 `?` の早期 return でこの値を書かずにそのままプロセス終了する。host は
-/// `child_status == STARTING` のまま child が消えたことを `try_wait` で判別する前提。PR-1b で
-/// この値を実際に書く経路を追加する場合、host 側の判定ロジックとセットで設計すること）。
+/// **PR-1a 時点では未使用の予約値**（child が load に失敗して終了する直前の状態を表す想定）。
+/// child は load 失敗時 `?` の早期 return でこの値を書かずにそのままプロセス終了する。host は
+/// （初回起動時に限り）`child_status == STARTING` のまま child が消えたことを `try_wait` で
+/// 判別する前提（PR-1b でこの値を実際に書く経路を追加する場合、host 側の判定ロジックとセットで
+/// 設計すること）。
+///
+/// **respawn 注意**: shm は daemon 起動時に一度だけ truncate され、respawn（`EffectChildSupervisor`/
+/// `InstrumentChildSupervisor` の watchdog による再起動）は同一 shm を再利用する（再 truncate しない）
+/// ため、一度 READY に達した後の respawn 失敗では `child_status` は STARTING でなく前 incarnation の
+/// READY が残留する。PR-1b のポーラーは spawn 直前に host が STARTING へ明示リセットする、または
+/// try_wait の生死判定と併用する必要がある。
 pub const CHILD_STATUS_LOAD_FAILED: u32 = 2;
 
 /// child のロード結果を表す bit flags（PR-431）。bit0 = has_audio_input
@@ -339,6 +346,58 @@ mod tests {
         }
         drop(mmap);
         let _ = std::fs::remove_file(&p);
+    }
+
+    // publish_child_ready の直接検証（PR #439 review・pr-test-analyzer）: has_audio_input の
+    // true/false 分岐で child_flags/child_status が期待どおり Release store されることを、
+    // ヘルパを介さず本関数呼び出し1回ずつで確認する（既存テストは child_status/child_flags の
+    // 初期値のみを検証しており、この関数自体を直接呼ぶテストが無かった）。
+    #[test]
+    fn publish_child_ready_stores_flags_and_status_for_both_branches() {
+        use std::sync::atomic::Ordering::Relaxed;
+
+        // has_audio_input = true: CHILD_FLAG_HAS_AUDIO_INPUT が立ち、status は READY。
+        let p_true = std::env::temp_dir().join(format!(
+            "orbit-sbx-publish-ready-true-{}.shm",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&p_true);
+        let mmap_true = create_shared(&p_true).expect("create");
+        let region_true = region_ptr(&mmap_true);
+        // SAFETY: create_shared が返した生存 mapping を指す。
+        unsafe {
+            publish_child_ready(region_true, true);
+            assert_eq!(
+                (*region_true).child_flags.load(Relaxed),
+                CHILD_FLAG_HAS_AUDIO_INPUT
+            );
+            assert_eq!(
+                (*region_true).child_status.load(Relaxed),
+                CHILD_STATUS_READY
+            );
+        }
+        drop(mmap_true);
+        let _ = std::fs::remove_file(&p_true);
+
+        // has_audio_input = false: flags は 0 のまま、status は READY。
+        let p_false = std::env::temp_dir().join(format!(
+            "orbit-sbx-publish-ready-false-{}.shm",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&p_false);
+        let mmap_false = create_shared(&p_false).expect("create");
+        let region_false = region_ptr(&mmap_false);
+        // SAFETY: create_shared が返した生存 mapping を指す。
+        unsafe {
+            publish_child_ready(region_false, false);
+            assert_eq!((*region_false).child_flags.load(Relaxed), 0);
+            assert_eq!(
+                (*region_false).child_status.load(Relaxed),
+                CHILD_STATUS_READY
+            );
+        }
+        drop(mmap_false);
+        let _ = std::fs::remove_file(&p_false);
     }
 
     // 存在しないファイルは map せず Err(open は read-only open なので作成しない)。

--- a/rust/crates/orbit-clap-effect-child/src/main.rs
+++ b/rust/crates/orbit-clap-effect-child/src/main.rs
@@ -24,7 +24,6 @@ use std::path::PathBuf;
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 use anyhow::{bail, Context, Result};
-use orbit_audio_sandbox::transport::{CHILD_FLAG_HAS_AUDIO_INPUT, CHILD_STATUS_READY};
 use orbit_audio_sandbox::{
     open_shared, region_ptr, slot_index, slot_offset, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_FRAMES,
 };
@@ -81,16 +80,9 @@ fn main() -> Result<()> {
     )
     .with_context(|| format!("load CLAP effect {:?}", args.plugin))?;
 
-    let flags = if effect.has_audio_input() {
-        CHILD_FLAG_HAS_AUDIO_INPUT
-    } else {
-        0
-    };
-    // SAFETY: region は host が REGION_BYTES に truncate 済みの共有ファイルを指す。flags を先に
-    // publish し、status の Release store を readiness の公開点にする。
+    // SAFETY: region は host が REGION_BYTES に truncate 済みの共有ファイルを指す。
     unsafe {
-        (*region).child_flags.store(flags, Release);
-        (*region).child_status.store(CHILD_STATUS_READY, Release);
+        orbit_audio_sandbox::transport::publish_child_ready(region, effect.has_audio_input());
     }
 
     // in-place process_block 用の作業バッファ（ループ前に確保 = RT 安全）。

--- a/rust/crates/orbit-clap-effect-child/src/main.rs
+++ b/rust/crates/orbit-clap-effect-child/src/main.rs
@@ -24,6 +24,7 @@ use std::path::PathBuf;
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 use anyhow::{bail, Context, Result};
+use orbit_audio_sandbox::transport::{CHILD_FLAG_HAS_AUDIO_INPUT, CHILD_STATUS_READY};
 use orbit_audio_sandbox::{
     open_shared, region_ptr, slot_index, slot_offset, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_FRAMES,
 };
@@ -79,6 +80,18 @@ fn main() -> Result<()> {
         MAX_FRAMES as u32,
     )
     .with_context(|| format!("load CLAP effect {:?}", args.plugin))?;
+
+    let flags = if effect.has_audio_input() {
+        CHILD_FLAG_HAS_AUDIO_INPUT
+    } else {
+        0
+    };
+    // SAFETY: region は host が REGION_BYTES に truncate 済みの共有ファイルを指す。flags を先に
+    // publish し、status の Release store を readiness の公開点にする。
+    unsafe {
+        (*region).child_flags.store(flags, Release);
+        (*region).child_status.store(CHILD_STATUS_READY, Release);
+    }
 
     // in-place process_block 用の作業バッファ（ループ前に確保 = RT 安全）。
     let mut scratch = vec![0.0f32; BUF_LEN];

--- a/rust/crates/orbit-clap-host/src/effect.rs
+++ b/rust/crates/orbit-clap-host/src/effect.rs
@@ -107,6 +107,11 @@ impl ClapEffectProcessor {
         Ok((processor, loaded.info))
     }
 
+    /// Whether the loaded plugin exposes an audio input port.
+    pub fn has_audio_input(&self) -> bool {
+        self.buffers.has_audio_input()
+    }
+
     /// interleaved stereo f32 ブロックを in-place で effect 処理する。
     ///
     /// 戻り値は `plugin.process()` が成功したか。失敗時は `data` を素通しする（[`process_block_core`] 準拠）。

--- a/rust/crates/orbit-clap-host/src/instrument.rs
+++ b/rust/crates/orbit-clap-host/src/instrument.rs
@@ -96,6 +96,11 @@ impl ClapInstrumentProcessor {
         Ok((processor, loaded.info))
     }
 
+    /// Whether the loaded plugin exposes an audio input port.
+    pub fn has_audio_input(&self) -> bool {
+        self.buffers.has_audio_input()
+    }
+
     /// host → plugin の CLAP event を渡し、instrument の出力を `data` に加算する。
     ///
     /// `events` は呼び出し側が [`crate::push_neutral_event`] で構築した CLAP event buffer。

--- a/rust/crates/orbit-clap-instrument-child/src/main.rs
+++ b/rust/crates/orbit-clap-instrument-child/src/main.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 use anyhow::{bail, Context, Result};
+use orbit_audio_sandbox::transport::{CHILD_FLAG_HAS_AUDIO_INPUT, CHILD_STATUS_READY};
 use orbit_audio_sandbox::{
     open_shared, region_ptr, slot_index, slot_offset, EventRecord, EventSpillFifo, NeutralEvent,
     SharedRegion, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_EVENTS_PER_BLOCK, MAX_FRAMES,
@@ -179,6 +180,17 @@ fn main() -> Result<()> {
         MAX_FRAMES as u32,
     )
     .with_context(|| format!("load CLAP instrument {:?}", args.plugin))?;
+    let flags = if instrument.has_audio_input() {
+        CHILD_FLAG_HAS_AUDIO_INPUT
+    } else {
+        0
+    };
+    // SAFETY: region は host が REGION_BYTES に truncate 済みの共有ファイルを指す。flags を先に
+    // publish し、status の Release store を readiness の公開点にする。
+    unsafe {
+        (*region).child_flags.store(flags, Release);
+        (*region).child_status.store(CHILD_STATUS_READY, Release);
+    }
     let mut scratch = vec![0.0f32; BUF_LEN];
     // Event window 分を事前確保し、hot loop での buffer 再確保を避ける。
     let mut event_buf = EventBuffer::with_capacity(MAX_EVENTS_PER_BLOCK);

--- a/rust/crates/orbit-clap-instrument-child/src/main.rs
+++ b/rust/crates/orbit-clap-instrument-child/src/main.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 use anyhow::{bail, Context, Result};
-use orbit_audio_sandbox::transport::{CHILD_FLAG_HAS_AUDIO_INPUT, CHILD_STATUS_READY};
 use orbit_audio_sandbox::{
     open_shared, region_ptr, slot_index, slot_offset, EventRecord, EventSpillFifo, NeutralEvent,
     SharedRegion, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_EVENTS_PER_BLOCK, MAX_FRAMES,
@@ -180,16 +179,9 @@ fn main() -> Result<()> {
         MAX_FRAMES as u32,
     )
     .with_context(|| format!("load CLAP instrument {:?}", args.plugin))?;
-    let flags = if instrument.has_audio_input() {
-        CHILD_FLAG_HAS_AUDIO_INPUT
-    } else {
-        0
-    };
-    // SAFETY: region は host が REGION_BYTES に truncate 済みの共有ファイルを指す。flags を先に
-    // publish し、status の Release store を readiness の公開点にする。
+    // SAFETY: region は host が REGION_BYTES に truncate 済みの共有ファイルを指す。
     unsafe {
-        (*region).child_flags.store(flags, Release);
-        (*region).child_status.store(CHILD_STATUS_READY, Release);
+        orbit_audio_sandbox::transport::publish_child_ready(region, instrument.has_audio_input());
     }
     let mut scratch = vec![0.0f32; BUF_LEN];
     // Event window 分を事前確保し、hot loop での buffer 再確保を避ける。


### PR DESCRIPTION
Refs #431 / Epic #424

## 概要

Epic #424 の DoD「1 effect + 1 instrument を DSL から同時にロードして演奏」を達成する最後のピース #431（OOP post-boot attach + effect/instrument 同時使用）の第一段。実装規模が大きいため 3 PR に段階分割（PR-1: substrate → PR-2: 共存 → PR-3: DoD 配線）し、**PR-1 をさらに2段階に分割した前半（1a: 非侵襲的準備）**。この PR 単体では機能追加をしない。

## 設計の要（Fable 実装前相談 GO・D1-D7 一発判断）

- transport 層（`SharedRegion`）は各 child が専用 shm ファイルを持つため既に N-child 対応（構造変更不要）
- 真のギャップ = `PostProcessor` に engaged ゲートが無いこと。child 不在時 `PipelinedEffectHost::process_block` の READ 分岐は `seq_tag` 一致が一度も無いため `primed` が永久 false のまま無音で埋める（**恒久的無音**）
- 合成順序は構造的に確定: instrument = add-mix・effect = overwrite。`instrument → effect` の順で 1 つの `CompositePostProcessor` に包めば `output.rs` は変更不要
- **見落とし発見**: TS ガード撤去だけでは不十分——in-process daemon にも cross-role reject が必要（PR-3 に反映）

## 実装内容（Codex 委譲・8ファイル・+164/-4・非侵襲的）

- `SharedRegion` に `child_status`/`child_flags`（`AtomicU32`）を**既存フィールド末尾に追記**（ABI 互換保持）
- effect/instrument 両 child binary: load 成功直後に `child_flags`（has_audio_input 判定）→ `child_status = READY` の順で Release store
- `ClapEffectProcessor`/`ClapInstrumentProcessor` に `has_audio_input()` accessor 追加（既存の in-process 判定関数への単純委譲）
- `OutProcEffectPostProcessor`/`OutProcInstrumentPostProcessor` に `engaged: Arc<AtomicBool>` ゲート追加（`teardown_requested` チェックの後・処理委譲の前）。**全既存起動経路は `engaged=true` で構築するため挙動は1bitも変わらない**

## 受け入れ監査（Fable・GO・Minor 1件）

- ABI 互換性・Release/Acquire 順序・engaged ゲート配置・`has_audio_input` 委譲を全て一次コード精読で確認
- **mutation による fail-before/pass-after 実証**: engaged ゲートを一時除去して実行 → 新規 disengaged テスト2件が red → 復元（shasum で byte-identical 確認）で green
- Minor 1件（`CHILD_STATUS_LOAD_FAILED` の予約値 doc）適用済み
- PR-1b への申し送り2点を Issue #431 に記録（respawn 時の READY 残留・engaged Arc 未保持）

## 検証

- `cargo test --workspace --features outproc-effect`（protocol 28件含む）・`--features outproc-instrument`: 全 green
- `cargo build --features clap-host`: green
- fmt/clippy（両 feature）: green・`cargo deny --offline check`: green

## 関連

- PR-1b（実際の post-boot attach: ChildSlot・LateChildGuard・LoadPlugin OOP 受け口）が次
- 親: #431（3段階計画記録済み）/ Epic #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015R9Km7edyaAgqzVFsUm7uX