### PR TITLE
fix(daemon): OOP attach-failure fast-fail + retry recoverability (#431 PR-1c)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,52 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.255 fix(daemon): OOP attach 失敗の fast-fail + retry 可能化 #441 PR-1c (Jul 16, 2026)
+
+**Date**: 2026-07-16
+**Status**: ✅ 実装・検証済み（PR 作成へ）
+**Branch**: `441-oop-attach-fast-fail-retry`
+**Commit**: `b09a45e`
+
+Epic #424 DoD ゲート項目。PR #440 レビュー4体 + Fable 裁定で確定した attach エラー処理の
+一体的2欠陥（child 早期 crash が10秒 timeout でしか検出されない / 訂正可能なユーザーミスが
+slot を daemon 再起動まで殺す）を解消。実装 = Codex 委譲4周（main = Fable が実装前設計を
+確定し、diff 精読 + 検証で各周を受け入れ）。
+
+**実装（7ファイル・+383/-33）**:
+- (b) fast-fail: stats に `initial_attach_pending` / `child_early_exit`（AtomicBool）を追加。
+  watchdog は初回 attach 中（pending=true **かつ** shm `child_status != READY`）の child exit を
+  respawn せず `child_early_exit` を publish して終了。ready-ack ループがこれを poll し、10秒
+  timeout を待たず即エラー。READY 到達済み crash は従来の respawn 経路（レース回避の二重条件は
+  Fable レビューで発見 → Codex 2周目で修正）
+- (a) retry 可能化: supervisor に `detach_keep_shm()`（`unlink_shm` フラグで shm unlink をスキップ
+  する teardown）を追加。role mismatch / timeout / early-exit の3分岐を `Closed` から
+  `Empty(launch)` 復帰へ変更（unlink 所有権は launch に戻る = PR-1b `c436a22` フリップ前提の
+  再設計）。teardown が書いた `CONTROL_QUIT` は新 helper `reset_control_run` で `CONTROL_RUN` へ
+  戻す（残留すると次 incarnation の child が即終了する）。`open_shared` 失敗・supervisor spawn
+  失敗は真の daemon 破損なので `Closed` のまま
+- (e) エラーコード細分化: `WrapError::OutProcAttachFailed`（retryable）/ `OutProcSlotClosed`
+  （恒久）を追加し、`wrap_err_to_protocol` で `OUTPROC_ATTACH_FAILED` / `OUTPROC_SLOT_CLOSED` に
+  分離（#405 `CLAP_NOT_LOADED` の前例に倣う）。TS 側が機械判別可能に
+- transport: `CHILD_STATUS_LOAD_FAILED` の decision record コメントを PR-1c 実装後の実態に更新
+
+**テスト**:
+- fast-fail unit（`exit 1` スタブ・実プラグイン不要）: 5秒未満で `OutProcAttachFailed` +
+  slot Empty + shm 残存 + control RUN を検証
+- retry unit（role mismatch 経由・`exec sleep 20` スタブ + テスト側 `publish_child_ready` 注入）:
+  1回目失敗 → 同一 slot で2回目 Active 成功。同期合図は `current_child_pid` 遷移
+  （Loading 観測だと `reset_child_starting` に READY が wipe される flake window → Fable 指摘で修正）
+- gated E2E ×2（effect / instrument・実機）: typo path → 即エラー（<10s）→ 正しい path 再送 →
+  成功・音声処理確認。**実機 RUN 済み**（effect 2.59s / instrument 2.75s PASS）
+- 回帰: post-READY crash respawn テスト（lib）+ kill-test gated 実機 RUN（respawn 復帰・
+  ratio 0.50000・measurement_invalid false）PASS
+- fail-before/pass-after 変異実証: early-exit チェック無効化 → fast-fail テスト failure（10s 退行）、
+  role-mismatch arm を Closed 化 → retry テスト failure を確認後、復元して green
+- フルスイート: effect / instrument 各 feature 全テスト + sandbox 49 + clippy 3本 + gated compile
+  全パス（ホスト実行）
+
+**次**: PR 作成 → /simplify → /code:pr-review-team → bot review → PR-2（共存）へ
+
 ### 6.254 feat(daemon): 実際の post-boot attach #431 PR-1b (Jul 14, 2026)
 
 **Date**: 2026-07-14

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -73,6 +73,12 @@ pub enum WrapError {
     /// out-of-process instrument の runtime failure。
     #[error("out-of-process instrument runtime error: {0}")]
     OutProcInstrument(String),
+    /// Attach failed after child launch but the shm slot was restored and may be retried.
+    #[error("out-of-process attach failed: {0}")]
+    OutProcAttachFailed(String),
+    /// The OOP slot is permanently closed (startup infrastructure failure).
+    #[error("out-of-process slot closed: {0}")]
+    OutProcSlotClosed(String),
 }
 
 /// 共有可能なエンジン wrapper。
@@ -238,8 +244,8 @@ pub(crate) struct ChildLaunch {
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
 impl Drop for ChildLaunch {
     fn drop(&mut self) {
-        // cleanup_shm_on_drop=true は「この launch が unlink の唯一の所有者」を意味する
-        // （supervisor へ所有権が移った経路は flag を false に倒す）。よって NotFound を含む
+        // cleanup_shm_on_drop=true は retryable attach failure 後を含め、この launch が unlink の
+        // 唯一の所有者であることを意味する。よって NotFound を含む
         // あらゆる失敗が異常であり、無条件で warn する。
         if self.cleanup_shm_on_drop {
             if let Err(error) = std::fs::remove_file(&self.shm_path) {
@@ -603,7 +609,7 @@ impl EngineWrap {
     /// shm → adapter → stream までを daemon boot 時に構築し、child supervisor は初回
     /// `LoadPlugin(role=effect)` まで遅延する。
     #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
-    fn start_outproc_effect_post_boot(
+    pub fn start_outproc_effect_post_boot(
         cfg: crate::outproc_effect::OutProcEffectConfig,
     ) -> Result<(Arc<Self>, StreamGuard), WrapError> {
         use crate::outproc_effect::{
@@ -713,7 +719,7 @@ impl EngineWrap {
         not(feature = "link-audio"),
         not(feature = "outproc-effect")
     ))]
-    fn start_outproc_instrument_post_boot(
+    pub fn start_outproc_instrument_post_boot(
         cfg: crate::outproc_instrument::OutProcInstrumentConfig,
     ) -> Result<(Arc<Self>, StreamGuard), WrapError> {
         use crate::outproc_instrument::{
@@ -1003,8 +1009,8 @@ impl EngineWrap {
                 )));
             }
             ChildSlot::Closed => {
-                return Err(outproc_runtime_error(
-                    "outproc child slot is closed after an unrecoverable attach failure",
+                return Err(WrapError::OutProcSlotClosed(
+                    "outproc child slot is closed after an unrecoverable attach failure".into(),
                 ));
             }
             ChildSlot::Empty(_) => {}
@@ -1041,6 +1047,15 @@ impl EngineWrap {
         // readiness を初期化し、前 incarnation の READY を誤認しない。
         unsafe { orbit_audio_sandbox::transport::reset_child_starting(region) };
 
+        // Set before spawn so an immediately-exiting child cannot race into normal respawn.
+        launch
+            .stats
+            .initial_attach_pending
+            .store(true, Ordering::Release);
+        launch
+            .stats
+            .child_early_exit
+            .store(false, Ordering::Release);
         let first_child = match spawn_outproc_child(&launch, &path, plugin_id.as_deref()) {
             Ok(child) => child,
             Err(error) => {
@@ -1086,30 +1101,45 @@ impl EngineWrap {
             if status == orbit_audio_sandbox::transport::CHILD_STATUS_READY {
                 let flags = unsafe { (*region).child_flags.load(Ordering::Acquire) };
                 if !outproc_role_matches(flags) {
-                    // supervisor drop の teardown が shm を unlink する。launch の fallback は解除。
-                    drop(supervisor);
-                    launch.cleanup_shm_on_drop = false;
+                    supervisor.detach_keep_shm();
+                    // teardown wrote QUIT; the retry child must start in RUN mode.
+                    unsafe { orbit_audio_sandbox::transport::reset_control_run(region) };
                     let mut slot = child_slot
                         .lock()
                         .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
                     debug_assert_slot_loading(&slot);
-                    *slot = ChildSlot::Closed;
-                    return Err(outproc_runtime_error(format!(
+                    *slot = ChildSlot::Empty(launch);
+                    return Err(WrapError::OutProcAttachFailed(format!(
                         "loaded plugin role does not match daemon role (child_flags={flags:#x})"
                     )));
                 }
+                launch
+                    .stats
+                    .initial_attach_pending
+                    .store(false, Ordering::Release);
                 break;
             }
-            if std::time::Instant::now() >= deadline {
-                // supervisor drop の teardown が shm を unlink する。launch の fallback は解除。
-                drop(supervisor);
-                launch.cleanup_shm_on_drop = false;
+            if launch.stats.child_early_exit.load(Ordering::Acquire) {
+                supervisor.detach_keep_shm();
+                unsafe { orbit_audio_sandbox::transport::reset_control_run(region) };
                 let mut slot = child_slot
                     .lock()
                     .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
                 debug_assert_slot_loading(&slot);
-                *slot = ChildSlot::Closed;
-                return Err(outproc_runtime_error(format!(
+                *slot = ChildSlot::Empty(launch);
+                return Err(WrapError::OutProcAttachFailed(
+                    "child exited before publishing READY".into(),
+                ));
+            }
+            if std::time::Instant::now() >= deadline {
+                supervisor.detach_keep_shm();
+                unsafe { orbit_audio_sandbox::transport::reset_control_run(region) };
+                let mut slot = child_slot
+                    .lock()
+                    .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
+                debug_assert_slot_loading(&slot);
+                *slot = ChildSlot::Empty(launch);
+                return Err(WrapError::OutProcAttachFailed(format!(
                     "timed out waiting {:?} for child READY",
                     CHILD_READY_TIMEOUT
                 )));
@@ -2863,13 +2893,123 @@ mod outproc_load_error_test_support {
     fn write_slow_child_script(unique_path: &impl Fn() -> PathBuf) -> PathBuf {
         use std::os::unix::fs::PermissionsExt;
         let script_path = unique_path().with_extension("sh");
-        std::fs::write(&script_path, "#!/bin/sh\nsleep 20\n").expect("write slow child script");
+        std::fs::write(&script_path, "#!/bin/sh\nexec sleep 20\n")
+            .expect("write slow child script");
         let mut perms = std::fs::metadata(&script_path)
             .expect("stat slow child script")
             .permissions();
         perms.set_mode(0o755);
         std::fs::set_permissions(&script_path, perms).expect("chmod slow child script");
         script_path
+    }
+
+    fn write_exit_child_script(unique_path: &impl Fn() -> PathBuf) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let script_path = unique_path().with_extension("sh");
+        std::fs::write(&script_path, "#!/bin/sh\nexit 1\n").expect("write exit child script");
+        let mut perms = std::fs::metadata(&script_path)
+            .expect("stat exit script")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).expect("chmod exit script");
+        script_path
+    }
+
+    pub(super) fn early_exit_fast_fails_and_keeps_retry_shm(
+        unique_path: impl Fn() -> PathBuf,
+        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        plugin_path: &str,
+    ) {
+        let shm_path = unique_path();
+        let _ = std::fs::remove_file(&shm_path);
+        let mmap = orbit_audio_sandbox::create_shared(&shm_path).expect("create shared memory");
+        let child_exe = write_exit_child_script(&unique_path);
+        let stats = OutProcChildStats::new();
+        let (wrap, slot) = inject(
+            ChildSlot::Empty(child_launch(shm_path.clone(), child_exe.clone(), stats)),
+            OutProcChildStats::new(),
+        );
+        let started = std::time::Instant::now();
+        let error = match wrap.load_outproc_plugin(PathBuf::from(plugin_path), None) {
+            Ok(_) => panic!("immediately exiting child must fail attach"),
+            Err(error) => error,
+        };
+        assert!(
+            matches!(error, WrapError::OutProcAttachFailed(ref msg) if msg.contains("exited before publishing READY"))
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "early exit waited too long"
+        );
+        assert!(matches!(*slot.lock().unwrap(), ChildSlot::Empty(_)));
+        assert!(shm_path.exists(), "retry shm must remain linked");
+        let region = orbit_audio_sandbox::region_ptr(&mmap);
+        assert_eq!(
+            unsafe { (*region).control.load(std::sync::atomic::Ordering::Acquire) },
+            orbit_audio_sandbox::CONTROL_RUN
+        );
+        let _ = std::fs::remove_file(child_exe);
+    }
+
+    pub(super) fn role_mismatch_retries_same_slot(
+        unique_path: impl Fn() -> PathBuf,
+        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        plugin_path: &str,
+        wrong_has_audio_input: bool,
+        correct_has_audio_input: bool,
+    ) {
+        let shm_path = unique_path();
+        let _ = std::fs::remove_file(&shm_path);
+        let mmap = orbit_audio_sandbox::create_shared(&shm_path).expect("create shared memory");
+        let child_exe = write_slow_child_script(&unique_path);
+        let stats = OutProcChildStats::new();
+        let (wrap, slot) = inject(
+            ChildSlot::Empty(child_launch(
+                shm_path.clone(),
+                child_exe.clone(),
+                stats.clone(),
+            )),
+            stats.clone(),
+        );
+        for (attempt, has_input) in [(1, wrong_has_audio_input), (2, correct_has_audio_input)] {
+            stats
+                .current_child_pid
+                .store(0, std::sync::atomic::Ordering::Relaxed);
+            let wrap_call = wrap.clone();
+            let path = PathBuf::from(plugin_path);
+            let call = std::thread::spawn(move || wrap_call.load_outproc_plugin(path, None));
+            let deadline = std::time::Instant::now() + Duration::from_secs(2);
+            // PID is published after reset_child_starting, so this READY cannot be wiped by it.
+            while stats
+                .current_child_pid
+                .load(std::sync::atomic::Ordering::Relaxed)
+                == 0
+            {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "attempt {attempt} never completed child spawn"
+                );
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            let region = orbit_audio_sandbox::region_ptr(&mmap);
+            unsafe { orbit_audio_sandbox::transport::publish_child_ready(region, has_input) };
+            let result = call.join().expect("load thread panicked");
+            if attempt == 1 {
+                assert!(
+                    matches!(result, Err(WrapError::OutProcAttachFailed(ref msg)) if msg.contains("role does not match"))
+                );
+                assert!(matches!(*slot.lock().unwrap(), ChildSlot::Empty(_)));
+                assert!(shm_path.exists());
+                assert_eq!(
+                    unsafe { (*region).control.load(std::sync::atomic::Ordering::Acquire) },
+                    orbit_audio_sandbox::CONTROL_RUN
+                );
+            } else {
+                result.expect("second attach must reuse Empty slot and succeed");
+                assert!(matches!(*slot.lock().unwrap(), ChildSlot::Active { .. }));
+            }
+        }
+        let _ = std::fs::remove_file(child_exe);
     }
 
     /// Important finding 1: f36e99c の regression guard。`Loading` 中の 2 本目の `LoadPlugin` は、
@@ -2999,7 +3139,9 @@ mod outproc_health_tests {
 
     fn assert_effect_runtime_error_contains(error: WrapError, expected: &str) {
         assert!(
-            matches!(&error, WrapError::OutProcEffect(message) if message.contains(expected)),
+            matches!(&error,
+                WrapError::OutProcEffect(message) | WrapError::OutProcSlotClosed(message)
+                if message.contains(expected)),
             "expected OutProcEffect error containing {expected:?}, got {error:?}"
         );
     }
@@ -3021,6 +3163,26 @@ mod outproc_health_tests {
             wrap_with_child_slot,
             assert_effect_runtime_error_contains,
             "unused-effect.clap",
+        );
+    }
+
+    #[test]
+    fn effect_load_outproc_early_exit_fast_fails_and_keeps_retry_shm() {
+        super::outproc_load_error_test_support::early_exit_fast_fails_and_keeps_retry_shm(
+            crate::outproc_effect::unique_shm_path,
+            wrap_with_child_slot,
+            "exit-effect.clap",
+        );
+    }
+
+    #[test]
+    fn effect_load_outproc_role_mismatch_retries_same_slot() {
+        super::outproc_load_error_test_support::role_mismatch_retries_same_slot(
+            crate::outproc_effect::unique_shm_path,
+            wrap_with_child_slot,
+            "retry-effect.clap",
+            false,
+            true,
         );
     }
 
@@ -3231,7 +3393,9 @@ mod outproc_instrument_health_tests {
 
     fn assert_instrument_runtime_error_contains(error: WrapError, expected: &str) {
         assert!(
-            matches!(&error, WrapError::OutProcInstrument(message) if message.contains(expected)),
+            matches!(&error,
+                WrapError::OutProcInstrument(message) | WrapError::OutProcSlotClosed(message)
+                if message.contains(expected)),
             "expected OutProcInstrument error containing {expected:?}, got {error:?}"
         );
     }
@@ -3253,6 +3417,26 @@ mod outproc_instrument_health_tests {
             wrap_with_child_slot,
             assert_instrument_runtime_error_contains,
             "unused-instrument.clap",
+        );
+    }
+
+    #[test]
+    fn instrument_load_outproc_early_exit_fast_fails_and_keeps_retry_shm() {
+        super::outproc_load_error_test_support::early_exit_fast_fails_and_keeps_retry_shm(
+            crate::outproc_instrument::unique_shm_path,
+            wrap_with_child_slot,
+            "exit-instrument.clap",
+        );
+    }
+
+    #[test]
+    fn instrument_load_outproc_role_mismatch_retries_same_slot() {
+        super::outproc_load_error_test_support::role_mismatch_retries_same_slot(
+            crate::outproc_instrument::unique_shm_path,
+            wrap_with_child_slot,
+            "retry-instrument.clap",
+            true,
+            false,
         );
     }
 

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -7,6 +7,8 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+use std::sync::MutexGuard;
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
 use std::sync::Weak;
 use std::sync::{Arc, Mutex};
 #[cfg(any(
@@ -967,9 +969,7 @@ impl EngineWrap {
                 .ok_or_else(|| outproc_runtime_error("outproc instrument stream is closed"))?
         };
 
-        let mut slot = child_slot
-            .lock()
-            .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
+        let mut slot = lock_child_slot_recovering(&child_slot, "initial state check");
 
         match &*slot {
             ChildSlot::Active {
@@ -1031,9 +1031,7 @@ impl EngineWrap {
         let ready_mmap = match orbit_audio_sandbox::open_shared(&launch.shm_path) {
             Ok(mmap) => mmap,
             Err(error) => {
-                let mut slot = child_slot
-                    .lock()
-                    .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
+                let mut slot = lock_child_slot_recovering(&child_slot, "open_shared failure");
                 debug_assert_slot_loading(&slot);
                 *slot = ChildSlot::Closed;
                 return Err(outproc_runtime_error(format!(
@@ -1060,9 +1058,7 @@ impl EngineWrap {
             Ok(child) => child,
             Err(error) => {
                 let child_exe = launch.child_exe.clone();
-                let mut slot = child_slot
-                    .lock()
-                    .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
+                let mut slot = lock_child_slot_recovering(&child_slot, "child spawn failure");
                 debug_assert_slot_loading(&slot);
                 *slot = ChildSlot::Empty(launch);
                 return Err(outproc_runtime_error(format!(
@@ -1083,9 +1079,8 @@ impl EngineWrap {
                     // spawn_outproc_supervisor はエラー時に自身の cleanup で shm を unlink して返るため、
                     // この slot は再利用不能。launch の fallback unlink は解除。
                     launch.cleanup_shm_on_drop = false;
-                    let mut slot = child_slot
-                        .lock()
-                        .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
+                    let mut slot =
+                        lock_child_slot_recovering(&child_slot, "supervisor spawn failure");
                     debug_assert_slot_loading(&slot);
                     *slot = ChildSlot::Closed;
                     return Err(outproc_runtime_error(format!(
@@ -1145,9 +1140,7 @@ impl EngineWrap {
         let summary = outproc_plugin_summary(&path, &plugin_id);
         // Active supervisor が以後の unlink を所有する。local launch の fallback cleanup は解除する。
         launch.cleanup_shm_on_drop = false;
-        let mut slot = child_slot
-            .lock()
-            .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
+        let mut slot = lock_child_slot_recovering(&child_slot, "successful attach");
         debug_assert_slot_loading(&slot);
         *slot = ChildSlot::Active {
             path,
@@ -2083,6 +2076,19 @@ fn debug_assert_slot_loading(slot: &ChildSlot) {
     );
 }
 
+/// child slot の poison は attach state machine の停止理由にせず、唯一の書き手である本関数が
+/// 回復して本来の遷移を完遂する。放置すると Loading/Closed/Empty の中間状態が恒久化する。
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+fn lock_child_slot_recovering<'a>(
+    child_slot: &'a Mutex<ChildSlot>,
+    site: &'static str,
+) -> MutexGuard<'a, ChildSlot> {
+    child_slot.lock().unwrap_or_else(|poisoned| {
+        tracing::error!("child slot mutex poisoned during {site}; recovering");
+        poisoned.into_inner()
+    })
+}
+
 /// retryable な attach 失敗（role mismatch / early-exit / timeout）の共通終端処理。
 /// supervisor を unlink 抜きで teardown し（unlink 所有権は launch に戻る）、teardown が
 /// 書いた QUIT を RUN へ戻して、slot を retry 可能な `Empty(launch)` に復帰させる。
@@ -2101,13 +2107,7 @@ fn retryable_attach_failure(
     supervisor.detach_keep_shm();
     // teardown が CONTROL_QUIT を書いたので、retry する child は RUN モードで起動する必要がある。
     unsafe { orbit_audio_sandbox::transport::reset_control_run(region) };
-    let mut slot = child_slot.lock().unwrap_or_else(|poisoned| {
-        // poison はロック保持中の他 thread panic を意味するが、Loading→X の書き手は本関数のみ
-        // なので回復して Empty 復帰を完遂する（放置すると slot が Loading で恒久スタックし、
-        // 以後の LoadPlugin が偽の「in progress」で永久に失敗する）。
-        tracing::error!("child slot mutex poisoned during retryable attach failure; recovering");
-        poisoned.into_inner()
-    });
+    let mut slot = lock_child_slot_recovering(child_slot, "retryable attach failure");
     debug_assert_slot_loading(&slot);
     *slot = ChildSlot::Empty(launch);
     WrapError::OutProcAttachFailed(message)
@@ -2722,6 +2722,44 @@ mod outproc_load_error_test_support {
         );
     }
 
+    #[cfg(feature = "outproc-effect")]
+    pub(super) fn poisoned_slot_open_shared_failure_recovers_to_closed(
+        unique_path: impl Fn() -> PathBuf,
+        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        plugin_path: &str,
+    ) {
+        let shm_path = unique_path();
+        let _ = std::fs::remove_file(&shm_path);
+        let stats = OutProcChildStats::new();
+        let (wrap, child_slot) = inject(
+            ChildSlot::Empty(child_launch(
+                shm_path,
+                PathBuf::from("unused-child-executable"),
+                stats.clone(),
+            )),
+            stats,
+        );
+        let poison_slot = child_slot.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = poison_slot.lock().expect("lock slot for poison");
+            panic!("intentional child slot poison");
+        })
+        .join();
+
+        let error = match wrap.load_outproc_plugin(PathBuf::from(plugin_path), None) {
+            Ok(_) => panic!("missing shm must take the Closed terminal transition after recovery"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            WrapError::OutProcEffect(_) | WrapError::OutProcInstrument(_)
+        ));
+        assert!(matches!(
+            *child_slot.lock().unwrap_or_else(|p| p.into_inner()),
+            ChildSlot::Closed
+        ));
+    }
+
     pub(super) fn spawn_failure_restores_empty_for_retry(
         unique_path: impl Fn() -> PathBuf,
         inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
@@ -3177,6 +3215,15 @@ mod outproc_health_tests {
             wrap_with_child_slot,
             assert_effect_runtime_error_contains,
             "unused-effect.clap",
+        );
+    }
+
+    #[test]
+    fn effect_load_outproc_poisoned_slot_recovers_to_closed_on_open_shared_failure() {
+        super::outproc_load_error_test_support::poisoned_slot_open_shared_failure_recovers_to_closed(
+            crate::outproc_effect::unique_shm_path,
+            wrap_with_child_slot,
+            "poisoned-effect.clap",
         );
     }
 

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -73,10 +73,10 @@ pub enum WrapError {
     /// out-of-process instrument の runtime failure。
     #[error("out-of-process instrument runtime error: {0}")]
     OutProcInstrument(String),
-    /// Attach failed after child launch but the shm slot was restored and may be retried.
+    /// child launch 後の attach が失敗したが、shm slot は復元済みで再試行可能。
     #[error("out-of-process attach failed: {0}")]
     OutProcAttachFailed(String),
-    /// The OOP slot is permanently closed (startup infrastructure failure).
+    /// OOP slot が永久に closed（起動インフラの失敗）。
     #[error("out-of-process slot closed: {0}")]
     OutProcSlotClosed(String),
 }
@@ -1047,7 +1047,7 @@ impl EngineWrap {
         // readiness を初期化し、前 incarnation の READY を誤認しない。
         unsafe { orbit_audio_sandbox::transport::reset_child_starting(region) };
 
-        // Set before spawn so an immediately-exiting child cannot race into normal respawn.
+        // spawn 前にセットしておくことで、即座に終了する child が通常の respawn 経路に紛れ込むのを防ぐ。
         launch
             .stats
             .initial_attach_pending
@@ -2097,13 +2097,17 @@ fn retryable_attach_failure(
     launch: ChildLaunch,
     message: String,
 ) -> WrapError {
+    tracing::warn!("outproc attach failed (retryable): {message}");
     supervisor.detach_keep_shm();
-    // teardown wrote QUIT; the retry child must start in RUN mode.
+    // teardown が CONTROL_QUIT を書いたので、retry する child は RUN モードで起動する必要がある。
     unsafe { orbit_audio_sandbox::transport::reset_control_run(region) };
-    let mut slot = match child_slot.lock() {
-        Ok(slot) => slot,
-        Err(_) => return outproc_runtime_error("child slot mutex poisoned"),
-    };
+    let mut slot = child_slot.lock().unwrap_or_else(|poisoned| {
+        // poison はロック保持中の他 thread panic を意味するが、Loading→X の書き手は本関数のみ
+        // なので回復して Empty 復帰を完遂する（放置すると slot が Loading で恒久スタックし、
+        // 以後の LoadPlugin が偽の「in progress」で永久に失敗する）。
+        tracing::error!("child slot mutex poisoned during retryable attach failure; recovering");
+        poisoned.into_inner()
+    });
     debug_assert_slot_loading(&slot);
     *slot = ChildSlot::Empty(launch);
     WrapError::OutProcAttachFailed(message)
@@ -2999,7 +3003,7 @@ mod outproc_load_error_test_support {
             let path = PathBuf::from(plugin_path);
             let call = std::thread::spawn(move || wrap_call.load_outproc_plugin(path, None));
             let deadline = std::time::Instant::now() + Duration::from_secs(2);
-            // PID is published after reset_child_starting, so this READY cannot be wiped by it.
+            // PID は reset_child_starting の後に publish されるため、この READY はそれによって消されない。
             while stats
                 .current_child_pid
                 .load(std::sync::atomic::Ordering::Relaxed)

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -1101,17 +1101,15 @@ impl EngineWrap {
             if status == orbit_audio_sandbox::transport::CHILD_STATUS_READY {
                 let flags = unsafe { (*region).child_flags.load(Ordering::Acquire) };
                 if !outproc_role_matches(flags) {
-                    supervisor.detach_keep_shm();
-                    // teardown wrote QUIT; the retry child must start in RUN mode.
-                    unsafe { orbit_audio_sandbox::transport::reset_control_run(region) };
-                    let mut slot = child_slot
-                        .lock()
-                        .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
-                    debug_assert_slot_loading(&slot);
-                    *slot = ChildSlot::Empty(launch);
-                    return Err(WrapError::OutProcAttachFailed(format!(
-                        "loaded plugin role does not match daemon role (child_flags={flags:#x})"
-                    )));
+                    return Err(retryable_attach_failure(
+                        supervisor,
+                        region,
+                        &child_slot,
+                        launch,
+                        format!(
+                            "loaded plugin role does not match daemon role (child_flags={flags:#x})"
+                        ),
+                    ));
                 }
                 launch
                     .stats
@@ -1120,29 +1118,25 @@ impl EngineWrap {
                 break;
             }
             if launch.stats.child_early_exit.load(Ordering::Acquire) {
-                supervisor.detach_keep_shm();
-                unsafe { orbit_audio_sandbox::transport::reset_control_run(region) };
-                let mut slot = child_slot
-                    .lock()
-                    .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
-                debug_assert_slot_loading(&slot);
-                *slot = ChildSlot::Empty(launch);
-                return Err(WrapError::OutProcAttachFailed(
+                return Err(retryable_attach_failure(
+                    supervisor,
+                    region,
+                    &child_slot,
+                    launch,
                     "child exited before publishing READY".into(),
                 ));
             }
             if std::time::Instant::now() >= deadline {
-                supervisor.detach_keep_shm();
-                unsafe { orbit_audio_sandbox::transport::reset_control_run(region) };
-                let mut slot = child_slot
-                    .lock()
-                    .map_err(|_| outproc_runtime_error("child slot mutex poisoned"))?;
-                debug_assert_slot_loading(&slot);
-                *slot = ChildSlot::Empty(launch);
-                return Err(WrapError::OutProcAttachFailed(format!(
-                    "timed out waiting {:?} for child READY",
-                    CHILD_READY_TIMEOUT
-                )));
+                return Err(retryable_attach_failure(
+                    supervisor,
+                    region,
+                    &child_slot,
+                    launch,
+                    format!(
+                        "timed out waiting {:?} for child READY",
+                        CHILD_READY_TIMEOUT
+                    ),
+                ));
             }
             std::thread::sleep(CHILD_READY_POLL);
         }
@@ -2087,6 +2081,32 @@ fn debug_assert_slot_loading(slot: &ChildSlot) {
         "load_outproc_plugin: slot must still be Loading (only this function \
          transitions Loading -> Active/Closed/Empty)"
     );
+}
+
+/// retryable な attach 失敗（role mismatch / early-exit / timeout）の共通終端処理。
+/// supervisor を unlink 抜きで teardown し（unlink 所有権は launch に戻る）、teardown が
+/// 書いた QUIT を RUN へ戻して、slot を retry 可能な `Empty(launch)` に復帰させる。
+///
+/// SAFETY 前提: `region` は呼び出し元 scope で生存する `ready_mmap` を指すこと
+/// （`load_outproc_plugin` の ready-ack ループからのみ呼ばれる）。
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+fn retryable_attach_failure(
+    supervisor: OutProcChildSupervisor,
+    region: *mut orbit_audio_sandbox::transport::SharedRegion,
+    child_slot: &Mutex<ChildSlot>,
+    launch: ChildLaunch,
+    message: String,
+) -> WrapError {
+    supervisor.detach_keep_shm();
+    // teardown wrote QUIT; the retry child must start in RUN mode.
+    unsafe { orbit_audio_sandbox::transport::reset_control_run(region) };
+    let mut slot = match child_slot.lock() {
+        Ok(slot) => slot,
+        Err(_) => return outproc_runtime_error("child slot mutex poisoned"),
+    };
+    debug_assert_slot_loading(&slot);
+    *slot = ChildSlot::Empty(launch);
+    WrapError::OutProcAttachFailed(message)
 }
 
 #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]

--- a/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
@@ -488,11 +488,11 @@ impl EffectChildSupervisor {
                         Ok(Some(_)) if shutdown_thread.load(Ordering::Acquire) => break,
                         Ok(Some(status)) => {
                             try_wait_errors = 0;
-                            // READY publication races with the host clearing initial_attach_pending:
-                            // a child can publish READY and then crash in that window.  Treating it
-                            // as an early attach exit would stop this watchdog, while the host can
-                            // still observe READY and install a dead Active slot.  Only pre-READY
-                            // exits fast-fail; post-READY exits must use the normal respawn path.
+                            // READY の publish は host が initial_attach_pending をクリアする処理と競合する:
+                            // child は READY を publish した直後にその窓で crash しうる。これを attach 初期の
+                            // 早期 exit として扱うと本 watchdog が停止してしまう一方、host は READY を観測して
+                            // 死んだ Active slot を install しうる。pre-READY の exit のみ fast-fail とし、
+                            // post-READY の exit は通常の respawn 経路を使わなければならない。
                             if stats.initial_attach_pending.load(Ordering::Acquire)
                                 && unsafe {
                                     (*region).child_status.load(Ordering::Acquire)
@@ -594,7 +594,8 @@ impl EffectChildSupervisor {
         })
     }
 
-    /// Stop/reap the child but leave shm unlink ownership with `ChildLaunch` for a retry.
+    /// shm の unlink 所有権を `ChildLaunch` に残したまま supervisor を teardown する（retry 用）。
+    /// 本体は `unlink_shm` を倒すだけで、stop/reap は値渡しで consume した self の即時 Drop が行う。
     pub fn detach_keep_shm(mut self) {
         self.unlink_shm = false;
     }
@@ -883,12 +884,12 @@ mod tests {
     fn supervisor_respawns_child_on_unexpected_exit() {
         let shm = make_shm();
         let stats = OutProcEffectStats::new();
-        // Regression for #441: READY may be visible while the host has not yet cleared this flag.
-        // The watchdog must respawn rather than taking the initial-attach fast-fail branch.
+        // #441 の regression: host がまだこのフラグをクリアしていない間も READY は見えうる。
+        // watchdog は initial-attach fast-fail 分岐ではなく respawn を行わなければならない。
         stats.initial_attach_pending.store(true, Ordering::Release);
         let mmap = open_shared(&shm).expect("open shm to publish READY");
         let region = region_ptr(&mmap);
-        // SAFETY: mmap owns the live shared region for this test.
+        // SAFETY: mmap はこのテストの生存する shared region を所有する。
         unsafe { orbit_audio_sandbox::transport::publish_child_ready(region, true) };
         let first = Command::new("sleep")
             .arg("0.2")

--- a/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
@@ -177,6 +177,10 @@ fn default_child_exe(format: PluginFormat) -> Result<PathBuf, String> {
 /// reader は daemon の accessor / gated harness（slot 数決定の `stale` / RT 健全性）。
 #[derive(Default)]
 pub struct OutProcEffectStats {
+    /// 初回 attach の READY 待ち中。watchdog はこの間の child exit を respawn せず fast-fail へ渡す。
+    pub initial_attach_pending: AtomicBool,
+    /// 初回 attach 中に child が exit したことを watchdog が publish する。
+    pub child_early_exit: AtomicBool,
     /// child から fresh な出力を読めた callback 数。
     pub fresh: AtomicU64,
     /// child が間に合わず repeat-previous した callback 数（slot 数決定の主指標の一つ）。
@@ -409,6 +413,7 @@ pub struct EffectChildSupervisor {
     shutdown: Arc<AtomicBool>,
     watchdog: Option<JoinHandle<()>>,
     shm_path: PathBuf,
+    unlink_shm: bool,
 }
 
 impl EffectChildSupervisor {
@@ -483,6 +488,21 @@ impl EffectChildSupervisor {
                         Ok(Some(_)) if shutdown_thread.load(Ordering::Acquire) => break,
                         Ok(Some(status)) => {
                             try_wait_errors = 0;
+                            // READY publication races with the host clearing initial_attach_pending:
+                            // a child can publish READY and then crash in that window.  Treating it
+                            // as an early attach exit would stop this watchdog, while the host can
+                            // still observe READY and install a dead Active slot.  Only pre-READY
+                            // exits fast-fail; post-READY exits must use the normal respawn path.
+                            if stats.initial_attach_pending.load(Ordering::Acquire)
+                                && unsafe {
+                                    (*region).child_status.load(Ordering::Acquire)
+                                        != orbit_audio_sandbox::transport::CHILD_STATUS_READY
+                                }
+                            {
+                                tracing::warn!("orbit-clap-effect-child exited during initial attach ({status})");
+                                stats.child_early_exit.store(true, Ordering::Release);
+                                break;
+                            }
                             tracing::warn!(
                                 "orbit-clap-effect-child が異常終了（{status}）→ respawn する"
                             );
@@ -570,7 +590,13 @@ impl EffectChildSupervisor {
             shutdown,
             watchdog: Some(watchdog),
             shm_path,
+            unlink_shm: true,
         })
+    }
+
+    /// Stop/reap the child but leave shm unlink ownership with `ChildLaunch` for a retry.
+    pub fn detach_keep_shm(mut self) {
+        self.unlink_shm = false;
     }
 }
 
@@ -587,9 +613,11 @@ impl Drop for EffectChildSupervisor {
         }
         // 3. shm unlink（この時点で host mmap は stream drop で、ctl mmap は watchdog 終了で消えており
         //    どのプロセスもこの shm を map していない）。
-        if let Err(e) = std::fs::remove_file(&self.shm_path) {
-            // 既に消えている等は無害（warn のみ・teardown は続行）。
-            tracing::warn!("OOP effect shm 削除失敗 {:?}: {e}", self.shm_path);
+        if self.unlink_shm {
+            if let Err(e) = std::fs::remove_file(&self.shm_path) {
+                // 既に消えている等は無害（warn のみ・teardown は続行）。
+                tracing::warn!("OOP effect shm 削除失敗 {:?}: {e}", self.shm_path);
+            }
         }
     }
 }
@@ -855,6 +883,13 @@ mod tests {
     fn supervisor_respawns_child_on_unexpected_exit() {
         let shm = make_shm();
         let stats = OutProcEffectStats::new();
+        // Regression for #441: READY may be visible while the host has not yet cleared this flag.
+        // The watchdog must respawn rather than taking the initial-attach fast-fail branch.
+        stats.initial_attach_pending.store(true, Ordering::Release);
+        let mmap = open_shared(&shm).expect("open shm to publish READY");
+        let region = region_ptr(&mmap);
+        // SAFETY: mmap owns the live shared region for this test.
+        unsafe { orbit_audio_sandbox::transport::publish_child_ready(region, true) };
         let first = Command::new("sleep")
             .arg("0.2")
             .spawn()

--- a/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
@@ -117,6 +117,8 @@ fn default_child_exe() -> Result<PathBuf, String> {
 
 #[derive(Default)]
 pub struct OutProcInstrumentStats {
+    pub initial_attach_pending: AtomicBool,
+    pub child_early_exit: AtomicBool,
     pub fresh: AtomicU64,
     pub callback_count: AtomicU64,
     pub respawn_count: AtomicU64,
@@ -329,6 +331,7 @@ pub struct InstrumentChildSupervisor {
     shutdown: Arc<AtomicBool>,
     watchdog: Option<JoinHandle<()>>,
     shm_path: PathBuf,
+    unlink_shm: bool,
 }
 
 impl InstrumentChildSupervisor {
@@ -413,6 +416,20 @@ impl InstrumentChildSupervisor {
                         Ok(Some(_)) if shutdown_thread.load(Ordering::Acquire) => break,
                         Ok(Some(status)) => {
                             try_wait_errors = 0;
+                            // READY publication races with the host clearing initial_attach_pending:
+                            // a child can publish READY and then crash in that window.  Only a
+                            // pre-READY exit is an attach fast-fail; a post-READY exit must reach
+                            // the normal respawn path or the host could install a dead Active slot.
+                            if stats.initial_attach_pending.load(Ordering::Acquire)
+                                && unsafe {
+                                    (*region).child_status.load(Ordering::Acquire)
+                                        != orbit_audio_sandbox::transport::CHILD_STATUS_READY
+                                }
+                            {
+                                tracing::warn!("orbit-clap-instrument-child exited during initial attach ({status})");
+                                stats.child_early_exit.store(true, Ordering::Release);
+                                break;
+                            }
                             tracing::warn!(
                                 "orbit-clap-instrument-child exited ({status}); respawning"
                             );
@@ -508,7 +525,13 @@ impl InstrumentChildSupervisor {
             shutdown,
             watchdog: Some(watchdog),
             shm_path,
+            unlink_shm: true,
         })
+    }
+
+    /// Stop/reap the child but leave shm unlink ownership with `ChildLaunch` for a retry.
+    pub fn detach_keep_shm(mut self) {
+        self.unlink_shm = false;
     }
 }
 
@@ -520,11 +543,13 @@ impl Drop for InstrumentChildSupervisor {
                 tracing::error!("outproc instrument watchdog panicked during shutdown");
             }
         }
-        if let Err(error) = std::fs::remove_file(&self.shm_path) {
-            tracing::warn!(
-                "OOP instrument shm removal failed {:?}: {error}",
-                self.shm_path
-            );
+        if self.unlink_shm {
+            if let Err(error) = std::fs::remove_file(&self.shm_path) {
+                tracing::warn!(
+                    "OOP instrument shm removal failed {:?}: {error}",
+                    self.shm_path
+                );
+            }
         }
     }
 }
@@ -952,6 +977,12 @@ mod tests {
     fn supervisor_respawns_child_on_unexpected_exit() {
         let shm = make_shm();
         let stats = OutProcInstrumentStats::new();
+        // Regression for #441: a post-READY crash while attach is still pending must respawn.
+        stats.initial_attach_pending.store(true, Ordering::Release);
+        let mmap = open_shared(&shm).expect("open shm to publish READY");
+        let region = region_ptr(&mmap);
+        // SAFETY: mmap owns the live shared region for this test.
+        unsafe { orbit_audio_sandbox::transport::publish_child_ready(region, false) };
         let first = Command::new("sleep")
             .arg("0.2")
             .spawn()

--- a/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
@@ -416,10 +416,10 @@ impl InstrumentChildSupervisor {
                         Ok(Some(_)) if shutdown_thread.load(Ordering::Acquire) => break,
                         Ok(Some(status)) => {
                             try_wait_errors = 0;
-                            // READY publication races with the host clearing initial_attach_pending:
-                            // a child can publish READY and then crash in that window.  Only a
-                            // pre-READY exit is an attach fast-fail; a post-READY exit must reach
-                            // the normal respawn path or the host could install a dead Active slot.
+                            // READY の publish は host が initial_attach_pending をクリアする処理と競合する:
+                            // child は READY を publish した直後にその窓で crash しうる。pre-READY の exit の
+                            // みが attach fast-fail であり、post-READY の exit は通常の respawn 経路に到達
+                            // しなければならない（さもないと host が死んだ Active slot を install しうる）。
                             if stats.initial_attach_pending.load(Ordering::Acquire)
                                 && unsafe {
                                     (*region).child_status.load(Ordering::Acquire)
@@ -529,7 +529,8 @@ impl InstrumentChildSupervisor {
         })
     }
 
-    /// Stop/reap the child but leave shm unlink ownership with `ChildLaunch` for a retry.
+    /// shm の unlink 所有権を `ChildLaunch` に残したまま supervisor を teardown する（retry 用）。
+    /// 本体は `unlink_shm` を倒すだけで、stop/reap は値渡しで consume した self の即時 Drop が行う。
     pub fn detach_keep_shm(mut self) {
         self.unlink_shm = false;
     }
@@ -977,11 +978,11 @@ mod tests {
     fn supervisor_respawns_child_on_unexpected_exit() {
         let shm = make_shm();
         let stats = OutProcInstrumentStats::new();
-        // Regression for #441: a post-READY crash while attach is still pending must respawn.
+        // #441 の regression: attach 保留中の post-READY crash は respawn しなければならない。
         stats.initial_attach_pending.store(true, Ordering::Release);
         let mmap = open_shared(&shm).expect("open shm to publish READY");
         let region = region_ptr(&mmap);
-        // SAFETY: mmap owns the live shared region for this test.
+        // SAFETY: mmap はこのテストの生存する shared region を所有する。
         unsafe { orbit_audio_sandbox::transport::publish_child_ready(region, false) };
         let first = Command::new("sleep")
             .arg("0.2")

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -1027,6 +1027,10 @@ fn wrap_err_to_protocol(e: &WrapError) -> ProtocolError {
         WrapError::OutProcInstrument(msg) => {
             ProtocolError::new("OUTPROC_INSTRUMENT_RUNTIME", msg.clone())
         }
+        WrapError::OutProcAttachFailed(msg) => {
+            ProtocolError::new("OUTPROC_ATTACH_FAILED", msg.clone())
+        }
+        WrapError::OutProcSlotClosed(msg) => ProtocolError::new("OUTPROC_SLOT_CLOSED", msg.clone()),
     }
 }
 
@@ -1095,6 +1099,18 @@ mod tests {
         assert_eq!(
             wrap_err_to_protocol(&runtime).code,
             "OUTPROC_INSTRUMENT_RUNTIME"
+        );
+    }
+
+    #[test]
+    fn outproc_attach_failure_and_closed_slot_have_distinct_protocol_codes() {
+        assert_eq!(
+            wrap_err_to_protocol(&WrapError::OutProcAttachFailed("retry".into())).code,
+            "OUTPROC_ATTACH_FAILED"
+        );
+        assert_eq!(
+            wrap_err_to_protocol(&WrapError::OutProcSlotClosed("closed".into())).code,
+            "OUTPROC_SLOT_CLOSED"
         );
     }
 

--- a/rust/crates/orbit-audio-daemon/tests/outproc_effect_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_effect_gated.rs
@@ -182,6 +182,33 @@ fn outproc_effect_processes_audio_via_daemon() {
     // _guard drop で teardown（watchdog 停止 → QUIT → reap → unlink）。panic / UB なく完了することを検証。
 }
 
+#[test]
+#[ignore = "#441: needs a real output device + built child binary + test-effect dylib"]
+fn outproc_effect_attach_failure_can_retry_with_correct_plugin() {
+    let (cfg, wav) = setup_test(None);
+    let good_plugin = cfg.plugin.clone();
+    let (engine, _guard) = EngineWrap::start_outproc_effect_post_boot(cfg).expect("start daemon");
+    let started = Instant::now();
+    let error =
+        match engine.load_outproc_plugin(PathBuf::from("/definitely/not/a/plugin.clap"), None) {
+            Ok(_) => panic!("typo plugin must fail"),
+            Err(error) => error,
+        };
+    assert!(matches!(
+        error,
+        orbit_audio_daemon::engine_wrap::WrapError::OutProcAttachFailed(_)
+    ));
+    assert!(started.elapsed() < Duration::from_secs(10));
+    engine
+        .load_outproc_plugin(good_plugin, None)
+        .expect("retry correct plugin");
+    play_sine(&engine, &wav);
+    assert!(wait_until(Duration::from_secs(3), || engine
+        .outproc_effect_stats()
+        .map(|s| s.fresh > 0)
+        .unwrap_or(false)));
+}
+
 // ── kill-test: child SIGKILL → daemon 生存 → respawn → fresh 処理復帰 ─────────────────────────
 #[test]
 #[ignore = "γ M1 PR-C: needs a real output device + built child binary + test-effect dylib (local only)"]

--- a/rust/crates/orbit-audio-daemon/tests/outproc_instrument_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_instrument_gated.rs
@@ -164,6 +164,37 @@ fn outproc_instrument_sounds_via_daemon_note_on_off() {
 }
 
 #[test]
+#[ignore = "#441: needs a real output device + built instrument child + test-synth dylib"]
+fn outproc_instrument_attach_failure_can_retry_with_correct_plugin() {
+    let cfg = setup_test();
+    let good_plugin = cfg.plugin.clone();
+    let plugin_id = cfg.plugin_id.clone();
+    let (engine, _guard) =
+        EngineWrap::start_outproc_instrument_post_boot(cfg).expect("start daemon");
+    let started = Instant::now();
+    let error =
+        match engine.load_outproc_plugin(PathBuf::from("/definitely/not/a/plugin.clap"), None) {
+            Ok(_) => panic!("typo plugin must fail"),
+            Err(error) => error,
+        };
+    assert!(matches!(
+        error,
+        orbit_audio_daemon::engine_wrap::WrapError::OutProcAttachFailed(_)
+    ));
+    assert!(started.elapsed() < Duration::from_secs(10));
+    engine
+        .load_outproc_plugin(good_plugin, plugin_id)
+        .expect("retry correct plugin");
+    engine
+        .plugin_note_on(PROBE_NOTE_KEY, PROBE_NOTE_CHANNEL, 0.8)
+        .expect("note on");
+    assert!(wait_until(Duration::from_secs(3), || engine
+        .outproc_instrument_stats()
+        .map(|s| s.fresh > 0 && s.probe_live_count > 0)
+        .unwrap_or(false)));
+}
+
+#[test]
 #[ignore = "Issue #420 Part 3b: SIGKILL test needs a real output device + built child and synth"]
 fn outproc_instrument_survives_child_kill_and_sounds_again() {
     let (engine, _guard) =

--- a/rust/crates/orbit-audio-sandbox/src/transport.rs
+++ b/rust/crates/orbit-audio-sandbox/src/transport.rs
@@ -88,18 +88,17 @@ pub const CHILD_STATUS_STARTING: u32 = 0;
 /// child が load に成功し、以降 process loop に入る状態。
 pub const CHILD_STATUS_READY: u32 = 1;
 /// **現状は未使用の予約値**（child が load に失敗して終了する直前の状態を表す想定）。
-/// child は load 失敗時 `?` の早期 return でこの値を書かずにそのままプロセス終了する。host は
-/// 現時点では `child_status == STARTING` のまま child が消えたことを即時には判別しない。
+/// child は load 失敗時 `?` の早期 return でこの値を書かずにそのままプロセス終了する。PR-1c (#441)
+/// では watchdog が初回 attach 中の child exit を stats に publish し、host が timeout を待たずに
+/// retryable attach failure として返す。
 ///
 /// **respawn 注意**: shm は daemon 起動時に一度だけ truncate され、respawn（`EffectChildSupervisor`/
 /// `InstrumentChildSupervisor` の watchdog による再起動）は同一 shm を再利用する（再 truncate しない）
 /// ため、一度 READY に達した後の respawn 失敗では `child_status` は STARTING でなく前 incarnation の
 /// READY が残留する。PR-1b（#440）は spawn 直前の `reset_child_starting` による STARTING リセット
 /// のみを実装し、この前 incarnation の READY 残留誤認を解消した。一方、初回 attach 時に child が
-/// `CHILD_STATUS_LOAD_FAILED` を書かず即死するケースの `try_wait` ベース生死判定は PR-1b では実装
-/// しない。そのため child の早期 crash は `CHILD_READY_TIMEOUT`（最大 10s）のタイムアウトとしてのみ
-/// 検出される。この fast-fail 化と、失敗した slot を retry 可能状態へ戻す対応は PR-1c（#441・
-/// Epic #424 DoD ゲート項目）へ移管した。`CHILD_STATUS_LOAD_FAILED` は現状も write 箇所なしの予約値。
+/// `CHILD_STATUS_LOAD_FAILED` は現状も write 箇所なしの予約値であり、early-exit は上記 watchdog
+/// signal で検出する。
 pub const CHILD_STATUS_LOAD_FAILED: u32 = 2;
 
 /// child のロード結果を表す bit flags（PR-431）。bit0 = has_audio_input
@@ -295,6 +294,14 @@ pub unsafe fn reset_child_starting(region: *mut SharedRegion) {
     }
 }
 
+/// attach 失敗後に同じ shm を次の child incarnation へ引き継ぐ前、teardown が書いた QUIT を解除する。
+///
+/// # Safety
+/// `region` は呼び出し元が map 済みの生存 SharedRegion を指していること。
+pub unsafe fn reset_control_run(region: *mut SharedRegion) {
+    unsafe { (*region).control.store(CONTROL_RUN, Ordering::Release) }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -439,6 +446,25 @@ mod tests {
             );
         }
 
+        drop(mmap);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn reset_control_run_rearms_region_after_attach_teardown() {
+        let path = std::env::temp_dir().join(format!(
+            "orbit-sbx-reset-control-{}.shm",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let mmap = create_shared(&path).expect("create");
+        let region = region_ptr(&mmap);
+        // SAFETY: region points into the live mapping created above.
+        unsafe {
+            (*region).control.store(CONTROL_QUIT, Ordering::Release);
+            reset_control_run(region);
+            assert_eq!((*region).control.load(Ordering::Acquire), CONTROL_RUN);
+        }
         drop(mmap);
         let _ = std::fs::remove_file(path);
     }

--- a/rust/crates/orbit-audio-sandbox/src/transport.rs
+++ b/rust/crates/orbit-audio-sandbox/src/transport.rs
@@ -459,7 +459,7 @@ mod tests {
         let _ = std::fs::remove_file(&path);
         let mmap = create_shared(&path).expect("create");
         let region = region_ptr(&mmap);
-        // SAFETY: region points into the live mapping created above.
+        // SAFETY: region は上で作成した生存 mapping を指す。
         unsafe {
             (*region).control.store(CONTROL_QUIT, Ordering::Release);
             reset_control_run(region);


### PR DESCRIPTION
Closes #441

## 概要

Epic #424 DoD ゲート項目。`load_outproc_plugin` の attach エラー処理にあった一体的2欠陥（PR #440 レビュー4体 + Fable 裁定で確定）を解消する。

1. **child 早期 crash が10秒の汎用タイムアウトでしか検出されない** → watchdog シグナルによる fast-fail
2. **plugin path の typo のような訂正可能なミスが slot を daemon 再起動まで恒久的に殺す** → retry 可能化

## 変更内容

### (b) child 早期 crash の fast-fail
- stats に `initial_attach_pending` / `child_early_exit`（AtomicBool）を追加
- watchdog は初回 attach 中（pending=true **かつ** shm `child_status != READY`）の child exit を respawn せず `child_early_exit` を publish して終了（pre-READY respawn 抑止）
  - 二重条件は「READY 直後 crash → watchdog 停止 + host は残留 READY で Active 化 = dead-Active」レースの回避。READY 到達済み crash は従来の respawn 経路
- ready-ack ループが `child_early_exit` を poll し、timeout を待たず即エラー

### (a) 失敗 slot の retry 可能化
- supervisor に `detach_keep_shm()`（shm unlink をスキップする teardown）を追加
- role mismatch / timeout / early-exit の3分岐を `Closed` → `Empty(launch)` 復帰へ（unlink 所有権は launch に戻る = PR-1b `c436a22` フリップ前提の再設計）
- teardown が書いた `CONTROL_QUIT` は新 helper `reset_control_run` で `CONTROL_RUN` へ戻す（残留すると次 incarnation の child が即終了）
- `open_shared` 失敗・supervisor spawn 失敗は真の daemon 破損なので `Closed` のまま（非対称は意図的）

### (e) エラーコード細分化
- `WrapError::OutProcAttachFailed`（retryable）/ `OutProcSlotClosed`（恒久）→ `OUTPROC_ATTACH_FAILED` / `OUTPROC_SLOT_CLOSED`（#405 `CLAP_NOT_LOADED` の前例に倣う）

## 検証

- **unit**: fast-fail（`exit 1` スタブ・<5s assert）/ retry（role mismatch 経由・同一 slot 2回目成功・shm 残存・control RUN）/ エラーコード判別 / post-READY respawn 回帰
- **変異実証**: early-exit チェック無効化 → fast-fail テスト failure（10s 退行）、role-mismatch arm を Closed 化 → retry テスト failure。復元後 green
- **gated 実機 RUN 済み**: typo → 即エラー → 正しい path 再送 → 成功の E2E（effect 2.59s / instrument 2.75s PASS）+ kill-test 回帰（respawn 復帰・ratio 0.50000）PASS
- **フルスイート**: effect / instrument 各 feature 全テスト + sandbox 49 + clippy（per-feature）+ gated compile 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)