### PR TITLE
fix(daemon): add READY handshake to VST3 effect child (#445)

### DIFF
--- a/rust/crates/orbit-vst3-effect-child/src/main.rs
+++ b/rust/crates/orbit-vst3-effect-child/src/main.rs
@@ -77,9 +77,17 @@ fn main() -> Result<()> {
         );
     }
 
-    let (mut effect, _info) =
+    let (mut effect, info) =
         Vst3EffectProcessor::load(&args.plugin, args.sample_rate as f64, MAX_FRAMES as i32)
             .with_context(|| format!("load VST3 effect {:?}", args.plugin))?;
+
+    // load 成功を host へ handshake する（PR-1a の child readiness 契約・#445）。
+    // host の ready-ack ループ（PR-1b）はこれを待つため、publish しないと attach が
+    // CHILD_READY_TIMEOUT で必ず失敗する（CLAP effect child と同じ配置・同じ意味論）。
+    // SAFETY: region は host が REGION_BYTES に truncate 済みの共有ファイルを指す。
+    unsafe {
+        orbit_audio_sandbox::transport::publish_child_ready(region, info.audio_inputs > 0);
+    }
 
     let mut scratch = vec![0.0f32; BUF_LEN];
     let mut process_errors: u64 = 0;


### PR DESCRIPTION
Closes #445

## 問題

PR #440（#431 PR-1b）の ready-ack ループは child の `publish_child_ready` を前提とするが、handshake 実装は CLAP child 2本のみで **orbit-vst3-effect-child が未実装**。VST3 effect の attach が `CHILD_READY_TIMEOUT`(10s) で必ず失敗する退行が 2026-07-14 以降 main に存在した（VST3 gated が #431 期間中コンパイル確認のみだったため検出漏れ）。

## 修正

CLAP effect child と同じ配置（plugin load 成功直後）で `publish_child_ready(region, info.audio_inputs > 0)` を追加（9行）。

## 検証（実機）

- **ビスクト**: `f07451c`（PR-1a）PASS → `16d2484`（PR-1b）FAIL で退行点を特定
- 修正後 **VST3 gated 全4本 PASS**: C1 parity（ratio 1.00000 厳密一致）/ C2 kill-respawn / C3 stale-rate / C4 commercial smoke
- CLAP effect gated 回帰 PASS

## 位置づけ

VST3 横展開（→ #421 instrument）の前提修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)