### PR TITLE
feat(daemon): implement real post-boot attach (#431 PR-1b)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -70,9 +70,53 @@ fmt --check・clippy -D warnings 両 feature green。Codex 環境固有の loopb
   記録のみ）
 - 検証: `cargo build`/`test`（両 feature・0 failed）・`fmt --check`・`clippy -D warnings`
   （両 feature）全 green を main が非サンドボックスで確認
-- **未対応**: 2件目の `LoadPlugin` が Loading 中に即座に reject されることを直接検証する
-  統合テストは、実 child プロセス spawn を要する gated テストとしてしか書けないため
-  本セッションでは追加していない（既存の readiness/role テストは変更なしで green）
+- **テスト方針の訂正（2026-07-14・PR-1b レビュー Q3 / Fable 裁定 確信度90%）**: 当初ここに
+  「2件目の `LoadPlugin` が Loading 中に即座に reject されることを検証する統合テストは、実 child
+  プロセス spawn を要する gated テストとしてしか書けない」と記したが**不正確だった**。(1)
+  `ChildSlot::Loading` を直接注入すれば「in progress」reject の D4 意味論は実プロセスゼロで
+  unit test できる（後述の (c) で追加）。(2) `f36e99c` の lock-scope 修正が対象とした「2件目が
+  `.lock()` で最大10秒ブロックせず即座に Loading を観測する」並行タイミング性質の検証は直接注入では
+  fail-before/pass-after を満たさない（実プロセス spawn が要る）が、それも READY を書かず sleep する
+  ダミー実行ファイルで**非 gated・CI 実行可能**に書ける（＝gated 必須ではない・「実プロセス spawn が
+  要る」と「gated（要 CLAP dylib/audio device）」の混同だった）。この並行タイミングテストは flaky
+  リスクを踏まえ PR-1c（#441）で検討する。
+
+---
+
+**PR-1b レビュー結果と追加対応（2026-07-14・PR #440）**:
+
+`/code:pr-review-team` 相当の4体（code-reviewer / silent-failure-hunter / pr-test-analyzer /
+comment-analyzer）を PR #440 に対して実行。深刻度評価が割れたため **Fable 裁定**（難所の一発判断・
+確信度85%）を仰いだ。要点:
+
+- **裁定 Q1**: 「plugin path の typo → 10秒待ち → `ChildSlot::Closed`（daemon 再起動必須）」は
+  Epic #424 DoD「完全に動く」の運用面を塞ぐ**真の欠陥**（Epic 内で必ず直す）。ただし PR-1b 単独を
+  ブロックする Critical ではなく **packaging の問題**。silent-failure-hunter の「非対称に根拠なし」
+  という論拠は誤り（`Closed` は shm unlink 所有権設計の帰結）だが、深刻度評価は正しい。
+  code-reviewer の「確信度45・Minor未満」は較正ミス。
+- **裁定 Q2 + owner 追認**: (c) エラーパステスト + (d) doc/decision record は **PR-1b（本 PR）に積む**。
+  (a) 失敗 slot の retry 可能化 + (b) child 早期 crash の fast-fail + (e) エラーコード細分化は
+  **PR-1c（#441・Epic #424 DoD ゲート項目）** へ。「Epic 内 PR への移動は DoD ゲート内側であり
+  ゴールポスト下方修正ではない／Epic 外 follow-up へ送って DoD 宣言するのが下方修正」という線引き。
+  #441 は #431/#424 にコメントで DoD ゲート項目として明記（マージより先に可視化）。
+
+**(c) エラーパス unit test（実プロセス不要・Codex 委譲）**: `engine_wrap.rs` の
+`outproc_health_tests`/`outproc_instrument_health_tests` に共有ヘルパー
+`outproc_load_error_test_support` 経由で各 feature 4テスト（計8）を追加:
+① open_shared 失敗 → `Closed` 遷移 ② spawn 失敗 → `Empty` 復帰（2回試行で retry 可能を実証）
+③ `Closed` 拒否 ④ `Loading` 拒否（同一 path 保持を確認）。いずれも終端 variant を `matches!` で
+検査し fail-before/pass-after を満たす（main が open_shared パスの `Closed` 書き込みを一時変異させ、
+対応テストが「Closed 期待」で落ちることを実証・revert 済み）。
+
+**(d) doc 訂正**: `transport.rs` の module doc「host 側 poll は未実装・PR-1b で追加」を「実装済み」に
+更新。`CHILD_STATUS_LOAD_FAILED` doc に decision record を追記（PR-1b は reset-only 実装・try_wait
+生死判定と fast-fail/retry 可能化は PR-1c(#441) 移管）。
+
+**検証（main が非サンドボックスで再実行）**: `cargo test -p orbit-audio-daemon --lib` 両 feature
+各 **40 passed**（従来36 + 新規4）・fmt --check・clippy -D warnings 両 feature green。委譲時の
+教訓: 初回 background 委譲は成果物が作業ツリーに landing せず、codex-companion のタスク追跡が
+shared session の古いスレッド結果を返した。foreground（`--wait`）で再委譲し、**`git status`/
+`git diff` で作業ツリーの実変更を一次情報として確認**してから受け入れた。
 
 ### 6.253 feat(daemon): SharedRegion 拡張 + engaged ゲート導入 #431 PR-1a (Jul 14, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,37 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.254 feat(daemon): 実際の post-boot attach #431 PR-1b (Jul 14, 2026)
+
+**Date**: 2026-07-14
+**Status**: ✅ 実装・検証済み（PR 作成へ）
+**Branch**: `431-oop-plugin-coexistence`
+
+PR-1a（substrate: engaged ゲート・child readiness handshake）の上に、実際の post-boot
+attach を実装。Codex 委譲（設計は PR-1a と同一セッションの Fable 承認済み D1-D7 の
+延長のため、新規 advisor 相談は省略・トークン節約優先の owner 指示に従う）。
+
+**実装（5ファイル・+547/-96）**:
+- `ChildSlot`（`Empty/Loading/Active/Closed`）による遅延 supervisor 生成。daemon 起動時は
+  supervisor 無し、初回 `LoadPlugin` で spawn。`StreamGuard._child_guard` は
+  `Arc<Mutex<ChildSlot>>`（control 側は `Weak` 参照）で teardown 順序
+  （`_outproc_teardown → _stream → _child_guard`）を維持
+- `session.rs` の `LoadPlugin` ハンドラに role 検証つき OOP 実行時受け口を追加。初回 spawn・
+  同一 path 冪等 Ok・異なる path は reject
+- ready-ack: `child_status` を Acquire poll → READY 確認 → `child_flags` で role 一致検証
+  （10秒 timeout）してから応答。spawn 直前に `reset_child_starting` で前 incarnation の
+  READY 残留を除去（PR-1a doc コメントの申し送り事項に対応）
+- `engaged` を `false` 構築 → ready-ack 完了後に Release store で `true` へ遷移
+- Codex 自己修正: `StreamGuard` 先行 drop でも `EngineWrap` 側の strong `Arc` が
+  supervisor を延命しうる点を発見し teardown 順序を厳密化
+
+**検証**: Codex 実行環境（loopback bind 禁止のサンドボックス）では `tests/protocol.rs`
+28件が環境制約で FAIL したが、build/fmt/clippy は green・daemon unit 36件は green。
+main が非サンドボックスで独立再検証: `cargo test --workspace --features
+outproc-effect`/`outproc-instrument` 両方 **0 failed**（protocol 含む全 green）・
+fmt --check・clippy -D warnings 両 feature green。Codex 環境固有の loopback 制約が
+原因であり実装バグではないことを確認。
+
 ### 6.253 feat(daemon): SharedRegion 拡張 + engaged ゲート導入 #431 PR-1a (Jul 14, 2026)
 
 **Date**: 2026-07-14

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -154,6 +154,45 @@ security checklist ALL PASS に収束**（iteration 1回）。
   非ゲート項目として記録のみ（必要なら #441 で同梱検討）。
 - **bot feedback**: reviews/comments とも空・check-run 全 success（`bot_feedback_read` 記録済み）。
 
+---
+
+**@claude bot review（scoped）+ 対応（2026-07-14・コミット `53db770` 後）**:
+
+advisor 相談（opus フォールバック・確信度80%）の推奨に従い、bot review を**並行性シーム3点に
+スコープ限定**して起動（(a) lock-release-during-poll の不変条件 / (b) ready-ack と
+`reset_child_starting` の Acquire/Release 順序 / (c) in-flight load と teardown の競合。
+テスト群と WORK_LOG は内部レビュー済みとして対象外を明示）。bot は 7分27秒で完了し
+**(a)(b) は airtight と判定**。指摘3点（いずれも non-blocking）:
+
+1. 終端 blind write に `debug_assert!` の防波堤を推奨（defense-in-depth）
+2. **(c) で理論上の競合を発見**: StreamGuard が in-flight load 中に drop されると、成功パスの
+   `Ok` 返却直後に関数ローカル `Arc` drop が最後の強参照となり attach 直後の child が同期
+   teardown される（「成功応答=生きた plugin」が崩れる）。現行配線（main.rs のプロセス寿命
+   `_stream_guard`・gated テストの関数スコープ `_guard`、main が grep で全数確認）では到達不能
+3. round-1 fix が導入した `tracing::warn!` が、失敗パスの二重 unlink（supervisor が先に unlink →
+   `ChildLaunch::drop` が NotFound）で毎回偽 WARN を出す observability regression
+
+**advisor 確認（opus・2回目）**: 指摘3=修正（90%）・指摘1=同梱修正（88%）・指摘2=契約として
+doc 化+tracking 記録のみ（85%）。再レビューは「軽量検証で代替せず /simplify + pr-review-team を
+回す（小差分なら速く収束することで規模適合を満たす）・2周目 bot は不要（3変更はすべて bot 自身の
+指摘の実装）」との裁定。
+
+**修正（fixer 委譲 → main 受け入れ検証）**: ① 終端 write 6箇所に debug_assert ② StreamGuard
+契約を doc comment 化 ③ Drop の NotFound フィルタ。main が差分精読 + 両 feature 各44 passed +
+fmt + clippy green を再実行して受け入れ。
+
+**/simplify（4観点並行・2件適用）**:
+- simplification/reuse/altitude が独立に同一指摘: 6箇所の逐語同一 debug_assert ブロック →
+  `debug_assert_slot_loading(&ChildSlot)` ヘルパーに抽出（約30行→7行）
+- **altitude が bot 指摘3の修正をさらに深化**: NotFound の error-kind フィルタは症状への
+  パッチであり、既存イディオム（成功パスの `cleanup_shm_on_drop = false`）を所有権移転済みの
+  3分岐（supervisor spawn 失敗・role mismatch・timeout）にも適用するのが正: `drop(supervisor)`
+  直後に flag を false へ倒し、`ChildLaunch::drop` は無条件 warn に復帰（NotFound が本来の
+  異常シグナルとして回復。open_shared/spawn 失敗の sole-unlinker パスは true のまま）。
+  reuse の副次観察（フィルタ版は他3箇所の同型 Drop と発散する）とも整合
+- efficiency / doc comment: clean
+- 検証: 両 feature 各 44 passed・fmt・clippy -D warnings green（main 再実行）
+
 ### 6.253 feat(daemon): SharedRegion 拡張 + engaged ゲート導入 #431 PR-1a (Jul 14, 2026)
 
 **Date**: 2026-07-14

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -48,6 +48,32 @@ outproc-effect`/`outproc-instrument` 両方 **0 failed**（protocol 含む全 gr
 fmt --check・clippy -D warnings 両 feature green。Codex 環境固有の loopback 制約が
 原因であり実装バグではないことを確認。
 
+**/simplify（4観点並行レビュー・3件完了→1件（altitude）は advisor 呼び出しで45分超
+応答なしのため main が SendMessage で生存確認 → 応答なし → TaskStop）**:
+- simplification と efficiency が**独立に同一の設計不整合**へ収束（Important 相当）:
+  `load_outproc_plugin`（`engine_wrap.rs`）が `child_slot.lock()` の `MutexGuard` を
+  shm open・child spawn・supervisor spawn・**ready-ack poll ループ（最大10秒）**・
+  最終状態遷移まで関数末尾まで一度も drop せず保持していた。これにより2件目以降の
+  `LoadPlugin` 呼び出し（`Arc<EngineWrap>` は複数クライアント接続間で共有）は、
+  意図された `ChildSlot::Loading`（「in progress」で即座に reject する設計・D4 要件）
+  に到達する前に `.lock()` 自体で最大10秒ブロックされ、`Loading` 分岐が実質到達不能な
+  dead code になっていた（`let _ = engaged.load(...)` という無意味な読み捨てもその症状）
+- main が直接修正（fixer 委譲が同様に応答不能になったため self-fix）: `Loading` 書き込み
+  直後に `drop(slot)` してロックを解放し、shm open・spawn・ready-ack poll ループは
+  ロック外で実行。各エラーパス・成功パスで `child_slot.lock()` を再取得してから終端状態
+  （`Empty`/`Closed`/`Active`）を書き込む形に変更。`ChildSlot::Loading` から未使用になった
+  `engaged` フィールドを削除（dead_code 警告解消）。teardown は `child_slot` の `Arc` を
+  保持するだけで `.lock()` しないため、ロック解放中に他の書き込み主体は存在せず、
+  再取得後も `Loading` のままであることが構造的に保証される
+- reuse: 修正要求なし（poll-until-deadline パターンの重複は test-only スコープの既存
+  helper と production コードの型不一致により置き換え不可・将来的な技術的負債として
+  記録のみ）
+- 検証: `cargo build`/`test`（両 feature・0 failed）・`fmt --check`・`clippy -D warnings`
+  （両 feature）全 green を main が非サンドボックスで確認
+- **未対応**: 2件目の `LoadPlugin` が Loading 中に即座に reject されることを直接検証する
+  統合テストは、実 child プロセス spawn を要する gated テストとしてしか書けないため
+  本セッションでは追加していない（既存の readiness/role テストは変更なしで green）
+
 ### 6.253 feat(daemon): SharedRegion 拡張 + engaged ゲート導入 #431 PR-1a (Jul 14, 2026)
 
 **Date**: 2026-07-14

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -193,6 +193,13 @@ fmt + clippy green を再実行して受け入れ。
 - efficiency / doc comment: clean
 - 検証: 両 feature 各 44 passed・fmt・clippy -D warnings green（main 再実行）
 
+**`/code:pr-review-team 440` 2周目（`c436a22` 後・収束確認）**: 4体レビューで
+comment-analyzer の medium 1件のみ（supervisor spawn 失敗分岐のコメントが unlink 実施者を
+「supervisor の startup cleanup」と誤帰属 — 実際は `spawn_outproc_supervisor` 自身の
+エラーパス cleanup が unlink する。main が outproc_effect.rs の3エラーパスで裏取り）。
+fixer がコメント2行を修正 → 再レビュー4体全て No findings で **Critical=0/Important=0/
+security ALL PASS に収束**（bot への対応返信・#441 への StreamGuard 契約 tracking 記録済み）。
+
 ### 6.253 feat(daemon): SharedRegion 拡張 + engaged ゲート導入 #431 PR-1a (Jul 14, 2026)
 
 **Date**: 2026-07-14

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -118,6 +118,42 @@ comment-analyzer）を PR #440 に対して実行。深刻度評価が割れた�
 shared session の古いスレッド結果を返した。foreground（`--wait`）で再委譲し、**`git status`/
 `git diff` で作業ツリーの実変更を一次情報として確認**してから受け入れた。
 
+---
+
+**`/code:pr-review-team 440` 収束（2026-07-14・Skill 経由・state file 監査証跡あり）**:
+
+Round 1（4体並行 + CI PASS）で新規 finding 3件 → fixer（Agent tool・sonnet）委譲 →
+Round 2（selector 再実行 → fresh 4体で再レビュー）で **Critical=0 / Important=0 /
+security checklist ALL PASS に収束**（iteration 1回）。
+
+- **Critical（修正済み）**: `load_outproc_plugin` の `ChildSlot::Active` 冪等ガードが
+  `path` のみ比較で `plugin_id` を無視。同一 path・別 plugin_id（bundle 内の別サブプラグイン）
+  の `LoadPlugin` が**古い plugin_id のまま黙って `Ok`** を返していた（silent-failure-hunter
+  検出・code-reviewer も sub-80% で同箇所を指摘・main が `session.rs` の `params.get("plugin_id")`
+  から呼び出し側可変であることを裏取りして Critical 確定）。修正: match arm を3本に分割
+  （同 path+同 plugin_id=冪等 Ok / 同 path+別 plugin_id=replacement 拒否 / 別 path=既存拒否）。
+- **Important（修正済み・2件)**: ① `f36e99c` lock-scope 修正の regression test 不在 →
+  READY を publish しない slow-child shell script fixture で「1本目が ready-ack poll 中に
+  2本目が `Loading` を即観測して <1s で fail-fast する」ことを検証する並行テストを追加
+  （6.254 前段で「PR-1c で検討」とした件を本 PR で前倒し実装）。② `Active` arm 3種
+  （冪等再送 Ok / plugin_id 差し替え拒否 / path 差し替え拒否）の直接テスト不在 →
+  `spawn_outproc_supervisor` + sleep スタブ fixture で追加。計8テスト（4種 × 両 feature）。
+- **Minor（修正済み）**: `Drop for ChildLaunch` の shm `remove_file` 失敗を `let _ =` で
+  握り潰し → `tracing::warn!` でログ。
+- **スコープ規律**: `Closed` 遷移の retry 可能化・fast-fail・エラーコード細分化は
+  **#441（PR-1c）へ移管済みのため fixer プロンプトで明示的に out-of-scope 指定**し、
+  再レビュー時も再報告を抑止（churn 防止）。
+- **受け入れ検証（main）**: fixer の green 報告を鵜呑みにせず差分精読 + 非サンドボックスで
+  `cargo test --lib` 両 feature 各 **44 passed**・fmt --check・clippy -D warnings 両 feature
+  green を再実行。Critical 修正は **fail-before/pass-after を変異で実証**（ガードを
+  `path` のみ比較に一時変異 → `active_rejects_plugin_id_change` が失敗 → revert で pass）。
+- **Round 2 特記**: code-reviewer は新規並行テストを単独15回再実行して flake なしを確認。
+  pr-test-analyzer の残 Minor 1件（sleep 30 スタブが `CONTROL_QUIT` 非応答のため supervisor
+  Drop の `REAP_TIMEOUT` 2s × 6テストの CI 時間増・決定論的でリーク無し）と
+  silent-failure-hunter の sub-80% 提案（script を `exec sleep 20` にして PID 曖昧性除去）は
+  非ゲート項目として記録のみ（必要なら #441 で同梱検討）。
+- **bot feedback**: reviews/comments とも空・check-run 全 success（`bot_feedback_read` 記録済み）。
+
 ### 6.253 feat(daemon): SharedRegion 拡張 + engaged ゲート導入 #431 PR-1a (Jul 14, 2026)
 
 **Date**: 2026-07-14

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -2563,6 +2563,136 @@ mod capture_path_tests {
     }
 }
 
+#[cfg(all(test, any(feature = "outproc-effect", feature = "outproc-instrument")))]
+mod outproc_load_error_test_support {
+    use super::{ChildLaunch, ChildSlot, EngineWrap, OutProcChildStats, WrapError};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::AtomicBool;
+    use std::sync::{Arc, Mutex};
+
+    type InjectedSlot = (Arc<EngineWrap>, Arc<Mutex<ChildSlot>>);
+
+    fn child_launch(
+        shm_path: PathBuf,
+        child_exe: PathBuf,
+        stats: Arc<OutProcChildStats>,
+    ) -> ChildLaunch {
+        ChildLaunch {
+            shm_path,
+            child_exe,
+            sample_rate: 48_000,
+            stats,
+            engaged: Arc::new(AtomicBool::new(false)),
+            cleanup_shm_on_drop: true,
+        }
+    }
+
+    pub(super) fn open_shared_failure_closes_slot(
+        unique_path: impl Fn() -> PathBuf,
+        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        assert_error: impl Fn(WrapError, &str),
+        plugin_path: &str,
+    ) {
+        let shm_path = unique_path();
+        let _ = std::fs::remove_file(&shm_path);
+        let stats = OutProcChildStats::new();
+        let launch = child_launch(
+            shm_path,
+            PathBuf::from("unused-child-executable"),
+            stats.clone(),
+        );
+        let (wrap, child_slot) = inject(ChildSlot::Empty(launch), stats);
+
+        let error = wrap
+            .load_outproc_plugin(PathBuf::from(plugin_path), None)
+            .err()
+            .expect("missing shared memory must fail before spawn");
+
+        assert_error(error, "open child readiness mapping");
+        assert!(
+            matches!(
+                *child_slot.lock().expect("lock child slot"),
+                ChildSlot::Closed
+            ),
+            "open_shared failure must transition the slot to Closed"
+        );
+    }
+
+    pub(super) fn spawn_failure_restores_empty_for_retry(
+        unique_path: impl Fn() -> PathBuf,
+        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        assert_error: impl Fn(WrapError, &str),
+        plugin_path: &str,
+    ) {
+        let shm_path = unique_path();
+        let _ = std::fs::remove_file(&shm_path);
+        let _mmap = orbit_audio_sandbox::create_shared(&shm_path).expect("create shared memory");
+        let bad_child_exe = unique_path();
+        let _ = std::fs::remove_file(&bad_child_exe);
+        let stats = OutProcChildStats::new();
+        let launch = child_launch(shm_path, bad_child_exe, stats.clone());
+        let (wrap, child_slot) = inject(ChildSlot::Empty(launch), stats);
+
+        for attempt in 1..=2 {
+            let error = wrap
+                .load_outproc_plugin(PathBuf::from(plugin_path), None)
+                .err()
+                .expect("nonexistent child executable must fail to spawn");
+            assert_error(error, "spawn outproc child");
+            assert!(
+                matches!(
+                    *child_slot.lock().expect("lock child slot"),
+                    ChildSlot::Empty(_)
+                ),
+                "spawn failure attempt {attempt} must restore Empty so the same slot is retryable"
+            );
+        }
+    }
+
+    pub(super) fn closed_slot_is_rejected(
+        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        assert_error: impl Fn(WrapError, &str),
+        plugin_path: &str,
+    ) {
+        let (wrap, child_slot) = inject(ChildSlot::Closed, OutProcChildStats::new());
+
+        let error = wrap
+            .load_outproc_plugin(PathBuf::from(plugin_path), None)
+            .err()
+            .expect("Closed slot must reject attach");
+
+        assert_error(error, "closed after an unrecoverable attach failure");
+        assert!(matches!(
+            *child_slot.lock().expect("lock child slot"),
+            ChildSlot::Closed
+        ));
+    }
+
+    pub(super) fn loading_slot_is_rejected(
+        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        assert_error: impl Fn(WrapError, &str),
+        loading_path: &str,
+        second_path: &str,
+    ) {
+        let (wrap, child_slot) = inject(
+            ChildSlot::Loading {
+                path: PathBuf::from(loading_path),
+            },
+            OutProcChildStats::new(),
+        );
+
+        let error = wrap
+            .load_outproc_plugin(PathBuf::from(second_path), None)
+            .err()
+            .expect("Loading slot must reject concurrent attach");
+
+        assert_error(error, "already in progress");
+        assert!(
+            matches!(&*child_slot.lock().expect("lock child slot"), ChildSlot::Loading { path } if path == Path::new(loading_path))
+        );
+    }
+}
+
 /// `outproc_health()` の real body（`#[cfg(feature = "outproc-effect")]`）を直接叩く unit test。
 ///
 /// `tests/protocol.rs` の統合テストは default feature build（`outproc-effect` 無効）で走るため、
@@ -2575,12 +2705,12 @@ mod capture_path_tests {
 /// `EngineWrap` に対して real child を spawn せず `Some(OutProcControl)` を注入できる。
 #[cfg(all(test, feature = "outproc-effect"))]
 mod outproc_health_tests {
-    use super::{outproc_role_matches, EngineWrap, OutProcControl};
+    use super::{outproc_role_matches, ChildSlot, EngineWrap, OutProcControl, WrapError};
     use crate::backend::StubBackend;
     use crate::outproc_effect::OutProcEffectStats;
     use orbit_audio_native::CallbackTimeStats;
     use std::sync::atomic::Ordering;
-    use std::sync::{Arc, Weak};
+    use std::sync::{Arc, Mutex, Weak};
 
     /// `StubBackend` で `EngineWrap` を起動し、real child なしで組み立てた `OutProcControl` を
     /// `self.outproc` に注入する。返す `Arc<OutProcEffectStats>` はテスト側から直接
@@ -2595,6 +2725,67 @@ mod outproc_health_tests {
             child_slot: Weak::new(),
         });
         (wrap, stats)
+    }
+
+    fn wrap_with_child_slot(
+        slot: ChildSlot,
+        stats: Arc<OutProcEffectStats>,
+    ) -> (Arc<EngineWrap>, Arc<Mutex<ChildSlot>>) {
+        let (wrap, _guard) =
+            EngineWrap::start_with(StubBackend::default()).expect("stub backend start");
+        let child_slot = Arc::new(Mutex::new(slot));
+        *wrap.outproc.lock().expect("lock outproc for injection") = Some(OutProcControl {
+            stats,
+            cb_stats: CallbackTimeStats::new(),
+            child_slot: Arc::downgrade(&child_slot),
+        });
+        (wrap, child_slot)
+    }
+
+    fn assert_effect_runtime_error_contains(error: WrapError, expected: &str) {
+        assert!(
+            matches!(&error, WrapError::OutProcEffect(message) if message.contains(expected)),
+            "expected OutProcEffect error containing {expected:?}, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn effect_load_outproc_open_shared_failure_closes_slot() {
+        super::outproc_load_error_test_support::open_shared_failure_closes_slot(
+            crate::outproc_effect::unique_shm_path,
+            wrap_with_child_slot,
+            assert_effect_runtime_error_contains,
+            "unused-effect.clap",
+        );
+    }
+
+    #[test]
+    fn effect_load_outproc_spawn_failure_restores_empty_for_retry() {
+        super::outproc_load_error_test_support::spawn_failure_restores_empty_for_retry(
+            crate::outproc_effect::unique_shm_path,
+            wrap_with_child_slot,
+            assert_effect_runtime_error_contains,
+            "unused-effect.clap",
+        );
+    }
+
+    #[test]
+    fn effect_load_outproc_rejects_closed_slot() {
+        super::outproc_load_error_test_support::closed_slot_is_rejected(
+            wrap_with_child_slot,
+            assert_effect_runtime_error_contains,
+            "unused-effect.clap",
+        );
+    }
+
+    #[test]
+    fn effect_load_outproc_rejects_loading_slot() {
+        super::outproc_load_error_test_support::loading_slot_is_rejected(
+            wrap_with_child_slot,
+            assert_effect_runtime_error_contains,
+            "already-loading-effect.clap",
+            "second-effect.clap",
+        );
     }
 
     #[test]
@@ -2694,11 +2885,11 @@ mod outproc_health_tests {
 /// `OutProcInstrumentControl`（private struct）へ直接アクセスして注入する。
 #[cfg(all(test, feature = "outproc-instrument"))]
 mod outproc_instrument_health_tests {
-    use super::{outproc_role_matches, EngineWrap, OutProcInstrumentControl};
+    use super::{outproc_role_matches, ChildSlot, EngineWrap, OutProcInstrumentControl, WrapError};
     use crate::backend::StubBackend;
     use crate::outproc_instrument::OutProcInstrumentStats;
     use std::sync::atomic::Ordering;
-    use std::sync::{Arc, Weak};
+    use std::sync::{Arc, Mutex, Weak};
 
     /// `StubBackend` で `EngineWrap` を起動し、real child なしで組み立てた `OutProcInstrumentControl`
     /// を `self.outproc_instrument` に注入する。event_tx の consumer 側は即 drop するが、この
@@ -2717,6 +2908,71 @@ mod outproc_instrument_health_tests {
             child_slot: Weak::new(),
         });
         (wrap, stats)
+    }
+
+    fn wrap_with_child_slot(
+        slot: ChildSlot,
+        stats: Arc<OutProcInstrumentStats>,
+    ) -> (Arc<EngineWrap>, Arc<Mutex<ChildSlot>>) {
+        let (wrap, _guard) =
+            EngineWrap::start_with(StubBackend::default()).expect("stub backend start");
+        let child_slot = Arc::new(Mutex::new(slot));
+        let (event_tx, _event_rx) = rtrb::RingBuffer::new(4);
+        *wrap
+            .outproc_instrument
+            .lock()
+            .expect("lock instrument control for injection") = Some(OutProcInstrumentControl {
+            event_tx,
+            stats,
+            child_slot: Arc::downgrade(&child_slot),
+        });
+        (wrap, child_slot)
+    }
+
+    fn assert_instrument_runtime_error_contains(error: WrapError, expected: &str) {
+        assert!(
+            matches!(&error, WrapError::OutProcInstrument(message) if message.contains(expected)),
+            "expected OutProcInstrument error containing {expected:?}, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn instrument_load_outproc_open_shared_failure_closes_slot() {
+        super::outproc_load_error_test_support::open_shared_failure_closes_slot(
+            crate::outproc_instrument::unique_shm_path,
+            wrap_with_child_slot,
+            assert_instrument_runtime_error_contains,
+            "unused-instrument.clap",
+        );
+    }
+
+    #[test]
+    fn instrument_load_outproc_spawn_failure_restores_empty_for_retry() {
+        super::outproc_load_error_test_support::spawn_failure_restores_empty_for_retry(
+            crate::outproc_instrument::unique_shm_path,
+            wrap_with_child_slot,
+            assert_instrument_runtime_error_contains,
+            "unused-instrument.clap",
+        );
+    }
+
+    #[test]
+    fn instrument_load_outproc_rejects_closed_slot() {
+        super::outproc_load_error_test_support::closed_slot_is_rejected(
+            wrap_with_child_slot,
+            assert_instrument_runtime_error_contains,
+            "unused-instrument.clap",
+        );
+    }
+
+    #[test]
+    fn instrument_load_outproc_rejects_loading_slot() {
+        super::outproc_load_error_test_support::loading_slot_is_rejected(
+            wrap_with_child_slot,
+            assert_instrument_runtime_error_contains,
+            "already-loading-instrument.clap",
+            "second-instrument.clap",
+        );
     }
 
     #[test]

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -1065,8 +1065,8 @@ impl EngineWrap {
             match spawn_outproc_supervisor(first_child, &launch, path.clone(), plugin_id.clone()) {
                 Ok(supervisor) => supervisor,
                 Err(error) => {
-                    // supervisor の startup cleanup は shm を unlink するため、この slot は再利用不能。
-                    // unlink は startup cleanup が実施済み。launch の fallback は解除。
+                    // spawn_outproc_supervisor はエラー時に自身の cleanup で shm を unlink して返るため、
+                    // この slot は再利用不能。launch の fallback unlink は解除。
                     launch.cleanup_shm_on_drop = false;
                     let mut slot = child_slot
                         .lock()

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -238,6 +238,9 @@ pub(crate) struct ChildLaunch {
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
 impl Drop for ChildLaunch {
     fn drop(&mut self) {
+        // cleanup_shm_on_drop=true は「この launch が unlink の唯一の所有者」を意味する
+        // （supervisor へ所有権が移った経路は flag を false に倒す）。よって NotFound を含む
+        // あらゆる失敗が異常であり、無条件で warn する。
         if self.cleanup_shm_on_drop {
             if let Err(error) = std::fs::remove_file(&self.shm_path) {
                 tracing::warn!(
@@ -910,6 +913,12 @@ impl EngineWrap {
     ///
     /// blocking API: child の readiness を poll するため、session handler は `spawn_blocking` から
     /// 呼ぶこと。同一 path の再送は冪等、別 path への差し替えは v1 では拒否する。
+    ///
+    /// **契約（precondition）**: `StreamGuard`（`_child_guard` の唯一の強参照保持者）は in-flight
+    /// の本呼び出しより必ず長生きすること。破ると: 成功パスで `Ok` を返した直後、本関数ローカルの
+    /// `Arc` drop が最後の強参照となり、attach 直後の child が同期的に teardown（QUIT/reap/unlink）
+    /// されうる（「成功応答=生きた plugin」が崩れる）。現行の全配線（main.rs のプロセス寿命
+    /// `_stream_guard`・gated テストの関数スコープ `_guard`）はこれを満たす。
     #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
     pub fn load_outproc_plugin(
         &self,
@@ -1019,6 +1028,7 @@ impl EngineWrap {
                 let mut slot = child_slot
                     .lock()
                     .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
+                debug_assert_slot_loading(&slot);
                 *slot = ChildSlot::Closed;
                 return Err(outproc_runtime_error(format!(
                     "open child readiness mapping {:?}: {error}",
@@ -1038,6 +1048,7 @@ impl EngineWrap {
                 let mut slot = child_slot
                     .lock()
                     .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
+                debug_assert_slot_loading(&slot);
                 *slot = ChildSlot::Empty(launch);
                 return Err(outproc_runtime_error(format!(
                     "spawn outproc child {:?}: {error}",
@@ -1055,9 +1066,12 @@ impl EngineWrap {
                 Ok(supervisor) => supervisor,
                 Err(error) => {
                     // supervisor の startup cleanup は shm を unlink するため、この slot は再利用不能。
+                    // unlink は startup cleanup が実施済み。launch の fallback は解除。
+                    launch.cleanup_shm_on_drop = false;
                     let mut slot = child_slot
                         .lock()
                         .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
+                    debug_assert_slot_loading(&slot);
                     *slot = ChildSlot::Closed;
                     return Err(outproc_runtime_error(format!(
                         "spawn outproc watchdog: {error}"
@@ -1072,10 +1086,13 @@ impl EngineWrap {
             if status == orbit_audio_sandbox::transport::CHILD_STATUS_READY {
                 let flags = unsafe { (*region).child_flags.load(Ordering::Acquire) };
                 if !outproc_role_matches(flags) {
+                    // supervisor drop の teardown が shm を unlink する。launch の fallback は解除。
                     drop(supervisor);
+                    launch.cleanup_shm_on_drop = false;
                     let mut slot = child_slot
                         .lock()
                         .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
+                    debug_assert_slot_loading(&slot);
                     *slot = ChildSlot::Closed;
                     return Err(outproc_runtime_error(format!(
                         "loaded plugin role does not match daemon role (child_flags={flags:#x})"
@@ -1084,10 +1101,13 @@ impl EngineWrap {
                 break;
             }
             if std::time::Instant::now() >= deadline {
+                // supervisor drop の teardown が shm を unlink する。launch の fallback は解除。
                 drop(supervisor);
+                launch.cleanup_shm_on_drop = false;
                 let mut slot = child_slot
                     .lock()
                     .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
+                debug_assert_slot_loading(&slot);
                 *slot = ChildSlot::Closed;
                 return Err(outproc_runtime_error(format!(
                     "timed out waiting {:?} for child READY",
@@ -1104,6 +1124,7 @@ impl EngineWrap {
         let mut slot = child_slot
             .lock()
             .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
+        debug_assert_slot_loading(&slot);
         *slot = ChildSlot::Active {
             path,
             plugin_id,
@@ -2025,6 +2046,17 @@ impl EngineWrap {
             .lock()
             .map_err(|_| WrapError::Scheduler("samples mutex poisoned".to_string()))
     }
+}
+
+/// `load_outproc_plugin` の終端遷移直前の不変条件検査（release では noop）。
+/// Loading 以外を観測したら、この関数以外に slot への書き手が現れたことを意味する。
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+fn debug_assert_slot_loading(slot: &ChildSlot) {
+    debug_assert!(
+        matches!(slot, ChildSlot::Loading { .. }),
+        "load_outproc_plugin: slot must still be Loading (only this function \
+         transitions Loading -> Active/Closed/Empty)"
+    );
 }
 
 #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -239,7 +239,12 @@ pub(crate) struct ChildLaunch {
 impl Drop for ChildLaunch {
     fn drop(&mut self) {
         if self.cleanup_shm_on_drop {
-            let _ = std::fs::remove_file(&self.shm_path);
+            if let Err(error) = std::fs::remove_file(&self.shm_path) {
+                tracing::warn!(
+                    "ChildLaunch drop: shm 削除失敗 {:?}: {error}",
+                    self.shm_path
+                );
+            }
         }
     }
 }
@@ -957,10 +962,22 @@ impl EngineWrap {
                 plugin_id: active_plugin_id,
                 engaged,
                 ..
-            } if active_path == &path => {
+            } if active_path == &path && active_plugin_id == &plugin_id => {
                 // READY を確認済みの Active だけがここへ来る。冪等再送でも gate を維持する。
                 engaged.store(true, Ordering::Release);
                 return Ok(outproc_plugin_summary(active_path, active_plugin_id));
+            }
+            ChildSlot::Active {
+                path: active_path,
+                plugin_id: active_plugin_id,
+                ..
+            } if active_path == &path => {
+                // 同一 path だが plugin_id が異なる = bundle 内の別サブプラグインへの差し替え
+                // 要求。path 差し替えと同様 v1 は拒否する（呼び出し側が指定した plugin_id を
+                // 握り潰して古い plugin_id のまま黙って Ok を返さない）。
+                return Err(outproc_runtime_error(format!(
+                    "outproc plugin already loaded from {active_path:?} with plugin_id {active_plugin_id:?}; v1 does not support replacement with plugin_id {plugin_id:?}"
+                )));
             }
             ChildSlot::Active {
                 path: active_path, ..
@@ -2569,6 +2586,7 @@ mod outproc_load_error_test_support {
     use std::path::{Path, PathBuf};
     use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     type InjectedSlot = (Arc<EngineWrap>, Arc<Mutex<ChildSlot>>);
 
@@ -2691,6 +2709,211 @@ mod outproc_load_error_test_support {
             matches!(&*child_slot.lock().expect("lock child slot"), ChildSlot::Loading { path } if path == Path::new(loading_path))
         );
     }
+
+    /// 実際に生存する（が無害な）child を起動して `ChildSlot::Active` を直接構築する。
+    /// `EffectChildSupervisor`/`InstrumentChildSupervisor` は `spawn_effect_child` 経由の
+    /// `Command` 起動を要求するので、実 CLAP/VST3 plugin なしで到達するには `spawn_outproc_supervisor`
+    /// を直接呼び、`first_child` には（respawn を誘発しない）長寿命の `sleep` を渡す（outproc_effect.rs
+    /// の `supervisor_*` テストと同じ手法）。supervisor が以後の shm unlink を所有するため、ローカルの
+    /// `launch` の `cleanup_shm_on_drop` は production の `load_outproc_plugin` 成功パスと同様に外す。
+    fn active_child_slot(
+        unique_path: impl Fn() -> PathBuf,
+        plugin_path: &str,
+        plugin_id: Option<String>,
+    ) -> ChildSlot {
+        let shm_path = unique_path();
+        let _ = std::fs::remove_file(&shm_path);
+        let _mmap = orbit_audio_sandbox::create_shared(&shm_path).expect("create shared memory");
+
+        let mut launch = child_launch(
+            shm_path,
+            PathBuf::from("unused-child-executable-for-respawn-only"),
+            OutProcChildStats::new(),
+        );
+        let first_child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn stub child for Active fixture");
+
+        let path = PathBuf::from(plugin_path);
+        let supervisor =
+            super::spawn_outproc_supervisor(first_child, &launch, path.clone(), plugin_id.clone())
+                .expect("spawn supervisor for Active fixture");
+        launch.cleanup_shm_on_drop = false;
+
+        ChildSlot::Active {
+            path,
+            plugin_id,
+            engaged: Arc::new(AtomicBool::new(true)),
+            _supervisor: supervisor,
+        }
+    }
+
+    /// Important finding 2a: `ChildSlot::Active` への同一 path・同一 plugin_id の再送は冪等に
+    /// `Ok` を返し、slot を `Active` のまま維持すること。
+    pub(super) fn active_slot_accepts_idempotent_reload(
+        unique_path: impl Fn() -> PathBuf,
+        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        plugin_path: &str,
+        plugin_id: Option<String>,
+    ) {
+        let slot = active_child_slot(unique_path, plugin_path, plugin_id.clone());
+        let (wrap, child_slot) = inject(slot, OutProcChildStats::new());
+
+        wrap.load_outproc_plugin(PathBuf::from(plugin_path), plugin_id)
+            .expect("idempotent re-load of the same path+plugin_id while Active must succeed");
+        assert!(
+            matches!(
+                &*child_slot.lock().expect("lock child slot"),
+                ChildSlot::Active { .. }
+            ),
+            "idempotent re-load must keep the slot Active"
+        );
+    }
+
+    /// Critical finding: `ChildSlot::Active` への同一 path・**異なる** plugin_id は replacement
+    /// 要求として拒否すること（呼び出し側が指定した plugin_id を握り潰して古い plugin_id のまま
+    /// 黙って `Ok` を返してはならない）。
+    pub(super) fn active_slot_rejects_plugin_id_change(
+        unique_path: impl Fn() -> PathBuf,
+        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        assert_error: impl Fn(WrapError, &str),
+        plugin_path: &str,
+        initial_plugin_id: Option<String>,
+        changed_plugin_id: Option<String>,
+    ) {
+        let slot = active_child_slot(unique_path, plugin_path, initial_plugin_id.clone());
+        let (wrap, child_slot) = inject(slot, OutProcChildStats::new());
+
+        let error = wrap
+            .load_outproc_plugin(PathBuf::from(plugin_path), changed_plugin_id)
+            .err()
+            .expect("same path with a different plugin_id while Active must be rejected");
+        assert_error(error, "does not support replacement");
+        assert!(
+            matches!(
+                &*child_slot.lock().expect("lock child slot"),
+                ChildSlot::Active { plugin_id, .. } if *plugin_id == initial_plugin_id
+            ),
+            "rejected plugin_id change must not disturb the previously-active plugin_id"
+        );
+    }
+
+    /// Important finding 2b: `ChildSlot::Active` への **異なる** path は v1 では replacement
+    /// 拒否のまま（既存の Loading 側テストと対になる Active 側の直接検証）。
+    pub(super) fn active_slot_rejects_path_replacement(
+        unique_path: impl Fn() -> PathBuf,
+        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        assert_error: impl Fn(WrapError, &str),
+        plugin_path: &str,
+        other_path: &str,
+    ) {
+        let slot = active_child_slot(unique_path, plugin_path, None);
+        let (wrap, child_slot) = inject(slot, OutProcChildStats::new());
+
+        let error = wrap
+            .load_outproc_plugin(PathBuf::from(other_path), None)
+            .err()
+            .expect("a different path while Active must be rejected");
+        assert_error(error, "does not support replacement");
+        assert!(matches!(
+            &*child_slot.lock().expect("lock child slot"),
+            ChildSlot::Active { path, .. } if path == Path::new(plugin_path)
+        ));
+    }
+
+    /// テスト専用の「slow」child 実行可能ファイル。CLI 引数（`--shm`/`--plugin`/`--sample-rate`
+    /// 等）をすべて無視してただ sleep するだけの POSIX shell script。`load_outproc_plugin` が
+    /// 経由する `spawn_outproc_child` はこれらの引数を固定で付与するため、素の coreutils
+    /// （`sleep`/`cat` 等）は未知オプションとして即 exit してしまい「lock 外で長時間ブロックする」
+    /// 状態を再現できない（実際に `sleep` へこれらの引数を渡すと `illegal option` で即終了する）。
+    /// このクレートの CI は ubuntu-latest のみを対象とする（Windows 非対応）ので unix 専用で問題ない。
+    fn write_slow_child_script(unique_path: &impl Fn() -> PathBuf) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let script_path = unique_path().with_extension("sh");
+        std::fs::write(&script_path, "#!/bin/sh\nsleep 20\n").expect("write slow child script");
+        let mut perms = std::fs::metadata(&script_path)
+            .expect("stat slow child script")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).expect("chmod slow child script");
+        script_path
+    }
+
+    /// Important finding 1: f36e99c の regression guard。`Loading` 中の 2 本目の `LoadPlugin` は、
+    /// 1 本目が shm-open/spawn/ready-ack poll（lock 外・最大 `CHILD_READY_TIMEOUT`）で実際に
+    /// ブロックしている **最中**でも、mutex 待ちでなく `ChildSlot::Loading` を即座に観測して
+    /// fail-fast すること。この lock-scope fix が無いと 2 本目は `.lock()` 自体で最大 10 秒
+    /// ブロックされ、意図された「Loading 中は即座に in progress で reject」が到達不能になる。
+    pub(super) fn concurrent_load_call_observes_loading_without_blocking(
+        unique_path: impl Fn() -> PathBuf,
+        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        assert_error: impl Fn(WrapError, &str),
+        has_audio_input: bool,
+        loading_path: &str,
+        second_path: &str,
+    ) {
+        let shm_path = unique_path();
+        let _ = std::fs::remove_file(&shm_path);
+        let _mmap = orbit_audio_sandbox::create_shared(&shm_path).expect("create shared memory");
+        let child_exe = write_slow_child_script(&unique_path);
+
+        let stats = OutProcChildStats::new();
+        let launch = child_launch(shm_path.clone(), child_exe.clone(), stats.clone());
+        let (wrap, child_slot) = inject(ChildSlot::Empty(launch), stats);
+
+        let wrap_a = wrap.clone();
+        let loading_path_owned = PathBuf::from(loading_path);
+        let first_call =
+            std::thread::spawn(move || wrap_a.load_outproc_plugin(loading_path_owned, None));
+
+        // 1本目が Empty -> Loading へ遷移して lock を解放するまで待つ（shm open + spawn は同期的な
+        // syscall なので通常数 ms で観測できる。2s は CI 負荷下でも十分な余裕）。
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            if matches!(
+                &*child_slot.lock().expect("poll child slot"),
+                ChildSlot::Loading { .. }
+            ) {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "first LoadPlugin call never reached ChildSlot::Loading within 2s"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        // 1本目はまだ ready-ack poll 中（child script は READY を publish しない）。この状態で 2本目を
+        // 発行し、mutex 待ちでなく即座に "already in progress" で失敗することを検証する。
+        let start = std::time::Instant::now();
+        let error = wrap
+            .load_outproc_plugin(PathBuf::from(second_path), None)
+            .err()
+            .expect("concurrent call against a Loading slot must fail");
+        let elapsed = start.elapsed();
+
+        assert_error(error, "already in progress");
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "second LoadPlugin call took {elapsed:?} while the first was still parked in its \
+             lock-free readiness poll -- it must fail fast on ChildSlot::Loading, not block on \
+             the mutex for up to CHILD_READY_TIMEOUT (regression guard for f36e99c)"
+        );
+
+        // 後片付け: READY を publish して 1本目を Active まで完走させ、決定的に join する
+        // （detach したまま放置すると child プロセス / watchdog スレッドがテストを跨いで残る）。
+        let ready_mmap =
+            orbit_audio_sandbox::open_shared(&shm_path).expect("open shm to publish READY");
+        let region = orbit_audio_sandbox::region_ptr(&ready_mmap);
+        // SAFETY: region は直前に開いた ready_mmap を指し、この scope の間生存する。
+        unsafe { orbit_audio_sandbox::transport::publish_child_ready(region, has_audio_input) };
+        first_call
+            .join()
+            .expect("first LoadPlugin call thread panicked")
+            .expect("first LoadPlugin call must succeed once READY is published");
+        let _ = std::fs::remove_file(&child_exe);
+    }
 }
 
 /// `outproc_health()` の real body（`#[cfg(feature = "outproc-effect")]`）を直接叩く unit test。
@@ -2785,6 +3008,51 @@ mod outproc_health_tests {
             assert_effect_runtime_error_contains,
             "already-loading-effect.clap",
             "second-effect.clap",
+        );
+    }
+
+    #[test]
+    fn effect_load_outproc_concurrent_call_fails_fast_on_loading() {
+        super::outproc_load_error_test_support::concurrent_load_call_observes_loading_without_blocking(
+            crate::outproc_effect::unique_shm_path,
+            wrap_with_child_slot,
+            assert_effect_runtime_error_contains,
+            true, // effect role: CHILD_FLAG_HAS_AUDIO_INPUT set
+            "loading-effect.clap",
+            "second-effect.clap",
+        );
+    }
+
+    #[test]
+    fn effect_load_outproc_active_accepts_idempotent_reload() {
+        super::outproc_load_error_test_support::active_slot_accepts_idempotent_reload(
+            crate::outproc_effect::unique_shm_path,
+            wrap_with_child_slot,
+            "active-effect.clap",
+            Some("sub-a".to_string()),
+        );
+    }
+
+    #[test]
+    fn effect_load_outproc_active_rejects_plugin_id_change() {
+        super::outproc_load_error_test_support::active_slot_rejects_plugin_id_change(
+            crate::outproc_effect::unique_shm_path,
+            wrap_with_child_slot,
+            assert_effect_runtime_error_contains,
+            "active-effect.clap",
+            Some("sub-a".to_string()),
+            Some("sub-b".to_string()),
+        );
+    }
+
+    #[test]
+    fn effect_load_outproc_active_rejects_path_replacement() {
+        super::outproc_load_error_test_support::active_slot_rejects_path_replacement(
+            crate::outproc_effect::unique_shm_path,
+            wrap_with_child_slot,
+            assert_effect_runtime_error_contains,
+            "active-effect.clap",
+            "other-effect.clap",
         );
     }
 
@@ -2972,6 +3240,51 @@ mod outproc_instrument_health_tests {
             assert_instrument_runtime_error_contains,
             "already-loading-instrument.clap",
             "second-instrument.clap",
+        );
+    }
+
+    #[test]
+    fn instrument_load_outproc_concurrent_call_fails_fast_on_loading() {
+        super::outproc_load_error_test_support::concurrent_load_call_observes_loading_without_blocking(
+            crate::outproc_instrument::unique_shm_path,
+            wrap_with_child_slot,
+            assert_instrument_runtime_error_contains,
+            false, // instrument role: CHILD_FLAG_HAS_AUDIO_INPUT must stay clear
+            "loading-instrument.clap",
+            "second-instrument.clap",
+        );
+    }
+
+    #[test]
+    fn instrument_load_outproc_active_accepts_idempotent_reload() {
+        super::outproc_load_error_test_support::active_slot_accepts_idempotent_reload(
+            crate::outproc_instrument::unique_shm_path,
+            wrap_with_child_slot,
+            "active-instrument.clap",
+            Some("sub-a".to_string()),
+        );
+    }
+
+    #[test]
+    fn instrument_load_outproc_active_rejects_plugin_id_change() {
+        super::outproc_load_error_test_support::active_slot_rejects_plugin_id_change(
+            crate::outproc_instrument::unique_shm_path,
+            wrap_with_child_slot,
+            assert_instrument_runtime_error_contains,
+            "active-instrument.clap",
+            Some("sub-a".to_string()),
+            Some("sub-b".to_string()),
+        );
+    }
+
+    #[test]
+    fn instrument_load_outproc_active_rejects_path_replacement() {
+        super::outproc_load_error_test_support::active_slot_rejects_path_replacement(
+            crate::outproc_instrument::unique_shm_path,
+            wrap_with_child_slot,
+            assert_instrument_runtime_error_contains,
+            "active-instrument.clap",
+            "other-instrument.clap",
         );
     }
 

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -6,8 +6,14 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+use std::sync::Weak;
 use std::sync::{Arc, Mutex};
-#[cfg(feature = "clap-host")]
+#[cfg(any(
+    feature = "clap-host",
+    feature = "outproc-effect",
+    feature = "outproc-instrument"
+))]
 use std::time::Duration;
 
 use orbit_audio_core::{resolve_slice_region, sanitize_rate, Engine, Sample};
@@ -180,6 +186,8 @@ struct OutProcControl {
     stats: Arc<crate::outproc_effect::OutProcEffectStats>,
     /// callback-duration 統計（A0 §6: CoreAudio+cpal は xrun 不発火 → RT 健全性は callback 実測時間で測る）。
     cb_stats: Arc<orbit_audio_native::CallbackTimeStats>,
+    /// post-boot attach の状態。`StreamGuard` と共有し、supervisor は stream より後に drop する。
+    child_slot: Weak<Mutex<ChildSlot>>,
 }
 
 #[cfg(feature = "outproc-instrument")]
@@ -188,7 +196,60 @@ struct OutProcInstrumentControl {
     event_tx: rtrb::Producer<orbit_audio_sandbox::NeutralEvent>,
     /// Audio adapter と watchdog が更新し、gated harness が読む観測 stats。
     stats: Arc<crate::outproc_instrument::OutProcInstrumentStats>,
+    /// post-boot attach の状態。`StreamGuard` と共有し、supervisor は stream より後に drop する。
+    child_slot: Weak<Mutex<ChildSlot>>,
 }
+
+#[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+type OutProcChildSupervisor = crate::outproc_effect::EffectChildSupervisor;
+#[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+type OutProcChildStats = crate::outproc_effect::OutProcEffectStats;
+#[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
+type OutProcChildSupervisor = crate::outproc_instrument::InstrumentChildSupervisor;
+#[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
+type OutProcChildStats = crate::outproc_instrument::OutProcInstrumentStats;
+
+/// OOP child の post-boot attach 状態。v1 は一つの daemon role につき一つの plugin path 固定。
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+pub(crate) enum ChildSlot {
+    Empty(ChildLaunch),
+    Loading {
+        path: PathBuf,
+        engaged: Arc<AtomicBool>,
+    },
+    Active {
+        path: PathBuf,
+        plugin_id: Option<String>,
+        engaged: Arc<AtomicBool>,
+        _supervisor: OutProcChildSupervisor,
+    },
+    Closed,
+}
+
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+pub(crate) struct ChildLaunch {
+    shm_path: PathBuf,
+    child_exe: PathBuf,
+    sample_rate: u32,
+    stats: Arc<OutProcChildStats>,
+    engaged: Arc<AtomicBool>,
+    cleanup_shm_on_drop: bool,
+}
+
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+impl Drop for ChildLaunch {
+    fn drop(&mut self) {
+        if self.cleanup_shm_on_drop {
+            let _ = std::fs::remove_file(&self.shm_path);
+        }
+    }
+}
+
+/// child plugin load は通常 dlopen を含む。十分な上限を設け、応答を永久に保留しない。
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+const CHILD_READY_TIMEOUT: Duration = Duration::from_secs(10);
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+const CHILD_READY_POLL: Duration = Duration::from_millis(10);
 
 /// CLAP host の control-side ハンドル一式（feature `clap-host` 専用）。
 #[cfg(feature = "clap-host")]
@@ -358,11 +419,8 @@ pub struct StreamGuard {
     _clap_thread: crate::clap_host::ClapThreadGuard,
     /// γ M1 PR-C（outproc-effect）: stream 停止 **後** に drop され、watchdog を止めて（respawn 停止）
     /// child へ QUIT → reap → shm unlink する。**field 順は load-bearing**: `_stream` より後に宣言する。
-    #[cfg(feature = "outproc-effect")]
-    _child_guard: crate::outproc_effect::EffectChildSupervisor,
-    /// outproc-instrument: stream 停止後に watchdog/child/shm を teardown する。
-    #[cfg(feature = "outproc-instrument")]
-    _instrument_child_guard: crate::outproc_instrument::InstrumentChildSupervisor,
+    #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+    _child_guard: Arc<Mutex<ChildSlot>>,
 }
 
 impl StreamGuard {
@@ -519,20 +577,30 @@ impl EngineWrap {
     pub fn start() -> Result<(Arc<Self>, StreamGuard), WrapError> {
         let cfg = crate::outproc_effect::OutProcEffectConfig::from_env()
             .map_err(WrapError::OutProcEffectUnavailable)?;
-        Self::start_outproc_effect(cfg)
+        Self::start_outproc_effect_post_boot(cfg)
     }
 
-    /// OOP effect 経路の本体（`start()`（env 由来）と gated harness（明示 path）が共有する）。
-    /// shm 作成 → host mmap → adapter → cpal stream（sample_rate 確定）→ 初回 child spawn → watchdog
-    /// supervisor の順で組み、`StreamGuard` の field 順で teardown を強制する（drop 順は本ファイル冒頭の
-    /// `StreamGuard` doc 参照）。初回 child spawn 失敗は shm を掃除して `OutProcEffect` を返す。
+    /// 既存 gated harness 用の明示設定入口。従来どおり、返却前に設定済み plugin を attach する。
     #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
     pub fn start_outproc_effect(
         cfg: crate::outproc_effect::OutProcEffectConfig,
     ) -> Result<(Arc<Self>, StreamGuard), WrapError> {
+        let plugin = cfg.plugin.clone();
+        let plugin_id = cfg.plugin_id.clone();
+        let (wrap, guard) = Self::start_outproc_effect_post_boot(cfg)?;
+        wrap.load_outproc_plugin(plugin, plugin_id)?;
+        Ok((wrap, guard))
+    }
+
+    /// production daemon の OOP effect 経路本体。
+    /// shm → adapter → stream までを daemon boot 時に構築し、child supervisor は初回
+    /// `LoadPlugin(role=effect)` まで遅延する。
+    #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+    fn start_outproc_effect_post_boot(
+        cfg: crate::outproc_effect::OutProcEffectConfig,
+    ) -> Result<(Arc<Self>, StreamGuard), WrapError> {
         use crate::outproc_effect::{
-            spawn_effect_child, EffectChildSupervisor, OutProcEffectPostProcessor,
-            OutProcEffectStats, OutProcTeardownGuard,
+            OutProcEffectPostProcessor, OutProcEffectStats, OutProcTeardownGuard,
         };
         use std::sync::atomic::AtomicBool;
 
@@ -543,13 +611,13 @@ impl EngineWrap {
         let host = orbit_audio_sandbox::PipelinedEffectHost::from_mmap(host_mmap);
 
         // 2. engaged ゲート + teardown flags + 観測 stats + adapter。
-        let engaged = Arc::new(AtomicBool::new(true));
+        let engaged = Arc::new(AtomicBool::new(false));
         let teardown_requested = Arc::new(AtomicBool::new(false));
         let teardown_done = Arc::new(AtomicBool::new(false));
         let stats = OutProcEffectStats::new();
         let processor = Box::new(OutProcEffectPostProcessor::new(
             host,
-            engaged,
+            engaged.clone(),
             teardown_requested.clone(),
             teardown_done.clone(),
             stats.clone(),
@@ -566,41 +634,16 @@ impl EngineWrap {
             .map_err(WrapError::Output)?;
         let sample_rate = stream.sample_rate;
 
-        // 4. 初回 child を同期 spawn（spawn 失敗を呼び出し側に返すため supervisor 外で起動）。
-        //    失敗時は作成済み shm を掃除する（stream はこの関数の早期 return で drop される）。
-        let first_child = match spawn_effect_child(
-            &cfg.child_exe,
-            &shm_path,
-            &cfg.plugin,
-            cfg.plugin_id.as_deref(),
-            sample_rate,
-        ) {
-            Ok(c) => c,
-            Err(e) => {
-                let _ = std::fs::remove_file(&shm_path);
-                return Err(WrapError::OutProcEffect(format!(
-                    "spawn effect child {:?}: {e}",
-                    cfg.child_exe
-                )));
-            }
-        };
-        // current_child_pid を watchdog 起動前に publish（startup race 回避・advisor）: test が
-        // watchdog の初回 store を待たずに PID を読めるようにする。
-        stats
-            .current_child_pid
-            .store(first_child.id(), Ordering::Relaxed);
-
-        // 5. supervisor（watchdog spawn・2nd control mapping を内部で open）。
-        let supervisor = EffectChildSupervisor::spawn(
-            first_child,
+        // 4. child は初回 LoadPlugin まで作らない。engaged clone を slot に保持し、ready-ack 後に
+        //    control thread から Release store できるようにする。
+        let child_slot = Arc::new(Mutex::new(ChildSlot::Empty(ChildLaunch {
             shm_path,
-            stats.clone(),
-            cfg.child_exe,
-            cfg.plugin,
-            cfg.plugin_id,
+            child_exe: cfg.child_exe,
             sample_rate,
-        )
-        .map_err(|e| WrapError::OutProcEffect(format!("spawn watchdog: {e}")))?;
+            stats: stats.clone(),
+            engaged,
+            cleanup_shm_on_drop: true,
+        })));
 
         // 6. wrap 構築 + control 注入。
         let wrap = Self::build(engine, stream.sample_rate, stream.channels, stream_stats);
@@ -608,7 +651,11 @@ impl EngineWrap {
             .outproc
             .lock()
             .map_err(|_| WrapError::OutProcEffect("outproc mutex poisoned".into()))? =
-            Some(OutProcControl { stats, cb_stats });
+            Some(OutProcControl {
+                stats,
+                cb_stats,
+                child_slot: Arc::downgrade(&child_slot),
+            });
 
         // 7. StreamGuard（field 順 = teardown 順）。
         Ok((
@@ -616,7 +663,7 @@ impl EngineWrap {
             StreamGuard {
                 _outproc_teardown: OutProcTeardownGuard::new(teardown_requested, teardown_done),
                 _stream: stream,
-                _child_guard: supervisor,
+                _child_guard: child_slot,
             },
         ))
     }
@@ -632,11 +679,10 @@ impl EngineWrap {
     pub fn start() -> Result<(Arc<Self>, StreamGuard), WrapError> {
         let cfg = crate::outproc_instrument::OutProcInstrumentConfig::from_env()
             .map_err(WrapError::OutProcInstrumentUnavailable)?;
-        Self::start_outproc_instrument(cfg)
+        Self::start_outproc_instrument_post_boot(cfg)
     }
 
-    /// Constructs the out-of-process instrument transport, post-processor, stream, child, and
-    /// supervisor in teardown-safe ownership order.
+    /// Existing gated-harness entry point. Preserves its pre-existing eager attach behavior.
     #[cfg(all(
         feature = "outproc-instrument",
         not(feature = "clap-host"),
@@ -646,9 +692,26 @@ impl EngineWrap {
     pub fn start_outproc_instrument(
         cfg: crate::outproc_instrument::OutProcInstrumentConfig,
     ) -> Result<(Arc<Self>, StreamGuard), WrapError> {
+        let plugin = cfg.plugin.clone();
+        let plugin_id = cfg.plugin_id.clone();
+        let (wrap, guard) = Self::start_outproc_instrument_post_boot(cfg)?;
+        wrap.load_outproc_plugin(plugin, plugin_id)?;
+        Ok((wrap, guard))
+    }
+
+    /// Production daemon path: build transport and stream now, attach child on first LoadPlugin.
+    #[cfg(all(
+        feature = "outproc-instrument",
+        not(feature = "clap-host"),
+        not(feature = "link-audio"),
+        not(feature = "outproc-effect")
+    ))]
+    fn start_outproc_instrument_post_boot(
+        cfg: crate::outproc_instrument::OutProcInstrumentConfig,
+    ) -> Result<(Arc<Self>, StreamGuard), WrapError> {
         use crate::outproc_instrument::{
-            spawn_instrument_child, InstrumentChildSupervisor, OutProcInstrumentPostProcessor,
-            OutProcInstrumentStats, OutProcInstrumentTeardownGuard, NOTE_RING_CAPACITY,
+            OutProcInstrumentPostProcessor, OutProcInstrumentStats, OutProcInstrumentTeardownGuard,
+            NOTE_RING_CAPACITY,
         };
 
         let shm_path = crate::outproc_instrument::unique_shm_path();
@@ -657,7 +720,7 @@ impl EngineWrap {
         })?;
         let host = orbit_audio_sandbox::PipelinedInstrumentHost::from_mmap(host_mmap);
         let (event_tx, event_rx) = rtrb::RingBuffer::new(NOTE_RING_CAPACITY);
-        let engaged = Arc::new(AtomicBool::new(true));
+        let engaged = Arc::new(AtomicBool::new(false));
         let teardown_requested = Arc::new(AtomicBool::new(false));
         let teardown_done = Arc::new(AtomicBool::new(false));
         let stats = OutProcInstrumentStats::new();
@@ -665,7 +728,7 @@ impl EngineWrap {
             host,
             event_rx,
             NOTE_RING_CAPACITY,
-            engaged,
+            engaged.clone(),
             teardown_requested.clone(),
             teardown_done.clone(),
             stats.clone(),
@@ -680,40 +743,23 @@ impl EngineWrap {
             .map_err(WrapError::Output)?;
         let sample_rate = stream.sample_rate;
 
-        let first_child = match spawn_instrument_child(
-            &cfg.child_exe,
-            &shm_path,
-            &cfg.plugin,
-            cfg.plugin_id.as_deref(),
-            sample_rate,
-        ) {
-            Ok(child) => child,
-            Err(error) => {
-                let _ = std::fs::remove_file(&shm_path);
-                return Err(WrapError::OutProcInstrument(format!(
-                    "spawn instrument child {:?}: {error}",
-                    cfg.child_exe
-                )));
-            }
-        };
-        stats
-            .current_child_pid
-            .store(first_child.id(), Ordering::Relaxed);
-        let supervisor = InstrumentChildSupervisor::spawn(
-            first_child,
+        let child_slot = Arc::new(Mutex::new(ChildSlot::Empty(ChildLaunch {
             shm_path,
-            stats.clone(),
-            cfg.child_exe,
-            cfg.plugin,
-            cfg.plugin_id,
+            child_exe: cfg.child_exe,
             sample_rate,
-        )
-        .map_err(|error| WrapError::OutProcInstrument(format!("spawn watchdog: {error}")))?;
+            stats: stats.clone(),
+            engaged,
+            cleanup_shm_on_drop: true,
+        })));
 
         let wrap = Self::build(engine, stream.sample_rate, stream.channels, stream_stats);
         *wrap.outproc_instrument.lock().map_err(|_| {
             WrapError::OutProcInstrument("outproc instrument mutex poisoned".into())
-        })? = Some(OutProcInstrumentControl { event_tx, stats });
+        })? = Some(OutProcInstrumentControl {
+            event_tx,
+            stats,
+            child_slot: Arc::downgrade(&child_slot),
+        });
 
         Ok((
             wrap,
@@ -723,7 +769,7 @@ impl EngineWrap {
                     teardown_done,
                 ),
                 _stream: stream,
-                _instrument_child_guard: supervisor,
+                _child_guard: child_slot,
             },
         ))
     }
@@ -854,6 +900,182 @@ impl EngineWrap {
         Err(WrapError::LinkAudioUnavailable(
             "engine built without 'link-audio' feature".into(),
         ))
+    }
+
+    /// OOP feature の初回 `LoadPlugin` で child + watchdog を attach する。
+    ///
+    /// blocking API: child の readiness を poll するため、session handler は `spawn_blocking` から
+    /// 呼ぶこと。同一 path の再送は冪等、別 path への差し替えは v1 では拒否する。
+    #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+    pub fn load_outproc_plugin(
+        &self,
+        path: PathBuf,
+        plugin_id: Option<String>,
+    ) -> Result<LoadedPluginSummary, WrapError> {
+        #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+        let child_slot = {
+            let guard = self
+                .outproc
+                .lock()
+                .map_err(|_| outproc_runtime_error("outproc mutex poisoned"))?;
+            guard
+                .as_ref()
+                .ok_or_else(|| {
+                    WrapError::OutProcEffectUnavailable(
+                        "outproc effect not initialized (test backend has no outproc path)".into(),
+                    )
+                })?
+                .child_slot
+                .upgrade()
+                .ok_or_else(|| outproc_runtime_error("outproc effect stream is closed"))?
+        };
+        #[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
+        let child_slot = {
+            let guard = self
+                .outproc_instrument
+                .lock()
+                .map_err(|_| outproc_runtime_error("outproc instrument mutex poisoned"))?;
+            guard
+                .as_ref()
+                .ok_or_else(|| {
+                    WrapError::OutProcInstrumentUnavailable(
+                        "outproc instrument not initialized (test backend has no outproc path)"
+                            .into(),
+                    )
+                })?
+                .child_slot
+                .upgrade()
+                .ok_or_else(|| outproc_runtime_error("outproc instrument stream is closed"))?
+        };
+
+        let mut slot = child_slot
+            .lock()
+            .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
+
+        match &*slot {
+            ChildSlot::Active {
+                path: active_path,
+                plugin_id: active_plugin_id,
+                engaged,
+                ..
+            } if active_path == &path => {
+                // READY を確認済みの Active だけがここへ来る。冪等再送でも gate を維持する。
+                engaged.store(true, Ordering::Release);
+                return Ok(outproc_plugin_summary(active_path, active_plugin_id));
+            }
+            ChildSlot::Active {
+                path: active_path, ..
+            } => {
+                return Err(outproc_runtime_error(format!(
+                    "outproc plugin already loaded from {active_path:?}; v1 does not support replacement with {path:?}"
+                )));
+            }
+            ChildSlot::Loading {
+                path: loading_path,
+                engaged,
+            } => {
+                let _ = engaged.load(Ordering::Acquire);
+                return Err(outproc_runtime_error(format!(
+                    "outproc plugin load already in progress for {loading_path:?}"
+                )));
+            }
+            ChildSlot::Closed => {
+                return Err(outproc_runtime_error(
+                    "outproc child slot is closed after an unrecoverable attach failure",
+                ));
+            }
+            ChildSlot::Empty(_) => {}
+        }
+
+        let mut launch = match std::mem::replace(&mut *slot, ChildSlot::Closed) {
+            ChildSlot::Empty(launch) => launch,
+            _ => unreachable!("ChildSlot state was checked while holding the same mutex"),
+        };
+        *slot = ChildSlot::Loading {
+            path: path.clone(),
+            engaged: launch.engaged.clone(),
+        };
+
+        let ready_mmap = match orbit_audio_sandbox::open_shared(&launch.shm_path) {
+            Ok(mmap) => mmap,
+            Err(error) => {
+                *slot = ChildSlot::Closed;
+                return Err(outproc_runtime_error(format!(
+                    "open child readiness mapping {:?}: {error}",
+                    launch.shm_path
+                )));
+            }
+        };
+        let region = orbit_audio_sandbox::region_ptr(&ready_mmap);
+        // SAFETY: region はこの scope で生存する ready_mmap を指す。初回を含む全 spawn の直前に
+        // readiness を初期化し、前 incarnation の READY を誤認しない。
+        unsafe { orbit_audio_sandbox::transport::reset_child_starting(region) };
+
+        let first_child = match spawn_outproc_child(&launch, &path, plugin_id.as_deref()) {
+            Ok(child) => child,
+            Err(error) => {
+                let child_exe = launch.child_exe.clone();
+                *slot = ChildSlot::Empty(launch);
+                return Err(outproc_runtime_error(format!(
+                    "spawn outproc child {:?}: {error}",
+                    child_exe
+                )));
+            }
+        };
+        launch
+            .stats
+            .current_child_pid
+            .store(first_child.id(), Ordering::Relaxed);
+
+        let supervisor =
+            match spawn_outproc_supervisor(first_child, &launch, path.clone(), plugin_id.clone()) {
+                Ok(supervisor) => supervisor,
+                Err(error) => {
+                    // supervisor の startup cleanup は shm を unlink するため、この slot は再利用不能。
+                    *slot = ChildSlot::Closed;
+                    return Err(outproc_runtime_error(format!(
+                        "spawn outproc watchdog: {error}"
+                    )));
+                }
+            };
+
+        let deadline = std::time::Instant::now() + CHILD_READY_TIMEOUT;
+        loop {
+            // Acquire で READY を観測した後の flags load は child の publish 順と同期する。
+            let status = unsafe { (*region).child_status.load(Ordering::Acquire) };
+            if status == orbit_audio_sandbox::transport::CHILD_STATUS_READY {
+                let flags = unsafe { (*region).child_flags.load(Ordering::Acquire) };
+                if !outproc_role_matches(flags) {
+                    drop(supervisor);
+                    *slot = ChildSlot::Closed;
+                    return Err(outproc_runtime_error(format!(
+                        "loaded plugin role does not match daemon role (child_flags={flags:#x})"
+                    )));
+                }
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                drop(supervisor);
+                *slot = ChildSlot::Closed;
+                return Err(outproc_runtime_error(format!(
+                    "timed out waiting {:?} for child READY",
+                    CHILD_READY_TIMEOUT
+                )));
+            }
+            std::thread::sleep(CHILD_READY_POLL);
+        }
+
+        launch.engaged.store(true, Ordering::Release);
+        let summary = outproc_plugin_summary(&path, &plugin_id);
+        // Active supervisor が以後の unlink を所有する。local launch の fallback cleanup は解除する。
+        launch.cleanup_shm_on_drop = false;
+        *slot = ChildSlot::Active {
+            path,
+            plugin_id,
+            engaged: launch.engaged.clone(),
+            _supervisor: supervisor,
+        };
+        Ok(summary)
     }
 
     // ── CLAP plugin hosting（feature `clap-host` 専用・Issue #340）─────────────────────
@@ -1770,6 +1992,108 @@ impl EngineWrap {
     }
 }
 
+#[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+fn outproc_runtime_error(message: impl Into<String>) -> WrapError {
+    WrapError::OutProcEffect(message.into())
+}
+
+#[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
+fn outproc_runtime_error(message: impl Into<String>) -> WrapError {
+    WrapError::OutProcInstrument(message.into())
+}
+
+#[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+fn spawn_outproc_child(
+    launch: &ChildLaunch,
+    path: &std::path::Path,
+    plugin_id: Option<&str>,
+) -> std::io::Result<std::process::Child> {
+    crate::outproc_effect::spawn_effect_child(
+        &launch.child_exe,
+        &launch.shm_path,
+        path,
+        plugin_id,
+        launch.sample_rate,
+    )
+}
+
+#[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
+fn spawn_outproc_child(
+    launch: &ChildLaunch,
+    path: &std::path::Path,
+    plugin_id: Option<&str>,
+) -> std::io::Result<std::process::Child> {
+    crate::outproc_instrument::spawn_instrument_child(
+        &launch.child_exe,
+        &launch.shm_path,
+        path,
+        plugin_id,
+        launch.sample_rate,
+    )
+}
+
+#[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+fn spawn_outproc_supervisor(
+    child: std::process::Child,
+    launch: &ChildLaunch,
+    path: PathBuf,
+    plugin_id: Option<String>,
+) -> std::io::Result<OutProcChildSupervisor> {
+    crate::outproc_effect::EffectChildSupervisor::spawn(
+        child,
+        launch.shm_path.clone(),
+        launch.stats.clone(),
+        launch.child_exe.clone(),
+        path,
+        plugin_id,
+        launch.sample_rate,
+    )
+}
+
+#[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
+fn spawn_outproc_supervisor(
+    child: std::process::Child,
+    launch: &ChildLaunch,
+    path: PathBuf,
+    plugin_id: Option<String>,
+) -> std::io::Result<OutProcChildSupervisor> {
+    crate::outproc_instrument::InstrumentChildSupervisor::spawn(
+        child,
+        launch.shm_path.clone(),
+        launch.stats.clone(),
+        launch.child_exe.clone(),
+        path,
+        plugin_id,
+        launch.sample_rate,
+    )
+}
+
+#[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+fn outproc_role_matches(flags: u32) -> bool {
+    flags & orbit_audio_sandbox::transport::CHILD_FLAG_HAS_AUDIO_INPUT != 0
+}
+
+#[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
+fn outproc_role_matches(flags: u32) -> bool {
+    flags & orbit_audio_sandbox::transport::CHILD_FLAG_HAS_AUDIO_INPUT == 0
+}
+
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+fn outproc_plugin_summary(
+    path: &std::path::Path,
+    plugin_id: &Option<String>,
+) -> LoadedPluginSummary {
+    LoadedPluginSummary {
+        plugin_id: plugin_id
+            .clone()
+            .unwrap_or_else(|| path.to_string_lossy().into_owned()),
+        plugin_name: path
+            .file_stem()
+            .map(|name| name.to_string_lossy().into_owned()),
+        note_port_index: 0,
+    }
+}
+
 pub struct LoadedSample {
     pub sample_id: String,
     pub frames: usize,
@@ -2233,12 +2557,12 @@ mod capture_path_tests {
 /// `EngineWrap` に対して real child を spawn せず `Some(OutProcControl)` を注入できる。
 #[cfg(all(test, feature = "outproc-effect"))]
 mod outproc_health_tests {
-    use super::{EngineWrap, OutProcControl};
+    use super::{outproc_role_matches, EngineWrap, OutProcControl};
     use crate::backend::StubBackend;
     use crate::outproc_effect::OutProcEffectStats;
     use orbit_audio_native::CallbackTimeStats;
     use std::sync::atomic::Ordering;
-    use std::sync::Arc;
+    use std::sync::{Arc, Weak};
 
     /// `StubBackend` で `EngineWrap` を起動し、real child なしで組み立てた `OutProcControl` を
     /// `self.outproc` に注入する。返す `Arc<OutProcEffectStats>` はテスト側から直接
@@ -2250,8 +2574,17 @@ mod outproc_health_tests {
         *wrap.outproc.lock().expect("lock outproc for injection") = Some(OutProcControl {
             stats: stats.clone(),
             cb_stats: CallbackTimeStats::new(),
+            child_slot: Weak::new(),
         });
         (wrap, stats)
+    }
+
+    #[test]
+    fn effect_ready_ack_requires_audio_input_flag() {
+        assert!(outproc_role_matches(
+            orbit_audio_sandbox::transport::CHILD_FLAG_HAS_AUDIO_INPUT
+        ));
+        assert!(!outproc_role_matches(0));
     }
 
     #[test]
@@ -2343,11 +2676,11 @@ mod outproc_health_tests {
 /// `OutProcInstrumentControl`（private struct）へ直接アクセスして注入する。
 #[cfg(all(test, feature = "outproc-instrument"))]
 mod outproc_instrument_health_tests {
-    use super::{EngineWrap, OutProcInstrumentControl};
+    use super::{outproc_role_matches, EngineWrap, OutProcInstrumentControl};
     use crate::backend::StubBackend;
     use crate::outproc_instrument::OutProcInstrumentStats;
     use std::sync::atomic::Ordering;
-    use std::sync::Arc;
+    use std::sync::{Arc, Weak};
 
     /// `StubBackend` で `EngineWrap` を起動し、real child なしで組み立てた `OutProcInstrumentControl`
     /// を `self.outproc_instrument` に注入する。event_tx の consumer 側は即 drop するが、この
@@ -2363,8 +2696,17 @@ mod outproc_instrument_health_tests {
             .expect("lock instrument control for injection") = Some(OutProcInstrumentControl {
             event_tx,
             stats: stats.clone(),
+            child_slot: Weak::new(),
         });
         (wrap, stats)
+    }
+
+    #[test]
+    fn instrument_ready_ack_rejects_audio_input_flag() {
+        assert!(outproc_role_matches(0));
+        assert!(!outproc_role_matches(
+            orbit_audio_sandbox::transport::CHILD_FLAG_HAS_AUDIO_INPUT
+        ));
     }
 
     // `outproc_instrument_health()` mirrors `outproc_health_tests` (effect side) exactly --
@@ -2509,7 +2851,11 @@ mod outproc_instrument_note_tests {
         *wrap
             .outproc_instrument
             .lock()
-            .expect("lock instrument control") = Some(OutProcInstrumentControl { event_tx, stats });
+            .expect("lock instrument control") = Some(OutProcInstrumentControl {
+            event_tx,
+            stats,
+            child_slot: std::sync::Weak::new(),
+        });
         (wrap, event_rx)
     }
 

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -215,7 +215,6 @@ pub(crate) enum ChildSlot {
     Empty(ChildLaunch),
     Loading {
         path: PathBuf,
-        engaged: Arc<AtomicBool>,
     },
     Active {
         path: PathBuf,
@@ -971,10 +970,8 @@ impl EngineWrap {
                 )));
             }
             ChildSlot::Loading {
-                path: loading_path,
-                engaged,
+                path: loading_path, ..
             } => {
-                let _ = engaged.load(Ordering::Acquire);
                 return Err(outproc_runtime_error(format!(
                     "outproc plugin load already in progress for {loading_path:?}"
                 )));
@@ -991,14 +988,20 @@ impl EngineWrap {
             ChildSlot::Empty(launch) => launch,
             _ => unreachable!("ChildSlot state was checked while holding the same mutex"),
         };
-        *slot = ChildSlot::Loading {
-            path: path.clone(),
-            engaged: launch.engaged.clone(),
-        };
+        *slot = ChildSlot::Loading { path: path.clone() };
+        // Loading 書き込みを可視化した直後にロックを解放する。以降の shm open・spawn・
+        // ready-ack poll（最大 CHILD_READY_TIMEOUT）はロック外で行う。他の LoadPlugin
+        // 呼び出しは Loading を即座に観測して「in progress」で失敗できる（この関数だけが
+        // Loading→Active/Closed/Empty へ遷移させるため、再取得後も Loading のままである
+        // ことが保証される。teardown は child_slot の Arc を保持するだけで .lock() しない）。
+        drop(slot);
 
         let ready_mmap = match orbit_audio_sandbox::open_shared(&launch.shm_path) {
             Ok(mmap) => mmap,
             Err(error) => {
+                let mut slot = child_slot
+                    .lock()
+                    .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
                 *slot = ChildSlot::Closed;
                 return Err(outproc_runtime_error(format!(
                     "open child readiness mapping {:?}: {error}",
@@ -1015,6 +1018,9 @@ impl EngineWrap {
             Ok(child) => child,
             Err(error) => {
                 let child_exe = launch.child_exe.clone();
+                let mut slot = child_slot
+                    .lock()
+                    .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
                 *slot = ChildSlot::Empty(launch);
                 return Err(outproc_runtime_error(format!(
                     "spawn outproc child {:?}: {error}",
@@ -1032,6 +1038,9 @@ impl EngineWrap {
                 Ok(supervisor) => supervisor,
                 Err(error) => {
                     // supervisor の startup cleanup は shm を unlink するため、この slot は再利用不能。
+                    let mut slot = child_slot
+                        .lock()
+                        .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
                     *slot = ChildSlot::Closed;
                     return Err(outproc_runtime_error(format!(
                         "spawn outproc watchdog: {error}"
@@ -1047,6 +1056,9 @@ impl EngineWrap {
                 let flags = unsafe { (*region).child_flags.load(Ordering::Acquire) };
                 if !outproc_role_matches(flags) {
                     drop(supervisor);
+                    let mut slot = child_slot
+                        .lock()
+                        .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
                     *slot = ChildSlot::Closed;
                     return Err(outproc_runtime_error(format!(
                         "loaded plugin role does not match daemon role (child_flags={flags:#x})"
@@ -1056,6 +1068,9 @@ impl EngineWrap {
             }
             if std::time::Instant::now() >= deadline {
                 drop(supervisor);
+                let mut slot = child_slot
+                    .lock()
+                    .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
                 *slot = ChildSlot::Closed;
                 return Err(outproc_runtime_error(format!(
                     "timed out waiting {:?} for child READY",
@@ -1069,6 +1084,9 @@ impl EngineWrap {
         let summary = outproc_plugin_summary(&path, &plugin_id);
         // Active supervisor が以後の unlink を所有する。local launch の fallback cleanup は解除する。
         launch.cleanup_shm_on_drop = false;
+        let mut slot = child_slot
+            .lock()
+            .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
         *slot = ChildSlot::Active {
             path,
             plugin_id,

--- a/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
@@ -36,6 +36,7 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use orbit_audio_native::PostProcessor;
+use orbit_audio_sandbox::transport::reset_child_starting;
 use orbit_audio_sandbox::{open_shared, region_ptr, PipelinedEffectHost, CONTROL_QUIT};
 
 /// watchdog が child の生存を poll する周期（非 RT・control thread）。
@@ -485,6 +486,9 @@ impl EffectChildSupervisor {
                             tracing::warn!(
                                 "orbit-clap-effect-child が異常終了（{status}）→ respawn する"
                             );
+                            // SAFETY: region は watchdog が所有する生存 ctl_mmap を指す。
+                            // 前 incarnation の READY を消してから replacement を spawn する。
+                            unsafe { reset_child_starting(region) };
                             match spawn_effect_child(
                                 &child_exe,
                                 &shm_path_wd,

--- a/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
@@ -15,6 +15,7 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use orbit_audio_native::PostProcessor;
+use orbit_audio_sandbox::transport::reset_child_starting;
 use orbit_audio_sandbox::{
     open_shared, region_ptr, NeutralEvent, PipelinedInstrumentHost, TransportContext, VoiceKey,
     BUF_LEN, CONTROL_QUIT,
@@ -415,6 +416,9 @@ impl InstrumentChildSupervisor {
                             tracing::warn!(
                                 "orbit-clap-instrument-child exited ({status}); respawning"
                             );
+                            // SAFETY: region は watchdog が所有する生存 ctl_mmap を指す。
+                            // 前 incarnation の READY を消してから replacement を spawn する。
+                            unsafe { reset_child_starting(region) };
                             match spawn_instrument_child(
                                 &child_exe,
                                 &watchdog_shm_path,

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -48,6 +48,16 @@ fn daemon_error_event(severity: &str, code: &str, message: String) -> Event {
     )
 }
 
+#[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+fn outproc_role_param_is_valid(params: &Value) -> bool {
+    params.get("role").and_then(Value::as_str) == Some("effect")
+}
+
+#[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
+fn outproc_role_param_is_valid(params: &Value) -> bool {
+    params.get("role").and_then(Value::as_str) == Some("instrument")
+}
+
 pub async fn run(
     ws: WebSocketStream<TcpStream>,
     engine: Arc<EngineWrap>,
@@ -609,19 +619,49 @@ async fn handle_command(
                 ),
             ),
         },
-        // CLAP プラグインをロードして hot-install する（Issue #340・feature `clap-host`）。discovery +
-        // dlopen + activate は重いので LoadSample と同様 spawn_blocking で tokio ワーカーを塞がない。
-        // feature 無効ビルドは engine stub が CLAP_UNAVAILABLE を返す（command は feature 非依存）。
+        // CLAP プラグインをロードして hot-install する。in-process `clap-host` は既存 load path、
+        // OOP feature は role を検証して post-boot child attach path へ分岐する。どちらも dlopen を
+        // 含みうるため spawn_blocking で tokio worker から隔離する。
         "LoadPlugin" => match params.get("path").and_then(|p| p.as_str()) {
             Some(path_str) => {
+                #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+                if !outproc_role_param_is_valid(&params) {
+                    return err(
+                        &id,
+                        ProtocolError::new(
+                            "MALFORMED_REQUEST",
+                            "outproc-effect LoadPlugin requires role='effect'",
+                        ),
+                    );
+                }
+                #[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
+                if !outproc_role_param_is_valid(&params) {
+                    return err(
+                        &id,
+                        ProtocolError::new(
+                            "MALFORMED_REQUEST",
+                            "outproc-instrument LoadPlugin requires role='instrument'",
+                        ),
+                    );
+                }
+
                 let engine = engine.clone();
                 let path = std::path::PathBuf::from(path_str);
                 let plugin_id = params
                     .get("plugin_id")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
-                let res =
-                    tokio::task::spawn_blocking(move || engine.load_plugin(path, plugin_id)).await;
+                let res = tokio::task::spawn_blocking(move || {
+                    #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+                    {
+                        engine.load_outproc_plugin(path, plugin_id)
+                    }
+                    #[cfg(not(any(feature = "outproc-effect", feature = "outproc-instrument")))]
+                    {
+                        engine.load_plugin(path, plugin_id)
+                    }
+                })
+                .await;
                 match res {
                     Ok(Ok(info)) => ok(
                         &id,
@@ -993,6 +1033,22 @@ fn wrap_err_to_protocol(e: &WrapError) -> ProtocolError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "outproc-effect")]
+    #[test]
+    fn outproc_effect_load_plugin_accepts_only_effect_role() {
+        assert!(outproc_role_param_is_valid(&json!({"role": "effect"})));
+        assert!(!outproc_role_param_is_valid(&json!({"role": "instrument"})));
+        assert!(!outproc_role_param_is_valid(&json!({})));
+    }
+
+    #[cfg(feature = "outproc-instrument")]
+    #[test]
+    fn outproc_instrument_load_plugin_accepts_only_instrument_role() {
+        assert!(outproc_role_param_is_valid(&json!({"role": "instrument"})));
+        assert!(!outproc_role_param_is_valid(&json!({"role": "effect"})));
+        assert!(!outproc_role_param_is_valid(&json!({})));
+    }
 
     // LinkAudio エラーの protocol code 分割を pin（TS は UNAVAILABLE のみ握り潰し RUNTIME は rethrow）。
     #[test]

--- a/rust/crates/orbit-audio-sandbox/src/transport.rs
+++ b/rust/crates/orbit-audio-sandbox/src/transport.rs
@@ -275,6 +275,24 @@ pub unsafe fn publish_child_ready(region: *mut SharedRegion, has_audio_input: bo
     }
 }
 
+/// child spawn の直前に readiness handshake を初期状態へ戻す。
+///
+/// shm は watchdog respawn 間で再利用されるため、前 incarnation の `READY` を残したまま
+/// replacement child を起動すると host が新 child の load 完了前に ready-ack を誤認しうる。
+/// status を先に `STARTING` にしてから flags を消し、全 spawn 経路で同じ順序を使う。
+/// この順序なら並行 poller が前 incarnation の `READY` と消去済み flags を組み合わせない。
+///
+/// # Safety
+/// `region` は呼び出し元が map 済みの生存 SharedRegion を指していること。
+pub unsafe fn reset_child_starting(region: *mut SharedRegion) {
+    unsafe {
+        (*region)
+            .child_status
+            .store(CHILD_STATUS_STARTING, Ordering::Release);
+        (*region).child_flags.store(0, Ordering::Release);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -398,6 +416,29 @@ mod tests {
         }
         drop(mmap_false);
         let _ = std::fs::remove_file(&p_false);
+    }
+
+    #[test]
+    fn reset_child_starting_clears_previous_incarnation_readiness() {
+        let path =
+            std::env::temp_dir().join(format!("orbit-sbx-reset-ready-{}.shm", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let mmap = create_shared(&path).expect("create");
+        let region = region_ptr(&mmap);
+
+        // SAFETY: region は create_shared が返した生存 mapping を指す。
+        unsafe {
+            publish_child_ready(region, true);
+            reset_child_starting(region);
+            assert_eq!((*region).child_flags.load(Ordering::Relaxed), 0);
+            assert_eq!(
+                (*region).child_status.load(Ordering::Relaxed),
+                CHILD_STATUS_STARTING
+            );
+        }
+
+        drop(mmap);
+        let _ = std::fs::remove_file(path);
     }
 
     // 存在しないファイルは map せず Err(open は read-only open なので作成しない)。

--- a/rust/crates/orbit-audio-sandbox/src/transport.rs
+++ b/rust/crates/orbit-audio-sandbox/src/transport.rs
@@ -9,8 +9,8 @@
 //! - **host READ**: `seq_tag[slot(target)]` を Acquire で読み `== target` なら output が可視 → 出力にコピー。global monotone な `seq_done` でなく per-slot `seq_tag` で判定するのは、child が「latest 処理」で中間 seq を skip しても、その slot の tag が target に一致せず false-fresh を防げるから(seq_done では skip を検知できない)。
 //! - **host SUBMIT guard**: `seq_done` を Acquire で読み slot 再利用可否(下記不変条件)を判定する。
 //! - **child readiness**: child は `ClapEffectProcessor::load` / `ClapInstrumentProcessor::load`
-//!   成功直後に `child_flags` → `child_status` の順で Release store する。host は起動時にこれを poll
-//!   する（本 PR では poll する呼び出し元は未実装・PR-1b で追加）。
+//!   成功直後に `child_flags` → `child_status` の順で Release store する。host は初回 `LoadPlugin` 時に
+//!   `load_outproc_plugin` の ready-ack ループでこれを poll する（PR-1b・#431 で実装済み）。
 //!
 //! **ping-pong バッファ**: `input` / `output` は各 [`SLOTS`] 個の slot を持ち、seq を [`slot_offset`]
 //! で割り当てて交替する。slot を分けることで「host が seq s の slot を書く」のと「child が seq s-k の
@@ -87,17 +87,19 @@ pub const CONTROL_QUIT: u32 = 1;
 pub const CHILD_STATUS_STARTING: u32 = 0;
 /// child が load に成功し、以降 process loop に入る状態。
 pub const CHILD_STATUS_READY: u32 = 1;
-/// **PR-1a 時点では未使用の予約値**（child が load に失敗して終了する直前の状態を表す想定）。
+/// **現状は未使用の予約値**（child が load に失敗して終了する直前の状態を表す想定）。
 /// child は load 失敗時 `?` の早期 return でこの値を書かずにそのままプロセス終了する。host は
-/// （初回起動時に限り）`child_status == STARTING` のまま child が消えたことを `try_wait` で
-/// 判別する前提（PR-1b でこの値を実際に書く経路を追加する場合、host 側の判定ロジックとセットで
-/// 設計すること）。
+/// 現時点では `child_status == STARTING` のまま child が消えたことを即時には判別しない。
 ///
 /// **respawn 注意**: shm は daemon 起動時に一度だけ truncate され、respawn（`EffectChildSupervisor`/
 /// `InstrumentChildSupervisor` の watchdog による再起動）は同一 shm を再利用する（再 truncate しない）
 /// ため、一度 READY に達した後の respawn 失敗では `child_status` は STARTING でなく前 incarnation の
-/// READY が残留する。PR-1b のポーラーは spawn 直前に host が STARTING へ明示リセットする、または
-/// try_wait の生死判定と併用する必要がある。
+/// READY が残留する。PR-1b（#440）は spawn 直前の `reset_child_starting` による STARTING リセット
+/// のみを実装し、この前 incarnation の READY 残留誤認を解消した。一方、初回 attach 時に child が
+/// `CHILD_STATUS_LOAD_FAILED` を書かず即死するケースの `try_wait` ベース生死判定は PR-1b では実装
+/// しない。そのため child の早期 crash は `CHILD_READY_TIMEOUT`（最大 10s）のタイムアウトとしてのみ
+/// 検出される。この fast-fail 化と、失敗した slot を retry 可能状態へ戻す対応は PR-1c（#441・
+/// Epic #424 DoD ゲート項目）へ移管した。`CHILD_STATUS_LOAD_FAILED` は現状も write 箇所なしの予約値。
 pub const CHILD_STATUS_LOAD_FAILED: u32 = 2;
 
 /// child のロード結果を表す bit flags（PR-431）。bit0 = has_audio_input


### PR DESCRIPTION
Refs #431 / Epic #424

## 概要

PR-1a（マージ済み #439）で用意した substrate（engaged ゲート・child readiness handshake）の上に、実際の post-boot attach を実装する #431 の第二段。

## 実装

- `ChildSlot`（Empty/Loading/Active/Closed）による遅延 supervisor 生成。daemon 起動時は supervisor 無し、初回 `LoadPlugin` で spawn。`StreamGuard._child_guard` は `Arc<Mutex<ChildSlot>>`（control 側は `Weak` 参照）で teardown 順序（`_outproc_teardown → _stream → _child_guard`）を維持
- `session.rs` の `LoadPlugin` ハンドラに role 検証つき OOP 実行時受け口を追加。初回 spawn・同一 path 冪等 Ok・異なる path は reject
- ready-ack: `child_status` を Acquire poll → READY 確認 → `child_flags` で role 一致検証（10秒 timeout）してから応答。spawn 直前に `reset_child_starting` で前 incarnation の READY 残留を除去（PR-1a の申し送り事項に対応）
- `engaged` を `false` 構築 → ready-ack 完了後に Release store で `true` へ遷移

設計は PR-1a と同一セッションの Fable 実装前相談（D1-D7・GO 済み）の延長。

## 検証

- Codex 実行環境（loopback bind 禁止のサンドボックス）では `tests/protocol.rs` 28件が環境制約で FAIL したが build/fmt/clippy は green
- main が非サンドボックスで独立再検証: `cargo test --workspace --features outproc-effect`/`outproc-instrument` 両方 **0 failed**（protocol 含む全 green）・fmt --check・clippy -D warnings 両 feature green。Codex 環境固有の loopback 制約が原因であり実装バグではないことを確認済み

## 関連

- 親: #431（3段階計画）/ Epic #424
- 次: PR-2（outproc-effect × outproc-instrument の排他解消・CompositePostProcessor）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015R9Km7edyaAgqzVFsUm7uX