### PR TITLE
feat(daemon): OOP effect x instrument coexistence (#431 PR-2)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,45 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.256 feat(daemon): OOP effect × instrument 共存 #431 PR-2 (Jul 16, 2026)
+
+**Date**: 2026-07-16
+**Status**: ✅ 実装・実機検証済み（PR 作成へ）
+**Branch**: `431-oop-both-roles-coexistence`
+**Commit**: `02ddca5`
+
+Epic #424 の PR-2。`outproc-effect × outproc-instrument` の compile-time 排他を解消し、
+1つの daemon で両 role を同時ホスト可能に。実装 = Codex 委譲（2 Stage 分割）。
+
+**プロセス知見**: Codex は当初フルリファクタを3回連続で完走できず停止。原因 = PR-1c の
+全履歴を引き継いだ --resume スレッドの実行ウィンドウ圧迫。**fresh スレッド + 自己完結
+ブリーフ + Stage 分割**（Stage 1 = ジェネリック化のみ / Stage 2 = both 配線）で解決。
+
+**Stage 1（ジェネリック化・挙動不変）**:
+- `trait OutProcRole`（Stats/Supervisor 関連型 + spawn/detach/role_matches/stats アクセサ）
+  + `EffectRole`/`InstrumentRole` marker
+- `ChildLaunch<R>`/`ChildSlot<R>` 化・単一 role 型エイリアス撤去・`load_outproc_plugin_impl<R>`
+- 既存テスト 48+47 が無変更で全パス = 挙動不変の証明
+
+**Stage 2（both 配線）**:
+- `CompositePostProcessor`: instrument add-mix → effect serial insert の固定順・RT 経路
+  alloc/lock なし（output.rs 無改変）
+- `start_outproc_both()`: shm×2・processor×2・slot×2・単一 stream。StreamGuard は
+  teardown guard×2（stream 前）+ child guard×2（stream 後）
+- session.rs: both ビルドで role='effect'/'instrument' 両受理 → role 別 slot へ dispatch
+- buffer_frames 優先規則: 両 env が異なる値ならハードエラー（silent 優先禁止）+ unit テスト
+- instrument×effect の compile_error ペアのみ削除（clap-host/link-audio 排他は維持）
+
+**検証**:
+- 3構成フルスイート: effect 48 / instrument 47 / both 63 + clippy×3 + fmt 全グリーン
+- **both 実機 gated E2E PASS**: instrument 発音（fresh=3・probe live）→ effect serial
+  insert（post/dry ratio **0.50000** 厳密一致）が単一 callback で同時動作（2.10s）
+- single-role gated 回帰 全7本実機 PASS（parity / kill-test / stale-rate / attach-retry×2 /
+  発音 / respawn）— リファクタによる単体 role 退行なし
+
+**次**: PR 作成 → レビューフロー → PR-3（DoD 配線: TS ガード撤去 + in-process reject +
+配布 feature + 実機 E2E）→ Epic #424 DoD 宣言
+
 ### 6.255 fix(daemon): OOP attach 失敗の fast-fail + retry 可能化 #441 PR-1c (Jul 16, 2026)
 
 **Date**: 2026-07-16

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -425,6 +425,39 @@ impl<R: OutProcRole> Drop for ChildLaunch<R> {
     }
 }
 
+/// stream 起動前に失敗した場合だけ shm を回収する暫定所有者。
+/// `ChildLaunch` 構築後はそちらが unlink 所有者になるため、必ず disarm する。
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+struct ShmCleanupGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+impl ShmCleanupGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+impl Drop for ShmCleanupGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            if let Err(error) = std::fs::remove_file(&self.path) {
+                tracing::warn!(
+                    "ShmCleanupGuard drop: shm 削除失敗 {:?}: {error}",
+                    self.path
+                );
+            }
+        }
+    }
+}
+
 /// child plugin load は通常 dlopen を含む。十分な上限を設け、応答を永久に保留しない。
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
 const CHILD_READY_TIMEOUT: Duration = Duration::from_secs(10);
@@ -567,9 +600,9 @@ compile_error!(
 ///
 /// `outproc-instrument` も同じ teardown ordering を専用 guard/supervisor で維持する。
 ///
-/// なお `link-audio` / `clap-host` / `outproc-effect` / `outproc-instrument` は4者すべて併用不可
-/// （`compile_error!`）なので
-/// 複数ブロックが同時に存在することはない。
+/// `clap-host` / `link-audio` は outproc family と引き続き `compile_error!` で排他である。一方
+/// `outproc-effect` と `outproc-instrument` は both build で共存でき、その場合は両 child guard が
+/// 同時に存在する。
 pub struct StreamGuard {
     /// carry-forward #1（clap-host）: stream 停止 **前** に drop され、audio thread で `stop_processing`
     /// を済ませる（`ClapTeardownGuard::drop` が teardown_requested を立て teardown_done を待つ）。
@@ -596,7 +629,8 @@ pub struct StreamGuard {
     /// child へ QUIT → reap → shm unlink する。**field 順は load-bearing**: `_stream` より後に宣言する。
     #[cfg(feature = "outproc-effect")]
     _child_guard: Arc<Mutex<ChildSlot>>,
-    /// both build では同種 guard 間の順序は load-bearing ではない（どちらも stream 停止後）。
+    /// both build では同種 guard 間の順序は load-bearing ではない（どちらも stream 停止後）。別々の
+    /// child process / shm region を持ち supervisor 間に共有状態が無いため、独立に teardown できる。
     #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
     _instrument_child_guard: Arc<Mutex<ChildSlot<InstrumentRole>>>,
     #[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
@@ -788,6 +822,7 @@ impl EngineWrap {
         let shm_path = crate::outproc_effect::unique_shm_path();
         let host_mmap = orbit_audio_sandbox::create_shared(&shm_path)
             .map_err(|e| WrapError::OutProcEffect(format!("create shm {shm_path:?}: {e}")))?;
+        let mut shm_cleanup = ShmCleanupGuard::new(shm_path.clone());
         let host = orbit_audio_sandbox::PipelinedEffectHost::from_mmap(host_mmap);
 
         // 2. engaged ゲート + teardown flags + 観測 stats + adapter。
@@ -824,6 +859,8 @@ impl EngineWrap {
             engaged,
             cleanup_shm_on_drop: true,
         })));
+        // unlink 所有権を起動失敗用 guard から ChildLaunch へ移す。
+        shm_cleanup.disarm();
 
         // 6. wrap 構築 + control 注入。
         let wrap = Self::build(engine, stream.sample_rate, stream.channels, stream_stats);
@@ -898,6 +935,7 @@ impl EngineWrap {
         let host_mmap = orbit_audio_sandbox::create_shared(&shm_path).map_err(|error| {
             WrapError::OutProcInstrument(format!("create shm {shm_path:?}: {error}"))
         })?;
+        let mut shm_cleanup = ShmCleanupGuard::new(shm_path.clone());
         let host = orbit_audio_sandbox::PipelinedInstrumentHost::from_mmap(host_mmap);
         let (event_tx, event_rx) = rtrb::RingBuffer::new(NOTE_RING_CAPACITY);
         let engaged = Arc::new(AtomicBool::new(false));
@@ -931,6 +969,8 @@ impl EngineWrap {
             engaged,
             cleanup_shm_on_drop: true,
         })));
+        // unlink 所有権を起動失敗用 guard から ChildLaunch へ移す。
+        shm_cleanup.disarm();
 
         let wrap = Self::build(engine, stream.sample_rate, stream.channels, stream_stats);
         *wrap.outproc_instrument.lock().map_err(|_| {
@@ -992,12 +1032,14 @@ impl EngineWrap {
             orbit_audio_sandbox::create_shared(&effect_shm)
                 .map_err(|e| WrapError::OutProcEffect(format!("create shm {effect_shm:?}: {e}")))?,
         );
+        let mut effect_shm_cleanup = ShmCleanupGuard::new(effect_shm.clone());
         let instrument_shm = crate::outproc_instrument::unique_shm_path();
         let instrument_host = orbit_audio_sandbox::PipelinedInstrumentHost::from_mmap(
             orbit_audio_sandbox::create_shared(&instrument_shm).map_err(|e| {
                 WrapError::OutProcInstrument(format!("create shm {instrument_shm:?}: {e}"))
             })?,
         );
+        let mut instrument_shm_cleanup = ShmCleanupGuard::new(instrument_shm.clone());
         let (event_tx, event_rx) = rtrb::RingBuffer::new(NOTE_RING_CAPACITY);
         let effect_engaged = Arc::new(AtomicBool::new(false));
         let instrument_engaged = Arc::new(AtomicBool::new(false));
@@ -1040,6 +1082,8 @@ impl EngineWrap {
             engaged: effect_engaged,
             cleanup_shm_on_drop: true,
         })));
