### PR TITLE
feat(daemon): DoD wiring — cross-role reject + release features + DSL E2E (#431 PR-3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,7 @@ jobs:
         with:
           workspaces: rust
 
+      # Release daemon uses OOP-both; the in-process clap-host is dev/gated-test only.
       # Builds the native orbit-audio-daemon binary so scripts/copy-daemon-bin.sh
       # (invoked by `npm run build` -> build:engine, see packages/vscode-extension/
       # package.json) can bundle it into engine/bin/darwin-arm64/ before packaging
@@ -82,8 +83,10 @@ jobs:
       # ordering here determines whether the release .vsix ships with the daemon.
       # runner is macos-14 (Apple Silicon) -- matches the daemon's only bundled
       # target (darwin-arm64).
-      - name: Build orbit-audio-daemon (native Rust engine, default backend since #369)
-        run: cargo build --release -p orbit-audio-daemon --manifest-path rust/Cargo.toml
+      - name: Build OOP-both Rust daemon and CLAP child binaries
+        run: |
+          cargo build --release -p orbit-audio-daemon --features outproc-effect,outproc-instrument --manifest-path rust/Cargo.toml
+          cargo build --release -p orbit-clap-effect-child -p orbit-clap-instrument-child --manifest-path rust/Cargo.toml
 
       - name: Build engine + extension TypeScript
         working-directory: packages/vscode-extension
@@ -133,6 +136,19 @@ jobs:
             exit 1
           fi
           echo "orbit-audio-daemon present and executable in packaged .vsix"
+
+          for CHILD_BIN in orbit-clap-effect-child orbit-clap-instrument-child; do
+            CHILD_PATH="$VSIX_CHECK/extension/engine/bin/darwin-arm64/$CHILD_BIN"
+            if [ ! -f "$CHILD_PATH" ]; then
+              echo "::error::$CHILD_BIN missing from packaged .vsix at engine/bin/darwin-arm64/ — OOP plugin hosting cannot start its child" >&2
+              exit 1
+            fi
+            if [ ! -x "$CHILD_PATH" ]; then
+              echo "::error::$CHILD_BIN in packaged .vsix is not executable (lost +x bit?)" >&2
+              exit 1
+            fi
+            echo "$CHILD_BIN present and executable in packaged .vsix"
+          done
 
       # ─────────────────────────────────────────────────────────────────────
       # Steps below this point only run for tag pushes (not pull_request).

--- a/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
+++ b/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
@@ -1217,9 +1217,10 @@ global.effect("~/plugins/TAL-Reverb-4.clap")   // master bus insert
 
 ### PH.6 v1 制限（実装事実の開示）
 
-- effect と instrument の同一プロセス同時使用は現配管では不可（compile-time 排他 feature）。
-  解消は #431（daemon の OOP post-boot attach + 排他解消・Epic #424 Stage 2）のスコープであり、
-  **構文はこの制限に依存しない**（制限が解消されても構文は不変）。
+- release 既定の OOP-both 構成（`--features outproc-effect,outproc-instrument`）では、effect と
+  instrument の同一プロセス同時使用をサポートする（#431 で解消、Epic #424 DoD 達成）。
+  in-process `clap-host` は dev / gated-test 専用の単一 slot なので、異なる role への再ロードは
+  `CLAP_CROSS_ROLE_REJECTED` で拒否される。
 - note 発火は block-head 精度（sample-accurate 化は #428）。
 - ロード確認から audio 反映までの短い race window が残存する（#410）。
 - **param / CC 制御**（EQ-from-DSL 等）は本節のスコープ外 — M2 param path の成熟後に

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,42 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.257 feat(daemon): DoD 配線 — TS ガード撤去 + cross-role reject + 配布 feature + DSL 実機 E2E #431 PR-3 (Jul 16, 2026)
+
+**Date**: 2026-07-16
+**Status**: ✅ 実装・**Epic #424 DoD 実機達成**（PR 作成・レビューフローへ）
+**Branch**: `431-oop-dod-wiring`
+**Commit**: [PENDING]
+
+Epic #424 の最終 PR。実装 = Codex（Stage A/B + E2E 発見バグ修正）。
+
+**Stage A（ガード配線の付け替え）**:
+- TS: `assertNoCrossPluginDeclaration` 撤去（v1 排他の根拠 = daemon 単一 slot が PR-2 で解消）
+- daemon: in-process clap-host に cross-role reject 新設（`ClapControl.loaded_role` 記録 +
+  `CLAP_CROSS_ROLE_REJECTED`・撤去だけだと silent 置換になる #431 の罠に対応）。
+  in-process LoadPlugin は role 必須化
+- 受け入れ監査で clap gated テストのコンパイル破綻を検出し修正
+
+**Stage B（配布 feature 方針・#431 scope e 確定)**:
+- release daemon = `--features outproc-effect,outproc-instrument`（OOP both）。
+  in-process clap-host は dev/gated 専用
+- child binary 2本を .vsix に同梱（daemon の sibling 解決規約・追加配線不要）+
+  release.yml post-package gate に fail-loud 検証追加
+
+**E2E 発見バグ（production ブロッカー）**:
+- 配布構成 daemon が `ORBIT_EFFECT_PLUGIN not set` で boot 不能（from_env の eager 時代の遺物）
+  → Config.plugin を Option 化・plugin env 任意化・eager 系は None 明示エラー
+
+**Epic #424 DoD 実機達成**:
+- .orbs（`global.effect(CLAPTestEffect.clap)` + `seq.instrument(CLAPTestSynth.clap)` +
+  `play(1,3,5,8)`）を cli-audio.js + 配布構成 release daemon で実行
+- baseline（instrument のみ）capture peak **0.25000**（synth 既知振幅）/
+  effect+instrument 同時 peak **0.12500**・**ratio 0.50000 厳密一致**
+- 「DSL から CLAP effect 1 つ + instrument 1 つを同時ロードし、Pitch DSL の note で演奏し、
+  両方が実機で鳴る」= **DoD の文言通りを客観実証**（スピーカー実再生込み）
+
+**検証**: 3構成 lib（51/50/82）+ 全ターゲットコンパイル + clippy + TS 1330 passed
+
 ### 6.256 feat(daemon): OOP effect × instrument 共存 #431 PR-2 (Jul 16, 2026)
 
 **Date**: 2026-07-16

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -263,35 +263,14 @@ export class Global {
     return this.linkAudioManager.isEnabled()
   }
 
-  /**
-   * v1 mutual exclusion between `global.effect()` and `seq.instrument()`
-   * (daemon single-plugin slot limitation; planned for #431). Checked here —
-   * rather than inside each manager — so neither manager needs a closure over
-   * the other (mirrors the `linkAudio()` cross-manager check above). Each
-   * caller passes the *other* manager, so a repeat call declaring the same
-   * plugin again (idempotent path, handled inside the manager itself) is
-   * unaffected.
-   */
-  private assertNoCrossPluginDeclaration(
-    other: PluginEffectManager | PluginInstrumentManager,
-  ): void {
-    if (other.hasDeclaration()) {
-      throw new Error(
-        'v1 does not support simultaneous effect and instrument use (daemon single-plugin slot limitation; planned for #431).',
-      )
-    }
-  }
-
   /** Eagerly load the v1 single master-insert plugin. */
   async effect(path: string, pluginId?: string): Promise<this> {
-    this.assertNoCrossPluginDeclaration(this.pluginInstrumentManager)
     await this.pluginEffectManager.effect(path, pluginId)
     return this
   }
 
   /** Eagerly load the v1 single hosted instrument plugin (shared by note sequences). */
   async instrument(path: string, pluginId?: string): Promise<this> {
-    this.assertNoCrossPluginDeclaration(this.pluginEffectManager)
     await this.pluginInstrumentManager.instrument(path, pluginId)
     return this
   }

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -2853,6 +2853,84 @@ mod plugin_load_gate_tests {
     }
 
     #[test]
+    fn failed_first_load_leaves_role_unset_and_permits_a_different_role() {
+        let (wrap, cmd_rx) = loadable_engine();
+        let responder = std::thread::spawn(move || {
+            for message in ["first load failed", "second load failed"] {
+                let crate::clap_host::ClapCommand::LoadPlugin { reply, .. } = cmd_rx
+                    .recv_timeout(Duration::from_secs(5))
+                    .expect("both loads should reach clap host while no role is loaded");
+                reply
+                    .send(Err(message.to_string()))
+                    .expect("caller waits for reply");
+            }
+        });
+
+        let first = wrap.load_plugin(PathBuf::from("first.clap"), None, ClapPluginRole::Effect);
+        assert!(matches!(first, Err(WrapError::Clap(message)) if message == "first load failed"));
+        assert_eq!(
+            wrap.clap
+                .lock()
+                .expect("clap mutex")
+                .as_ref()
+                .expect("clap control")
+                .loaded_role,
+            None,
+            "failed first load must not claim a role"
+        );
+
+        let second = wrap.load_plugin(
+            PathBuf::from("second.clap"),
+            None,
+            ClapPluginRole::Instrument,
+        );
+        responder.join().expect("responder thread should not panic");
+        assert!(
+            matches!(second, Err(WrapError::Clap(message)) if message == "second load failed"),
+            "different role after a failed first load must reach clap host, not cross-role reject"
+        );
+    }
+
+    #[test]
+    fn failed_same_role_reload_preserves_the_successfully_loaded_role() {
+        let (wrap, cmd_rx) = loadable_engine();
+        let responder = std::thread::spawn(move || {
+            let crate::clap_host::ClapCommand::LoadPlugin { reply, .. } = cmd_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("first load should reach clap host");
+            reply
+                .send(Ok(orbit_clap_host::LoadedPluginInfo {
+                    plugin_id: "com.example.dummy".to_string(),
+                    plugin_name: Some("Dummy".to_string()),
+                    note_port_index: 0,
+                }))
+                .expect("caller waits for first reply");
+            let crate::clap_host::ClapCommand::LoadPlugin { reply, .. } = cmd_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("same-role reload should reach clap host");
+            reply
+                .send(Err("reload failed".to_string()))
+                .expect("caller waits for reload reply");
+        });
+
+        let first = wrap.load_plugin(PathBuf::from("dummy.clap"), None, ClapPluginRole::Effect);
+        assert!(first.is_ok(), "first load should succeed");
+        let reload = wrap.load_plugin(PathBuf::from("dummy.clap"), None, ClapPluginRole::Effect);
+        responder.join().expect("responder thread should not panic");
+        assert!(matches!(reload, Err(WrapError::Clap(message)) if message == "reload failed"));
+        assert_eq!(
+            wrap.clap
+                .lock()
+                .expect("clap mutex")
+                .as_ref()
+                .expect("clap control")
+                .loaded_role,
+            Some(ClapPluginRole::Effect),
+            "failed same-role reload must preserve the successful load's role"
+        );
+    }
+
+    #[test]
     fn different_role_resend_is_rejected_before_clap_host_replacement() {
         let (wrap, cmd_rx) = loadable_engine();
         wrap.clap
@@ -2939,6 +3017,47 @@ mod plugin_load_gate_tests {
         );
         assert!(consumer.pop().is_ok());
         assert!(consumer.pop().is_ok());
+    }
+}
+
+#[cfg(all(test, feature = "outproc-effect", not(feature = "outproc-instrument")))]
+mod outproc_effect_eager_start_tests {
+    use super::{EngineWrap, WrapError};
+    use crate::outproc_effect::{OutProcEffectConfig, PluginFormat};
+    use std::path::PathBuf;
+
+    #[test]
+    fn eager_effect_start_requires_a_plugin_path_before_device_access() {
+        let result = EngineWrap::start_outproc_effect(OutProcEffectConfig {
+            format: PluginFormat::Clap,
+            child_exe: PathBuf::from("unused-child"),
+            plugin: None,
+            plugin_id: None,
+            buffer_frames: None,
+        });
+        assert!(
+            matches!(result, Err(WrapError::OutProcEffect(message)) if message == "eager start requires a plugin path")
+        );
+    }
+}
+
+#[cfg(all(test, feature = "outproc-instrument", not(feature = "outproc-effect")))]
+mod outproc_instrument_eager_start_tests {
+    use super::{EngineWrap, WrapError};
+    use crate::outproc_instrument::OutProcInstrumentConfig;
+    use std::path::PathBuf;
+
+    #[test]
+    fn eager_instrument_start_requires_a_plugin_path_before_device_access() {
+        let result = EngineWrap::start_outproc_instrument(OutProcInstrumentConfig {
+            child_exe: PathBuf::from("unused-child"),
+            plugin: None,
+            plugin_id: None,
+            buffer_frames: None,
+        });
+        assert!(
+            matches!(result, Err(WrapError::OutProcInstrument(message)) if message == "eager start requires a plugin path")
+        );
     }
 }
 

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -57,6 +57,9 @@ pub enum WrapError {
     /// 専用スレッド不在・mutex poison 等）。TS 層は feature-gap と区別して rethrow する。
     #[error("clap host runtime error: {0}")]
     Clap(String),
+    /// in-process CLAP host は単一 slot のため、先にロード済みの role と異なる再ロードを拒否する。
+    #[error("clap cross-role load rejected: {0}")]
+    ClapCrossRoleRejected(String),
     /// CLAP plugin hosting は利用可能だが、まだ一度も `load_plugin` に成功していない（#405）。
     /// feature-gap（`ClapUnavailable`）でも汎用 runtime エラー（`Clap`）でもなく、専用コードにすることで
     /// クライアントが「LoadPlugin をまだ呼んでいない／失敗した」ことを actionable に判定できるようにする
@@ -498,6 +501,8 @@ const CHILD_READY_POLL: Duration = Duration::from_millis(10);
 struct ClapControl {
     /// 専用スレッドへ `LoadPlugin` を送る Sender。
     cmd_tx: std::sync::mpsc::Sender<crate::clap_host::ClapCommand>,
+    /// 単一 CLAP slot に正常ロード済みの plugin role。成功応答後だけ更新する。
+    loaded_role: Option<ClapPluginRole>,
     /// audio thread（cpal callback の `ClapPostProcessor`）へ note を渡す event ring producer。
     event_tx: rtrb::Producer<orbit_clap_host::PluginEvent>,
     /// CLAP processor 統計（post-mix peak / process error 等）。daemon が読む。
@@ -505,6 +510,13 @@ struct ClapControl {
     /// callback-duration 統計（A0 §6: CoreAudio+cpal は xrun 不発火 → RT 健全性は callback 実測時間で
     /// 測る）。daemon の RT 監視 / gated test の budget 検証が読む。
     cb_stats: Arc<orbit_audio_native::CallbackTimeStats>,
+}
+
+/// in-process CLAP host の単一 slot に紐付く plugin role。
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ClapPluginRole {
+    Effect,
+    Instrument,
 }
 
 /// CLAP plugin の activate に渡す最大フレーム数。daemon の cpal stream は可変 buffer（`None`）なので
@@ -794,6 +806,7 @@ impl EngineWrap {
             .lock()
             .map_err(|_| WrapError::Clap("clap mutex poisoned".into()))? = Some(ClapControl {
             cmd_tx,
+            loaded_role: None,
             event_tx: parts.event_producer,
             stats: parts.stats,
             cb_stats,
@@ -1604,19 +1617,28 @@ impl EngineWrap {
         &self,
         path: PathBuf,
         plugin_id: Option<String>,
+        role: ClapPluginRole,
     ) -> Result<LoadedPluginSummary, WrapError> {
         let (reply_tx, reply_rx) = std::sync::mpsc::channel();
         {
             // lock は send までで解放し、reply 待ちの blocking を mutex 外で行う。
-            let guard = self
+            let mut guard = self
                 .clap
                 .lock()
                 .map_err(|_| WrapError::Clap("clap mutex poisoned".into()))?;
-            let ctl = guard.as_ref().ok_or_else(|| {
+            let ctl = guard.as_mut().ok_or_else(|| {
                 WrapError::ClapUnavailable(
                     "clap host not initialized (test backend has no clap path)".into(),
                 )
             })?;
+            if let Some(loaded_role) = ctl.loaded_role {
+                if loaded_role != role {
+                    return Err(WrapError::ClapCrossRoleRejected(
+                        "in-process clap-host has one plugin slot; unload before changing role"
+                            .into(),
+                    ));
+                }
+            }
             ctl.cmd_tx
                 .send(crate::clap_host::ClapCommand::LoadPlugin {
                     path,
@@ -1632,6 +1654,11 @@ impl EngineWrap {
             Ok(Ok(info)) => {
                 // #405: 以後 push_plugin_event が「未ロード」を検知して事前に弾けるようにする。
                 self.plugin_loaded.store(true, Ordering::Relaxed);
+                if let Ok(mut guard) = self.clap.lock() {
+                    if let Some(ctl) = guard.as_mut() {
+                        ctl.loaded_role = Some(role);
+                    }
+                }
                 Ok(LoadedPluginSummary {
                     plugin_id: info.plugin_id,
                     plugin_name: info.plugin_name,
@@ -1649,6 +1676,7 @@ impl EngineWrap {
         &self,
         _path: PathBuf,
         _plugin_id: Option<String>,
+        _role: ClapPluginRole,
     ) -> Result<LoadedPluginSummary, WrapError> {
         Err(WrapError::ClapUnavailable(
             "engine built without 'clap-host' feature".into(),
@@ -2709,6 +2737,7 @@ mod plugin_load_gate_tests {
         let cb_stats = orbit_audio_native::CallbackTimeStats::new();
         *wrap.clap.lock().expect("clap mutex") = Some(ClapControl {
             cmd_tx,
+            loaded_role: None,
             event_tx,
             stats,
             cb_stats,
@@ -2777,7 +2806,7 @@ mod plugin_load_gate_tests {
                 .expect("load_plugin should still be waiting for reply");
         });
 
-        let result = wrap.load_plugin(PathBuf::from("dummy.clap"), None);
+        let result = wrap.load_plugin(PathBuf::from("dummy.clap"), None, ClapPluginRole::Effect);
         responder.join().expect("responder thread should not panic");
 
         // `LoadedPluginSummary` は Debug 未実装のため `assert!(result.is_ok(), "{result:?}")`
@@ -2789,6 +2818,60 @@ mod plugin_load_gate_tests {
         assert!(
             wrap.plugin_loaded.load(Ordering::Relaxed),
             "load_plugin success branch must set plugin_loaded"
+        );
+    }
+
+    #[test]
+    fn same_role_resend_reaches_existing_already_loaded_path() {
+        let (wrap, cmd_rx) = loadable_engine();
+        wrap.clap
+            .lock()
+            .expect("clap mutex")
+            .as_mut()
+            .expect("clap control")
+            .loaded_role = Some(ClapPluginRole::Effect);
+        let responder = std::thread::spawn(move || {
+            let crate::clap_host::ClapCommand::LoadPlugin { reply, .. } = cmd_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("same-role resend should reach clap host");
+            reply
+                .send(Err("AlreadyLoaded".to_string()))
+                .expect("caller should wait for reply");
+        });
+
+        let result = wrap.load_plugin(PathBuf::from("dummy.clap"), None, ClapPluginRole::Effect);
+        responder.join().expect("responder thread should not panic");
+        assert!(
+            matches!(result, Err(WrapError::Clap(message)) if message == "AlreadyLoaded"),
+            "same-role resend must preserve the clap host's AlreadyLoaded behavior"
+        );
+    }
+
+    #[test]
+    fn different_role_resend_is_rejected_before_clap_host_replacement() {
+        let (wrap, cmd_rx) = loadable_engine();
+        wrap.clap
+            .lock()
+            .expect("clap mutex")
+            .as_mut()
+            .expect("clap control")
+            .loaded_role = Some(ClapPluginRole::Effect);
+
+        let result = wrap.load_plugin(
+            PathBuf::from("dummy.clap"),
+            None,
+            ClapPluginRole::Instrument,
+        );
+        assert!(
+            matches!(result, Err(WrapError::ClapCrossRoleRejected(_))),
+            "different role must be rejected before the single slot can be replaced"
+        );
+        assert!(
+            matches!(
+                cmd_rx.recv_timeout(Duration::from_millis(50)),
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+            ),
+            "cross-role rejection must not send a replacement command to clap host"
         );
     }
 

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -825,8 +825,8 @@ impl EngineWrap {
     }
 
     /// feature `outproc-effect` 版（γ M1 PR-C・Issue #359）: cpal 出力を OOP effect master-bus
-    /// post-processor 経路付きで起動する。production は環境変数（`ORBIT_EFFECT_PLUGIN` 等）から設定を
-    /// 組む。設定不足は `OutProcEffectUnavailable`（feature-gap と同じ握り潰し対象）。
+    /// post-processor 経路付きで起動する。production は環境変数から child 設定を組み、plugin は
+    /// `LoadPlugin` で post-boot attach する。
     #[cfg(all(
         feature = "outproc-effect",
         not(feature = "clap-host"),
@@ -844,7 +844,10 @@ impl EngineWrap {
     pub fn start_outproc_effect(
         cfg: crate::outproc_effect::OutProcEffectConfig,
     ) -> Result<(Arc<Self>, StreamGuard), WrapError> {
-        let plugin = cfg.plugin.clone();
+        let plugin = cfg
+            .plugin
+            .clone()
+            .ok_or_else(|| WrapError::OutProcEffect("eager start requires a plugin path".into()))?;
         let plugin_id = cfg.plugin_id.clone();
         let (wrap, guard) = Self::start_outproc_effect_post_boot(cfg)?;
         wrap.load_outproc_plugin(plugin, plugin_id)?;
@@ -954,7 +957,9 @@ impl EngineWrap {
     pub fn start_outproc_instrument(
         cfg: crate::outproc_instrument::OutProcInstrumentConfig,
     ) -> Result<(Arc<Self>, StreamGuard), WrapError> {
-        let plugin = cfg.plugin.clone();
+        let plugin = cfg.plugin.clone().ok_or_else(|| {
+            WrapError::OutProcInstrument("eager start requires a plugin path".into())
+        })?;
         let plugin_id = cfg.plugin_id.clone();
         let (wrap, guard) = Self::start_outproc_instrument_post_boot(cfg)?;
         wrap.load_outproc_plugin(plugin, plugin_id)?;

--- a/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
@@ -84,24 +84,17 @@ impl PluginFormat {
             Self::Vst3 => "orbit-vst3-effect-child",
         }
     }
-
-    fn plugin_kind(self) -> &'static str {
-        match self {
-            Self::Clap => ".clap",
-            Self::Vst3 => ".vst3",
-        }
-    }
 }
 
-/// OOP effect の起動設定（child binary path + plugin）。`start_outproc_effect` と gated test が使う。
+/// OOP effect の起動設定。plugin は post-boot attach では不要で、eager start と gated test のみ使う。
 /// sample_rate は device 確定後に渡すので含めない。
 pub struct OutProcEffectConfig {
     /// plugin format（既定 env は `clap`）。
     pub format: PluginFormat,
     /// effect child binary（format に応じた child）のパス。
     pub child_exe: PathBuf,
-    /// host する plugin bundle のパス（load-time param のみ・M1 は per-block automation なし）。
-    pub plugin: PathBuf,
+    /// eager start で host する plugin bundle のパス。post-boot attach は `LoadPlugin` で受け取る。
+    pub plugin: Option<PathBuf>,
     /// plugin id（CLAP は id、VST3 Phase 1 は CLI symmetry のため渡すだけ）。
     pub plugin_id: Option<String>,
     /// cpal に要求する固定バッファフレーム数（gated stale-rate harness が 32/64 を渡す）。`None` は
@@ -114,7 +107,7 @@ impl OutProcEffectConfig {
     /// - `ORBIT_EFFECT_FORMAT`: `clap` | `vst3`（省略時 `clap`）。
     /// - `ORBIT_EFFECT_CHILD_BIN`: child binary path（省略時は daemon exe と同一ディレクトリの
     ///   format 対応 child）。
-    /// - `ORBIT_EFFECT_PLUGIN`: plugin bundle path（**必須**）。
+    /// - `ORBIT_EFFECT_PLUGIN`: plugin bundle path（任意。post-boot attach は `LoadPlugin` で渡す）。
     /// - `ORBIT_EFFECT_PLUGIN_ID`: plugin id（任意）。
     pub fn from_env() -> Result<Self, String> {
         let format = PluginFormat::from_env_value(std::env::var("ORBIT_EFFECT_FORMAT").ok())?;
@@ -122,14 +115,7 @@ impl OutProcEffectConfig {
             Some(v) => PathBuf::from(v),
             None => default_child_exe(format)?,
         };
-        let plugin = std::env::var_os("ORBIT_EFFECT_PLUGIN")
-            .map(PathBuf::from)
-            .ok_or_else(|| {
-                format!(
-                    "ORBIT_EFFECT_PLUGIN not set (out-of-process effect needs a {} bundle path)",
-                    format.plugin_kind()
-                )
-            })?;
+        let plugin = std::env::var_os("ORBIT_EFFECT_PLUGIN").map(PathBuf::from);
         let plugin_id = std::env::var("ORBIT_EFFECT_PLUGIN_ID").ok();
         // production は通常 device 既定。`ORBIT_EFFECT_BUFFER_FRAMES` で明示できる。**設定済みなのに無効**
         // （非正・parse 不能）な場合は黙って無視せず warn を出す（silent fallback 回避）。未設定は device 既定。
@@ -658,6 +644,23 @@ impl Drop for OutProcTeardownGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static EFFECT_PLUGIN_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn from_env_allows_plugin_to_be_unset_for_post_boot_attach() {
+        let _guard = EFFECT_PLUGIN_ENV_LOCK.lock().expect("effect env mutex");
+        let previous = std::env::var_os("ORBIT_EFFECT_PLUGIN");
+        std::env::remove_var("ORBIT_EFFECT_PLUGIN");
+
+        let config = OutProcEffectConfig::from_env().expect("plugin path is optional at boot");
+
+        if let Some(value) = previous {
+            std::env::set_var("ORBIT_EFFECT_PLUGIN", value);
+        }
+        assert_eq!(config.plugin, None);
+    }
 
     /// 実 mmap（zero-init・unlink 後もマッピングは有効）を所有する production 構築子経由の host を作る。
     /// unsafe を使わず（`from_mmap`）テスト用に zeroed SharedRegion を得る。

--- a/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
@@ -57,7 +57,8 @@ pub fn unique_shm_path() -> PathBuf {
 
 pub struct OutProcInstrumentConfig {
     pub child_exe: PathBuf,
-    pub plugin: PathBuf,
+    /// eager start で host する plugin bundle のパス。post-boot attach は `LoadPlugin` で受け取る。
+    pub plugin: Option<PathBuf>,
     pub plugin_id: Option<String>,
     pub buffer_frames: Option<u32>,
 }
@@ -68,12 +69,7 @@ impl OutProcInstrumentConfig {
             Some(value) => PathBuf::from(value),
             None => default_child_exe()?,
         };
-        let plugin = std::env::var_os("ORBIT_INSTRUMENT_PLUGIN")
-            .map(PathBuf::from)
-            .ok_or_else(|| {
-                "ORBIT_INSTRUMENT_PLUGIN not set (out-of-process instrument needs a .clap bundle path)"
-                    .to_string()
-            })?;
+        let plugin = std::env::var_os("ORBIT_INSTRUMENT_PLUGIN").map(PathBuf::from);
         let plugin_id = std::env::var("ORBIT_INSTRUMENT_PLUGIN_ID").ok();
         let buffer_frames = parse_buffer_frames(
             std::env::var("ORBIT_INSTRUMENT_BUFFER_FRAMES")
@@ -587,6 +583,25 @@ impl Drop for OutProcInstrumentTeardownGuard {
 mod tests {
     use super::*;
     use orbit_audio_sandbox::{slot_index, VoiceAddr, VoiceKey, CHANNELS};
+    use std::sync::Mutex;
+
+    static INSTRUMENT_PLUGIN_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn from_env_allows_plugin_to_be_unset_for_post_boot_attach() {
+        let _guard = INSTRUMENT_PLUGIN_ENV_LOCK
+            .lock()
+            .expect("instrument env mutex");
+        let previous = std::env::var_os("ORBIT_INSTRUMENT_PLUGIN");
+        std::env::remove_var("ORBIT_INSTRUMENT_PLUGIN");
+
+        let config = OutProcInstrumentConfig::from_env().expect("plugin path is optional at boot");
+
+        if let Some(value) = previous {
+            std::env::set_var("ORBIT_INSTRUMENT_PLUGIN", value);
+        }
+        assert_eq!(config.plugin, None);
+    }
 
     fn engaged(value: bool) -> Arc<AtomicBool> {
         Arc::new(AtomicBool::new(value))

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -16,6 +16,8 @@ use tokio::sync::mpsc;
 use tokio_tungstenite::{tungstenite::Message, WebSocketStream};
 use tracing::warn;
 
+#[cfg(not(any(feature = "outproc-effect", feature = "outproc-instrument")))]
+use crate::engine_wrap::ClapPluginRole;
 use crate::engine_wrap::{EngineWrap, WrapError};
 use crate::protocol::{
     Command, ErrorResponse, Event, Handshake, OkResponse, ProtocolError,
@@ -51,6 +53,17 @@ fn daemon_error_event(severity: &str, code: &str, message: String) -> Event {
 #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
 fn outproc_role_param_is_valid(params: &Value) -> bool {
     params.get("role").and_then(Value::as_str) == Some("effect")
+}
+
+/// in-process client は常に role を送る。旧 daemon との通信互換のため role を省略していた client は、
+/// 単一 slot を安全に保護できないので明示的に拒否する。
+#[cfg(not(any(feature = "outproc-effect", feature = "outproc-instrument")))]
+fn clap_role_param(params: &Value) -> Option<ClapPluginRole> {
+    match params.get("role").and_then(Value::as_str) {
+        Some("effect") => Some(ClapPluginRole::Effect),
+        Some("instrument") => Some(ClapPluginRole::Instrument),
+        _ => None,
+    }
 }
 
 #[cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
@@ -632,6 +645,19 @@ async fn handle_command(
         // 含みうるため spawn_blocking で tokio worker から隔離する。
         "LoadPlugin" => match params.get("path").and_then(|p| p.as_str()) {
             Some(path_str) => {
+                #[cfg(not(any(feature = "outproc-effect", feature = "outproc-instrument")))]
+                let clap_role = match clap_role_param(&params) {
+                    Some(role) => role,
+                    None => {
+                        return err(
+                            &id,
+                            ProtocolError::new(
+                                "MALFORMED_REQUEST",
+                                "in-process LoadPlugin requires role='effect' or role='instrument'",
+                            ),
+                        );
+                    }
+                };
                 #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
                 if !outproc_role_param_is_valid(&params) {
                     return err(
@@ -697,7 +723,7 @@ async fn handle_command(
                     }
                     #[cfg(not(any(feature = "outproc-effect", feature = "outproc-instrument")))]
                     {
-                        engine.load_plugin(path, plugin_id)
+                        engine.load_plugin(path, plugin_id, clap_role)
                     }
                 })
                 .await;
@@ -1052,6 +1078,9 @@ fn wrap_err_to_protocol(e: &WrapError) -> ProtocolError {
         // CLAP も LinkAudio と同様 feature-gap（UNAVAILABLE）と runtime 失敗を別コードにする。
         WrapError::ClapUnavailable(msg) => ProtocolError::new("CLAP_UNAVAILABLE", msg.clone()),
         WrapError::Clap(msg) => ProtocolError::new("CLAP_RUNTIME", msg.clone()),
+        WrapError::ClapCrossRoleRejected(msg) => {
+            ProtocolError::new("CLAP_CROSS_ROLE_REJECTED", msg.clone())
+        }
         // 未ロード（LoadPlugin 未送信 / 失敗後）は feature-gap でも汎用 runtime エラーでもない専用
         // コード（#405）。TS 層が「まだロードしていない」ことを actionable に判定できるようにする。
         WrapError::ClapNotLoaded(msg) => ProtocolError::new("CLAP_NOT_LOADED", msg.clone()),
@@ -1076,6 +1105,21 @@ fn wrap_err_to_protocol(e: &WrapError) -> ProtocolError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(not(any(feature = "outproc-effect", feature = "outproc-instrument")))]
+    #[test]
+    fn inprocess_load_plugin_requires_a_known_role() {
+        assert_eq!(
+            clap_role_param(&json!({"role": "effect"})),
+            Some(ClapPluginRole::Effect)
+        );
+        assert_eq!(
+            clap_role_param(&json!({"role": "instrument"})),
+            Some(ClapPluginRole::Instrument)
+        );
+        assert_eq!(clap_role_param(&json!({})), None);
+        assert_eq!(clap_role_param(&json!({"role": "unknown"})), None);
+    }
 
     #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
     #[test]
@@ -1127,6 +1171,12 @@ mod tests {
     fn clap_runtime_maps_to_runtime_code() {
         let e = WrapError::Clap("plugin event ring full".into());
         assert_eq!(wrap_err_to_protocol(&e).code, "CLAP_RUNTIME");
+    }
+
+    #[test]
+    fn clap_cross_role_rejection_maps_to_dedicated_code() {
+        let e = WrapError::ClapCrossRoleRejected("single slot".into());
+        assert_eq!(wrap_err_to_protocol(&e).code, "CLAP_CROSS_ROLE_REJECTED");
     }
 
     // 未ロードは feature-gap / 汎用 runtime エラーのどちらとも別コードにする（#405）。

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -55,8 +55,8 @@ fn outproc_role_param_is_valid(params: &Value) -> bool {
     params.get("role").and_then(Value::as_str) == Some("effect")
 }
 
-/// in-process client は常に role を送る。旧 daemon との通信互換のため role を省略していた client は、
-/// 単一 slot を安全に保護できないので明示的に拒否する。
+/// in-process build の LoadPlugin にはこの PR 前は role 概念がなかった。単一 slot を安全に保護するため
+/// role は現在必須であり、省略する client は明示的に拒否する。
 #[cfg(not(any(feature = "outproc-effect", feature = "outproc-instrument")))]
 fn clap_role_param(params: &Value) -> Option<ClapPluginRole> {
     match params.get("role").and_then(Value::as_str) {

--- a/rust/crates/orbit-audio-daemon/tests/clap_effect_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/clap_effect_gated.rs
@@ -22,7 +22,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use orbit_audio_daemon::engine_wrap::EngineWrap;
+use orbit_audio_daemon::engine_wrap::{ClapPluginRole, EngineWrap};
 
 /// repo ルート相対パスを解決する（MANIFEST_DIR = rust/crates/orbit-audio-daemon）。
 fn repo_path(rel: &str) -> PathBuf {
@@ -66,7 +66,7 @@ fn effect_processes_audio_via_daemon() {
     // ── Phase B: effect ロード（serial insert）───────────────────────────────────────
     // 単一プラグインなので id=None。
     let info = engine
-        .load_plugin(effect.clone(), None)
+        .load_plugin(effect.clone(), None, ClapPluginRole::Effect)
         .expect("load test-effect plugin");
     assert_eq!(
         info.plugin_id, "com.signalcompose.clap-test-effect",

--- a/rust/crates/orbit-audio-daemon/tests/clap_host_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/clap_host_gated.rs
@@ -28,7 +28,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use orbit_audio_daemon::engine_wrap::EngineWrap;
+use orbit_audio_daemon::engine_wrap::{ClapPluginRole, EngineWrap};
 
 /// repo ルート相対パスを解決する（MANIFEST_DIR = rust/crates/orbit-audio-daemon）。
 fn repo_path(rel: &str) -> PathBuf {
@@ -51,7 +51,7 @@ fn synth_processes_audio_via_daemon() {
 
     // プラグインをロード（discovery + activate + install ring push）。単一プラグインなので id=None。
     let info = engine
-        .load_plugin(synth.clone(), None)
+        .load_plugin(synth.clone(), None, ClapPluginRole::Instrument)
         .expect("load test-synth plugin");
     assert_eq!(
         info.plugin_id, "com.signalcompose.clap-test-synth",
@@ -59,7 +59,7 @@ fn synth_processes_audio_via_daemon() {
     );
 
     // 二重ロードは AlreadyLoaded で弾く（controller の double-load guard を駆動し、サイレント除去を検知）。
-    let second = engine.load_plugin(synth.clone(), None);
+    let second = engine.load_plugin(synth.clone(), None, ClapPluginRole::Instrument);
     assert!(
         second.is_err(),
         "二重ロードは AlreadyLoaded エラーを返すべきだが Ok が返った"

--- a/rust/crates/orbit-audio-daemon/tests/outproc_both_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_both_gated.rs
@@ -35,13 +35,21 @@ fn setup_test() -> (OutProcEffectConfig, OutProcInstrumentConfig) {
         plugin_id: Some(PLUGIN_ID.to_owned()),
         buffer_frames: None,
     };
-    assert!(effect.plugin.as_ref().expect("gated config has an effect plugin").exists(), "test-effect dylib が無い: {} — 先に `cargo build --manifest-path rust-spike/clap-test-effect/Cargo.toml`", effect.plugin.as_ref().expect("gated config has an effect plugin").display());
+    let effect_plugin = effect
+        .plugin
+        .as_ref()
+        .expect("gated config has an effect plugin");
+    assert!(effect_plugin.exists(), "test-effect dylib が無い: {} — 先に `cargo build --manifest-path rust-spike/clap-test-effect/Cargo.toml`", effect_plugin.display());
     assert!(
         effect.child_exe.exists(),
         "effect child binary が無い: {} — 先に `cargo build -p orbit-clap-effect-child`",
         effect.child_exe.display()
     );
-    assert!(instrument.plugin.as_ref().expect("gated config has an instrument plugin").exists(), "test-synth dylib が無い: {} — 先に `cargo build --manifest-path rust-spike/clap-test-synth/Cargo.toml`", instrument.plugin.as_ref().expect("gated config has an instrument plugin").display());
+    let instrument_plugin = instrument
+        .plugin
+        .as_ref()
+        .expect("gated config has an instrument plugin");
+    assert!(instrument_plugin.exists(), "test-synth dylib が無い: {} — 先に `cargo build --manifest-path rust-spike/clap-test-synth/Cargo.toml`", instrument_plugin.display());
     assert!(
         instrument.child_exe.exists(),
         "instrument child binary が無い: {} — 先に `cargo build -p orbit-clap-instrument-child`",

--- a/rust/crates/orbit-audio-daemon/tests/outproc_both_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_both_gated.rs
@@ -21,23 +21,27 @@ fn setup_test() -> (OutProcEffectConfig, OutProcInstrumentConfig) {
     let effect = OutProcEffectConfig {
         format: PluginFormat::Clap,
         child_exe: child_exe("orbit-clap-effect-child"),
-        plugin: repo_path("rust-spike/clap-test-effect/target/debug/libclap_test_effect.dylib"),
+        plugin: Some(repo_path(
+            "rust-spike/clap-test-effect/target/debug/libclap_test_effect.dylib",
+        )),
         plugin_id: None,
         buffer_frames: None,
     };
     let instrument = OutProcInstrumentConfig {
         child_exe: child_exe("orbit-clap-instrument-child"),
-        plugin: repo_path("rust-spike/clap-test-synth/target/debug/libclap_test_synth.dylib"),
+        plugin: Some(repo_path(
+            "rust-spike/clap-test-synth/target/debug/libclap_test_synth.dylib",
+        )),
         plugin_id: Some(PLUGIN_ID.to_owned()),
         buffer_frames: None,
     };
-    assert!(effect.plugin.exists(), "test-effect dylib が無い: {} — 先に `cargo build --manifest-path rust-spike/clap-test-effect/Cargo.toml`", effect.plugin.display());
+    assert!(effect.plugin.as_ref().expect("gated config has an effect plugin").exists(), "test-effect dylib が無い: {} — 先に `cargo build --manifest-path rust-spike/clap-test-effect/Cargo.toml`", effect.plugin.as_ref().expect("gated config has an effect plugin").display());
     assert!(
         effect.child_exe.exists(),
         "effect child binary が無い: {} — 先に `cargo build -p orbit-clap-effect-child`",
         effect.child_exe.display()
     );
-    assert!(instrument.plugin.exists(), "test-synth dylib が無い: {} — 先に `cargo build --manifest-path rust-spike/clap-test-synth/Cargo.toml`", instrument.plugin.display());
+    assert!(instrument.plugin.as_ref().expect("gated config has an instrument plugin").exists(), "test-synth dylib が無い: {} — 先に `cargo build --manifest-path rust-spike/clap-test-synth/Cargo.toml`", instrument.plugin.as_ref().expect("gated config has an instrument plugin").display());
     assert!(
         instrument.child_exe.exists(),
         "instrument child binary が無い: {} — 先に `cargo build -p orbit-clap-instrument-child`",
@@ -50,9 +54,15 @@ fn setup_test() -> (OutProcEffectConfig, OutProcInstrumentConfig) {
 #[ignore = "both-role OOP: needs a real output device + built effect/instrument children and test dylibs (local only)"]
 fn both_roles_attach_in_instrument_then_effect_order() {
     let (effect_cfg, instrument_cfg) = setup_test();
-    let synth_path = instrument_cfg.plugin.clone();
+    let synth_path = instrument_cfg
+        .plugin
+        .clone()
+        .expect("gated config has an instrument plugin");
     let synth_id = instrument_cfg.plugin_id.clone();
-    let effect_path = effect_cfg.plugin.clone();
+    let effect_path = effect_cfg
+        .plugin
+        .clone()
+        .expect("gated config has an effect plugin");
     let (engine, _guard) = EngineWrap::start_outproc_both(effect_cfg, instrument_cfg)
         .expect("start both-role OOP daemon");
 

--- a/rust/crates/orbit-audio-daemon/tests/outproc_effect_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_effect_gated.rs
@@ -48,15 +48,15 @@ fn setup_test(buffer_frames: Option<u32>) -> (OutProcEffectConfig, PathBuf) {
     let cfg = OutProcEffectConfig {
         format: PluginFormat::Clap,
         child_exe: child_exe("orbit-clap-effect-child"),
-        plugin: test_effect_dylib(),
+        plugin: Some(test_effect_dylib()),
         plugin_id: None, // 単一プラグイン bundle なので id 省略可
         buffer_frames,
     };
     let wav = repo_path("test-assets/audio/sine_440.wav");
     assert!(
-        cfg.plugin.exists(),
+        cfg.plugin.as_ref().expect("gated config has a plugin").exists(),
         "test-effect dylib が無い: {} — 先に `cargo build --manifest-path rust-spike/clap-test-effect/Cargo.toml`",
-        cfg.plugin.display()
+        cfg.plugin.as_ref().expect("gated config has a plugin").display()
     );
     assert!(
         cfg.child_exe.exists(),
@@ -158,7 +158,7 @@ fn outproc_effect_processes_audio_via_daemon() {
 #[ignore = "#441: needs a real output device + built child binary + test-effect dylib"]
 fn outproc_effect_attach_failure_can_retry_with_correct_plugin() {
     let (cfg, wav) = setup_test(None);
-    let good_plugin = cfg.plugin.clone();
+    let good_plugin = cfg.plugin.clone().expect("gated config has a plugin");
     let (engine, _guard) = EngineWrap::start_outproc_effect_post_boot(cfg).expect("start daemon");
     let started = Instant::now();
     let error =

--- a/rust/crates/orbit-audio-daemon/tests/outproc_effect_vst3_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_effect_vst3_gated.rs
@@ -103,7 +103,7 @@ fn setup_test(buffer_frames: Option<u32>) -> (OutProcEffectConfig, PathBuf) {
     let cfg = OutProcEffectConfig {
         format: PluginFormat::Vst3,
         child_exe: vst3_child_exe(),
-        plugin: package_oracle(),
+        plugin: Some(package_oracle()),
         plugin_id: None, // 単一プラグイン bundle なので id 省略可
         buffer_frames,
     };
@@ -114,9 +114,15 @@ fn setup_test(buffer_frames: Option<u32>) -> (OutProcEffectConfig, PathBuf) {
         cfg.child_exe.display()
     );
     assert!(
-        cfg.plugin.exists(),
+        cfg.plugin
+            .as_ref()
+            .expect("gated config has a plugin")
+            .exists(),
         "VST3 gain oracle bundle が無い: {}",
-        cfg.plugin.display()
+        cfg.plugin
+            .as_ref()
+            .expect("gated config has a plugin")
+            .display()
     );
     assert!(wav.exists(), "音源 WAV が無い: {}", wav.display());
     (cfg, wav)
@@ -437,7 +443,7 @@ fn outproc_effect_vst3_commercial_plugin_smoke() {
     let cfg = OutProcEffectConfig {
         format: PluginFormat::Vst3,
         child_exe,
-        plugin: plugin.clone(),
+        plugin: Some(plugin.clone()),
         plugin_id: std::env::var("ORBIT_EFFECT_PLUGIN_ID").ok(),
         buffer_frames: None,
     };

--- a/rust/crates/orbit-audio-daemon/tests/outproc_instrument_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_instrument_gated.rs
@@ -36,14 +36,22 @@ fn test_synth_dylib() -> PathBuf {
 fn setup_test() -> OutProcInstrumentConfig {
     let config = OutProcInstrumentConfig {
         child_exe: child_exe("orbit-clap-instrument-child"),
-        plugin: test_synth_dylib(),
+        plugin: Some(test_synth_dylib()),
         plugin_id: Some(PLUGIN_ID.to_owned()),
         buffer_frames: None,
     };
     assert!(
-        config.plugin.exists(),
+        config
+            .plugin
+            .as_ref()
+            .expect("gated config has a plugin")
+            .exists(),
         "test-synth dylib が無い: {} — 先に `cargo build --manifest-path rust-spike/clap-test-synth/Cargo.toml`",
-        config.plugin.display()
+        config
+            .plugin
+            .as_ref()
+            .expect("gated config has a plugin")
+            .display()
     );
     assert!(
         config.child_exe.exists(),
@@ -144,7 +152,7 @@ fn outproc_instrument_sounds_via_daemon_note_on_off() {
 #[ignore = "#441: needs a real output device + built instrument child + test-synth dylib"]
 fn outproc_instrument_attach_failure_can_retry_with_correct_plugin() {
     let cfg = setup_test();
-    let good_plugin = cfg.plugin.clone();
+    let good_plugin = cfg.plugin.clone().expect("gated config has a plugin");
     let plugin_id = cfg.plugin_id.clone();
     let (engine, _guard) =
         EngineWrap::start_outproc_instrument_post_boot(cfg).expect("start daemon");

--- a/scripts/copy-daemon-bin.sh
+++ b/scripts/copy-daemon-bin.sh
@@ -30,11 +30,16 @@
 # NOT covered by that gate and can produce a .vsix whose default backend
 # (rust) is unable to start.
 #
+# The release daemon uses OOP-both plugin hosting, so its effect and instrument
+# child executables are bundled beside the daemon. The daemon resolves them as
+# siblings of its own executable, requiring no additional runtime wiring.
+#
 # Usage:
 #   bash scripts/copy-daemon-bin.sh
 #
-# Build the daemon first if you want it bundled:
-#   cd rust && cargo build --release -p orbit-audio-daemon
+# Build the release binaries first if you want them bundled:
+#   cd rust && cargo build --release -p orbit-audio-daemon --features outproc-effect,outproc-instrument
+#   cargo build --release -p orbit-clap-effect-child -p orbit-clap-instrument-child
 
 set -euo pipefail
 
@@ -45,20 +50,25 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 # single platform this bounded first version supports.
 PLATFORM="darwin-arm64"
 
-DAEMON_SRC="$PROJECT_ROOT/rust/target/release/orbit-audio-daemon"
 DEST_DIR="$PROJECT_ROOT/packages/vscode-extension/engine/bin/$PLATFORM"
 
-if [ ! -f "$DAEMON_SRC" ]; then
-  echo "⚠️  orbit-audio-daemon not found at $DAEMON_SRC — skipping bundle." >&2
-  echo "    rust is the default backend, so this build's default backend will not" >&2
-  echo "    be able to start unless you set orbitscore.engine to \"sc\". To bundle" >&2
-  echo "    the daemon and restore the default:" >&2
-  echo "      cd rust && cargo build --release -p orbit-audio-daemon" >&2
-  exit 0
-fi
-
 mkdir -p "$DEST_DIR"
-cp "$DAEMON_SRC" "$DEST_DIR/orbit-audio-daemon"
-chmod +x "$DEST_DIR/orbit-audio-daemon"
 
-echo "Bundled orbit-audio-daemon ($PLATFORM) -> $DEST_DIR/orbit-audio-daemon"
+copy_binary() {
+  local binary_name="$1"
+  local source_path="$PROJECT_ROOT/rust/target/release/$binary_name"
+  local destination_path="$DEST_DIR/$binary_name"
+
+  if [ ! -f "$source_path" ]; then
+    echo "⚠️  $binary_name not found at $source_path — skipping bundle." >&2
+    return
+  fi
+
+  cp "$source_path" "$destination_path"
+  chmod +x "$destination_path"
+  echo "Bundled $binary_name ($PLATFORM) -> $destination_path"
+}
+
+copy_binary "orbit-audio-daemon"
+copy_binary "orbit-clap-effect-child"
+copy_binary "orbit-clap-instrument-child"

--- a/scripts/copy-daemon-bin.sh
+++ b/scripts/copy-daemon-bin.sh
@@ -24,11 +24,11 @@
 #
 # This best-effort skip is safe only because release.yml's post-package gate
 # fails loud (aborts the release) if engine/bin/darwin-arm64/orbit-audio-daemon
-# is missing from the packaged .vsix — that gate is what actually guarantees
-# the *shipped* artifact has the daemon. Packaging paths that don't go through
-# release.yml (e.g. a manual `vsce package` after a plain `npm run build`) are
-# NOT covered by that gate and can produce a .vsix whose default backend
-# (rust) is unable to start.
+# or either OOP child binary is missing from the packaged .vsix — that gate is
+# what actually guarantees the *shipped* artifact has its daemon and children.
+# Packaging paths that don't go through release.yml (e.g. a manual `vsce package`
+# after a plain `npm run build`) are NOT covered by that gate and can produce a
+# .vsix whose default backend (rust) is unable to start.
 #
 # The release daemon uses OOP-both plugin hosting, so its effect and instrument
 # child executables are bundled beside the daemon. The daemon resolves them as

--- a/tests/core/plugin-instrument.spec.ts
+++ b/tests/core/plugin-instrument.spec.ts
@@ -61,14 +61,14 @@ describe('PluginInstrumentManager', () => {
     expect(loadPlugin).toHaveBeenCalledTimes(2)
   })
 
-  it('rejects effect and instrument in both declaration orders, including the same path', async () => {
+  it('allows effect and instrument declarations in both orders, including the same path', async () => {
     const first = makeGlobal().global
     await first.effect('shared.clap')
-    await expect(first.instrument('shared.clap')).rejects.toThrow('#431')
+    await expect(first.instrument('shared.clap')).resolves.toBe(first)
 
     const second = makeGlobal().global
     await second.instrument('shared.clap')
-    await expect(second.effect('shared.clap')).rejects.toThrow('#431')
+    await expect(second.effect('shared.clap')).resolves.toBe(second)
   })
 
   it('rejects LinkAudio in both declaration orders', async () => {


### PR DESCRIPTION
Closes #431

## 概要

Epic #424 の最終 PR（PR-3 / DoD 配線）。**Epic #424 DoD「DSL から CLAP effect 1 つ + CLAP instrument 1 つを同時にロードし、Pitch DSL の note で演奏し、両方が実機で鳴る」を実機で達成**。

## 変更内容

### ガード配線の付け替え
- TS: `assertNoCrossPluginDeclaration` 撤去（v1 排他の根拠 = daemon 単一 slot 制約が PR-2 の共存で解消）
- daemon: in-process clap-host（単一 slot）に **cross-role reject** 新設（`loaded_role` 記録 + `CLAP_CROSS_ROLE_REJECTED`）。TS ガード撤去だけだと role の異なる 2 回目 LoadPlugin が silent 置換になる #431 既知の罠に対応。in-process LoadPlugin は role param 必須化

### 配布 feature 方針（#431 scope e・owner veto 可能な形で確定）
- **release daemon = `--features outproc-effect,outproc-instrument`（OOP both）**。in-process clap-host は dev/gated テスト専用（outproc と排他）
- child binary 2本（orbit-clap-effect-child / orbit-clap-instrument-child）を .vsix に同梱（daemon sibling 解決規約・追加配線不要）+ release.yml post-package gate に fail-loud 検証

### E2E 発見の production ブロッカー修正
- 配布構成 daemon が `ORBIT_EFFECT_PLUGIN not set` で boot 不能（`from_env` の eager 時代の遺物・post-boot attach 設計と矛盾）→ `Config.plugin` を Option 化・plugin env 任意化・eager 系（gated 用）は None を明示エラー

## Epic #424 DoD 実機実証

`.orbs`（`global.effect()` + `seq.instrument()` + `play(1,3,5,8)`）を配布構成 release daemon で実行:

| run | capture peak | 意味 |
|---|---|---|
| baseline（instrument のみ） | **0.25000** | test-synth 既知振幅・厳密一致 |
| effect + instrument 同時 | **0.12500** | 0.25 × gain 0.5・**ratio 0.50000 厳密一致** |

DSL → LoadPlugin(role)×2 → OOP child×2 → Pitch DSL note 演奏 → composite（instrument add-mix → effect insert）→ スピーカー実再生、の全経路を客観実証。

## 検証
- 3構成 lib テスト: effect 51 / instrument 50 / both 82 + 全ターゲットコンパイル + clippy 全 green
- TS フルスイート 1330 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)