+        // unlink 所有権を起動失敗用 guard から ChildLaunch へ移す。
+        effect_shm_cleanup.disarm();
         let instrument_slot = Arc::new(Mutex::new(ChildSlot::<InstrumentRole>::Empty(
             ChildLaunch {
                 shm_path: instrument_shm,
@@ -1050,6 +1094,8 @@ impl EngineWrap {
                 cleanup_shm_on_drop: true,
             },
         )));
+        // unlink 所有権を起動失敗用 guard から ChildLaunch へ移す。
+        instrument_shm_cleanup.disarm();
         let wrap = Self::build(engine, stream.sample_rate, stream.channels, stream_stats);
         *wrap
             .outproc
@@ -2508,6 +2554,35 @@ fn outproc_plugin_summary(
             .file_stem()
             .map(|name| name.to_string_lossy().into_owned()),
         note_port_index: 0,
+    }
+}
+
+#[cfg(all(test, any(feature = "outproc-effect", feature = "outproc-instrument")))]
+mod shm_cleanup_guard_tests {
+    use super::ShmCleanupGuard;
+    use std::path::PathBuf;
+
+    fn unique_path() -> PathBuf {
+        std::env::temp_dir().join(format!("orbitscore-shm-cleanup-{}", uuid::Uuid::new_v4()))
+    }
+
+    #[test]
+    fn armed_drop_removes_file_and_disarmed_drop_keeps_it() {
+        let armed = unique_path();
+        std::fs::write(&armed, b"guard test").expect("create armed guard file");
+        drop(ShmCleanupGuard::new(armed.clone()));
+        assert!(!armed.exists(), "armed guard must remove shm file");
+
+        let disarmed = unique_path();
+        std::fs::write(&disarmed, b"guard test").expect("create disarmed guard file");
+        let mut guard = ShmCleanupGuard::new(disarmed.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(
+            disarmed.exists(),
+            "disarmed guard must leave ChildLaunch-owned file"
+        );
+        std::fs::remove_file(disarmed).expect("remove retained test file");
     }
 }
 

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -231,8 +231,11 @@ impl PostProcessor for CompositePostProcessor {
 /// OOP role ごとの差分を child-slot state machine から分離する。
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
 pub(crate) trait OutProcRole: Sized {
-    type Stats;
-    type Supervisor;
+    /// `Send + Sync` は生産コード上も既に前提（watchdog スレッドが `Arc<Self::Stats>` を共有する）。
+    /// ジェネリックなテストヘルパーが `Arc<Mutex<ChildSlot<R>>>` をスレッド間で受け渡す際、
+    /// コンパイラにその前提を明示するために必要。
+    type Stats: Send + Sync;
+    type Supervisor: Send;
     const ROLE_NAME: &'static str;
 
     fn spawn_child(
@@ -253,6 +256,16 @@ pub(crate) trait OutProcRole: Sized {
     fn set_child_early_exit(stats: &Self::Stats, value: bool);
     fn child_early_exit(stats: &Self::Stats) -> bool;
     fn set_current_child_pid(stats: &Self::Stats, pid: u32);
+    /// テスト専用: role ジェネリックなテストヘルパーが `Self::Stats` を構築するためのコンストラクタ。
+    /// production コードはこれを呼ばない（`load_outproc_plugin_impl` 等は呼び出し側から渡された
+    /// `ChildLaunch::stats` を使う）。
+    #[cfg(test)]
+    fn new_stats() -> Arc<Self::Stats>;
+    /// テスト専用: `current_child_pid` の生 atomic への参照。`role_mismatch_retries_same_slot` が
+    /// spawn 完了の同期に使う（両 role の `Stats` に同名 `pub` field があるが、`Self::Stats` への
+    /// ジェネリックコードからは field アクセスできないため trait 経由にする）。
+    #[cfg(test)]
+    fn current_child_pid_atomic(stats: &Self::Stats) -> &std::sync::atomic::AtomicU32;
 }
 
 #[cfg(feature = "outproc-effect")]
@@ -323,6 +336,14 @@ impl OutProcRole for EffectRole {
     fn set_current_child_pid(stats: &Self::Stats, pid: u32) {
         stats.current_child_pid.store(pid, Ordering::Relaxed);
     }
+    #[cfg(test)]
+    fn new_stats() -> Arc<Self::Stats> {
+        crate::outproc_effect::OutProcEffectStats::new()
+    }
+    #[cfg(test)]
+    fn current_child_pid_atomic(stats: &Self::Stats) -> &std::sync::atomic::AtomicU32 {
+        &stats.current_child_pid
+    }
 }
 
 #[cfg(feature = "outproc-instrument")]
@@ -379,6 +400,14 @@ impl OutProcRole for InstrumentRole {
     }
     fn set_current_child_pid(stats: &Self::Stats, pid: u32) {
         stats.current_child_pid.store(pid, Ordering::Relaxed);
+    }
+    #[cfg(test)]
+    fn new_stats() -> Arc<Self::Stats> {
+        crate::outproc_instrument::OutProcInstrumentStats::new()
+    }
+    #[cfg(test)]
+    fn current_child_pid_atomic(stats: &Self::Stats) -> &std::sync::atomic::AtomicU32 {
+        &stats.current_child_pid
     }
 }
 
@@ -2523,24 +2552,6 @@ fn retryable_attach_failure<R: OutProcRole>(
     WrapError::OutProcAttachFailed(message)
 }
 
-#[cfg(all(test, any(feature = "outproc-effect", feature = "outproc-instrument")))]
-type OutProcChildStats = <DefaultOutProcRole as OutProcRole>::Stats;
-
-#[cfg(all(test, any(feature = "outproc-effect", feature = "outproc-instrument")))]
-fn spawn_outproc_supervisor(
-    child: std::process::Child,
-    launch: &ChildLaunch,
-    path: PathBuf,
-    plugin_id: Option<String>,
-) -> std::io::Result<<DefaultOutProcRole as OutProcRole>::Supervisor> {
-    DefaultOutProcRole::spawn_supervisor(child, launch, path, plugin_id)
-}
-
-#[cfg(all(test, any(feature = "outproc-effect", feature = "outproc-instrument")))]
-fn outproc_role_matches(flags: u32) -> bool {
-    DefaultOutProcRole::role_matches(flags)
-}
-
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
 fn outproc_plugin_summary(
     path: &std::path::Path,
@@ -3057,19 +3068,19 @@ mod capture_path_tests {
 
 #[cfg(all(test, any(feature = "outproc-effect", feature = "outproc-instrument")))]
 mod outproc_load_error_test_support {
-    use super::{ChildLaunch, ChildSlot, EngineWrap, OutProcChildStats, WrapError};
+    use super::{ChildLaunch, ChildSlot, EngineWrap, OutProcRole, WrapError};
     use std::path::{Path, PathBuf};
     use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
-    type InjectedSlot = (Arc<EngineWrap>, Arc<Mutex<ChildSlot>>);
+    type InjectedSlot<R> = (Arc<EngineWrap>, Arc<Mutex<ChildSlot<R>>>);
 
-    fn child_launch(
+    fn child_launch<R: OutProcRole>(
         shm_path: PathBuf,
         child_exe: PathBuf,
-        stats: Arc<OutProcChildStats>,
-    ) -> ChildLaunch {
+        stats: Arc<R::Stats>,
+    ) -> ChildLaunch<R> {
         ChildLaunch {
             shm_path,
             child_exe,
@@ -3080,16 +3091,16 @@ mod outproc_load_error_test_support {
         }
     }
 
-    pub(super) fn open_shared_failure_closes_slot(
+    pub(super) fn open_shared_failure_closes_slot<R: OutProcRole>(
         unique_path: impl Fn() -> PathBuf,
-        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        inject: impl Fn(ChildSlot<R>, Arc<R::Stats>) -> InjectedSlot<R>,
         assert_error: impl Fn(WrapError, &str),
         plugin_path: &str,
     ) {
         let shm_path = unique_path();
         let _ = std::fs::remove_file(&shm_path);
-        let stats = OutProcChildStats::new();
-        let launch = child_launch(
+        let stats = R::new_stats();
+        let launch = child_launch::<R>(
             shm_path,
             PathBuf::from("unused-child-executable"),
             stats.clone(),
@@ -3097,7 +3108,7 @@ mod outproc_load_error_test_support {
         let (wrap, child_slot) = inject(ChildSlot::Empty(launch), stats);
 
         let error = wrap
-            .load_outproc_plugin(PathBuf::from(plugin_path), None)
+            .load_outproc_plugin_impl::<R>(child_slot.clone(), PathBuf::from(plugin_path), None)
             .err()
             .expect("missing shared memory must fail before spawn");
 
@@ -3112,16 +3123,16 @@ mod outproc_load_error_test_support {
     }
 
     #[cfg(feature = "outproc-effect")]
-    pub(super) fn poisoned_slot_open_shared_failure_recovers_to_closed(
+    pub(super) fn poisoned_slot_open_shared_failure_recovers_to_closed<R: OutProcRole + 'static>(
         unique_path: impl Fn() -> PathBuf,
-        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        inject: impl Fn(ChildSlot<R>, Arc<R::Stats>) -> InjectedSlot<R>,
         plugin_path: &str,
     ) {
         let shm_path = unique_path();
         let _ = std::fs::remove_file(&shm_path);
-        let stats = OutProcChildStats::new();
+        let stats = R::new_stats();
         let (wrap, child_slot) = inject(
-            ChildSlot::Empty(child_launch(
+            ChildSlot::Empty(child_launch::<R>(
                 shm_path,
                 PathBuf::from("unused-child-executable"),
                 stats.clone(),
@@ -3135,7 +3146,11 @@ mod outproc_load_error_test_support {
         })
         .join();
 
-        let error = match wrap.load_outproc_plugin(PathBuf::from(plugin_path), None) {
+        let error = match wrap.load_outproc_plugin_impl::<R>(
+            child_slot.clone(),
+            PathBuf::from(plugin_path),
+            None,
+        ) {
             Ok(_) => panic!("missing shm must take the Closed terminal transition after recovery"),
             Err(error) => error,
         };
@@ -3149,9 +3164,9 @@ mod outproc_load_error_test_support {
         ));
     }
 
-    pub(super) fn spawn_failure_restores_empty_for_retry(
+    pub(super) fn spawn_failure_restores_empty_for_retry<R: OutProcRole>(
         unique_path: impl Fn() -> PathBuf,
-        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        inject: impl Fn(ChildSlot<R>, Arc<R::Stats>) -> InjectedSlot<R>,
         assert_error: impl Fn(WrapError, &str),
         plugin_path: &str,
     ) {
@@ -3160,13 +3175,13 @@ mod outproc_load_error_test_support {
         let _mmap = orbit_audio_sandbox::create_shared(&shm_path).expect("create shared memory");
         let bad_child_exe = unique_path();
         let _ = std::fs::remove_file(&bad_child_exe);
-        let stats = OutProcChildStats::new();
-        let launch = child_launch(shm_path, bad_child_exe, stats.clone());
+        let stats = R::new_stats();
+        let launch = child_launch::<R>(shm_path, bad_child_exe, stats.clone());
         let (wrap, child_slot) = inject(ChildSlot::Empty(launch), stats);
 
         for attempt in 1..=2 {
             let error = wrap
-                .load_outproc_plugin(PathBuf::from(plugin_path), None)
+                .load_outproc_plugin_impl::<R>(child_slot.clone(), PathBuf::from(plugin_path), None)
                 .err()
                 .expect("nonexistent child executable must fail to spawn");
             assert_error(error, "spawn outproc child");
@@ -3180,15 +3195,15 @@ mod outproc_load_error_test_support {
         }
     }
 
-    pub(super) fn closed_slot_is_rejected(
-        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+    pub(super) fn closed_slot_is_rejected<R: OutProcRole>(
+        inject: impl Fn(ChildSlot<R>, Arc<R::Stats>) -> InjectedSlot<R>,
         assert_error: impl Fn(WrapError, &str),
         plugin_path: &str,
     ) {
-        let (wrap, child_slot) = inject(ChildSlot::Closed, OutProcChildStats::new());
+        let (wrap, child_slot) = inject(ChildSlot::Closed, R::new_stats());
 
         let error = wrap
-            .load_outproc_plugin(PathBuf::from(plugin_path), None)
+            .load_outproc_plugin_impl::<R>(child_slot.clone(), PathBuf::from(plugin_path), None)
             .err()
             .expect("Closed slot must reject attach");
 
@@ -3199,8 +3214,8 @@ mod outproc_load_error_test_support {
         ));
     }
 
-    pub(super) fn loading_slot_is_rejected(
-        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+    pub(super) fn loading_slot_is_rejected<R: OutProcRole>(
+        inject: impl Fn(ChildSlot<R>, Arc<R::Stats>) -> InjectedSlot<R>,
         assert_error: impl Fn(WrapError, &str),
         loading_path: &str,
         second_path: &str,
@@ -3209,11 +3224,11 @@ mod outproc_load_error_test_support {
             ChildSlot::Loading {
                 path: PathBuf::from(loading_path),
             },
-            OutProcChildStats::new(),
+            R::new_stats(),
         );
 
         let error = wrap
-            .load_outproc_plugin(PathBuf::from(second_path), None)
+            .load_outproc_plugin_impl::<R>(child_slot.clone(), PathBuf::from(second_path), None)
             .err()
             .expect("Loading slot must reject concurrent attach");
 
@@ -3225,23 +3240,23 @@ mod outproc_load_error_test_support {
 
     /// 実際に生存する（が無害な）child を起動して `ChildSlot::Active` を直接構築する。
     /// `EffectChildSupervisor`/`InstrumentChildSupervisor` は `spawn_effect_child` 経由の
-    /// `Command` 起動を要求するので、実 CLAP/VST3 plugin なしで到達するには `spawn_outproc_supervisor`
+    /// `Command` 起動を要求するので、実 CLAP/VST3 plugin なしで到達するには `R::spawn_supervisor`
     /// を直接呼び、`first_child` には（respawn を誘発しない）長寿命の `sleep` を渡す（outproc_effect.rs
     /// の `supervisor_*` テストと同じ手法）。supervisor が以後の shm unlink を所有するため、ローカルの
     /// `launch` の `cleanup_shm_on_drop` は production の `load_outproc_plugin` 成功パスと同様に外す。
-    fn active_child_slot(
+    fn active_child_slot<R: OutProcRole>(
         unique_path: impl Fn() -> PathBuf,
         plugin_path: &str,
         plugin_id: Option<String>,
-    ) -> ChildSlot {
+    ) -> ChildSlot<R> {
         let shm_path = unique_path();
         let _ = std::fs::remove_file(&shm_path);
         let _mmap = orbit_audio_sandbox::create_shared(&shm_path).expect("create shared memory");
 
-        let mut launch = child_launch(
+        let mut launch = child_launch::<R>(
             shm_path,
             PathBuf::from("unused-child-executable-for-respawn-only"),
-            OutProcChildStats::new(),
+            R::new_stats(),
         );
         let first_child = std::process::Command::new("sleep")
             .arg("30")
@@ -3249,9 +3264,8 @@ mod outproc_load_error_test_support {
             .expect("spawn stub child for Active fixture");
 
         let path = PathBuf::from(plugin_path);
-        let supervisor =
-            super::spawn_outproc_supervisor(first_child, &launch, path.clone(), plugin_id.clone())
-                .expect("spawn supervisor for Active fixture");
+        let supervisor = R::spawn_supervisor(first_child, &launch, path.clone(), plugin_id.clone())
+            .expect("spawn supervisor for Active fixture");
         launch.cleanup_shm_on_drop = false;
 
         ChildSlot::Active {
@@ -3264,17 +3278,21 @@ mod outproc_load_error_test_support {
 
     /// Important finding 2a: `ChildSlot::Active` への同一 path・同一 plugin_id の再送は冪等に
     /// `Ok` を返し、slot を `Active` のまま維持すること。
-    pub(super) fn active_slot_accepts_idempotent_reload(
+    pub(super) fn active_slot_accepts_idempotent_reload<R: OutProcRole>(
         unique_path: impl Fn() -> PathBuf,
-        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        inject: impl Fn(ChildSlot<R>, Arc<R::Stats>) -> InjectedSlot<R>,
         plugin_path: &str,
         plugin_id: Option<String>,
     ) {
-        let slot = active_child_slot(unique_path, plugin_path, plugin_id.clone());
-        let (wrap, child_slot) = inject(slot, OutProcChildStats::new());
+        let slot = active_child_slot::<R>(unique_path, plugin_path, plugin_id.clone());
+        let (wrap, child_slot) = inject(slot, R::new_stats());
 
-        wrap.load_outproc_plugin(PathBuf::from(plugin_path), plugin_id)
-            .expect("idempotent re-load of the same path+plugin_id while Active must succeed");
+        wrap.load_outproc_plugin_impl::<R>(
+            child_slot.clone(),
+            PathBuf::from(plugin_path),
+            plugin_id,
+        )
+        .expect("idempotent re-load of the same path+plugin_id while Active must succeed");
         assert!(
             matches!(
                 &*child_slot.lock().expect("lock child slot"),
@@ -3287,19 +3305,23 @@ mod outproc_load_error_test_support {
     /// Critical finding: `ChildSlot::Active` への同一 path・**異なる** plugin_id は replacement
     /// 要求として拒否すること（呼び出し側が指定した plugin_id を握り潰して古い plugin_id のまま
     /// 黙って `Ok` を返してはならない）。
-    pub(super) fn active_slot_rejects_plugin_id_change(
+    pub(super) fn active_slot_rejects_plugin_id_change<R: OutProcRole>(
         unique_path: impl Fn() -> PathBuf,
-        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        inject: impl Fn(ChildSlot<R>, Arc<R::Stats>) -> InjectedSlot<R>,
         assert_error: impl Fn(WrapError, &str),
         plugin_path: &str,
         initial_plugin_id: Option<String>,
         changed_plugin_id: Option<String>,
     ) {
-        let slot = active_child_slot(unique_path, plugin_path, initial_plugin_id.clone());
-        let (wrap, child_slot) = inject(slot, OutProcChildStats::new());
+        let slot = active_child_slot::<R>(unique_path, plugin_path, initial_plugin_id.clone());
+        let (wrap, child_slot) = inject(slot, R::new_stats());
 
         let error = wrap
-            .load_outproc_plugin(PathBuf::from(plugin_path), changed_plugin_id)
+            .load_outproc_plugin_impl::<R>(
+                child_slot.clone(),
+                PathBuf::from(plugin_path),
+                changed_plugin_id,
+            )
             .err()
             .expect("same path with a different plugin_id while Active must be rejected");
         assert_error(error, "does not support replacement");
@@ -3314,18 +3336,18 @@ mod outproc_load_error_test_support {
 
     /// Important finding 2b: `ChildSlot::Active` への **異なる** path は v1 では replacement
     /// 拒否のまま（既存の Loading 側テストと対になる Active 側の直接検証）。
-    pub(super) fn active_slot_rejects_path_replacement(
+    pub(super) fn active_slot_rejects_path_replacement<R: OutProcRole>(
         unique_path: impl Fn() -> PathBuf,
-        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        inject: impl Fn(ChildSlot<R>, Arc<R::Stats>) -> InjectedSlot<R>,
         assert_error: impl Fn(WrapError, &str),
         plugin_path: &str,
         other_path: &str,
     ) {
-        let slot = active_child_slot(unique_path, plugin_path, None);
-        let (wrap, child_slot) = inject(slot, OutProcChildStats::new());
+        let slot = active_child_slot::<R>(unique_path, plugin_path, None);
+        let (wrap, child_slot) = inject(slot, R::new_stats());
 
         let error = wrap
-            .load_outproc_plugin(PathBuf::from(other_path), None)
+            .load_outproc_plugin_impl::<R>(child_slot.clone(), PathBuf::from(other_path), None)
             .err()
             .expect("a different path while Active must be rejected");
         assert_error(error, "does not support replacement");
@@ -3366,22 +3388,30 @@ mod outproc_load_error_test_support {
         script_path
     }
 
-    pub(super) fn early_exit_fast_fails_and_keeps_retry_shm(
+    pub(super) fn early_exit_fast_fails_and_keeps_retry_shm<R: OutProcRole>(
         unique_path: impl Fn() -> PathBuf,
-        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        inject: impl Fn(ChildSlot<R>, Arc<R::Stats>) -> InjectedSlot<R>,
         plugin_path: &str,
     ) {
         let shm_path = unique_path();
         let _ = std::fs::remove_file(&shm_path);
         let mmap = orbit_audio_sandbox::create_shared(&shm_path).expect("create shared memory");
         let child_exe = write_exit_child_script(&unique_path);
-        let stats = OutProcChildStats::new();
+        let stats = R::new_stats();
         let (wrap, slot) = inject(
-            ChildSlot::Empty(child_launch(shm_path.clone(), child_exe.clone(), stats)),
-            OutProcChildStats::new(),
+            ChildSlot::Empty(child_launch::<R>(
+                shm_path.clone(),
+                child_exe.clone(),
+                stats,
+            )),
+            R::new_stats(),
         );
         let started = std::time::Instant::now();
-        let error = match wrap.load_outproc_plugin(PathBuf::from(plugin_path), None) {
+        let error = match wrap.load_outproc_plugin_impl::<R>(
+            slot.clone(),
+            PathBuf::from(plugin_path),
+            None,
+        ) {
             Ok(_) => panic!("immediately exiting child must fail attach"),
             Err(error) => error,
         };
@@ -3402,9 +3432,9 @@ mod outproc_load_error_test_support {
         let _ = std::fs::remove_file(child_exe);
     }
 
-    pub(super) fn role_mismatch_retries_same_slot(
+    pub(super) fn role_mismatch_retries_same_slot<R: OutProcRole + 'static>(
         unique_path: impl Fn() -> PathBuf,
-        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        inject: impl Fn(ChildSlot<R>, Arc<R::Stats>) -> InjectedSlot<R>,
         plugin_path: &str,
         wrong_has_audio_input: bool,
         correct_has_audio_input: bool,
@@ -3413,9 +3443,9 @@ mod outproc_load_error_test_support {
         let _ = std::fs::remove_file(&shm_path);
         let mmap = orbit_audio_sandbox::create_shared(&shm_path).expect("create shared memory");
         let child_exe = write_slow_child_script(&unique_path);
-        let stats = OutProcChildStats::new();
+        let stats = R::new_stats();
         let (wrap, slot) = inject(
-            ChildSlot::Empty(child_launch(
+            ChildSlot::Empty(child_launch::<R>(
                 shm_path.clone(),
                 child_exe.clone(),
                 stats.clone(),
@@ -3423,17 +3453,16 @@ mod outproc_load_error_test_support {
             stats.clone(),
         );
         for (attempt, has_input) in [(1, wrong_has_audio_input), (2, correct_has_audio_input)] {
-            stats
-                .current_child_pid
-                .store(0, std::sync::atomic::Ordering::Relaxed);
+            R::current_child_pid_atomic(&stats).store(0, std::sync::atomic::Ordering::Relaxed);
             let wrap_call = wrap.clone();
+            let slot_call = slot.clone();
             let path = PathBuf::from(plugin_path);
-            let call = std::thread::spawn(move || wrap_call.load_outproc_plugin(path, None));
+            let call = std::thread::spawn(move || {
+                wrap_call.load_outproc_plugin_impl::<R>(slot_call, path, None)
+            });
             let deadline = std::time::Instant::now() + Duration::from_secs(2);
             // PID は reset_child_starting の後に publish されるため、この READY はそれによって消されない。
-            while stats
-                .current_child_pid
-                .load(std::sync::atomic::Ordering::Relaxed)
+            while R::current_child_pid_atomic(&stats).load(std::sync::atomic::Ordering::Relaxed)
                 == 0
             {
                 assert!(
@@ -3468,9 +3497,11 @@ mod outproc_load_error_test_support {
     /// ブロックしている **最中**でも、mutex 待ちでなく `ChildSlot::Loading` を即座に観測して
     /// fail-fast すること。この lock-scope fix が無いと 2 本目は `.lock()` 自体で最大 10 秒
     /// ブロックされ、意図された「Loading 中は即座に in progress で reject」が到達不能になる。
-    pub(super) fn concurrent_load_call_observes_loading_without_blocking(
+    pub(super) fn concurrent_load_call_observes_loading_without_blocking<
+        R: OutProcRole + 'static,
+    >(
         unique_path: impl Fn() -> PathBuf,
-        inject: impl Fn(ChildSlot, Arc<OutProcChildStats>) -> InjectedSlot,
+        inject: impl Fn(ChildSlot<R>, Arc<R::Stats>) -> InjectedSlot<R>,
         assert_error: impl Fn(WrapError, &str),
         has_audio_input: bool,
         loading_path: &str,
@@ -3481,14 +3512,16 @@ mod outproc_load_error_test_support {
         let _mmap = orbit_audio_sandbox::create_shared(&shm_path).expect("create shared memory");
         let child_exe = write_slow_child_script(&unique_path);
 
-        let stats = OutProcChildStats::new();
-        let launch = child_launch(shm_path.clone(), child_exe.clone(), stats.clone());
+        let stats = R::new_stats();
+        let launch = child_launch::<R>(shm_path.clone(), child_exe.clone(), stats.clone());
         let (wrap, child_slot) = inject(ChildSlot::Empty(launch), stats);
 
         let wrap_a = wrap.clone();
+        let slot_a = child_slot.clone();
         let loading_path_owned = PathBuf::from(loading_path);
-        let first_call =
-            std::thread::spawn(move || wrap_a.load_outproc_plugin(loading_path_owned, None));
+        let first_call = std::thread::spawn(move || {
+            wrap_a.load_outproc_plugin_impl::<R>(slot_a, loading_path_owned, None)
+        });
 
         // 1本目が Empty -> Loading へ遷移して lock を解放するまで待つ（shm open + spawn は同期的な
         // syscall なので通常数 ms で観測できる。2s は CI 負荷下でも十分な余裕）。
@@ -3511,7 +3544,7 @@ mod outproc_load_error_test_support {
         // 発行し、mutex 待ちでなく即座に "already in progress" で失敗することを検証する。
         let start = std::time::Instant::now();
         let error = wrap
-            .load_outproc_plugin(PathBuf::from(second_path), None)
+            .load_outproc_plugin_impl::<R>(child_slot.clone(), PathBuf::from(second_path), None)
             .err()
             .expect("concurrent call against a Loading slot must fail");
         let elapsed = start.elapsed();
@@ -3551,7 +3584,7 @@ mod outproc_load_error_test_support {
 /// `EngineWrap` に対して real child を spawn せず `Some(OutProcControl)` を注入できる。
 #[cfg(all(test, feature = "outproc-effect"))]
 mod outproc_health_tests {
-    use super::{outproc_role_matches, ChildSlot, EngineWrap, OutProcControl, WrapError};
+    use super::{ChildSlot, EffectRole, EngineWrap, OutProcControl, OutProcRole, WrapError};
     use crate::backend::StubBackend;
     use crate::outproc_effect::OutProcEffectStats;
     use orbit_audio_native::CallbackTimeStats;
@@ -3574,9 +3607,9 @@ mod outproc_health_tests {
     }
 
     fn wrap_with_child_slot(
-        slot: ChildSlot,
+        slot: ChildSlot<EffectRole>,
         stats: Arc<OutProcEffectStats>,
-    ) -> (Arc<EngineWrap>, Arc<Mutex<ChildSlot>>) {
+    ) -> (Arc<EngineWrap>, Arc<Mutex<ChildSlot<EffectRole>>>) {
         let (wrap, _guard) =
             EngineWrap::start_with(StubBackend::default()).expect("stub backend start");
         let child_slot = Arc::new(Mutex::new(slot));
@@ -3712,10 +3745,10 @@ mod outproc_health_tests {
 
     #[test]
     fn effect_ready_ack_requires_audio_input_flag() {
-        assert!(outproc_role_matches(
+        assert!(EffectRole::role_matches(
             orbit_audio_sandbox::transport::CHILD_FLAG_HAS_AUDIO_INPUT
         ));
-        assert!(!outproc_role_matches(0));
+        assert!(!EffectRole::role_matches(0));
     }
 
     #[test]
@@ -3805,9 +3838,11 @@ mod outproc_health_tests {
 /// build で走るため real body の match arm がどのテストからも一度も compile even されない）で、この
 /// `#[cfg(test)]` submodule から `EngineWrap::outproc_instrument`（private field）と
 /// `OutProcInstrumentControl`（private struct）へ直接アクセスして注入する。
-#[cfg(all(test, feature = "outproc-instrument", not(feature = "outproc-effect")))]
+#[cfg(all(test, feature = "outproc-instrument"))]
 mod outproc_instrument_health_tests {
-    use super::{outproc_role_matches, ChildSlot, EngineWrap, OutProcInstrumentControl, WrapError};
+    use super::{
+        ChildSlot, EngineWrap, InstrumentRole, OutProcInstrumentControl, OutProcRole, WrapError,
+    };
     use crate::backend::StubBackend;
     use crate::outproc_instrument::OutProcInstrumentStats;
     use std::sync::atomic::Ordering;
@@ -3833,9 +3868,9 @@ mod outproc_instrument_health_tests {
     }
 
     fn wrap_with_child_slot(
-        slot: ChildSlot,
+        slot: ChildSlot<InstrumentRole>,
         stats: Arc<OutProcInstrumentStats>,
-    ) -> (Arc<EngineWrap>, Arc<Mutex<ChildSlot>>) {
+    ) -> (Arc<EngineWrap>, Arc<Mutex<ChildSlot<InstrumentRole>>>) {
         let (wrap, _guard) =
             EngineWrap::start_with(StubBackend::default()).expect("stub backend start");
         let child_slot = Arc::new(Mutex::new(slot));
@@ -3966,8 +4001,8 @@ mod outproc_instrument_health_tests {
 
     #[test]
     fn instrument_ready_ack_rejects_audio_input_flag() {
-        assert!(outproc_role_matches(0));
-        assert!(!outproc_role_matches(
+        assert!(InstrumentRole::role_matches(0));
+        assert!(!InstrumentRole::role_matches(
             orbit_audio_sandbox::transport::CHILD_FLAG_HAS_AUDIO_INPUT
         ));
     }

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -208,19 +208,271 @@ struct OutProcInstrumentControl {
     child_slot: Weak<Mutex<ChildSlot>>,
 }
 
+/// OOP role ごとの差分を child-slot state machine から分離する。
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+pub(crate) trait OutProcRole: Sized {
+    type Stats;
+    type Supervisor;
+    const ROLE_NAME: &'static str;
+
+    fn spawn_child(
+        launch: &ChildLaunch<Self>,
+        path: &std::path::Path,
+        plugin_id: Option<&str>,
+    ) -> std::io::Result<std::process::Child>;
+    fn spawn_supervisor(
+        child: std::process::Child,
+        launch: &ChildLaunch<Self>,
+        path: PathBuf,
+        plugin_id: Option<String>,
+    ) -> std::io::Result<Self::Supervisor>;
+    fn detach_keep_shm(supervisor: Self::Supervisor);
+    fn role_matches(child_flags: u32) -> bool;
+    fn runtime_error(message: String) -> WrapError;
+    fn set_initial_attach_pending(stats: &Self::Stats, value: bool);
+    fn set_child_early_exit(stats: &Self::Stats, value: bool);
+    fn child_early_exit(stats: &Self::Stats) -> bool;
+    fn set_current_child_pid(stats: &Self::Stats, pid: u32);
+}
+
+#[cfg(feature = "outproc-effect")]
+pub(crate) struct EffectRole;
+#[cfg(feature = "outproc-instrument")]
+pub(crate) struct InstrumentRole;
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+pub(crate) struct DefaultOutProcRole;
+
 #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
-type OutProcChildSupervisor = crate::outproc_effect::EffectChildSupervisor;
-#[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
-type OutProcChildStats = crate::outproc_effect::OutProcEffectStats;
+impl OutProcRole for DefaultOutProcRole {
+    type Stats = crate::outproc_effect::OutProcEffectStats;
+    type Supervisor = crate::outproc_effect::EffectChildSupervisor;
+    const ROLE_NAME: &'static str = EffectRole::ROLE_NAME;
+    fn spawn_child(
+        launch: &ChildLaunch<Self>,
+        path: &std::path::Path,
+        plugin_id: Option<&str>,
+    ) -> std::io::Result<std::process::Child> {
+        crate::outproc_effect::spawn_effect_child(
+            &launch.child_exe,
+            &launch.shm_path,
+            path,
+            plugin_id,
+            launch.sample_rate,
+        )
+    }
+    fn spawn_supervisor(
+        child: std::process::Child,
+        launch: &ChildLaunch<Self>,
+        path: PathBuf,
+        plugin_id: Option<String>,
+    ) -> std::io::Result<Self::Supervisor> {
+        crate::outproc_effect::EffectChildSupervisor::spawn(
+            child,
+            launch.shm_path.clone(),
+            launch.stats.clone(),
+            launch.child_exe.clone(),
+            path,
+            plugin_id,
+            launch.sample_rate,
+        )
+    }
+    fn detach_keep_shm(supervisor: Self::Supervisor) {
+        supervisor.detach_keep_shm();
+    }
+    fn role_matches(flags: u32) -> bool {
+        EffectRole::role_matches(flags)
+    }
+    fn runtime_error(message: String) -> WrapError {
+        EffectRole::runtime_error(message)
+    }
+    fn set_initial_attach_pending(stats: &Self::Stats, value: bool) {
+        EffectRole::set_initial_attach_pending(stats, value)
+    }
+    fn set_child_early_exit(stats: &Self::Stats, value: bool) {
+        EffectRole::set_child_early_exit(stats, value)
+    }
+    fn child_early_exit(stats: &Self::Stats) -> bool {
+        EffectRole::child_early_exit(stats)
+    }
+    fn set_current_child_pid(stats: &Self::Stats, pid: u32) {
+        EffectRole::set_current_child_pid(stats, pid)
+    }
+}
 #[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
-type OutProcChildSupervisor = crate::outproc_instrument::InstrumentChildSupervisor;
-#[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
-type OutProcChildStats = crate::outproc_instrument::OutProcInstrumentStats;
+impl OutProcRole for DefaultOutProcRole {
+    type Stats = crate::outproc_instrument::OutProcInstrumentStats;
+    type Supervisor = crate::outproc_instrument::InstrumentChildSupervisor;
+    const ROLE_NAME: &'static str = InstrumentRole::ROLE_NAME;
+    fn spawn_child(
+        launch: &ChildLaunch<Self>,
+        path: &std::path::Path,
+        plugin_id: Option<&str>,
+    ) -> std::io::Result<std::process::Child> {
+        crate::outproc_instrument::spawn_instrument_child(
+            &launch.child_exe,
+            &launch.shm_path,
+            path,
+            plugin_id,
+            launch.sample_rate,
+        )
+    }
+    fn spawn_supervisor(
+        child: std::process::Child,
+        launch: &ChildLaunch<Self>,
+        path: PathBuf,
+        plugin_id: Option<String>,
+    ) -> std::io::Result<Self::Supervisor> {
+        crate::outproc_instrument::InstrumentChildSupervisor::spawn(
+            child,
+            launch.shm_path.clone(),
+            launch.stats.clone(),
+            launch.child_exe.clone(),
+            path,
+            plugin_id,
+            launch.sample_rate,
+        )
+    }
+    fn detach_keep_shm(supervisor: Self::Supervisor) {
+        supervisor.detach_keep_shm();
+    }
+    fn role_matches(flags: u32) -> bool {
+        InstrumentRole::role_matches(flags)
+    }
+    fn runtime_error(message: String) -> WrapError {
+        InstrumentRole::runtime_error(message)
+    }
+    fn set_initial_attach_pending(stats: &Self::Stats, value: bool) {
+        InstrumentRole::set_initial_attach_pending(stats, value)
+    }
+    fn set_child_early_exit(stats: &Self::Stats, value: bool) {
+        InstrumentRole::set_child_early_exit(stats, value)
+    }
+    fn child_early_exit(stats: &Self::Stats) -> bool {
+        InstrumentRole::child_early_exit(stats)
+    }
+    fn set_current_child_pid(stats: &Self::Stats, pid: u32) {
+        InstrumentRole::set_current_child_pid(stats, pid)
+    }
+}
+
+#[cfg(feature = "outproc-effect")]
+impl OutProcRole for EffectRole {
+    type Stats = crate::outproc_effect::OutProcEffectStats;
+    type Supervisor = crate::outproc_effect::EffectChildSupervisor;
+    const ROLE_NAME: &'static str = "effect";
+    fn spawn_child(
+        launch: &ChildLaunch<Self>,
+        path: &std::path::Path,
+        plugin_id: Option<&str>,
+    ) -> std::io::Result<std::process::Child> {
+        crate::outproc_effect::spawn_effect_child(
+            &launch.child_exe,
+            &launch.shm_path,
+            path,
+            plugin_id,
+            launch.sample_rate,
+        )
+    }
+    fn spawn_supervisor(
+        child: std::process::Child,
+        launch: &ChildLaunch<Self>,
+        path: PathBuf,
+        plugin_id: Option<String>,
+    ) -> std::io::Result<Self::Supervisor> {
+        crate::outproc_effect::EffectChildSupervisor::spawn(
+            child,
+            launch.shm_path.clone(),
+            launch.stats.clone(),
+            launch.child_exe.clone(),
+            path,
+            plugin_id,
+            launch.sample_rate,
+        )
+    }
+    fn detach_keep_shm(supervisor: Self::Supervisor) {
+        supervisor.detach_keep_shm();
+    }
+    fn role_matches(flags: u32) -> bool {
+        flags & orbit_audio_sandbox::transport::CHILD_FLAG_HAS_AUDIO_INPUT != 0
+    }
+    fn runtime_error(message: String) -> WrapError {
+        WrapError::OutProcEffect(message)
+    }
+    fn set_initial_attach_pending(stats: &Self::Stats, value: bool) {
+        stats.initial_attach_pending.store(value, Ordering::Release);
+    }
+    fn set_child_early_exit(stats: &Self::Stats, value: bool) {
+        stats.child_early_exit.store(value, Ordering::Release);
+    }
+    fn child_early_exit(stats: &Self::Stats) -> bool {
+        stats.child_early_exit.load(Ordering::Acquire)
+    }
+    fn set_current_child_pid(stats: &Self::Stats, pid: u32) {
+        stats.current_child_pid.store(pid, Ordering::Relaxed);
+    }
+}
+
+#[cfg(feature = "outproc-instrument")]
+impl OutProcRole for InstrumentRole {
+    type Stats = crate::outproc_instrument::OutProcInstrumentStats;
+    type Supervisor = crate::outproc_instrument::InstrumentChildSupervisor;
+    const ROLE_NAME: &'static str = "instrument";
+    fn spawn_child(
+        launch: &ChildLaunch<Self>,
+        path: &std::path::Path,
+        plugin_id: Option<&str>,
+    ) -> std::io::Result<std::process::Child> {
+        crate::outproc_instrument::spawn_instrument_child(
+            &launch.child_exe,
+            &launch.shm_path,
+            path,
+            plugin_id,
+            launch.sample_rate,
+        )
+    }
+    fn spawn_supervisor(
+        child: std::process::Child,
+        launch: &ChildLaunch<Self>,
+        path: PathBuf,
+        plugin_id: Option<String>,
+    ) -> std::io::Result<Self::Supervisor> {
+        crate::outproc_instrument::InstrumentChildSupervisor::spawn(
+            child,
+            launch.shm_path.clone(),
+            launch.stats.clone(),
+            launch.child_exe.clone(),
+            path,
+            plugin_id,
+            launch.sample_rate,
+        )
+    }
+    fn detach_keep_shm(supervisor: Self::Supervisor) {
+        supervisor.detach_keep_shm();
+    }
+    fn role_matches(flags: u32) -> bool {
+        flags & orbit_audio_sandbox::transport::CHILD_FLAG_HAS_AUDIO_INPUT == 0
+    }
+    fn runtime_error(message: String) -> WrapError {
+        WrapError::OutProcInstrument(message)
+    }
+    fn set_initial_attach_pending(stats: &Self::Stats, value: bool) {
+        stats.initial_attach_pending.store(value, Ordering::Release);
+    }
+    fn set_child_early_exit(stats: &Self::Stats, value: bool) {
+        stats.child_early_exit.store(value, Ordering::Release);
+    }
+    fn child_early_exit(stats: &Self::Stats) -> bool {
+        stats.child_early_exit.load(Ordering::Acquire)
+    }
+    fn set_current_child_pid(stats: &Self::Stats, pid: u32) {
+        stats.current_child_pid.store(pid, Ordering::Relaxed);
+    }
+}
 
 /// OOP child の post-boot attach 状態。v1 は一つの daemon role につき一つの plugin path 固定。
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
-pub(crate) enum ChildSlot {
-    Empty(ChildLaunch),
+pub(crate) enum ChildSlot<R: OutProcRole = DefaultOutProcRole> {
+    Empty(ChildLaunch<R>),
     Loading {
         path: PathBuf,
     },
@@ -228,23 +480,23 @@ pub(crate) enum ChildSlot {
         path: PathBuf,
         plugin_id: Option<String>,
         engaged: Arc<AtomicBool>,
-        _supervisor: OutProcChildSupervisor,
+        _supervisor: R::Supervisor,
     },
     Closed,
 }
 
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
-pub(crate) struct ChildLaunch {
+pub(crate) struct ChildLaunch<R: OutProcRole = DefaultOutProcRole> {
     shm_path: PathBuf,
     child_exe: PathBuf,
     sample_rate: u32,
-    stats: Arc<OutProcChildStats>,
+    stats: Arc<R::Stats>,
     engaged: Arc<AtomicBool>,
     cleanup_shm_on_drop: bool,
 }
 
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
-impl Drop for ChildLaunch {
+impl<R: OutProcRole> Drop for ChildLaunch<R> {
     fn drop(&mut self) {
         // cleanup_shm_on_drop=true は retryable attach failure 後を含め、この launch が unlink の
         // 唯一の所有者であることを意味する。よって NotFound を含む
@@ -379,11 +631,6 @@ compile_error!(
     "features `outproc-instrument` and `link-audio` are mutually exclusive \
      (both integrate the single cpal callback)"
 );
-#[cfg(all(feature = "outproc-instrument", feature = "outproc-effect"))]
-compile_error!(
-    "features `outproc-instrument` and `outproc-effect` are mutually exclusive \
-     (both own the single master-bus post-processor seam)"
-);
 
 /// `cpal::Stream` を保持する guard。drop されるとストリーム停止。`!Send`。
 ///
@@ -435,6 +682,9 @@ pub struct StreamGuard {
     /// γ M1 PR-C（outproc-effect）: stream 停止 **後** に drop され、watchdog を止めて（respawn 停止）
     /// child へ QUIT → reap → shm unlink する。**field 順は load-bearing**: `_stream` より後に宣言する。
     #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+    #[cfg(feature = "outproc-effect")]
+    _child_guard: Arc<Mutex<ChildSlot>>,
+    #[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
     _child_guard: Arc<Mutex<ChildSlot>>,
 }
 
@@ -938,7 +1188,7 @@ impl EngineWrap {
             let guard = self
                 .outproc
                 .lock()
-                .map_err(|_| outproc_runtime_error("outproc mutex poisoned"))?;
+                .map_err(|_| EffectRole::runtime_error("outproc mutex poisoned".into()))?;
             guard
                 .as_ref()
                 .ok_or_else(|| {
@@ -948,14 +1198,15 @@ impl EngineWrap {
                 })?
                 .child_slot
                 .upgrade()
-                .ok_or_else(|| outproc_runtime_error("outproc effect stream is closed"))?
+                .ok_or_else(|| {
+                    EffectRole::runtime_error("outproc effect stream is closed".into())
+                })?
         };
         #[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
         let child_slot = {
-            let guard = self
-                .outproc_instrument
-                .lock()
-                .map_err(|_| outproc_runtime_error("outproc instrument mutex poisoned"))?;
+            let guard = self.outproc_instrument.lock().map_err(|_| {
+                InstrumentRole::runtime_error("outproc instrument mutex poisoned".into())
+            })?;
             guard
                 .as_ref()
                 .ok_or_else(|| {
@@ -966,9 +1217,24 @@ impl EngineWrap {
                 })?
                 .child_slot
                 .upgrade()
-                .ok_or_else(|| outproc_runtime_error("outproc instrument stream is closed"))?
+                .ok_or_else(|| {
+                    InstrumentRole::runtime_error("outproc instrument stream is closed".into())
+                })?
         };
+        #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+        return self.load_outproc_plugin_impl::<DefaultOutProcRole>(child_slot, path, plugin_id);
+        #[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
+        return self.load_outproc_plugin_impl::<DefaultOutProcRole>(child_slot, path, plugin_id);
+    }
 
+    #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+    fn load_outproc_plugin_impl<R: OutProcRole>(
+        &self,
+        child_slot: Arc<Mutex<ChildSlot<R>>>,
+        path: PathBuf,
+        plugin_id: Option<String>,
+    ) -> Result<LoadedPluginSummary, WrapError> {
+        let _role_name = R::ROLE_NAME;
         let mut slot = lock_child_slot_recovering(&child_slot, "initial state check");
 
         match &*slot {
@@ -990,21 +1256,21 @@ impl EngineWrap {
                 // 同一 path だが plugin_id が異なる = bundle 内の別サブプラグインへの差し替え
                 // 要求。path 差し替えと同様 v1 は拒否する（呼び出し側が指定した plugin_id を
                 // 握り潰して古い plugin_id のまま黙って Ok を返さない）。
-                return Err(outproc_runtime_error(format!(
+                return Err(R::runtime_error(format!(
                     "outproc plugin already loaded from {active_path:?} with plugin_id {active_plugin_id:?}; v1 does not support replacement with plugin_id {plugin_id:?}"
                 )));
             }
             ChildSlot::Active {
                 path: active_path, ..
             } => {
-                return Err(outproc_runtime_error(format!(
+                return Err(R::runtime_error(format!(
                     "outproc plugin already loaded from {active_path:?}; v1 does not support replacement with {path:?}"
                 )));
             }
             ChildSlot::Loading {
                 path: loading_path, ..
             } => {
-                return Err(outproc_runtime_error(format!(
+                return Err(R::runtime_error(format!(
                     "outproc plugin load already in progress for {loading_path:?}"
                 )));
             }
@@ -1034,7 +1300,7 @@ impl EngineWrap {
                 let mut slot = lock_child_slot_recovering(&child_slot, "open_shared failure");
                 debug_assert_slot_loading(&slot);
                 *slot = ChildSlot::Closed;
-                return Err(outproc_runtime_error(format!(
+                return Err(R::runtime_error(format!(
                     "open child readiness mapping {:?}: {error}",
                     launch.shm_path
                 )));
@@ -1046,34 +1312,25 @@ impl EngineWrap {
         unsafe { orbit_audio_sandbox::transport::reset_child_starting(region) };
 
         // spawn 前にセットしておくことで、即座に終了する child が通常の respawn 経路に紛れ込むのを防ぐ。
-        launch
-            .stats
-            .initial_attach_pending
-            .store(true, Ordering::Release);
-        launch
-            .stats
-            .child_early_exit
-            .store(false, Ordering::Release);
-        let first_child = match spawn_outproc_child(&launch, &path, plugin_id.as_deref()) {
+        R::set_initial_attach_pending(&launch.stats, true);
+        R::set_child_early_exit(&launch.stats, false);
+        let first_child = match R::spawn_child(&launch, &path, plugin_id.as_deref()) {
             Ok(child) => child,
             Err(error) => {
                 let child_exe = launch.child_exe.clone();
                 let mut slot = lock_child_slot_recovering(&child_slot, "child spawn failure");
                 debug_assert_slot_loading(&slot);
                 *slot = ChildSlot::Empty(launch);
-                return Err(outproc_runtime_error(format!(
+                return Err(R::runtime_error(format!(
                     "spawn outproc child {:?}: {error}",
                     child_exe
                 )));
             }
         };
-        launch
-            .stats
-            .current_child_pid
-            .store(first_child.id(), Ordering::Relaxed);
+        R::set_current_child_pid(&launch.stats, first_child.id());
 
         let supervisor =
-            match spawn_outproc_supervisor(first_child, &launch, path.clone(), plugin_id.clone()) {
+            match R::spawn_supervisor(first_child, &launch, path.clone(), plugin_id.clone()) {
                 Ok(supervisor) => supervisor,
                 Err(error) => {
                     // spawn_outproc_supervisor はエラー時に自身の cleanup で shm を unlink して返るため、
@@ -1083,9 +1340,7 @@ impl EngineWrap {
                         lock_child_slot_recovering(&child_slot, "supervisor spawn failure");
                     debug_assert_slot_loading(&slot);
                     *slot = ChildSlot::Closed;
-                    return Err(outproc_runtime_error(format!(
-                        "spawn outproc watchdog: {error}"
-                    )));
+                    return Err(R::runtime_error(format!("spawn outproc watchdog: {error}")));
                 }
             };
 
@@ -1095,7 +1350,7 @@ impl EngineWrap {
             let status = unsafe { (*region).child_status.load(Ordering::Acquire) };
             if status == orbit_audio_sandbox::transport::CHILD_STATUS_READY {
                 let flags = unsafe { (*region).child_flags.load(Ordering::Acquire) };
-                if !outproc_role_matches(flags) {
+                if !R::role_matches(flags) {
                     return Err(retryable_attach_failure(
                         supervisor,
                         region,
@@ -1106,13 +1361,10 @@ impl EngineWrap {
                         ),
                     ));
                 }
-                launch
-                    .stats
-                    .initial_attach_pending
-                    .store(false, Ordering::Release);
+                R::set_initial_attach_pending(&launch.stats, false);
                 break;
             }
-            if launch.stats.child_early_exit.load(Ordering::Acquire) {
+            if R::child_early_exit(&launch.stats) {
                 return Err(retryable_attach_failure(
                     supervisor,
                     region,
@@ -2068,7 +2320,7 @@ impl EngineWrap {
 /// `load_outproc_plugin` の終端遷移直前の不変条件検査（release では noop）。
 /// Loading 以外を観測したら、この関数以外に slot への書き手が現れたことを意味する。
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
-fn debug_assert_slot_loading(slot: &ChildSlot) {
+fn debug_assert_slot_loading<R: OutProcRole>(slot: &ChildSlot<R>) {
     debug_assert!(
         matches!(slot, ChildSlot::Loading { .. }),
         "load_outproc_plugin: slot must still be Loading (only this function \
@@ -2079,10 +2331,10 @@ fn debug_assert_slot_loading(slot: &ChildSlot) {
 /// child slot の poison は attach state machine の停止理由にせず、唯一の書き手である本関数が
 /// 回復して本来の遷移を完遂する。放置すると Loading/Closed/Empty の中間状態が恒久化する。
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
-fn lock_child_slot_recovering<'a>(
-    child_slot: &'a Mutex<ChildSlot>,
+fn lock_child_slot_recovering<'a, R: OutProcRole>(
+    child_slot: &'a Mutex<ChildSlot<R>>,
     site: &'static str,
-) -> MutexGuard<'a, ChildSlot> {
+) -> MutexGuard<'a, ChildSlot<R>> {
     child_slot.lock().unwrap_or_else(|poisoned| {
         tracing::error!("child slot mutex poisoned during {site}; recovering");
         poisoned.into_inner()
@@ -2096,15 +2348,15 @@ fn lock_child_slot_recovering<'a>(
 /// SAFETY 前提: `region` は呼び出し元 scope で生存する `ready_mmap` を指すこと
 /// （`load_outproc_plugin` の ready-ack ループからのみ呼ばれる）。
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
-fn retryable_attach_failure(
-    supervisor: OutProcChildSupervisor,
+fn retryable_attach_failure<R: OutProcRole>(
+    supervisor: R::Supervisor,
     region: *mut orbit_audio_sandbox::transport::SharedRegion,
-    child_slot: &Mutex<ChildSlot>,
-    launch: ChildLaunch,
+    child_slot: &Mutex<ChildSlot<R>>,
+    launch: ChildLaunch<R>,
     message: String,
 ) -> WrapError {
     tracing::warn!("outproc attach failed (retryable): {message}");
-    supervisor.detach_keep_shm();
+    R::detach_keep_shm(supervisor);
     // teardown が CONTROL_QUIT を書いたので、retry する child は RUN モードで起動する必要がある。
     unsafe { orbit_audio_sandbox::transport::reset_control_run(region) };
     let mut slot = lock_child_slot_recovering(child_slot, "retryable attach failure");
@@ -2113,90 +2365,22 @@ fn retryable_attach_failure(
     WrapError::OutProcAttachFailed(message)
 }
 
-#[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
-fn outproc_runtime_error(message: impl Into<String>) -> WrapError {
-    WrapError::OutProcEffect(message.into())
-}
+#[cfg(test)]
+type OutProcChildStats = <DefaultOutProcRole as OutProcRole>::Stats;
 
-#[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
-fn outproc_runtime_error(message: impl Into<String>) -> WrapError {
-    WrapError::OutProcInstrument(message.into())
-}
-
-#[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
-fn spawn_outproc_child(
-    launch: &ChildLaunch,
-    path: &std::path::Path,
-    plugin_id: Option<&str>,
-) -> std::io::Result<std::process::Child> {
-    crate::outproc_effect::spawn_effect_child(
-        &launch.child_exe,
-        &launch.shm_path,
-        path,
-        plugin_id,
-        launch.sample_rate,
-    )
-}
-
-#[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
-fn spawn_outproc_child(
-    launch: &ChildLaunch,
-    path: &std::path::Path,
-    plugin_id: Option<&str>,
-) -> std::io::Result<std::process::Child> {
-    crate::outproc_instrument::spawn_instrument_child(
-        &launch.child_exe,
-        &launch.shm_path,
-        path,
-        plugin_id,
-        launch.sample_rate,
-    )
-}
-
-#[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+#[cfg(test)]
 fn spawn_outproc_supervisor(
     child: std::process::Child,
     launch: &ChildLaunch,
     path: PathBuf,
     plugin_id: Option<String>,
-) -> std::io::Result<OutProcChildSupervisor> {
-    crate::outproc_effect::EffectChildSupervisor::spawn(
-        child,
-        launch.shm_path.clone(),
-        launch.stats.clone(),
-        launch.child_exe.clone(),
-        path,
-        plugin_id,
-        launch.sample_rate,
-    )
+) -> std::io::Result<<DefaultOutProcRole as OutProcRole>::Supervisor> {
+    DefaultOutProcRole::spawn_supervisor(child, launch, path, plugin_id)
 }
 
-#[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
-fn spawn_outproc_supervisor(
-    child: std::process::Child,
-    launch: &ChildLaunch,
-    path: PathBuf,
-    plugin_id: Option<String>,
-) -> std::io::Result<OutProcChildSupervisor> {
-    crate::outproc_instrument::InstrumentChildSupervisor::spawn(
-        child,
-        launch.shm_path.clone(),
-        launch.stats.clone(),
-        launch.child_exe.clone(),
-        path,
-        plugin_id,
-        launch.sample_rate,
-    )
-}
-
-#[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+#[cfg(test)]
 fn outproc_role_matches(flags: u32) -> bool {
-    flags & orbit_audio_sandbox::transport::CHILD_FLAG_HAS_AUDIO_INPUT != 0
-}
-
-#[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
-fn outproc_role_matches(flags: u32) -> bool {
-    flags & orbit_audio_sandbox::transport::CHILD_FLAG_HAS_AUDIO_INPUT == 0
+    DefaultOutProcRole::role_matches(flags)
 }
 
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -19,6 +19,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use orbit_audio_core::{resolve_slice_region, sanitize_rate, Engine, Sample};
+#[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+use orbit_audio_native::PostProcessor;
 use orbit_audio_native::{
     load_sample_resampled, LoaderError, OutputError, OutputStream, ResampleError, StreamStats,
     StreamStatsSnapshot,
@@ -205,7 +207,25 @@ struct OutProcInstrumentControl {
     /// Audio adapter と watchdog が更新し、gated harness が読む観測 stats。
     stats: Arc<crate::outproc_instrument::OutProcInstrumentStats>,
     /// post-boot attach の状態。`StreamGuard` と共有し、supervisor は stream より後に drop する。
+    #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+    child_slot: Weak<Mutex<ChildSlot<InstrumentRole>>>,
+    #[cfg(not(all(feature = "outproc-effect", feature = "outproc-instrument")))]
     child_slot: Weak<Mutex<ChildSlot>>,
+}
+
+/// instrument の add-mix 後に effect の serial insert を適用する RT 専用の合成 processor。
+#[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+struct CompositePostProcessor {
+    instrument: crate::outproc_instrument::OutProcInstrumentPostProcessor,
+    effect: crate::outproc_effect::OutProcEffectPostProcessor,
+}
+
+#[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+impl PostProcessor for CompositePostProcessor {
+    fn process(&mut self, data: &mut [f32]) {
+        self.instrument.process(data);
+        self.effect.process(data);
+    }
 }
 
 /// OOP role ごとの差分を child-slot state machine から分離する。
@@ -352,6 +372,62 @@ impl OutProcRole for DefaultOutProcRole {
     }
     fn set_current_child_pid(stats: &Self::Stats, pid: u32) {
         InstrumentRole::set_current_child_pid(stats, pid)
+    }
+}
+#[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+impl OutProcRole for DefaultOutProcRole {
+    type Stats = crate::outproc_effect::OutProcEffectStats;
+    type Supervisor = crate::outproc_effect::EffectChildSupervisor;
+    const ROLE_NAME: &'static str = EffectRole::ROLE_NAME;
+    fn spawn_child(
+        launch: &ChildLaunch<Self>,
+        path: &std::path::Path,
+        plugin_id: Option<&str>,
+    ) -> std::io::Result<std::process::Child> {
+        crate::outproc_effect::spawn_effect_child(
+            &launch.child_exe,
+            &launch.shm_path,
+            path,
+            plugin_id,
+            launch.sample_rate,
+        )
+    }
+    fn spawn_supervisor(
+        child: std::process::Child,
+        launch: &ChildLaunch<Self>,
+        path: PathBuf,
+        plugin_id: Option<String>,
+    ) -> std::io::Result<Self::Supervisor> {
+        crate::outproc_effect::EffectChildSupervisor::spawn(
+            child,
+            launch.shm_path.clone(),
+            launch.stats.clone(),
+            launch.child_exe.clone(),
+            path,
+            plugin_id,
+            launch.sample_rate,
+        )
+    }
+    fn detach_keep_shm(supervisor: Self::Supervisor) {
+        supervisor.detach_keep_shm()
+    }
+    fn role_matches(flags: u32) -> bool {
+        EffectRole::role_matches(flags)
+    }
+    fn runtime_error(message: String) -> WrapError {
+        EffectRole::runtime_error(message)
+    }
+    fn set_initial_attach_pending(stats: &Self::Stats, value: bool) {
+        EffectRole::set_initial_attach_pending(stats, value)
+    }
+    fn set_child_early_exit(stats: &Self::Stats, value: bool) {
+        EffectRole::set_child_early_exit(stats, value)
+    }
+    fn child_early_exit(stats: &Self::Stats) -> bool {
+        EffectRole::child_early_exit(stats)
+    }
+    fn set_current_child_pid(stats: &Self::Stats, pid: u32) {
+        EffectRole::set_current_child_pid(stats, pid)
     }
 }
 
@@ -684,6 +760,9 @@ pub struct StreamGuard {
     #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
     #[cfg(feature = "outproc-effect")]
     _child_guard: Arc<Mutex<ChildSlot>>,
+    /// both build では同種 guard 間の順序は load-bearing ではない（どちらも stream 停止後）。
+    #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+    _instrument_child_guard: Arc<Mutex<ChildSlot<InstrumentRole>>>,
     #[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
     _child_guard: Arc<Mutex<ChildSlot>>,
 }
@@ -1039,6 +1118,148 @@ impl EngineWrap {
         ))
     }
 
+    /// both build の buffer size を解決する。両方指定され値が異なる場合は、RT 設定の暗黙優先を
+    /// 作らず hard error にする。片方だけならその値、両方未指定なら `None` を使う。
+    #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+    fn resolve_outproc_both_buffer_frames(
+        effect: Option<u32>,
+        instrument: Option<u32>,
+    ) -> Result<Option<u32>, WrapError> {
+        match (effect, instrument) {
+            (Some(effect), Some(instrument)) if effect != instrument => Err(WrapError::OutProcEffect(format!(
+                    "ORBIT_EFFECT_BUFFER_FRAMES ({effect}) and ORBIT_INSTRUMENT_BUFFER_FRAMES ({instrument}) must match"
+                ))),
+            (Some(value), _) | (_, Some(value)) => Ok(Some(value)),
+            (None, None) => Ok(None),
+        }
+    }
+
+    /// effect と instrument の transport を一つの callback に合成して起動する。
+    #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+    pub fn start_outproc_both(
+        effect_cfg: crate::outproc_effect::OutProcEffectConfig,
+        instrument_cfg: crate::outproc_instrument::OutProcInstrumentConfig,
+    ) -> Result<(Arc<Self>, StreamGuard), WrapError> {
+        use crate::outproc_effect::{
+            OutProcEffectPostProcessor, OutProcEffectStats, OutProcTeardownGuard,
+        };
+        use crate::outproc_instrument::{
+            OutProcInstrumentPostProcessor, OutProcInstrumentStats, OutProcInstrumentTeardownGuard,
+            NOTE_RING_CAPACITY,
+        };
+        let buffer_frames = Self::resolve_outproc_both_buffer_frames(
+            effect_cfg.buffer_frames,
+            instrument_cfg.buffer_frames,
+        )?;
+        let effect_shm = crate::outproc_effect::unique_shm_path();
+        let effect_host = orbit_audio_sandbox::PipelinedEffectHost::from_mmap(
+            orbit_audio_sandbox::create_shared(&effect_shm)
+                .map_err(|e| WrapError::OutProcEffect(format!("create shm {effect_shm:?}: {e}")))?,
+        );
+        let instrument_shm = crate::outproc_instrument::unique_shm_path();
+        let instrument_host = orbit_audio_sandbox::PipelinedInstrumentHost::from_mmap(
+            orbit_audio_sandbox::create_shared(&instrument_shm).map_err(|e| {
+                WrapError::OutProcInstrument(format!("create shm {instrument_shm:?}: {e}"))
+            })?,
+        );
+        let (event_tx, event_rx) = rtrb::RingBuffer::new(NOTE_RING_CAPACITY);
+        let effect_engaged = Arc::new(AtomicBool::new(false));
+        let instrument_engaged = Arc::new(AtomicBool::new(false));
+        let effect_stop = Arc::new(AtomicBool::new(false));
+        let effect_done = Arc::new(AtomicBool::new(false));
+        let instrument_stop = Arc::new(AtomicBool::new(false));
+        let instrument_done = Arc::new(AtomicBool::new(false));
+        let effect_stats = OutProcEffectStats::new();
+        let instrument_stats = OutProcInstrumentStats::new();
+        let processor = Box::new(CompositePostProcessor {
+            instrument: OutProcInstrumentPostProcessor::new(
+                instrument_host,
+                event_rx,
+                NOTE_RING_CAPACITY,
+                instrument_engaged.clone(),
+                instrument_stop.clone(),
+                instrument_done.clone(),
+                instrument_stats.clone(),
+            ),
+            effect: OutProcEffectPostProcessor::new(
+                effect_host,
+                effect_engaged.clone(),
+                effect_stop.clone(),
+                effect_done.clone(),
+                effect_stats.clone(),
+            ),
+        });
+        let (engine, stream, stream_stats, effect_cb_stats) =
+            orbit_audio_native::start_default_output_with_clap(
+                processor,
+                buffer_frames,
+                capture_path_from_env(),
+            )
+            .map_err(WrapError::Output)?;
+        let effect_slot = Arc::new(Mutex::new(ChildSlot::Empty(ChildLaunch {
+            shm_path: effect_shm,
+            child_exe: effect_cfg.child_exe,
+            sample_rate: stream.sample_rate,
+            stats: effect_stats.clone(),
+            engaged: effect_engaged,
+            cleanup_shm_on_drop: true,
+        })));
+        let instrument_slot = Arc::new(Mutex::new(ChildSlot::<InstrumentRole>::Empty(
+            ChildLaunch {
+                shm_path: instrument_shm,
+                child_exe: instrument_cfg.child_exe,
+                sample_rate: stream.sample_rate,
+                stats: instrument_stats.clone(),
+                engaged: instrument_engaged,
+                cleanup_shm_on_drop: true,
+            },
+        )));
+        let wrap = Self::build(engine, stream.sample_rate, stream.channels, stream_stats);
+        *wrap
+            .outproc
+            .lock()
+            .map_err(|_| WrapError::OutProcEffect("outproc mutex poisoned".into()))? =
+            Some(OutProcControl {
+                stats: effect_stats,
+                cb_stats: effect_cb_stats,
+                child_slot: Arc::downgrade(&effect_slot),
+            });
+        *wrap.outproc_instrument.lock().map_err(|_| {
+            WrapError::OutProcInstrument("outproc instrument mutex poisoned".into())
+        })? = Some(OutProcInstrumentControl {
+            event_tx,
+            stats: instrument_stats,
+            child_slot: Arc::downgrade(&instrument_slot),
+        });
+        Ok((
+            wrap,
+            StreamGuard {
+                _outproc_teardown: OutProcTeardownGuard::new(effect_stop, effect_done),
+                _outproc_instrument_teardown: OutProcInstrumentTeardownGuard::new(
+                    instrument_stop,
+                    instrument_done,
+                ),
+                _stream: stream,
+                _child_guard: effect_slot,
+                _instrument_child_guard: instrument_slot,
+            },
+        ))
+    }
+
+    #[cfg(all(
+        feature = "outproc-effect",
+        feature = "outproc-instrument",
+        not(feature = "clap-host"),
+        not(feature = "link-audio")
+    ))]
+    pub fn start() -> Result<(Arc<Self>, StreamGuard), WrapError> {
+        let effect = crate::outproc_effect::OutProcEffectConfig::from_env()
+            .map_err(WrapError::OutProcEffectUnavailable)?;
+        let instrument = crate::outproc_instrument::OutProcInstrumentConfig::from_env()
+            .map_err(WrapError::OutProcInstrumentUnavailable)?;
+        Self::start_outproc_both(effect, instrument)
+    }
+
     /// [`AudioBackend`] 経由で起動する（integration test 用）。
     ///
     /// guard は `Box<dyn Any + Send>` の不透明ハンドル。scope 終了まで
@@ -1183,6 +1404,8 @@ impl EngineWrap {
         path: PathBuf,
         plugin_id: Option<String>,
     ) -> Result<LoadedPluginSummary, WrapError> {
+        #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+        return self.load_outproc_effect_plugin(path, plugin_id);
         #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
         let child_slot = {
             let guard = self
@@ -1225,6 +1448,54 @@ impl EngineWrap {
         return self.load_outproc_plugin_impl::<DefaultOutProcRole>(child_slot, path, plugin_id);
         #[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
         return self.load_outproc_plugin_impl::<DefaultOutProcRole>(child_slot, path, plugin_id);
+    }
+
+    /// both build で effect slot へ attach する。
+    #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+    pub fn load_outproc_effect_plugin(
+        &self,
+        path: PathBuf,
+        plugin_id: Option<String>,
+    ) -> Result<LoadedPluginSummary, WrapError> {
+        let slot = self
+            .outproc
+            .lock()
+            .map_err(|_| WrapError::OutProcEffect("outproc mutex poisoned".into()))?
+            .as_ref()
+            .ok_or_else(|| {
+                WrapError::OutProcEffectUnavailable(
+                    "outproc effect not initialized (test backend has no outproc path)".into(),
+                )
+            })?
+            .child_slot
+            .upgrade()
+            .ok_or_else(|| WrapError::OutProcEffect("outproc effect stream is closed".into()))?;
+        self.load_outproc_plugin_impl::<DefaultOutProcRole>(slot, path, plugin_id)
+    }
+
+    /// both build で instrument slot へ attach する。
+    #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+    pub fn load_outproc_instrument_plugin(
+        &self,
+        path: PathBuf,
+        plugin_id: Option<String>,
+    ) -> Result<LoadedPluginSummary, WrapError> {
+        let slot = self
+            .outproc_instrument
+            .lock()
+            .map_err(|_| WrapError::OutProcInstrument("outproc instrument mutex poisoned".into()))?
+            .as_ref()
+            .ok_or_else(|| {
+                WrapError::OutProcInstrumentUnavailable(
+                    "outproc instrument not initialized (test backend has no outproc path)".into(),
+                )
+            })?
+            .child_slot
+            .upgrade()
+            .ok_or_else(|| {
+                WrapError::OutProcInstrument("outproc instrument stream is closed".into())
+            })?;
+        self.load_outproc_plugin_impl::<InstrumentRole>(slot, path, plugin_id)
     }
 
     #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
@@ -2396,6 +2667,24 @@ fn outproc_plugin_summary(
             .file_stem()
             .map(|name| name.to_string_lossy().into_owned()),
         note_port_index: 0,
+    }
+}
+
+#[cfg(all(test, feature = "outproc-effect", feature = "outproc-instrument"))]
+mod outproc_both_tests {
+    use super::EngineWrap;
+
+    #[test]
+    fn both_buffer_frames_rejects_conflicting_values() {
+        assert!(EngineWrap::resolve_outproc_both_buffer_frames(Some(32), Some(64)).is_err());
+        assert_eq!(
+            EngineWrap::resolve_outproc_both_buffer_frames(Some(32), None).unwrap(),
+            Some(32)
+        );
+        assert_eq!(
+            EngineWrap::resolve_outproc_both_buffer_frames(None, None).unwrap(),
+            None
+        );
     }
 }
 
@@ -3600,7 +3889,7 @@ mod outproc_health_tests {
 /// build で走るため real body の match arm がどのテストからも一度も compile even されない）で、この
 /// `#[cfg(test)]` submodule から `EngineWrap::outproc_instrument`（private field）と
 /// `OutProcInstrumentControl`（private struct）へ直接アクセスして注入する。
-#[cfg(all(test, feature = "outproc-instrument"))]
+#[cfg(all(test, feature = "outproc-instrument", not(feature = "outproc-effect")))]
 mod outproc_instrument_health_tests {
     use super::{outproc_role_matches, ChildSlot, EngineWrap, OutProcInstrumentControl, WrapError};
     use crate::backend::StubBackend;

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -259,177 +259,14 @@ pub(crate) trait OutProcRole: Sized {
 pub(crate) struct EffectRole;
 #[cfg(feature = "outproc-instrument")]
 pub(crate) struct InstrumentRole;
-#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
-pub(crate) struct DefaultOutProcRole;
-
+/// single-role ビルドの既定 role（both ビルドでは legacy API 用に effect を指す）。
+/// 委譲 impl を複製せず type alias で本体 impl を継承する。
 #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
-impl OutProcRole for DefaultOutProcRole {
-    type Stats = crate::outproc_effect::OutProcEffectStats;
-    type Supervisor = crate::outproc_effect::EffectChildSupervisor;
-    const ROLE_NAME: &'static str = EffectRole::ROLE_NAME;
-    fn spawn_child(
-        launch: &ChildLaunch<Self>,
-        path: &std::path::Path,
-        plugin_id: Option<&str>,
-    ) -> std::io::Result<std::process::Child> {
-        crate::outproc_effect::spawn_effect_child(
-            &launch.child_exe,
-            &launch.shm_path,
-            path,
-            plugin_id,
-            launch.sample_rate,
-        )
-    }
-    fn spawn_supervisor(
-        child: std::process::Child,
-        launch: &ChildLaunch<Self>,
-        path: PathBuf,
-        plugin_id: Option<String>,
-    ) -> std::io::Result<Self::Supervisor> {
-        crate::outproc_effect::EffectChildSupervisor::spawn(
-            child,
-            launch.shm_path.clone(),
-            launch.stats.clone(),
-            launch.child_exe.clone(),
-            path,
-            plugin_id,
-            launch.sample_rate,
-        )
-    }
-    fn detach_keep_shm(supervisor: Self::Supervisor) {
-        supervisor.detach_keep_shm();
-    }
-    fn role_matches(flags: u32) -> bool {
-        EffectRole::role_matches(flags)
-    }
-    fn runtime_error(message: String) -> WrapError {
-        EffectRole::runtime_error(message)
-    }
-    fn set_initial_attach_pending(stats: &Self::Stats, value: bool) {
-        EffectRole::set_initial_attach_pending(stats, value)
-    }
-    fn set_child_early_exit(stats: &Self::Stats, value: bool) {
-        EffectRole::set_child_early_exit(stats, value)
-    }
-    fn child_early_exit(stats: &Self::Stats) -> bool {
-        EffectRole::child_early_exit(stats)
-    }
-    fn set_current_child_pid(stats: &Self::Stats, pid: u32) {
-        EffectRole::set_current_child_pid(stats, pid)
-    }
-}
+pub(crate) type DefaultOutProcRole = EffectRole;
 #[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
-impl OutProcRole for DefaultOutProcRole {
-    type Stats = crate::outproc_instrument::OutProcInstrumentStats;
-    type Supervisor = crate::outproc_instrument::InstrumentChildSupervisor;
-    const ROLE_NAME: &'static str = InstrumentRole::ROLE_NAME;
-    fn spawn_child(
-        launch: &ChildLaunch<Self>,
-        path: &std::path::Path,
-        plugin_id: Option<&str>,
-    ) -> std::io::Result<std::process::Child> {
-        crate::outproc_instrument::spawn_instrument_child(
-            &launch.child_exe,
-            &launch.shm_path,
-            path,
-            plugin_id,
-            launch.sample_rate,
-        )
-    }
-    fn spawn_supervisor(
-        child: std::process::Child,
-        launch: &ChildLaunch<Self>,
-        path: PathBuf,
-        plugin_id: Option<String>,
-    ) -> std::io::Result<Self::Supervisor> {
-        crate::outproc_instrument::InstrumentChildSupervisor::spawn(
-            child,
-            launch.shm_path.clone(),
-            launch.stats.clone(),
-            launch.child_exe.clone(),
-            path,
-            plugin_id,
-            launch.sample_rate,
-        )
-    }
-    fn detach_keep_shm(supervisor: Self::Supervisor) {
-        supervisor.detach_keep_shm();
-    }
-    fn role_matches(flags: u32) -> bool {
-        InstrumentRole::role_matches(flags)
-    }
-    fn runtime_error(message: String) -> WrapError {
-        InstrumentRole::runtime_error(message)
-    }
-    fn set_initial_attach_pending(stats: &Self::Stats, value: bool) {
-        InstrumentRole::set_initial_attach_pending(stats, value)
-    }
-    fn set_child_early_exit(stats: &Self::Stats, value: bool) {
-        InstrumentRole::set_child_early_exit(stats, value)
-    }
-    fn child_early_exit(stats: &Self::Stats) -> bool {
-        InstrumentRole::child_early_exit(stats)
-    }
-    fn set_current_child_pid(stats: &Self::Stats, pid: u32) {
-        InstrumentRole::set_current_child_pid(stats, pid)
-    }
-}
+pub(crate) type DefaultOutProcRole = InstrumentRole;
 #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
-impl OutProcRole for DefaultOutProcRole {
-    type Stats = crate::outproc_effect::OutProcEffectStats;
-    type Supervisor = crate::outproc_effect::EffectChildSupervisor;
-    const ROLE_NAME: &'static str = EffectRole::ROLE_NAME;
-    fn spawn_child(
-        launch: &ChildLaunch<Self>,
-        path: &std::path::Path,
-        plugin_id: Option<&str>,
-    ) -> std::io::Result<std::process::Child> {
-        crate::outproc_effect::spawn_effect_child(
-            &launch.child_exe,
-            &launch.shm_path,
-            path,
-            plugin_id,
-            launch.sample_rate,
-        )
-    }
-    fn spawn_supervisor(
-        child: std::process::Child,
-        launch: &ChildLaunch<Self>,
-        path: PathBuf,
-        plugin_id: Option<String>,
-    ) -> std::io::Result<Self::Supervisor> {
-        crate::outproc_effect::EffectChildSupervisor::spawn(
-            child,
-            launch.shm_path.clone(),
-            launch.stats.clone(),
-            launch.child_exe.clone(),
-            path,
-            plugin_id,
-            launch.sample_rate,
-        )
-    }
-    fn detach_keep_shm(supervisor: Self::Supervisor) {
-        supervisor.detach_keep_shm()
-    }
-    fn role_matches(flags: u32) -> bool {
-        EffectRole::role_matches(flags)
-    }
-    fn runtime_error(message: String) -> WrapError {
-        EffectRole::runtime_error(message)
-    }
-    fn set_initial_attach_pending(stats: &Self::Stats, value: bool) {
-        EffectRole::set_initial_attach_pending(stats, value)
-    }
-    fn set_child_early_exit(stats: &Self::Stats, value: bool) {
-        EffectRole::set_child_early_exit(stats, value)
-    }
-    fn child_early_exit(stats: &Self::Stats) -> bool {
-        EffectRole::child_early_exit(stats)
-    }
-    fn set_current_child_pid(stats: &Self::Stats, pid: u32) {
-        EffectRole::set_current_child_pid(stats, pid)
-    }
-}
+pub(crate) type DefaultOutProcRole = EffectRole;
 
 #[cfg(feature = "outproc-effect")]
 impl OutProcRole for EffectRole {
@@ -757,7 +594,6 @@ pub struct StreamGuard {
     _clap_thread: crate::clap_host::ClapThreadGuard,
     /// γ M1 PR-C（outproc-effect）: stream 停止 **後** に drop され、watchdog を止めて（respawn 停止）
     /// child へ QUIT → reap → shm unlink する。**field 順は load-bearing**: `_stream` より後に宣言する。
-    #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
     #[cfg(feature = "outproc-effect")]
     _child_guard: Arc<Mutex<ChildSlot>>,
     /// both build では同種 guard 間の順序は load-bearing ではない（どちらも stream 停止後）。
@@ -1398,6 +1234,11 @@ impl EngineWrap {
     /// `Arc` drop が最後の強参照となり、attach 直後の child が同期的に teardown（QUIT/reap/unlink）
     /// されうる（「成功応答=生きた plugin」が崩れる）。現行の全配線（main.rs のプロセス寿命
     /// `_stream_guard`・gated テストの関数スコープ `_guard`）はこれを満たす。
+    ///
+    /// **both ビルドでの意味論**: この legacy 単一 role API は **effect slot 専用**になる
+    /// （instrument slot には触れない）。production 経路（session.rs の LoadPlugin dispatch）は
+    /// both ビルドでは本メソッドを使わず、必ず role 別の `load_outproc_effect_plugin` /
+    /// `load_outproc_instrument_plugin` を呼ぶこと。
     #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
     pub fn load_outproc_plugin(
         &self,

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -644,6 +644,9 @@ pub struct StreamGuard {
     #[cfg(feature = "outproc-effect")]
     _outproc_teardown: crate::outproc_effect::OutProcTeardownGuard,
     /// outproc-instrument: stream 前に audio-thread adapter を quiesce する。
+    /// both build における `_outproc_teardown` との相対順序は load-bearing ではない
+    /// （各 guard は自 role 専用の requested/done atomic のみを操作し共有状態がない。
+    /// stream 停止後の child guard 2つと同じ独立性）。
     #[cfg(feature = "outproc-instrument")]
     _outproc_instrument_teardown: crate::outproc_instrument::OutProcInstrumentTeardownGuard,
     _stream: OutputStream,

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -2636,10 +2636,10 @@ fn retryable_attach_failure<R: OutProcRole>(
     WrapError::OutProcAttachFailed(message)
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "outproc-effect", feature = "outproc-instrument")))]
 type OutProcChildStats = <DefaultOutProcRole as OutProcRole>::Stats;
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "outproc-effect", feature = "outproc-instrument")))]
 fn spawn_outproc_supervisor(
     child: std::process::Child,
     launch: &ChildLaunch,
@@ -2649,7 +2649,7 @@ fn spawn_outproc_supervisor(
     DefaultOutProcRole::spawn_supervisor(child, launch, path, plugin_id)
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "outproc-effect", feature = "outproc-instrument")))]
 fn outproc_role_matches(flags: u32) -> bool {
     DefaultOutProcRole::role_matches(flags)
 }

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -58,6 +58,14 @@ fn outproc_role_param_is_valid(params: &Value) -> bool {
     params.get("role").and_then(Value::as_str) == Some("instrument")
 }
 
+#[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+fn outproc_role_param_is_valid(params: &Value) -> bool {
+    matches!(
+        params.get("role").and_then(Value::as_str),
+        Some("effect" | "instrument")
+    )
+}
+
 pub async fn run(
     ws: WebSocketStream<TcpStream>,
     engine: Arc<EngineWrap>,
@@ -644,6 +652,16 @@ async fn handle_command(
                         ),
                     );
                 }
+                #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+                if !outproc_role_param_is_valid(&params) {
+                    return err(
+                        &id,
+                        ProtocolError::new(
+                            "MALFORMED_REQUEST",
+                            "outproc LoadPlugin requires role='effect' or role='instrument'",
+                        ),
+                    );
+                }
 
                 let engine = engine.clone();
                 let path = std::path::PathBuf::from(path_str);
@@ -651,9 +669,30 @@ async fn handle_command(
                     .get("plugin_id")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
+                #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+                let params_role = params
+                    .get("role")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned);
                 let res = tokio::task::spawn_blocking(move || {
                     #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
                     {
+                        #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+                        {
+                            match params_role.as_deref() {
+                                Some("effect") => {
+                                    engine.load_outproc_effect_plugin(path, plugin_id)
+                                }
+                                Some("instrument") => {
+                                    engine.load_outproc_instrument_plugin(path, plugin_id)
+                                }
+                                _ => unreachable!("role was validated before spawn_blocking"),
+                            }
+                        }
+                        #[cfg(not(all(
+                            feature = "outproc-effect",
+                            feature = "outproc-instrument"
+                        )))]
                         engine.load_outproc_plugin(path, plugin_id)
                     }
                     #[cfg(not(any(feature = "outproc-effect", feature = "outproc-instrument")))]
@@ -1038,7 +1077,7 @@ fn wrap_err_to_protocol(e: &WrapError) -> ProtocolError {
 mod tests {
     use super::*;
 
-    #[cfg(feature = "outproc-effect")]
+    #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
     #[test]
     fn outproc_effect_load_plugin_accepts_only_effect_role() {
         assert!(outproc_role_param_is_valid(&json!({"role": "effect"})));
@@ -1046,11 +1085,20 @@ mod tests {
         assert!(!outproc_role_param_is_valid(&json!({})));
     }
 
-    #[cfg(feature = "outproc-instrument")]
+    #[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
     #[test]
     fn outproc_instrument_load_plugin_accepts_only_instrument_role() {
         assert!(outproc_role_param_is_valid(&json!({"role": "instrument"})));
         assert!(!outproc_role_param_is_valid(&json!({"role": "effect"})));
+        assert!(!outproc_role_param_is_valid(&json!({})));
+    }
+
+    #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+    #[test]
+    fn outproc_both_load_plugin_accepts_both_roles_and_rejects_invalid_role() {
+        assert!(outproc_role_param_is_valid(&json!({"role": "effect"})));
+        assert!(outproc_role_param_is_valid(&json!({"role": "instrument"})));
+        assert!(!outproc_role_param_is_valid(&json!({"role": "invalid"})));
         assert!(!outproc_role_param_is_valid(&json!({})));
     }
 

--- a/rust/crates/orbit-audio-daemon/tests/gated_common/mod.rs
+++ b/rust/crates/orbit-audio-daemon/tests/gated_common/mod.rs
@@ -1,0 +1,36 @@
+//! gated（実機）テスト群の共有ヘルパー。feature 非依存の純 std のみを置く
+//! （tokio/WebSocket を使う integration harness は `tests/common/mod.rs` が別に持つ）。
+
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+/// repo ルート相対パスを解決する（MANIFEST_DIR = rust/crates/orbit-audio-daemon）。
+pub fn repo_path(rel: &str) -> PathBuf {
+    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../..")).join(rel)
+}
+
+/// 別 crate の child binary パスを解決する。`CARGO_BIN_EXE_*` は使えないため、
+/// test 実行ファイル（`target/<profile>/deps/<name>-<hash>`）の祖先から sibling を導く（profile 非依存）。
+pub fn child_exe(name: &str) -> PathBuf {
+    let mut path = std::env::current_exe().expect("current_exe");
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push(name);
+    path
+}
+
+/// `timeout` まで 20ms 間隔で `condition` を poll し、成立したら true を返す。
+pub fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if condition() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    condition()
+}

--- a/rust/crates/orbit-audio-daemon/tests/outproc_both_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_both_gated.rs
@@ -6,8 +6,7 @@
 mod gated_common;
 use gated_common::{child_exe, repo_path, wait_until};
 
-use std::path::PathBuf;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use orbit_audio_daemon::engine_wrap::EngineWrap;
 use orbit_audio_daemon::outproc_effect::{OutProcEffectConfig, PluginFormat};

--- a/rust/crates/orbit-audio-daemon/tests/outproc_both_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_both_gated.rs
@@ -1,0 +1,137 @@
+//! both-role OOP の実機 gated test。instrument の add-mix を effect の serial insert が加工する順を
+//! daemon の単一 callback で検証する。CI は `--no-run` の compile contract のみを持つ。
+
+#![cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use orbit_audio_daemon::engine_wrap::EngineWrap;
+use orbit_audio_daemon::outproc_effect::{OutProcEffectConfig, PluginFormat};
+use orbit_audio_daemon::outproc_instrument::{OutProcInstrumentConfig, PROBE_KEY};
+
+const EFFECT_GAIN: f32 = 0.5;
+const PLUGIN_ID: &str = "com.signalcompose.clap-test-synth";
+const PROBE_NOTE_KEY: u8 = PROBE_KEY.key as u8;
+const PROBE_NOTE_CHANNEL: u8 = PROBE_KEY.channel as u8;
+
+fn repo_path(rel: &str) -> PathBuf {
+    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../..")).join(rel)
+}
+
+fn child_exe(name: &str) -> PathBuf {
+    let mut path = std::env::current_exe().expect("current_exe");
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push(name);
+    path
+}
+
+fn setup_test() -> (OutProcEffectConfig, OutProcInstrumentConfig) {
+    let effect = OutProcEffectConfig {
+        format: PluginFormat::Clap,
+        child_exe: child_exe("orbit-clap-effect-child"),
+        plugin: repo_path("rust-spike/clap-test-effect/target/debug/libclap_test_effect.dylib"),
+        plugin_id: None,
+        buffer_frames: None,
+    };
+    let instrument = OutProcInstrumentConfig {
+        child_exe: child_exe("orbit-clap-instrument-child"),
+        plugin: repo_path("rust-spike/clap-test-synth/target/debug/libclap_test_synth.dylib"),
+        plugin_id: Some(PLUGIN_ID.to_owned()),
+        buffer_frames: None,
+    };
+    assert!(effect.plugin.exists(), "test-effect dylib が無い: {} — 先に `cargo build --manifest-path rust-spike/clap-test-effect/Cargo.toml`", effect.plugin.display());
+    assert!(
+        effect.child_exe.exists(),
+        "effect child binary が無い: {} — 先に `cargo build -p orbit-clap-effect-child`",
+        effect.child_exe.display()
+    );
+    assert!(instrument.plugin.exists(), "test-synth dylib が無い: {} — 先に `cargo build --manifest-path rust-spike/clap-test-synth/Cargo.toml`", instrument.plugin.display());
+    assert!(
+        instrument.child_exe.exists(),
+        "instrument child binary が無い: {} — 先に `cargo build -p orbit-clap-instrument-child`",
+        instrument.child_exe.display()
+    );
+    (effect, instrument)
+}
+
+fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if condition() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    condition()
+}
+
+#[test]
+#[ignore = "both-role OOP: needs a real output device + built effect/instrument children and test dylibs (local only)"]
+fn both_roles_attach_in_instrument_then_effect_order() {
+    let (effect_cfg, instrument_cfg) = setup_test();
+    let synth_path = instrument_cfg.plugin.clone();
+    let synth_id = instrument_cfg.plugin_id.clone();
+    let effect_path = effect_cfg.plugin.clone();
+    let (engine, _guard) = EngineWrap::start_outproc_both(effect_cfg, instrument_cfg)
+        .expect("start both-role OOP daemon");
+
+    engine
+        .load_outproc_instrument_plugin(synth_path, synth_id)
+        .expect("attach test-synth to instrument slot");
+    engine
+        .load_outproc_effect_plugin(effect_path, None)
+        .expect("attach test-effect to effect slot");
+
+    engine
+        .plugin_note_on(PROBE_NOTE_KEY, PROBE_NOTE_CHANNEL, 0.8)
+        .expect("send probe note on");
+    let instrument_live = wait_until(Duration::from_secs(3), || {
+        engine
+            .outproc_instrument_stats()
+            .map(|s| s.fresh > 0 && s.probe_live_count > 0)
+            .unwrap_or(false)
+    });
+    let effect_fresh = wait_until(Duration::from_secs(3), || {
+        engine
+            .outproc_effect_stats()
+            .map(|s| s.fresh > 0 && s.dry_peak > 0.01)
+            .unwrap_or(false)
+    });
+    engine
+        .plugin_note_off(PROBE_NOTE_KEY, PROBE_NOTE_CHANNEL, 0.0)
+        .expect("send probe note off");
+
+    let instrument = engine.outproc_instrument_stats().expect("instrument stats");
+    let effect = engine.outproc_effect_stats().expect("effect stats");
+    let ratio = if effect.dry_peak > 0.0 {
+        effect.post_peak / effect.dry_peak
+    } else {
+        0.0
+    };
+    println!("both OOP: instrument fresh={} live={} post_peak={:.5}; effect fresh={} dry={:.5} post={:.5} ratio={ratio:.5}", instrument.fresh, instrument.probe_live_count, instrument.post_peak, effect.fresh, effect.dry_peak, effect.post_peak);
+    assert!(
+        instrument_live,
+        "instrument の fresh/probe_live_count が note-on 後に立たなかった (fresh={}, live={})",
+        instrument.fresh, instrument.probe_live_count
+    );
+    assert!(
+        effect_fresh,
+        "effect が instrument の非無音出力を fresh 処理しなかった (fresh={}, dry_peak={:.5})",
+        effect.fresh, effect.dry_peak
+    );
+    assert!(
+        !instrument.measurement_invalid,
+        "instrument child の計測が無効"
+    );
+    assert!(!effect.measurement_invalid, "effect child の計測が無効");
+    // effect の dry は composite 内で instrument add-mix 後の buffer、post はその serial insert 後なので、
+    // 単体 effect の sine 入力と同じ post/dry 契約がそのまま成立する。
+    assert!(
+        (0.4..=0.6).contains(&ratio),
+        "effect の post/dry gain 比が想定外: {ratio:.5}（期待 ~{EFFECT_GAIN}）"
+    );
+}

--- a/rust/crates/orbit-audio-daemon/tests/outproc_both_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_both_gated.rs
@@ -3,6 +3,9 @@
 
 #![cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
 
+mod gated_common;
+use gated_common::{child_exe, repo_path, wait_until};
+
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -14,20 +17,6 @@ const EFFECT_GAIN: f32 = 0.5;
 const PLUGIN_ID: &str = "com.signalcompose.clap-test-synth";
 const PROBE_NOTE_KEY: u8 = PROBE_KEY.key as u8;
 const PROBE_NOTE_CHANNEL: u8 = PROBE_KEY.channel as u8;
-
-fn repo_path(rel: &str) -> PathBuf {
-    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../..")).join(rel)
-}
-
-fn child_exe(name: &str) -> PathBuf {
-    let mut path = std::env::current_exe().expect("current_exe");
-    path.pop();
-    if path.ends_with("deps") {
-        path.pop();
-    }
-    path.push(name);
-    path
-}
 
 fn setup_test() -> (OutProcEffectConfig, OutProcInstrumentConfig) {
     let effect = OutProcEffectConfig {
@@ -56,17 +45,6 @@ fn setup_test() -> (OutProcEffectConfig, OutProcInstrumentConfig) {
         instrument.child_exe.display()
     );
     (effect, instrument)
-}
-
-fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) -> bool {
-    let deadline = Instant::now() + timeout;
-    while Instant::now() < deadline {
-        if condition() {
-            return true;
-        }
-        std::thread::sleep(Duration::from_millis(20));
-    }
-    condition()
 }
 
 #[test]

--- a/rust/crates/orbit-audio-daemon/tests/outproc_effect_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_effect_gated.rs
@@ -20,7 +20,10 @@
 //! （cross-process は same-build determinism なので両プロセスが再コンパイルされる）。本テストの assert は
 //! 「catastrophic でない」sanity floor で、SLOTS の最終判断は printed verdict を owner が読んで行う。
 
-#![cfg(feature = "outproc-effect")]
+#![cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+
+mod gated_common;
+use gated_common::{child_exe, repo_path, wait_until};
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -34,25 +37,6 @@ const EFFECT_GAIN: f32 = 0.5;
 /// RT 健全性の callback 所要時間上限（synth/clap gated と同じ保守的上限 20ms）。
 const CALLBACK_MAX_BUDGET_NS: u64 = 20_000_000;
 
-/// repo ルート相対パスを解決する（MANIFEST_DIR = rust/crates/orbit-audio-daemon）。
-fn repo_path(rel: &str) -> PathBuf {
-    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../..")).join(rel)
-}
-
-/// effect child binary（`orbit-clap-effect-child`）のパスを解決する。
-///
-/// 別 crate の binary なので `CARGO_BIN_EXE_*` は使えない。test 実行ファイル
-/// （`target/<profile>/deps/<name>-<hash>`）の祖先から sibling binary を導く（profile 非依存）。
-fn child_exe() -> PathBuf {
-    let mut p = std::env::current_exe().expect("current_exe");
-    p.pop(); // test exe 名を除く → deps/
-    if p.ends_with("deps") {
-        p.pop(); // deps/ を除く → target/<profile>/
-    }
-    p.push("orbit-clap-effect-child");
-    p
-}
-
 /// test-effect の .clap dylib（standalone crate なので独自 target/debug 配下）。
 fn test_effect_dylib() -> PathBuf {
     repo_path("rust-spike/clap-test-effect/target/debug/libclap_test_effect.dylib")
@@ -63,7 +47,7 @@ fn test_effect_dylib() -> PathBuf {
 fn setup_test(buffer_frames: Option<u32>) -> (OutProcEffectConfig, PathBuf) {
     let cfg = OutProcEffectConfig {
         format: PluginFormat::Clap,
-        child_exe: child_exe(),
+        child_exe: child_exe("orbit-clap-effect-child"),
         plugin: test_effect_dylib(),
         plugin_id: None, // 単一プラグイン bundle なので id 省略可
         buffer_frames,
@@ -92,18 +76,6 @@ fn play_sine(engine: &EngineWrap, wav: &Path) {
     engine
         .play_at(&sample.sample_id, onset, 1.0, 0.0, 0.0, 0.0, 1.0, None)
         .expect("play sine");
-}
-
-/// `cond` が真になるまで（または timeout まで）20ms 間隔で poll する。真で抜けたら true。
-fn wait_until(timeout: Duration, mut cond: impl FnMut() -> bool) -> bool {
-    let deadline = Instant::now() + timeout;
-    while Instant::now() < deadline {
-        if cond() {
-            return true;
-        }
-        std::thread::sleep(Duration::from_millis(20));
-    }
-    cond()
 }
 
 // ── parity: OOP effect が master bus を加工する（post/dry ≈ EFFECT_GAIN）─────────────────────

--- a/rust/crates/orbit-audio-daemon/tests/outproc_effect_vst3_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_effect_vst3_gated.rs
@@ -33,7 +33,7 @@
 //!
 //! device / dylib / child binary が揃わない env（headless CI 等）では owner へ stop&report（手動 fallback）。
 
-#![cfg(feature = "outproc-effect")]
+#![cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
 
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/rust/crates/orbit-audio-daemon/tests/outproc_instrument_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_instrument_gated.rs
@@ -9,7 +9,10 @@
 //!
 //! 実際にスピーカーから 0.25 振幅の sine が鳴るため、実行前に出力デバイスを確認すること。
 
-#![cfg(feature = "outproc-instrument")]
+#![cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
+
+mod gated_common;
+use gated_common::{child_exe, repo_path, wait_until};
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -25,21 +28,6 @@ const PLUGIN_ID: &str = "com.signalcompose.clap-test-synth";
 const PROBE_NOTE_KEY: u8 = PROBE_KEY.key as u8;
 const PROBE_NOTE_CHANNEL: u8 = PROBE_KEY.channel as u8;
 
-fn repo_path(rel: &str) -> PathBuf {
-    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../..")).join(rel)
-}
-
-/// 別 crate の binary なので、test executable の sibling binary として解決する。
-fn child_exe() -> PathBuf {
-    let mut path = std::env::current_exe().expect("current_exe");
-    path.pop();
-    if path.ends_with("deps") {
-        path.pop();
-    }
-    path.push("orbit-clap-instrument-child");
-    path
-}
-
 fn test_synth_dylib() -> PathBuf {
     repo_path("rust-spike/clap-test-synth/target/debug/libclap_test_synth.dylib")
 }
@@ -47,7 +35,7 @@ fn test_synth_dylib() -> PathBuf {
 /// 実機 test の prerequisites を loud に検証し、production 起動用 config を返す。
 fn setup_test() -> OutProcInstrumentConfig {
     let config = OutProcInstrumentConfig {
-        child_exe: child_exe(),
+        child_exe: child_exe("orbit-clap-instrument-child"),
         plugin: test_synth_dylib(),
         plugin_id: Some(PLUGIN_ID.to_owned()),
         buffer_frames: None,
@@ -63,17 +51,6 @@ fn setup_test() -> OutProcInstrumentConfig {
         config.child_exe.display()
     );
     config
-}
-
-fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) -> bool {
-    let deadline = Instant::now() + timeout;
-    while Instant::now() < deadline {
-        if condition() {
-            return true;
-        }
-        std::thread::sleep(Duration::from_millis(20));
-    }
-    condition()
 }
 
 #[test]


### PR DESCRIPTION
Refs #431（PR-2 / Epic #424 Stage 2）

## 概要

`outproc-effect × outproc-instrument` の compile-time 排他を解消し、**1つの daemon で CLAP effect と instrument を同時ホスト**できるようにする。Epic #424 DoD「effect + instrument が完全に動く」の中核。

## 変更内容

### Stage 1: ChildSlot 機構の role ジェネリック化（挙動不変）
- `trait OutProcRole`（Stats/Supervisor 関連型 + spawn/detach/role_matches/stats アクセサ）+ `EffectRole`/`InstrumentRole` marker
- `ChildLaunch<R>`/`ChildSlot<R>` 化・単一 role 型エイリアス撤去・`load_outproc_plugin_impl<R>` へ本体移動
- PR-1c の状態機械意味論（Empty/Loading/Active/Closed・retryable_attach_failure・poison 回復）は両 role で完全維持
- **既存テスト 48+47 が無変更で全パス = 挙動不変の証明**

### Stage 2: both ビルド配線
- `CompositePostProcessor`: instrument add-mix → effect serial insert の固定順（RT 経路 alloc/lock なし・orbit-audio-native 無改変）
- `start_outproc_both()`: shm×2・processor×2・slot×2・単一 stream。StreamGuard は teardown guard×2（stream 前）+ child guard×2（stream 後）
- session.rs: both ビルドで role='effect'/'instrument' 両受理 → role 別 slot へ dispatch
- buffer_frames 優先規則: 両 env が異なる値ならハードエラー（silent 優先禁止）
- instrument×effect の compile_error ペアのみ削除（clap-host / link-audio 排他は維持）

## 検証

- 3構成フルスイート: effect 48 / instrument 47 / **both 63** + clippy×3 + default-features + fmt 全グリーン
- **both 実機 gated E2E PASS（2.10s）**: instrument 発音（fresh=3・probe live）→ effect serial insert（post/dry ratio **0.50000** 厳密一致）が単一 callback で同時動作
- single-role gated 回帰 **全7本実機 PASS**（parity / kill-test / stale-rate / attach-retry×2 / 発音 / respawn）— リファクタによる退行なし

## 残り（PR-3 スコープ・本 PR には含まない）

TS の `assertNoCrossPluginDeclaration` 撤去 + in-process daemon 側 cross-role reject + 配布 feature + DSL からの実機 E2E → Epic #424 DoD 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)