### PR TITLE
feat(vst3): VST3 instrument production — Pitch DSL plays through VST3 (#421)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Build OOP-both Rust daemon and CLAP child binaries
         run: |
           cargo build --release -p orbit-audio-daemon --features outproc-effect,outproc-instrument --manifest-path rust/Cargo.toml
-          cargo build --release -p orbit-clap-effect-child -p orbit-clap-instrument-child --manifest-path rust/Cargo.toml
+          cargo build --release -p orbit-clap-effect-child -p orbit-clap-instrument-child -p orbit-vst3-instrument-child --manifest-path rust/Cargo.toml
 
       - name: Build engine + extension TypeScript
         working-directory: packages/vscode-extension
@@ -137,7 +137,7 @@ jobs:
           fi
           echo "orbit-audio-daemon present and executable in packaged .vsix"
 
-          for CHILD_BIN in orbit-clap-effect-child orbit-clap-instrument-child; do
+          for CHILD_BIN in orbit-clap-effect-child orbit-clap-instrument-child orbit-vst3-instrument-child; do
             CHILD_PATH="$VSIX_CHECK/extension/engine/bin/darwin-arm64/$CHILD_BIN"
             if [ ! -f "$CHILD_PATH" ]; then
               echo "::error::$CHILD_BIN missing from packaged .vsix at engine/bin/darwin-arm64/ — OOP plugin hosting cannot start its child" >&2

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,66 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.258 feat(vst3): VST3 instrument production — Pitch DSL が VST3 で鳴る実機 E2E #421 (Jul 16, 2026)
+
+**Date**: 2026-07-16
+**Status**: ✅ 実装・実機 E2E PASS（PR 作成・レビューフローへ）
+**Branch**: `421-vst3-instrument-production`
+**Commits**: `25e5360` (Stage 1) / Stage 2 / Stage 3 / `a09d7fb` (Stage 4)
+
+Epic #424 の CLAP instrument 経路（#427）を VST3 に横展開。単一 PR + Stage ごとの
+細かいコミットで実装（owner 確定方針・overnight 自律走行）。実装 = Codex fresh
+スレッド×4（Stage 分割・自己完結ブリーフ）+ main の受け入れ監査。
+
+**スコープ = note on/off のみ**。CC→IMidiMapping / per-note expression / tempo(#408) は
+owner 設計セッションへ明示先送り（PR に doc 化）。
+
+**Stage 1（orbit-vst3-host）**: `Vst3InstrumentProcessor` 新設 — instrument 判定
+（audio in=0/out>0・event input bus 必須・effect は NotInstrument で明示拒否）、
+headless EditController + IConnectionPoint、event input bus の明示 activateBus、
+note on/off を積む `HostInputEventList`（IEventList 実装）、process は add-mix
+（CLAP 版と同意味論）、teardown は effect の規律踏襲。
+
+**Stage 2（orbit-vst3-instrument-child 新 crate）**: clap 版の transport ミラー
+（event slot 消費・in-order seq・output window/spill・publish_child_ready）。
+**VST3 に NOTE_END が無い非対称は child 内で吸収**: NoteOff/NoteChoke 処理時に
+同 addr/sample_offset の synthetic NoteEnd を output window へ書く（host の
+(port,channel,key) 参照カウント簿記は無改変・Fable 確定設計）。wildcard は 0 丸め、
+NoteChoke は velocity 0 の NoteOff 化。push API に sample_offset 追加。
+
+**Stage 3（テスト）**: `orbit-vst3-synth-oracle` 新設（clap-test-synth の SineVoice
+ミラー・振幅 0.25・package-oracle.sh）+ offline テスト（発音→0.25±0.01→note off→無音、
+effect 拒否の負テスト）+ `outproc_instrument_vst3_gated.rs`（CLAP 版ミラー3本）。
+**gated 実機 RUN 3/3 PASS**: post_mix_peak=0.25000・synthetic NOTE_END で
+probe_live_count 0 復帰・SIGKILL respawn 回復。
+
+**Stage 4（daemon + DSL 配線）**: attach 時に拡張子で instrument child を選択
+（.vst3 → orbit-vst3-instrument-child・それ以外は従来どおり CLAP child。
+デフォルト名 child の同ディレクトリ差し替え = 対称・冪等な純関数）。
+`validatePluginExtension` を role 対応化（instrument = .clap/.vst3・effect = .clap のみ）。
+release.yml / copy-daemon-bin.sh に VST3 child 同梱。
+
+**受け入れ監査で Codex 実装から2点修正（実機 gated RUN で検出・#445 の教訓が的中）**:
+① 拡張子 validation が CLAP gated の raw .dylib attach を破壊 → 未知拡張子は
+reject せず CLAP child へ ② child exe 再導出が current_exe 基準でテストハーネス
+（deps/ 配下）を壊す + retry 後に .clap へ戻らない → 親ディレクトリ基準の対称読み替えに。
+fail-before/pass-after: CLAP gated 0/3 → 3/3。
+
+**実機 E2E（DoD・self-run は owner 常時許可の範囲）**:
+.orbs（`global.key("C")` + `seq.instrument("SynthOracle.vst3")` + `play(1,3,5,8)` +
+`RUN(synth)`）を配布構成 release daemon + cli-audio.js + `ORBIT_CAPTURE_WAV` で実行 →
+**capture peak = 0.25000（厳密一致・synth 既知振幅）**。CLAP baseline も同手順で
+0.25000（経路パリティ）。DSL → LoadPlugin(role=instrument) → 拡張子ベース child 選択 →
+VST3 child → IEventList note on/off → sine 発音 → master bus の全経路を客観実証
+（スピーカー実再生込み）。
+※ ハーネスの学び: `play()` はパターン buffering のみで発音には `RUN(seq)` が必要
+（WORK_LOG 6.x 既知の RUN/LOOP 忘れ silent 再現を踏んだ）。
+
+**検証**: cargo workspace build / clippy -D warnings / fmt・daemon unit 54 + protocol 28・
+CLAP gated 3/3 + VST3 gated 3/3（実機）・npm test 1333 passed / 0 failed。
+既知 flake: offline テスト初回ビルド時の oracle packaging 並行競合（既存パターン・
+Stage 1 以前から存在・再実行で安定 green）。
+
 ### 6.257 feat(daemon): DoD 配線 — TS ガード撤去 + cross-role reject + 配布 feature + DSL 実機 E2E #431 PR-3 (Jul 16, 2026)
 
 **Date**: 2026-07-16

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -77,6 +77,28 @@ CLAP gated 3/3 + VST3 gated 3/3（実機）・npm test 1333 passed / 0 failed。
 既知 flake: offline テスト初回ビルド時の oracle packaging 並行競合（既存パターン・
 Stage 1 以前から存在・再実行で安定 green）。
 
+**/simplify（4観点並行・PR #447）**: reuse/efficiency/altitude = クリーン判定。
+simplification 2件適用（oracle packaging ヘルパー統合・NoteOff/NoteChoke 分岐統合）。
+適用後 gated 3/3 実機再RUN green（`2389f12`）。
+
+**/code:pr-review-team（round 1-3・収束）**:
+- round 1（4レビュアー並行）: Critical 2（plugin-resolver doc 例の stale シグネチャ /
+  select_child_exe 配線の CI テスト欠如）+ Important 4（ガード早期 return の stale
+  input events / event_decode_error_count 未ミラー / child 選択の log なし /
+  process() tresult 破棄）+ テスト増強2件 → fixer 一括適用（`a34fce0`・
+  classify_event 純関数抽出 + unit テスト5本含む）
+- round 2（収束チェック）: 残余 Important 1（decode counter が ticker 経路まで
+  届いていない）+ Minor 2 を検出 → 7-tuple 化 + 新 WARNING
+  `OUTPROC_INSTRUMENT_EVENT_DECODE` 配線等で解消（`beedd24`）
+- round 3: **全 RESOLVED・新規指摘なし・Critical/Important = 0 で収束**
+- CI 4/4 pass（fmt/clippy/test・code-review・packaging・license gate）
+- 各 round 後に CLAP/VST3 gated 実機再RUN で退行なしを確認
+- 既知 flake: 高負荷時（並行 cargo と競合）に voice-leading / random 等の
+  timing 依存 spec が落ちる。隔離再実行で毎回 green を確認済み
+
+**状態**: PR #447 open・レビュー収束済み・CI green。マージと Epic #424 クローズは
+owner 指示待ち（overnight 自律走行の停止点）。
+
 ### 6.257 feat(daemon): DoD 配線 — TS ガード撤去 + cross-role reject + 配布 feature + DSL 実機 E2E #431 PR-3 (Jul 16, 2026)
 
 **Date**: 2026-07-16

--- a/packages/engine/src/core/global/plugin-effect-manager.ts
+++ b/packages/engine/src/core/global/plugin-effect-manager.ts
@@ -30,7 +30,7 @@ export class PluginEffectManager {
     // yet (unsaved file) makes `resolvePluginPath` throw a "cannot resolve"
     // error; if that ran before the LinkAudio gate, it would mask the more
     // relevant LinkAudio-conflict error with a confusing resolve failure.
-    validatePluginExtension(spec)
+    validatePluginExtension(spec, 'effect')
 
     if (this.linkAudioManager.isEnabled()) {
       throw new Error('global.effect() cannot be used while LinkAudio is enabled in v1.')
@@ -40,6 +40,7 @@ export class PluginEffectManager {
       spec,
       this.audioManager.getAudioPaths(),
       this.audioManager.getDocumentDirectory(),
+      'effect',
     )
 
     const existing = this.declaration

--- a/packages/engine/src/core/global/plugin-instrument-manager.ts
+++ b/packages/engine/src/core/global/plugin-instrument-manager.ts
@@ -25,7 +25,7 @@ export class PluginInstrumentManager {
   }
 
   async instrument(spec: string, pluginId?: string): Promise<void> {
-    validatePluginExtension(spec)
+    validatePluginExtension(spec, 'instrument')
     if (this.linkAudioManager.isEnabled()) {
       throw new Error('seq.instrument() cannot be used while LinkAudio is enabled in v1.')
     }
@@ -34,6 +34,7 @@ export class PluginInstrumentManager {
       spec,
       this.audioManager.getAudioPaths(),
       this.audioManager.getDocumentDirectory(),
+      'instrument',
     )
     const existing = this.declaration
     if (existing) {

--- a/packages/engine/src/core/global/plugin-resolver.ts
+++ b/packages/engine/src/core/global/plugin-resolver.ts
@@ -1,10 +1,8 @@
 /**
  * Plugin path resolver.
  *
- * Shared extension-validation + path-resolution logic for `.clap` plugin
- * specs. Extracted from `PluginEffectManager` (`global.effect()`) so #427's
- * `seq.instrument()` can reuse the same validation + resolution without
- * duplicating it.
+ * Shared role-aware extension-validation + path-resolution logic for plugin
+ * specs.
  *
  * `resolvePluginPath` validates the extension first, then resolves the path
  * (`resolvePathDirect`) — this single entry point always does both, in that
@@ -24,18 +22,23 @@ export function resolvePluginPath(
   spec: string,
   audioPaths: readonly string[],
   documentDirectory: string,
+  role: PluginRole,
 ): string {
-  validatePluginExtension(spec)
+  validatePluginExtension(spec, role)
   return resolvePathDirect(spec, audioPaths, documentDirectory)
 }
 
-export function validatePluginExtension(spec: string): void {
+export type PluginRole = 'effect' | 'instrument'
+
+export function validatePluginExtension(spec: string, role: PluginRole): void {
   const extension = path.extname(spec).toLowerCase()
   if (extension === '.clap') return
+  if (extension === '.vst3' && role === 'instrument') return
   if (extension === '.vst3' || extension === '.component') {
     throw new Error(
-      `${extension} plugins are not yet supported (reserved for future VST3/AU support).`,
+      `${extension} plugins are not yet supported for ${role} (reserved for future VST3/AU support).`,
     )
   }
-  throw new Error(`Unknown plugin extension "${extension || '(none)'}"; expected .clap.`)
+  const expected = role === 'instrument' ? '.clap or .vst3' : '.clap'
+  throw new Error(`Unknown plugin extension "${extension || '(none)'}"; expected ${expected}.`)
 }

--- a/packages/engine/src/core/global/plugin-resolver.ts
+++ b/packages/engine/src/core/global/plugin-resolver.ts
@@ -11,7 +11,8 @@
  * while LinkAudio is enabled) should run that check *between* validation and
  * resolution — call `validatePluginExtension(spec)` directly first, do the
  * gating check, then call `resolvePluginPath` (which re-validates; the
- * function is pure so the repeat call is harmless).
+ * function is pure so the repeat call is harmless). Example:
+ * `validatePluginExtension(spec, role)`.
  */
 
 import path from 'node:path'

--- a/packages/engine/src/core/global/plugin-resolver.ts
+++ b/packages/engine/src/core/global/plugin-resolver.ts
@@ -9,10 +9,9 @@
  * order, so callers can't accidentally skip validation. Callers that also
  * need to gate on other state (e.g. `PluginEffectManager.effect()` rejecting
  * while LinkAudio is enabled) should run that check *between* validation and
- * resolution — call `validatePluginExtension(spec)` directly first, do the
+ * resolution — call `validatePluginExtension(spec, role)` directly first, do the
  * gating check, then call `resolvePluginPath` (which re-validates; the
- * function is pure so the repeat call is harmless). Example:
- * `validatePluginExtension(spec, role)`.
+ * function is pure so the repeat call is harmless).
  */
 
 import path from 'node:path'

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1063,6 +1063,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "orbit-vst3-synth-oracle"
+version = "0.0.1"
+dependencies = [
+ "vst3",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1054,6 +1054,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "orbit-vst3-instrument-child"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "orbit-audio-sandbox",
+ "orbit-vst3-host",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "crates/orbit-audio-sandbox",
   "crates/orbit-vst3-host",
   "crates/orbit-vst3-gain-oracle",
+  "crates/orbit-vst3-synth-oracle",
 ]
 # 🔴 orbit-link-audio(GPL 隔離 crate)は **member にしない**。
 # member にすると default の `cargo build` / cargo-deny がこの GPL crate を root として

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "crates/orbit-clap-effect-child",
   "crates/orbit-clap-instrument-child",
   "crates/orbit-vst3-effect-child",
+  "crates/orbit-vst3-instrument-child",
   "crates/orbit-sandbox-spike",
   "crates/orbit-audio-sandbox",
   "crates/orbit-vst3-host",

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -2098,7 +2098,7 @@ impl EngineWrap {
 
     /// OOP instrument の全 health signal を `(child_process_error_count, respawn_count,
     /// measurement_invalid, output_event_dropped_count, output_event_spilled_count,
-    /// output_note_end_dropped_count)` で返す（daemon の 1 Hz ticker が polling して WARNING event
+    /// output_note_end_dropped_count, event_decode_error_count)` で返す（daemon の 1 Hz ticker が polling して WARNING event
     /// で surface する非 RT observability）。`outproc_health()`（effect 側）と同じ「1 tick = 1
     /// try_lock + 1 snapshot」設計 — child-process 系 3 signal と output-event overflow 系 3 signal を
     /// 1 accessor に統合し、同一 tick 内で `outproc_instrument` mutex を複数回 `try_lock` する
@@ -2108,7 +2108,7 @@ impl EngineWrap {
     /// （cumulative なので drop しない）、**Poisoned** は warn して real 分を 0/false に丸める
     /// （injected 分は失わない）。instrument 未起動 / outproc-instrument 無効時は injected 分のみ返す。
     #[cfg(feature = "outproc-instrument")]
-    pub fn outproc_instrument_health(&self) -> (u64, u64, bool, u64, u64, u64) {
+    pub fn outproc_instrument_health(&self) -> (u64, u64, bool, u64, u64, u64, u64) {
         let injected_errors = self.outproc_instrument_child_errors.load(Ordering::Relaxed);
         let injected_respawns = self.outproc_instrument_respawns.load(Ordering::Relaxed);
         let injected_invalid = self
@@ -2129,6 +2129,7 @@ impl EngineWrap {
                         s.output_event_dropped_count + injected_dropped,
                         s.output_event_spilled_count,
                         s.output_note_end_dropped_count,
+                        s.event_decode_error_count,
                     )
                 })
                 .unwrap_or((
@@ -2138,12 +2139,14 @@ impl EngineWrap {
                     injected_dropped,
                     0,
                     0,
+                    0,
                 )),
             Err(std::sync::TryLockError::WouldBlock) => (
                 injected_errors,
                 injected_respawns,
                 injected_invalid,
                 injected_dropped,
+                0,
                 0,
                 0,
             ),
@@ -2160,6 +2163,7 @@ impl EngineWrap {
                     injected_dropped,
                     0,
                     0,
+                    0,
                 )
             }
         }
@@ -2167,7 +2171,7 @@ impl EngineWrap {
 
     /// feature `outproc-instrument` 無効ビルド用の stub。本番は常に injected 分のみ（control が無い）。
     #[cfg(not(feature = "outproc-instrument"))]
-    pub fn outproc_instrument_health(&self) -> (u64, u64, bool, u64, u64, u64) {
+    pub fn outproc_instrument_health(&self) -> (u64, u64, bool, u64, u64, u64, u64) {
         (
             self.outproc_instrument_child_errors.load(Ordering::Relaxed),
             self.outproc_instrument_respawns.load(Ordering::Relaxed),
@@ -2175,6 +2179,7 @@ impl EngineWrap {
                 .load(Ordering::Relaxed),
             self.outproc_instrument_output_dropped
                 .load(Ordering::Relaxed),
+            0,
             0,
             0,
         )
@@ -4297,9 +4302,9 @@ mod outproc_instrument_health_tests {
 
     // `outproc_instrument_health()` mirrors `outproc_health_tests` (effect side) exactly --
     // Ok(None)/Ok(Some)/WouldBlock/Poisoned branches. It bundles all 6 instrument health signals
-    // (child-process trio + output-event-overflow trio) into one accessor/one try_lock, so every
-    // test below uses 6 *distinct* values to catch a field-to-field mapping swap at either half
-    // of the tuple.
+    // (child-process trio + output-event-overflow trio + event_decode_error_count) into one
+    // accessor/one try_lock, so every test below uses distinct values to catch a field-to-field
+    // mapping swap anywhere in the tuple.
 
     #[test]
     fn health_ok_none_reports_only_injected_values() {
@@ -4316,7 +4321,7 @@ mod outproc_instrument_health_tests {
             .fetch_add(7, Ordering::Relaxed);
         assert_eq!(
             wrap.outproc_instrument_health(),
-            (4, 2, true, 7, 0, 0),
+            (4, 2, true, 7, 0, 0, 0),
             "Ok(None): only injected counters/flag surface; real output-event fields are 0"
         );
     }
@@ -4340,6 +4345,7 @@ mod outproc_instrument_health_tests {
         stats
             .output_note_end_dropped_count
             .store(6, Ordering::Relaxed);
+        stats.event_decode_error_count.store(8, Ordering::Relaxed);
         wrap.outproc_instrument_child_errors_arc()
             .fetch_add(9, Ordering::Relaxed);
         wrap.outproc_instrument_respawns_arc()
@@ -4347,7 +4353,10 @@ mod outproc_instrument_health_tests {
         wrap.outproc_instrument_output_dropped_arc()
             .fetch_add(1, Ordering::Relaxed);
 
-        assert_eq!(wrap.outproc_instrument_health(), (12, 7, true, 12, 13, 6));
+        assert_eq!(
+            wrap.outproc_instrument_health(),
+            (12, 7, true, 12, 13, 6, 8)
+        );
     }
 
     #[test]
@@ -4380,7 +4389,7 @@ mod outproc_instrument_health_tests {
         });
         holding_rx.recv().expect("holder thread signaled lock held");
 
-        assert_eq!(wrap.outproc_instrument_health(), (1, 0, false, 4, 0, 0));
+        assert_eq!(wrap.outproc_instrument_health(), (1, 0, false, 4, 0, 0, 0));
 
         release_tx.send(()).expect("signal release");
         holder.join().expect("holder thread should not panic");
@@ -4417,7 +4426,7 @@ mod outproc_instrument_health_tests {
             "spawned thread should have panicked while holding the lock"
         );
 
-        assert_eq!(wrap.outproc_instrument_health(), (3, 0, false, 2, 0, 0));
+        assert_eq!(wrap.outproc_instrument_health(), (3, 0, false, 2, 0, 0, 0));
     }
 }
 

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -259,6 +259,11 @@ pub(crate) trait OutProcRole: Sized {
     fn set_child_early_exit(stats: &Self::Stats, value: bool);
     fn child_early_exit(stats: &Self::Stats) -> bool;
     fn set_current_child_pid(stats: &Self::Stats, pid: u32);
+    /// Attach path で plugin format に依存する child を選び直す。effect は env 設定のまま。
+    fn select_child_exe(
+        launch: &mut ChildLaunch<Self>,
+        path: &std::path::Path,
+    ) -> Result<(), String>;
     /// テスト専用: role ジェネリックなテストヘルパーが `Self::Stats` を構築するためのコンストラクタ。
     /// production コードはこれを呼ばない（`load_outproc_plugin_impl` 等は呼び出し側から渡された
     /// `ChildLaunch::stats` を使う）。
@@ -339,6 +344,12 @@ impl OutProcRole for EffectRole {
     fn set_current_child_pid(stats: &Self::Stats, pid: u32) {
         stats.current_child_pid.store(pid, Ordering::Relaxed);
     }
+    fn select_child_exe(
+        _launch: &mut ChildLaunch<Self>,
+        _path: &std::path::Path,
+    ) -> Result<(), String> {
+        Ok(())
+    }
     #[cfg(test)]
     fn new_stats() -> Arc<Self::Stats> {
         crate::outproc_effect::OutProcEffectStats::new()
@@ -403,6 +414,15 @@ impl OutProcRole for InstrumentRole {
     }
     fn set_current_child_pid(stats: &Self::Stats, pid: u32) {
         stats.current_child_pid.store(pid, Ordering::Relaxed);
+    }
+    fn select_child_exe(
+        launch: &mut ChildLaunch<Self>,
+        path: &std::path::Path,
+    ) -> Result<(), String> {
+        // 拡張子ベースの読み替え（.vst3 → VST3 child・それ以外 → CLAP child）。明示指定された
+        // child exe（デフォルト名以外）は保持される。詳細は `child_exe_for_attach` の doc 参照。
+        launch.child_exe = crate::outproc_instrument::child_exe_for_attach(&launch.child_exe, path);
+        Ok(())
     }
     #[cfg(test)]
     fn new_stats() -> Arc<Self::Stats> {
@@ -1494,6 +1514,10 @@ impl EngineWrap {
             ChildSlot::Empty(launch) => launch,
             _ => unreachable!("ChildSlot state was checked while holding the same mutex"),
         };
+        if let Err(error) = R::select_child_exe(&mut launch, &path) {
+            *slot = ChildSlot::Empty(launch);
+            return Err(R::runtime_error(error));
+        }
         *slot = ChildSlot::Loading { path: path.clone() };
         // Loading 書き込みを可視化した直後にロックを解放する。以降の shm open・spawn・
         // ready-ack poll（最大 CHILD_READY_TIMEOUT）はロック外で行う。他の LoadPlugin

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -422,6 +422,11 @@ impl OutProcRole for InstrumentRole {
         // 拡張子ベースの読み替え（.vst3 → VST3 child・それ以外 → CLAP child）。明示指定された
         // child exe（デフォルト名以外）は保持される。詳細は `child_exe_for_attach` の doc 参照。
         launch.child_exe = crate::outproc_instrument::child_exe_for_attach(&launch.child_exe, path);
+        tracing::debug!(
+            ?path,
+            child_exe = ?launch.child_exe,
+            "instrument child selected for attach"
+        );
         Ok(())
     }
     #[cfg(test)]
@@ -4075,11 +4080,13 @@ mod outproc_health_tests {
 #[cfg(all(test, feature = "outproc-instrument"))]
 mod outproc_instrument_health_tests {
     use super::{
-        ChildSlot, EngineWrap, InstrumentRole, OutProcInstrumentControl, OutProcRole, WrapError,
+        ChildLaunch, ChildSlot, EngineWrap, InstrumentRole, OutProcInstrumentControl, OutProcRole,
+        WrapError,
     };
     use crate::backend::StubBackend;
     use crate::outproc_instrument::OutProcInstrumentStats;
-    use std::sync::atomic::Ordering;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Mutex, Weak};
 
     /// `StubBackend` で `EngineWrap` を起動し、real child なしで組み立てた `OutProcInstrumentControl`
@@ -4166,6 +4173,53 @@ mod outproc_instrument_health_tests {
             "retry-instrument.clap",
             true,
             false,
+        );
+    }
+
+    #[test]
+    fn instrument_select_child_exe_swaps_default_child_by_extension() {
+        let stats = InstrumentRole::new_stats();
+        let mut launch = ChildLaunch::<InstrumentRole> {
+            shm_path: PathBuf::from("/tmp/unused-select-child-exe.shm"),
+            child_exe: PathBuf::from("/opt/orbitscore/orbit-clap-instrument-child"),
+            sample_rate: 48_000,
+            stats: stats.clone(),
+            engaged: Arc::new(AtomicBool::new(false)),
+            cleanup_shm_on_drop: false,
+        };
+
+        InstrumentRole::select_child_exe(&mut launch, Path::new("synth.vst3"))
+            .expect("select_child_exe must not error on default child name");
+        assert_eq!(
+            launch.child_exe.file_name().and_then(|name| name.to_str()),
+            Some("orbit-vst3-instrument-child")
+        );
+
+        // Symmetric: attaching a .clap plugin afterwards swaps back to the CLAP child.
+        InstrumentRole::select_child_exe(&mut launch, Path::new("synth.clap"))
+            .expect("select_child_exe must not error on default child name");
+        assert_eq!(
+            launch.child_exe.file_name().and_then(|name| name.to_str()),
+            Some("orbit-clap-instrument-child")
+        );
+
+        // An explicitly-named (non-default) child exe is preserved untouched.
+        let mut explicit_launch = ChildLaunch::<InstrumentRole> {
+            shm_path: PathBuf::from("/tmp/unused-select-child-exe-explicit.shm"),
+            child_exe: PathBuf::from("/opt/orbitscore/custom-instrument-child"),
+            sample_rate: 48_000,
+            stats,
+            engaged: Arc::new(AtomicBool::new(false)),
+            cleanup_shm_on_drop: false,
+        };
+        InstrumentRole::select_child_exe(&mut explicit_launch, Path::new("synth.vst3"))
+            .expect("select_child_exe must not error on explicit child name");
+        assert_eq!(
+            explicit_launch
+                .child_exe
+                .file_name()
+                .and_then(|name| name.to_str()),
+            Some("custom-instrument-child")
         );
     }
 

--- a/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
@@ -112,8 +112,10 @@ enum InstrumentPluginFormat {
 }
 
 impl InstrumentPluginFormat {
-    /// 拡張子 `.vst3`（大文字小文字不問）のみ VST3。**それ以外はすべて Clap** — CLAP gated
-    /// テストは未バンドルの raw `.dylib`（clap-test-synth）を attach するため、ここで未知
+    /// 拡張子 `.vst3`（大文字小文字不問）のみ VST3。**それ以外はすべて Clap** —
+    /// CLAP は VST3 対応前から唯一サポートされていた instrument フォーマットだった
+    /// ため、未知拡張子のフォールバック先として妥当。一例として、CLAP gated テストは
+    /// 未バンドルの raw `.dylib`（clap-test-synth）を attach するため、ここで未知
     /// 拡張子を reject すると既存経路が壊れる（本ブランチの実機 gated RUN で検出済み）。
     /// 不正な plugin path の失敗は従来どおり child 側の load エラーとして表面化する。
     fn from_plugin_path(path: &Path) -> Self {
@@ -183,6 +185,9 @@ pub struct OutProcInstrumentStats {
     /// 上記 output 方向 drop に `NoteEnd` が含まれた回数。`SharedRegion::output_note_end_dropped_count`
     /// のミラー(host の簿記リセット判断トリガと同じ counter だが、こちらは daemon health 可視化用)。
     pub output_note_end_dropped_count: AtomicU64,
+    /// child が decode できなかった input event / 未対応 `NeutralEvent` variant の数。
+    /// `SharedRegion::event_decode_error_count` のミラー(他カウンタと同じ mirror パターン)。
+    pub event_decode_error_count: AtomicU64,
     /// Gated cross-process probe: A4 (port 0 / channel 0 / key 69) の host-side live voice 数。
     pub probe_live_count: AtomicU16,
     /// Instrument 加算後の master bus の abs peak を f32 bits で累積する。非負 f32 の bits は
@@ -212,6 +217,7 @@ impl OutProcInstrumentStats {
             output_note_end_dropped_count: self
                 .output_note_end_dropped_count
                 .load(Ordering::Relaxed),
+            event_decode_error_count: self.event_decode_error_count.load(Ordering::Relaxed),
             probe_live_count: self.probe_live_count.load(Ordering::Relaxed),
             post_peak: f32::from_bits(self.post_peak_bits.load(Ordering::Relaxed)),
             current_child_pid: self.current_child_pid.load(Ordering::Relaxed),
@@ -229,6 +235,7 @@ pub struct OutProcInstrumentSnapshot {
     pub output_event_dropped_count: u64,
     pub output_event_spilled_count: u64,
     pub output_note_end_dropped_count: u64,
+    pub event_decode_error_count: u64,
     pub probe_live_count: u16,
     pub post_peak: f32,
     pub current_child_pid: u32,
@@ -460,6 +467,11 @@ impl InstrumentChildSupervisor {
                     stats
                         .output_note_end_dropped_count
                         .store(note_end_dropped, Ordering::Relaxed);
+                    let event_decode_errors =
+                        unsafe { (*region).event_decode_error_count.load(Ordering::Relaxed) };
+                    stats
+                        .event_decode_error_count
+                        .store(event_decode_errors, Ordering::Relaxed);
 
                     match child.try_wait() {
                         Ok(Some(_)) if shutdown_thread.load(Ordering::Acquire) => break,

--- a/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
@@ -103,12 +103,65 @@ fn parse_buffer_frames(value: Option<&str>) -> Option<u32> {
     }
 }
 
+/// instrument child のフォーマット別デフォルト binary 名。VST3 だけが専用 child を持ち、
+/// それ以外（.clap・raw .dylib CLAP 等）は従来どおり CLAP child が担当する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InstrumentPluginFormat {
+    Clap,
+    Vst3,
+}
+
+impl InstrumentPluginFormat {
+    /// 拡張子 `.vst3`（大文字小文字不問）のみ VST3。**それ以外はすべて Clap** — CLAP gated
+    /// テストは未バンドルの raw `.dylib`（clap-test-synth）を attach するため、ここで未知
+    /// 拡張子を reject すると既存経路が壊れる（本ブランチの実機 gated RUN で検出済み）。
+    /// 不正な plugin path の失敗は従来どおり child 側の load エラーとして表面化する。
+    fn from_plugin_path(path: &Path) -> Self {
+        match path.extension().and_then(|extension| extension.to_str()) {
+            Some(extension) if extension.eq_ignore_ascii_case("vst3") => Self::Vst3,
+            _ => Self::Clap,
+        }
+    }
+
+    fn default_child_name(self) -> &'static str {
+        match self {
+            Self::Clap => "orbit-clap-instrument-child",
+            Self::Vst3 => "orbit-vst3-instrument-child",
+        }
+    }
+}
+
+/// attach する plugin の拡張子から instrument child binary を選ぶ（純関数・unit テスト対象）。
+///
+/// - `current_child_exe` の file name がフォーマット別デフォルト名（clap/vst3 child）で
+///   ない場合は**明示指定と見なして触らない**（gated テストの config 直指定・
+///   `ORBIT_INSTRUMENT_CHILD_BIN` override を保護）。
+/// - デフォルト名の場合は**同じディレクトリ**でフォーマットに応じた binary に読み替える。
+///   `current_exe` からの再導出はしない（テストハーネスでは current_exe が
+///   `target/debug/deps/` 配下になり sibling 解決が壊れるため）。retryable attach 失敗で
+///   `ChildLaunch` が再利用されても、毎回この読み替えが走るので .vst3 → .clap の
+///   attach し直しで元の child に戻る（対称・冪等）。
+pub(crate) fn child_exe_for_attach(current_child_exe: &Path, plugin_path: &Path) -> PathBuf {
+    let is_default_name = matches!(
+        current_child_exe.file_name().and_then(|name| name.to_str()),
+        Some("orbit-clap-instrument-child") | Some("orbit-vst3-instrument-child")
+    );
+    if !is_default_name {
+        return current_child_exe.to_path_buf();
+    }
+    let desired = InstrumentPluginFormat::from_plugin_path(plugin_path).default_child_name();
+    match current_child_exe.parent() {
+        Some(dir) => dir.join(desired),
+        None => PathBuf::from(desired),
+    }
+}
+
 fn default_child_exe() -> Result<PathBuf, String> {
     let exe = std::env::current_exe().map_err(|error| format!("current_exe: {error}"))?;
     let dir = exe
         .parent()
         .ok_or_else(|| "current_exe has no parent directory".to_string())?;
-    Ok(dir.join("orbit-clap-instrument-child"))
+    Ok(dir.join(InstrumentPluginFormat::Clap.default_child_name()))
 }
 
 #[derive(Default)]
@@ -1096,5 +1149,44 @@ mod tests {
         drop(sup);
         drop(ctl_mmap);
         let _ = std::fs::remove_file(&shm);
+    }
+    #[test]
+    fn instrument_plugin_format_selects_child_name_from_extension() {
+        assert_eq!(
+            InstrumentPluginFormat::from_plugin_path(Path::new("synth.clap")).default_child_name(),
+            "orbit-clap-instrument-child"
+        );
+        assert_eq!(
+            InstrumentPluginFormat::from_plugin_path(Path::new("synth.VST3")).default_child_name(),
+            "orbit-vst3-instrument-child"
+        );
+        // 未知拡張子・raw dylib は従来どおり CLAP child（CLAP gated は未バンドル .dylib を使う）。
+        assert_eq!(
+            InstrumentPluginFormat::from_plugin_path(Path::new("libclap_test_synth.dylib"))
+                .default_child_name(),
+            "orbit-clap-instrument-child"
+        );
+    }
+
+    #[test]
+    fn child_exe_for_attach_swaps_default_names_in_place_and_is_symmetric() {
+        let clap = PathBuf::from("/target/debug/orbit-clap-instrument-child");
+        let vst3 = PathBuf::from("/target/debug/orbit-vst3-instrument-child");
+        // .vst3 attach はデフォルト CLAP child を同ディレクトリの VST3 child に読み替える。
+        assert_eq!(child_exe_for_attach(&clap, Path::new("synth.vst3")), vst3);
+        // retryable attach 失敗で child_exe が VST3 に書き換わったまま .clap を attach し直しても
+        // CLAP child に戻る（対称・冪等）。
+        assert_eq!(child_exe_for_attach(&vst3, Path::new("synth.clap")), clap);
+        assert_eq!(child_exe_for_attach(&vst3, Path::new("synth.vst3")), vst3);
+    }
+
+    #[test]
+    fn child_exe_for_attach_preserves_explicit_non_default_binaries() {
+        let custom = PathBuf::from("/tmp/gated-instrument-child");
+        assert_eq!(
+            child_exe_for_attach(&custom, Path::new("synth.vst3")),
+            custom,
+            "explicit child exe (env override / test fixture) must be retained"
+        );
     }
 }

--- a/rust/crates/orbit-audio-daemon/src/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/src/protocol.rs
@@ -144,6 +144,13 @@ pub const ERROR_CODE_OUTPROC_INSTRUMENT_RESPAWN: &str = "OUTPROC_INSTRUMENT_RESP
 /// `measurement_invalid` を検知して一度だけ発火する（fire-once）。`ERROR_CODE_OUTPROC_EFFECT_INVALID`
 /// の instrument 側ミラー（#420 PR #422 round 3）。
 pub const ERROR_CODE_OUTPROC_INSTRUMENT_INVALID: &str = "OUTPROC_INSTRUMENT_INVALID";
+/// out-of-process instrument child が input event を decode できなかった / 未対応の
+/// `NeutralEvent` variant を受けた（該当イベントは無音で消える）。WARNING severity。child が
+/// shm の cumulative counter（`event_decode_error_count`）に積み、daemon が 1 Hz ticker で増加を
+/// 検知して発火する（#421 pr-review-team round 2: counter の watchdog ミラーは round 1 で追加済み
+/// だったが daemon health 経路への配線が欠けており、per-note expression 等の未対応イベント消失が
+/// 一切可視化されなかった — silent-failure-hunter 指摘の残余）。
+pub const ERROR_CODE_OUTPROC_INSTRUMENT_EVENT_DECODE: &str = "OUTPROC_INSTRUMENT_EVENT_DECODE";
 
 /// Daemon → Client の event（通知、id なし）。
 #[derive(Debug, Serialize)]

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -25,10 +25,11 @@ use crate::protocol::{
     ERROR_CODE_ENGINE_LOCK_POISONED, ERROR_CODE_LINK_EGRESS_DROP, ERROR_CODE_OUTPROC_EFFECT_ERROR,
     ERROR_CODE_OUTPROC_EFFECT_FRAMES_CLAMPED, ERROR_CODE_OUTPROC_EFFECT_INVALID,
     ERROR_CODE_OUTPROC_EFFECT_RESPAWN, ERROR_CODE_OUTPROC_INSTRUMENT_ERROR,
-    ERROR_CODE_OUTPROC_INSTRUMENT_INVALID, ERROR_CODE_OUTPROC_INSTRUMENT_OUTPUT_DROPPED,
-    ERROR_CODE_OUTPROC_INSTRUMENT_RESPAWN, ERROR_CODE_PLUGIN_EVENT_RING_OVERFLOW,
-    ERROR_CODE_STREAM_XRUN, ERROR_SEVERITY_FATAL, ERROR_SEVERITY_WARNING, EVENT_DAEMON_ERROR,
-    EVENT_PLAY_ENDED, EVENT_PLAY_STARTED, EVENT_STREAM_STATS,
+    ERROR_CODE_OUTPROC_INSTRUMENT_EVENT_DECODE, ERROR_CODE_OUTPROC_INSTRUMENT_INVALID,
+    ERROR_CODE_OUTPROC_INSTRUMENT_OUTPUT_DROPPED, ERROR_CODE_OUTPROC_INSTRUMENT_RESPAWN,
+    ERROR_CODE_PLUGIN_EVENT_RING_OVERFLOW, ERROR_CODE_STREAM_XRUN, ERROR_SEVERITY_FATAL,
+    ERROR_SEVERITY_WARNING, EVENT_DAEMON_ERROR, EVENT_PLAY_ENDED, EVENT_PLAY_STARTED,
+    EVENT_STREAM_STATS,
 };
 
 /// writer task のキュー容量。過大に積まれると back pressure をかける。
@@ -120,6 +121,7 @@ pub async fn run(
             let mut last_outproc_instrument_output_dropped: u64 = 0;
             let mut last_outproc_instrument_errors: u64 = 0;
             let mut last_outproc_instrument_respawns: u64 = 0;
+            let mut last_outproc_instrument_decode_errors: u64 = 0;
             let mut last_engine_lock_contention: u64 = 0;
             let mut last_plugin_event_ring_overflow: u64 = 0;
             let mut outproc_invalid_reported = false;
@@ -345,7 +347,25 @@ pub async fn run(
                     outproc_instrument_dropped,
                     outproc_instrument_spilled,
                     outproc_instrument_note_end_dropped,
+                    outproc_instrument_decode_errors,
                 ) = engine.outproc_instrument_health();
+                // input 方向の decode 失敗 / 未対応 NeutralEvent variant（該当イベントは無音で
+                // 消える）。output overflow とは別枠の WARNING（#421 round 2 residual）。
+                if outproc_instrument_decode_errors > last_outproc_instrument_decode_errors {
+                    let evt = daemon_error_event(
+                        ERROR_SEVERITY_WARNING,
+                        ERROR_CODE_OUTPROC_INSTRUMENT_EVENT_DECODE,
+                        format!(
+                            "out-of-process instrument dropped undecodable/unsupported input \
+                             events ({outproc_instrument_decode_errors} total); those events \
+                             are silently lost to the plugin",
+                        ),
+                    );
+                    if tx.send(to_json_or_fallback(&evt)).await.is_err() {
+                        break;
+                    }
+                    last_outproc_instrument_decode_errors = outproc_instrument_decode_errors;
+                }
                 if outproc_instrument_errors > last_outproc_instrument_errors {
                     let evt = daemon_error_event(
                         ERROR_SEVERITY_WARNING,

--- a/rust/crates/orbit-audio-daemon/tests/outproc_instrument_vst3_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_instrument_vst3_gated.rs
@@ -1,0 +1,202 @@
+//! Gated real-device coverage for daemon -> VST3 instrument child -> synth oracle.
+//!
+//! Prerequisites:
+//!   cargo build -p orbit-vst3-instrument-child
+//! Run:
+//!   cargo test -p orbit-audio-daemon --features outproc-instrument \
+//!     --test outproc_instrument_vst3_gated -- --ignored --nocapture
+//!
+//! `ORBIT_INSTRUMENT_CHILD_BIN` may override the default VST3 child path.
+
+#![cfg(all(feature = "outproc-instrument", not(feature = "outproc-effect")))]
+
+mod gated_common;
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+use gated_common::{child_exe, repo_path, wait_until};
+use orbit_audio_daemon::engine_wrap::EngineWrap;
+use orbit_audio_daemon::outproc_instrument::{OutProcInstrumentConfig, PROBE_KEY};
+
+const PROBE_NOTE_KEY: u8 = PROBE_KEY.key as u8;
+const PROBE_NOTE_CHANNEL: u8 = PROBE_KEY.channel as u8;
+
+fn package_oracle() -> PathBuf {
+    let script = repo_path("rust/crates/orbit-vst3-synth-oracle/package-oracle.sh");
+    let output = Command::new(&script)
+        .output()
+        .unwrap_or_else(|error| panic!("run {}: {error}", script.display()));
+    assert!(
+        output.status.success(),
+        "VST3 synth oracle packaging failed (status={}): {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    PathBuf::from(String::from_utf8_lossy(&output.stdout).trim())
+}
+
+fn setup_test() -> OutProcInstrumentConfig {
+    let child_exe = std::env::var_os("ORBIT_INSTRUMENT_CHILD_BIN")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| child_exe("orbit-vst3-instrument-child"));
+    let plugin = package_oracle();
+    assert!(
+        child_exe.exists(),
+        "VST3 instrument child is missing: {} — run `cargo build -p orbit-vst3-instrument-child`",
+        child_exe.display()
+    );
+    assert!(
+        plugin.exists(),
+        "VST3 synth oracle bundle is missing: {}",
+        plugin.display()
+    );
+    OutProcInstrumentConfig {
+        child_exe,
+        plugin: Some(plugin),
+        plugin_id: None,
+        buffer_frames: None,
+    }
+}
+
+#[test]
+#[ignore = "VST3 Phase1: needs a real output device + built orbit-vst3-instrument-child (local only)"]
+fn outproc_vst3_instrument_sounds_at_oracle_amplitude_and_ends_note() {
+    let (engine, _guard) = EngineWrap::start_outproc_instrument(setup_test())
+        .expect("start OOP VST3 instrument daemon");
+
+    engine
+        .plugin_note_on(PROBE_NOTE_KEY, PROBE_NOTE_CHANNEL, 0.8)
+        .expect("send A4 note on");
+    let sounded = wait_until(Duration::from_secs(10), || {
+        engine
+            .outproc_instrument_stats()
+            .map(|stats| stats.post_peak > 0.01 && stats.fresh > 0 && stats.probe_live_count > 0)
+            .unwrap_or(false)
+    });
+    let sounding = engine
+        .outproc_instrument_stats()
+        .expect("instrument stats while sounding");
+    assert!(
+        sounded,
+        "VST3 instrument did not produce a fresh audible block"
+    );
+    assert!(
+        (sounding.post_peak - 0.25).abs() <= 0.01,
+        "synth peak was {}, expected 0.25 +/- 0.01",
+        sounding.post_peak
+    );
+
+    engine
+        .plugin_note_off(PROBE_NOTE_KEY, PROBE_NOTE_CHANNEL, 0.0)
+        .expect("send A4 note off");
+    // VST3 has no plugin NOTE_END callback. `orbit-vst3-instrument-child` synthesizes NOTE_END
+    // when it forwards NoteOff, so this verifies host bookkeeping rather than plugin feedback.
+    let note_end_received = wait_until(Duration::from_secs(3), || {
+        engine
+            .outproc_instrument_stats()
+            .map(|stats| stats.probe_live_count == 0)
+            .unwrap_or(false)
+    });
+    let stats = engine.outproc_instrument_stats().expect("instrument stats");
+    println!("=== VST3 OOP instrument oracle verdict ===");
+    println!("post_mix_peak:       {:.5}", stats.post_peak);
+    println!("fresh:               {}", stats.fresh);
+    println!("probe_live_count:    {}", stats.probe_live_count);
+    println!("child_proc_errors:   {}", stats.child_process_error_count);
+    println!("===========================================");
+    assert!(
+        note_end_received,
+        "synthetic VST3 NOTE_END did not clear host voice bookkeeping"
+    );
+    assert!(
+        !stats.measurement_invalid,
+        "child spawn/respawn failure invalidated measurement"
+    );
+    assert_eq!(
+        stats.child_process_error_count, 0,
+        "VST3 instrument child process error"
+    );
+    assert_eq!(
+        stats.output_note_end_dropped_count, 0,
+        "synthetic NOTE_END was dropped"
+    );
+}
+
+#[test]
+#[ignore = "VST3 Phase1: needs a real output device + built orbit-vst3-instrument-child (local only)"]
+fn outproc_vst3_instrument_attach_failure_can_retry_with_oracle() {
+    let config = setup_test();
+    let oracle = config.plugin.clone().expect("oracle plugin");
+    let (engine, _guard) =
+        EngineWrap::start_outproc_instrument_post_boot(config).expect("start daemon post boot");
+    assert!(engine
+        .load_outproc_plugin(PathBuf::from("/definitely/not/a/plugin.vst3"), None)
+        .is_err());
+    engine
+        .load_outproc_plugin(oracle, None)
+        .expect("retry synth oracle");
+    engine
+        .plugin_note_on(PROBE_NOTE_KEY, PROBE_NOTE_CHANNEL, 0.8)
+        .expect("note on");
+    assert!(wait_until(Duration::from_secs(10), || engine
+        .outproc_instrument_stats()
+        .map(|stats| stats.fresh > 0 && stats.probe_live_count > 0)
+        .unwrap_or(false)));
+}
+
+#[test]
+#[ignore = "VST3 Phase1: needs a real output device + built orbit-vst3-instrument-child (local only)"]
+fn outproc_vst3_instrument_survives_child_kill_and_sounds_again() {
+    let (engine, _guard) = EngineWrap::start_outproc_instrument(setup_test())
+        .expect("start OOP VST3 instrument daemon");
+    engine
+        .plugin_note_on(PROBE_NOTE_KEY, PROBE_NOTE_CHANNEL, 0.8)
+        .expect("pre-kill note on");
+    assert!(wait_until(Duration::from_secs(10), || engine
+        .outproc_instrument_stats()
+        .map(|stats| stats.post_peak > 0.01 && stats.fresh > 0)
+        .unwrap_or(false)));
+    let before = engine
+        .outproc_instrument_stats()
+        .expect("stats before kill");
+    let killed_pid = before.current_child_pid;
+    assert_ne!(killed_pid, 0, "child PID was not published");
+    Command::new("kill")
+        .args(["-9", &killed_pid.to_string()])
+        .status()
+        .expect("kill command")
+        .success()
+        .then_some(())
+        .expect("kill VST3 child");
+    assert!(wait_until(Duration::from_secs(5), || engine
+        .outproc_instrument_stats()
+        .map(|stats| stats.respawn_count > before.respawn_count)
+        .unwrap_or(false)));
+    engine.outproc_instrument_reset_post_peak();
+    let fresh_before = engine
+        .outproc_instrument_stats()
+        .expect("post-respawn stats")
+        .fresh;
+    engine
+        .plugin_note_on(PROBE_NOTE_KEY, PROBE_NOTE_CHANNEL, 0.8)
+        .expect("post-respawn note on");
+    assert!(wait_until(Duration::from_secs(10), || engine
+        .outproc_instrument_stats()
+        .map(|stats| stats.post_peak > 0.01 && stats.fresh > fresh_before)
+        .unwrap_or(false)));
+    let after = engine.outproc_instrument_stats().expect("recovery stats");
+    assert_ne!(
+        after.current_child_pid, killed_pid,
+        "child was not replaced"
+    );
+    assert!(
+        !after.measurement_invalid,
+        "respawn invalidated measurement"
+    );
+    assert_eq!(
+        after.child_process_error_count, 0,
+        "VST3 child process error"
+    );
+}

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -958,6 +958,8 @@ impl Vst3InstrumentProcessor {
             },
         }];
         let Ok(num_samples) = i32::try_from(frames) else {
+            // Same rationale as the guards above: drop stale queued events on early return.
+            self.input_events.clear();
             return false;
         };
         let mut process_data = ProcessData {

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -71,6 +71,11 @@ pub enum Vst3HostError {
         direction: &'static str,
         channels: i32,
     },
+    NotInstrument {
+        input_buses: i32,
+        output_buses: i32,
+    },
+    MissingEventInputBus,
 }
 
 impl Display for Vst3HostError {
@@ -122,6 +127,16 @@ impl Display for Vst3HostError {
                 f,
                 "primary {direction} bus is not stereo (expected {DEFAULT_CHANNELS} channels, got {channels})"
             ),
+            Self::NotInstrument {
+                input_buses,
+                output_buses,
+            } => write!(
+                f,
+                "VST3 plugin is not an instrument (audio input buses={input_buses}, audio output buses={output_buses}); expected no audio input buses and at least one audio output bus"
+            ),
+            Self::MissingEventInputBus => {
+                write!(f, "VST3 instrument has no event input bus")
+            }
         }
     }
 }
@@ -705,6 +720,262 @@ impl Vst3EffectProcessor {
 }
 
 impl Drop for Vst3EffectProcessor {
+    fn drop(&mut self) {
+        if let Some(processor) = self.processor.take() {
+            unsafe {
+                let _ = processor.setProcessing(0);
+            }
+        }
+        if let (Some(component_connection), Some(controller_connection)) = (
+            self.component_connection.as_ref(),
+            self.controller_connection.as_ref(),
+        ) {
+            unsafe {
+                let _ = component_connection.disconnect(controller_connection.as_ptr());
+                let _ = controller_connection.disconnect(component_connection.as_ptr());
+            }
+        }
+        let _ = self.component_connection.take();
+        let _ = self.controller_connection.take();
+        if let Some(controller) = self.controller.take() {
+            unsafe {
+                let _ = controller.terminate();
+            }
+        }
+        if let Some(component) = self.component.take() {
+            unsafe {
+                let _ = component.setActive(0);
+                let _ = component.terminate();
+            }
+        }
+        let _ = self.factory.take();
+    }
+}
+
+/// Single-threaded VST3 instrument processor.
+///
+/// `Rc` makes this type `!Send` and `!Sync`. Construct, process, and drop it on the same home
+/// thread. Its explicit teardown order intentionally matches [`Vst3EffectProcessor`].
+pub struct Vst3InstrumentProcessor {
+    processor: Option<ComPtr<IAudioProcessor>>,
+    controller: Option<ComPtr<IEditController>>,
+    component_connection: Option<ComPtr<IConnectionPoint>>,
+    controller_connection: Option<ComPtr<IConnectionPoint>>,
+    component: Option<ComPtr<IComponent>>,
+    _component_handler: Option<ComWrapper<HostComponentHandler>>,
+    _host_context: ComWrapper<HostApplication>,
+    factory: Option<ComPtr<IPluginFactory>>,
+    _home_thread: PhantomData<Rc<()>>,
+    _library: LoadedLibrary,
+    info: LoadedVst3Info,
+    input_events: InputEventList,
+    output_parameter_changes: ParameterChanges,
+    output_events: EventList,
+    process_output_l: Vec<f32>,
+    process_output_r: Vec<f32>,
+}
+
+impl Vst3InstrumentProcessor {
+    pub fn load(
+        bundle_path: &Path,
+        sample_rate: f64,
+        max_samples_per_block: i32,
+    ) -> Result<(Self, LoadedVst3Info), Vst3HostError> {
+        let library = LoadedLibrary::open(bundle_path)?;
+        let factory = unsafe { library.get_factory()? };
+        let class = find_audio_module_class(&factory)?;
+        let mut component_raw = ptr::null_mut();
+        let create_result = unsafe {
+            factory.createInstance(
+                class.cid.as_ptr() as FIDString,
+                IComponent_iid.as_ptr() as FIDString,
+                &mut component_raw,
+            )
+        };
+        if !is_ok(create_result) {
+            return Err(Vst3HostError::CreateInstance(create_result));
+        }
+        let component = unsafe { ComPtr::from_raw(component_raw as *mut IComponent) }
+            .ok_or(Vst3HostError::CreateInstance(create_result))?;
+        let host_context = ComWrapper::new(HostApplication);
+        let host_context_ptr = host_context
+            .as_com_ref::<IHostApplication>()
+            .expect("HostApplication exposes IHostApplication")
+            .as_ptr()
+            .cast::<FUnknown>();
+        let init_result = unsafe { component.initialize(host_context_ptr) };
+        if !is_ok(init_result) {
+            return Err(Vst3HostError::Initialize(init_result));
+        }
+        let processor = component
+            .as_com_ref()
+            .cast::<IAudioProcessor>()
+            .ok_or(Vst3HostError::QueryAudioProcessor)?;
+        let sample_size_result =
+            unsafe { processor.canProcessSampleSize(SymbolicSampleSizes_::kSample32 as i32) };
+        if !is_ok(sample_size_result) {
+            return Err(Vst3HostError::SampleSize(sample_size_result));
+        }
+
+        // Controller creation/connection precedes bus activation, matching the effect host.
+        let controller_handshake =
+            connect_controller(&factory, &component, &host_context, host_context_ptr)?;
+        let input_buses = unsafe {
+            component.getBusCount(MediaTypes_::kAudio as i32, BusDirections_::kInput as i32)
+        };
+        let output_buses = unsafe {
+            component.getBusCount(MediaTypes_::kAudio as i32, BusDirections_::kOutput as i32)
+        };
+        if input_buses != 0 || output_buses <= 0 {
+            return Err(Vst3HostError::NotInstrument {
+                input_buses,
+                output_buses,
+            });
+        }
+        let event_input_buses = unsafe {
+            component.getBusCount(MediaTypes_::kEvent as i32, BusDirections_::kInput as i32)
+        };
+        if event_input_buses <= 0 {
+            return Err(Vst3HostError::MissingEventInputBus);
+        }
+
+        configure_audio_buses(&component, &processor, input_buses, output_buses)?;
+        // The event input bus is required for note delivery; unlike audio activation it must not
+        // be left to a plugin default.
+        let event_result = unsafe {
+            component.activateBus(
+                MediaTypes_::kEvent as i32,
+                BusDirections_::kInput as i32,
+                0,
+                1,
+            )
+        };
+        if !is_ok(event_result) {
+            return Err(Vst3HostError::SetActive(event_result));
+        }
+
+        let mut setup = ProcessSetup {
+            processMode: ProcessModes_::kRealtime as i32,
+            symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
+            maxSamplesPerBlock: max_samples_per_block,
+            sampleRate: sample_rate,
+        };
+        let setup_result = unsafe { processor.setupProcessing(&mut setup) };
+        if !is_ok(setup_result) {
+            return Err(Vst3HostError::SetupProcessing(setup_result));
+        }
+        let active_result = unsafe { component.setActive(1) };
+        if !is_ok(active_result) {
+            return Err(Vst3HostError::SetActive(active_result));
+        }
+        let processing_result = unsafe { processor.setProcessing(1) };
+        if !is_ok(processing_result) && processing_result != kNotImplemented {
+            return Err(Vst3HostError::SetProcessing(processing_result));
+        }
+
+        let info = LoadedVst3Info {
+            name: class.name,
+            audio_inputs: input_buses,
+            audio_outputs: output_buses,
+            is_effect: false,
+        };
+        let scratch_len = max_samples_per_block.max(0) as usize;
+        Ok((
+            Self {
+                processor: Some(processor),
+                controller: controller_handshake.controller,
+                component_connection: controller_handshake.component_connection,
+                controller_connection: controller_handshake.controller_connection,
+                component: Some(component),
+                _component_handler: controller_handshake.component_handler,
+                _host_context: host_context,
+                factory: Some(factory),
+                _home_thread: PhantomData,
+                _library: library,
+                info: info.clone(),
+                input_events: InputEventList::new(),
+                output_parameter_changes: ParameterChanges::empty(),
+                output_events: EventList::empty(),
+                process_output_l: vec![0.0; scratch_len],
+                process_output_r: vec![0.0; scratch_len],
+            },
+            info,
+        ))
+    }
+
+    pub fn info(&self) -> &LoadedVst3Info {
+        &self.info
+    }
+
+    pub fn push_note_on(&self, channel: i16, pitch: i16, velocity: f32) {
+        self.input_events.push_note_on(channel, pitch, velocity);
+    }
+
+    pub fn push_note_off(&self, channel: i16, pitch: i16, velocity: f32) {
+        self.input_events.push_note_off(channel, pitch, velocity);
+    }
+
+    /// Queued note events are delivered at sample offset zero; successful plugin output is
+    /// add-mixed into interleaved stereo `data`.
+    #[must_use]
+    pub fn process_block(&mut self, data: &mut [f32]) -> bool {
+        if !data.len().is_multiple_of(DEFAULT_CHANNELS) {
+            return false;
+        }
+        let frames = data.len() / DEFAULT_CHANNELS;
+        if frames > self.process_output_l.len() {
+            return false;
+        }
+        self.process_output_l[..frames].fill(0.0);
+        self.process_output_r[..frames].fill(0.0);
+        let mut output_ptrs = [
+            self.process_output_l.as_mut_ptr(),
+            self.process_output_r.as_mut_ptr(),
+        ];
+        let mut outputs = [AudioBusBuffers {
+            numChannels: DEFAULT_CHANNELS as i32,
+            silenceFlags: 0,
+            __field0: AudioBusBuffers__type0 {
+                channelBuffers32: output_ptrs.as_mut_ptr(),
+            },
+        }];
+        let Ok(num_samples) = i32::try_from(frames) else {
+            return false;
+        };
+        let mut process_data = ProcessData {
+            processMode: ProcessModes_::kRealtime as i32,
+            symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
+            numSamples: num_samples,
+            numInputs: 0,
+            numOutputs: 1,
+            inputs: ptr::null_mut(),
+            outputs: outputs.as_mut_ptr(),
+            inputParameterChanges: ptr::null_mut(),
+            outputParameterChanges: self.output_parameter_changes.as_ptr(),
+            inputEvents: self.input_events.as_ptr(),
+            outputEvents: self.output_events.as_ptr(),
+            processContext: ptr::null_mut(),
+        };
+        let result = unsafe {
+            self.processor
+                .as_ref()
+                .expect("processor remains alive until drop")
+                .process(&mut process_data)
+        };
+        self.input_events.clear();
+        if !is_ok(result) {
+            return false;
+        }
+        for frame in 0..frames {
+            let base = frame * DEFAULT_CHANNELS;
+            data[base] += self.process_output_l[frame];
+            data[base + 1] += self.process_output_r[frame];
+        }
+        true
+    }
+}
+
+impl Drop for Vst3InstrumentProcessor {
     fn drop(&mut self) {
         if let Some(processor) = self.processor.take() {
             unsafe {
@@ -1423,6 +1694,109 @@ impl IBStreamTrait for MemoryStream {
             *pos = self.pos.get() as i64;
         }
         kResultOk
+    }
+}
+
+/// Working input event list for the instrument processor. `IEventList` is queried synchronously
+/// from `IAudioProcessor::process`, so `RefCell` lets the Rust-facing queue and COM callbacks
+/// share one allocation without requiring a mutable COM interface.
+struct InputEventList {
+    wrapper: ComWrapper<HostInputEventList>,
+    ptr: ComPtr<IEventList>,
+}
+
+impl InputEventList {
+    fn new() -> Self {
+        let wrapper = ComWrapper::new(HostInputEventList::new());
+        let ptr = wrapper
+            .to_com_ptr::<IEventList>()
+            .expect("HostInputEventList exposes IEventList");
+        Self { wrapper, ptr }
+    }
+
+    fn push_note_on(&self, channel: i16, pitch: i16, velocity: f32) {
+        self.wrapper.events.borrow_mut().push(Event {
+            busIndex: 0,
+            sampleOffset: 0,
+            ppqPosition: 0.0,
+            flags: Event_::EventFlags_::kIsLive as u16,
+            r#type: Event_::EventTypes_::kNoteOnEvent as u16,
+            __field0: Event__type0 {
+                noteOn: NoteOnEvent {
+                    channel,
+                    pitch,
+                    tuning: 0.0,
+                    velocity,
+                    length: 0,
+                    noteId: -1,
+                },
+            },
+        });
+    }
+
+    fn push_note_off(&self, channel: i16, pitch: i16, velocity: f32) {
+        self.wrapper.events.borrow_mut().push(Event {
+            busIndex: 0,
+            sampleOffset: 0,
+            ppqPosition: 0.0,
+            flags: Event_::EventFlags_::kIsLive as u16,
+            r#type: Event_::EventTypes_::kNoteOffEvent as u16,
+            __field0: Event__type0 {
+                noteOff: NoteOffEvent {
+                    channel,
+                    pitch,
+                    velocity,
+                    noteId: -1,
+                    tuning: 0.0,
+                },
+            },
+        });
+    }
+
+    fn clear(&self) {
+        self.wrapper.events.borrow_mut().clear();
+    }
+
+    fn as_ptr(&self) -> *mut IEventList {
+        self.ptr.as_ptr()
+    }
+}
+
+struct HostInputEventList {
+    events: RefCell<Vec<Event>>,
+}
+
+impl HostInputEventList {
+    fn new() -> Self {
+        Self {
+            events: RefCell::new(Vec::new()),
+        }
+    }
+}
+
+impl Class for HostInputEventList {
+    type Interfaces = (IEventList,);
+}
+
+impl IEventListTrait for HostInputEventList {
+    unsafe fn getEventCount(&self) -> i32 {
+        self.events.borrow().len().min(i32::MAX as usize) as i32
+    }
+
+    unsafe fn getEvent(&self, index: i32, event: *mut Event) -> tresult {
+        if index < 0 || event.is_null() {
+            return kInvalidArgument;
+        }
+        let events = self.events.borrow();
+        let Some(source) = events.get(index as usize) else {
+            return kInvalidArgument;
+        };
+        *event = *source;
+        kResultOk
+    }
+
+    unsafe fn addEvent(&self, _event: *mut Event) -> tresult {
+        kResultFalse
     }
 }
 

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -773,6 +773,9 @@ pub struct Vst3InstrumentProcessor {
     output_events: EventList,
     process_output_l: Vec<f32>,
     process_output_r: Vec<f32>,
+    /// Raw tresult of the most recent failing `process()` call (RT-safe: no logging on the hot
+    /// path, just stashed for the caller to surface out-of-band, e.g. on child process exit).
+    last_process_error: std::cell::Cell<i32>,
 }
 
 impl Vst3InstrumentProcessor {
@@ -898,6 +901,7 @@ impl Vst3InstrumentProcessor {
                 output_events: EventList::empty(),
                 process_output_l: vec![0.0; scratch_len],
                 process_output_r: vec![0.0; scratch_len],
+                last_process_error: std::cell::Cell::new(0),
             },
             info,
         ))
@@ -905,6 +909,13 @@ impl Vst3InstrumentProcessor {
 
     pub fn info(&self) -> &LoadedVst3Info {
         &self.info
+    }
+
+    /// Raw tresult of the most recent failing `process()` call (0 / `kResultOk` if none since
+    /// construction). Intended for out-of-band error reporting (e.g. child process exit summary),
+    /// not for the audio-thread hot path.
+    pub fn last_process_error(&self) -> i32 {
+        self.last_process_error.get()
     }
 
     pub fn push_note_on(&self, channel: i16, pitch: i16, velocity: f32, sample_offset: i32) {
@@ -922,10 +933,15 @@ impl Vst3InstrumentProcessor {
     #[must_use]
     pub fn process_block(&mut self, data: &mut [f32]) -> bool {
         if !data.len().is_multiple_of(DEFAULT_CHANNELS) {
+            // Clear queued input events so a rejected block doesn't leak stale note
+            // events (with now-invalid sample offsets) into the next successful block.
+            self.input_events.clear();
             return false;
         }
         let frames = data.len() / DEFAULT_CHANNELS;
         if frames > self.process_output_l.len() {
+            // Same rationale as above: drop stale queued events on early return.
+            self.input_events.clear();
             return false;
         }
         self.process_output_l[..frames].fill(0.0);
@@ -966,6 +982,7 @@ impl Vst3InstrumentProcessor {
         };
         self.input_events.clear();
         if !is_ok(result) {
+            self.last_process_error.set(result);
             return false;
         }
         for frame in 0..frames {

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -907,16 +907,18 @@ impl Vst3InstrumentProcessor {
         &self.info
     }
 
-    pub fn push_note_on(&self, channel: i16, pitch: i16, velocity: f32) {
-        self.input_events.push_note_on(channel, pitch, velocity);
+    pub fn push_note_on(&self, channel: i16, pitch: i16, velocity: f32, sample_offset: i32) {
+        self.input_events
+            .push_note_on(channel, pitch, velocity, sample_offset);
     }
 
-    pub fn push_note_off(&self, channel: i16, pitch: i16, velocity: f32) {
-        self.input_events.push_note_off(channel, pitch, velocity);
+    pub fn push_note_off(&self, channel: i16, pitch: i16, velocity: f32, sample_offset: i32) {
+        self.input_events
+            .push_note_off(channel, pitch, velocity, sample_offset);
     }
 
-    /// Queued note events are delivered at sample offset zero; successful plugin output is
-    /// add-mixed into interleaved stereo `data`.
+    /// Queued note events are delivered at their supplied sample offsets; successful plugin
+    /// output is add-mixed into interleaved stereo `data`.
     #[must_use]
     pub fn process_block(&mut self, data: &mut [f32]) -> bool {
         if !data.len().is_multiple_of(DEFAULT_CHANNELS) {
@@ -1714,10 +1716,10 @@ impl InputEventList {
         Self { wrapper, ptr }
     }
 
-    fn push_note_on(&self, channel: i16, pitch: i16, velocity: f32) {
+    fn push_note_on(&self, channel: i16, pitch: i16, velocity: f32, sample_offset: i32) {
         self.wrapper.events.borrow_mut().push(Event {
             busIndex: 0,
-            sampleOffset: 0,
+            sampleOffset: sample_offset,
             ppqPosition: 0.0,
             flags: Event_::EventFlags_::kIsLive as u16,
             r#type: Event_::EventTypes_::kNoteOnEvent as u16,
@@ -1734,10 +1736,10 @@ impl InputEventList {
         });
     }
 
-    fn push_note_off(&self, channel: i16, pitch: i16, velocity: f32) {
+    fn push_note_off(&self, channel: i16, pitch: i16, velocity: f32, sample_offset: i32) {
         self.wrapper.events.borrow_mut().push(Event {
             busIndex: 0,
-            sampleOffset: 0,
+            sampleOffset: sample_offset,
             ppqPosition: 0.0,
             flags: Event_::EventFlags_::kIsLive as u16,
             r#type: Event_::EventTypes_::kNoteOffEvent as u16,

--- a/rust/crates/orbit-vst3-host/tests/offline.rs
+++ b/rust/crates/orbit-vst3-host/tests/offline.rs
@@ -199,45 +199,30 @@ fn vst3_probe_path() -> PathBuf {
 
 fn package_oracle() -> Option<PathBuf> {
     static ORACLE: OnceLock<Option<PathBuf>> = OnceLock::new();
-    ORACLE.get_or_init(package_gain_oracle).clone()
-}
-
-fn package_gain_oracle() -> Option<PathBuf> {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let script = manifest_dir
-        .parent()
-        .expect("crate has parent")
-        .join("orbit-vst3-gain-oracle")
-        .join("package-oracle.sh");
-    let output = Command::new(&script).output().ok()?;
-    if !output.status.success() {
-        eprintln!(
-            "oracle packaging failed: status={} stderr={}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
-        );
-        return None;
-    }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Some(PathBuf::from(stdout.trim()))
+    ORACLE
+        .get_or_init(|| run_package_script("orbit-vst3-gain-oracle"))
+        .clone()
 }
 
 fn package_synth_oracle() -> Option<PathBuf> {
     static ORACLE: OnceLock<Option<PathBuf>> = OnceLock::new();
-    ORACLE.get_or_init(package_synth_oracle_once).clone()
+    ORACLE
+        .get_or_init(|| run_package_script("orbit-vst3-synth-oracle"))
+        .clone()
 }
 
-fn package_synth_oracle_once() -> Option<PathBuf> {
+/// `crates/<crate_dir>/package-oracle.sh` を実行して bundle の絶対パスを得る（失敗は loud skip）。
+fn run_package_script(crate_dir: &str) -> Option<PathBuf> {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let script = manifest_dir
         .parent()
         .expect("crate has parent")
-        .join("orbit-vst3-synth-oracle")
+        .join(crate_dir)
         .join("package-oracle.sh");
     let output = Command::new(&script).output().ok()?;
     if !output.status.success() {
         eprintln!(
-            "synth oracle packaging failed: status={} stderr={}",
+            "{crate_dir} packaging failed: status={} stderr={}",
             output.status,
             String::from_utf8_lossy(&output.stderr)
         );

--- a/rust/crates/orbit-vst3-host/tests/offline.rs
+++ b/rust/crates/orbit-vst3-host/tests/offline.rs
@@ -151,6 +151,73 @@ fn process_block_rejects_frames_exceeding_scratch() {
     );
 }
 
+// Mirror of process_block_rejects_non_stereo_length / process_block_rejects_frames_exceeding_scratch
+// for Vst3InstrumentProcessor (Fix 1: guard early-returns must clear queued input events so a
+// rejected block's note doesn't leak into the next successful block at a stale sample offset).
+#[test]
+fn instrument_process_block_rejects_non_stereo_length() {
+    let Some(bundle) = package_synth_oracle() else {
+        eprintln!("VST3 synth oracle build failed; loud skip for this machine");
+        return;
+    };
+    let (mut processor, _info) = Vst3InstrumentProcessor::load(&bundle, SAMPLE_RATE, FRAMES as i32)
+        .unwrap_or_else(|error| {
+            panic!("failed to load synth oracle {}: {error}", bundle.display())
+        });
+
+    processor.push_note_on(0, 69, 0.8, 0);
+    // Odd length: not a multiple of DEFAULT_CHANNELS(2).
+    let mut data = vec![0.0f32; 3];
+    assert!(
+        !processor.process_block(&mut data),
+        "non-multiple-of-channels length must be rejected"
+    );
+
+    // The queued note must not leak into the next (valid, silent) block.
+    let mut audio = vec![0.0f32; FRAMES * 2];
+    assert!(
+        processor.process_block(&mut audio),
+        "valid block after a rejected block must succeed"
+    );
+    let peak = audio
+        .iter()
+        .map(|sample| sample.abs())
+        .fold(0.0_f32, f32::max);
+    assert_eq!(peak, 0.0, "rejected block's queued note must not sound");
+}
+
+#[test]
+fn instrument_process_block_rejects_frames_exceeding_scratch() {
+    let Some(bundle) = package_synth_oracle() else {
+        eprintln!("VST3 synth oracle build failed; loud skip for this machine");
+        return;
+    };
+    let (mut processor, _info) = Vst3InstrumentProcessor::load(&bundle, SAMPLE_RATE, FRAMES as i32)
+        .unwrap_or_else(|error| {
+            panic!("failed to load synth oracle {}: {error}", bundle.display())
+        });
+
+    processor.push_note_on(0, 69, 0.8, 0);
+    // FRAMES(512) is the scratch length (max_samples_per_block); one frame beyond that must fail.
+    let mut data = vec![0.0f32; (FRAMES + 1) * 2];
+    assert!(
+        !processor.process_block(&mut data),
+        "frame count exceeding scratch length must be rejected"
+    );
+
+    // The queued note must not leak into the next (valid, silent) block.
+    let mut audio = vec![0.0f32; FRAMES * 2];
+    assert!(
+        processor.process_block(&mut audio),
+        "valid block after a rejected block must succeed"
+    );
+    let peak = audio
+        .iter()
+        .map(|sample| sample.abs())
+        .fold(0.0_f32, f32::max);
+    assert_eq!(peak, 0.0, "rejected block's queued note must not sound");
+}
+
 #[test]
 fn real_vst3_abi_loads_processes_and_drops() {
     let candidates = real_plugin_candidates();

--- a/rust/crates/orbit-vst3-host/tests/offline.rs
+++ b/rust/crates/orbit-vst3-host/tests/offline.rs
@@ -3,8 +3,9 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::OnceLock;
 
-use orbit_vst3_host::Vst3EffectProcessor;
+use orbit_vst3_host::{Vst3EffectProcessor, Vst3HostError, Vst3InstrumentProcessor};
 
 const SAMPLE_RATE: f64 = 48_000.0;
 const FRAMES: usize = 512;
@@ -57,6 +58,57 @@ fn gain_oracle_is_sample_exact() {
             "gain=0.5 right sample {index}"
         );
     }
+}
+
+#[test]
+fn synth_oracle_sounds_then_silences_on_note_off() {
+    let Some(bundle) = package_synth_oracle() else {
+        eprintln!("VST3 synth oracle build failed; loud skip for this machine");
+        return;
+    };
+    let (mut processor, info) = Vst3InstrumentProcessor::load(&bundle, SAMPLE_RATE, FRAMES as i32)
+        .unwrap_or_else(|error| {
+            panic!("failed to load synth oracle {}: {error}", bundle.display())
+        });
+    assert!(!info.is_effect, "oracle must be detected as an instrument");
+    assert_eq!(info.audio_inputs, 0);
+    assert_eq!(info.audio_outputs, 1);
+
+    processor.push_note_on(0, 69, 0.8, 0);
+    let mut audio = vec![0.0; FRAMES * 2];
+    assert!(processor.process_block(&mut audio));
+    audio.fill(0.0);
+    assert!(processor.process_block(&mut audio));
+    let peak = audio
+        .iter()
+        .map(|sample| sample.abs())
+        .fold(0.0_f32, f32::max);
+    assert!(
+        (peak - 0.25).abs() <= 0.01,
+        "synth peak was {peak}, expected 0.25 +/- 0.01"
+    );
+
+    processor.push_note_off(0, 69, 0.0, 0);
+    audio.fill(0.0);
+    assert!(processor.process_block(&mut audio));
+    assert!(processor.process_block(&mut audio));
+    assert!(
+        audio.iter().all(|sample| *sample == 0.0),
+        "note-off must return output to silence"
+    );
+}
+
+#[test]
+fn instrument_loader_rejects_gain_effect_oracle() {
+    let Some(bundle) = package_oracle() else {
+        eprintln!("VST3 oracle build failed; loud skip for this machine");
+        return;
+    };
+    let error = match Vst3InstrumentProcessor::load(&bundle, SAMPLE_RATE, FRAMES as i32) {
+        Ok(_) => panic!("effect oracle must not load as an instrument"),
+        Err(error) => error,
+    };
+    assert!(matches!(error, Vst3HostError::NotInstrument { .. }));
 }
 
 // I5(pr-review-team): `process_block`'s guard clauses (non-multiple-of-channels length, scratch
@@ -146,6 +198,11 @@ fn vst3_probe_path() -> PathBuf {
 }
 
 fn package_oracle() -> Option<PathBuf> {
+    static ORACLE: OnceLock<Option<PathBuf>> = OnceLock::new();
+    ORACLE.get_or_init(package_gain_oracle).clone()
+}
+
+fn package_gain_oracle() -> Option<PathBuf> {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let script = manifest_dir
         .parent()
@@ -163,6 +220,32 @@ fn package_oracle() -> Option<PathBuf> {
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
     Some(PathBuf::from(stdout.trim()))
+}
+
+fn package_synth_oracle() -> Option<PathBuf> {
+    static ORACLE: OnceLock<Option<PathBuf>> = OnceLock::new();
+    ORACLE.get_or_init(package_synth_oracle_once).clone()
+}
+
+fn package_synth_oracle_once() -> Option<PathBuf> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let script = manifest_dir
+        .parent()
+        .expect("crate has parent")
+        .join("orbit-vst3-synth-oracle")
+        .join("package-oracle.sh");
+    let output = Command::new(&script).output().ok()?;
+    if !output.status.success() {
+        eprintln!(
+            "synth oracle packaging failed: status={} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+    Some(PathBuf::from(
+        String::from_utf8_lossy(&output.stdout).trim(),
+    ))
 }
 
 fn known_stereo_input() -> (Vec<f32>, Vec<f32>) {

--- a/rust/crates/orbit-vst3-instrument-child/Cargo.toml
+++ b/rust/crates/orbit-vst3-instrument-child/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "orbit-vst3-instrument-child"
+version.workspace = true
+edition = "2021"
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Out-of-process VST3 instrument child hosting a real VST3 plugin over the orbit-audio-sandbox event transport"
+
+[[bin]]
+name = "orbit-vst3-instrument-child"
+path = "src/main.rs"
+
+[dependencies]
+orbit-vst3-host = { path = "../orbit-vst3-host" }
+orbit-audio-sandbox = { path = "../orbit-audio-sandbox" }
+anyhow = "1"

--- a/rust/crates/orbit-vst3-instrument-child/src/main.rs
+++ b/rust/crates/orbit-vst3-instrument-child/src/main.rs
@@ -1,0 +1,370 @@
+//! Out-of-process VST3 instrument child using the M2 shared-memory event transport.
+
+#![allow(unsafe_code)]
+
+#[cfg(target_os = "macos")]
+use std::path::PathBuf;
+#[cfg(target_os = "macos")]
+use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+
+#[cfg(target_os = "macos")]
+use anyhow::{bail, Context, Result};
+#[cfg(target_os = "macos")]
+use orbit_audio_sandbox::{
+    open_shared, region_ptr, slot_index, slot_offset, EventRecord, EventSpillFifo, NeutralEvent,
+    SharedRegion, VoiceAddr, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_EVENTS_PER_BLOCK, MAX_FRAMES,
+};
+#[cfg(target_os = "macos")]
+use orbit_vst3_host::Vst3InstrumentProcessor;
+
+#[cfg(target_os = "macos")]
+struct Args {
+    shm: PathBuf,
+    plugin: PathBuf,
+    plugin_id: Option<String>,
+    sample_rate: u32,
+}
+
+#[cfg(target_os = "macos")]
+fn parse_args() -> Result<Args> {
+    let mut shm = None;
+    let mut plugin = None;
+    let mut plugin_id = None;
+    let mut sample_rate = 48_000;
+    let mut it = std::env::args().skip(1);
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--shm" => shm = Some(PathBuf::from(it.next().context("--shm に値が必要")?)),
+            "--plugin" => plugin = Some(PathBuf::from(it.next().context("--plugin に値が必要")?)),
+            "--plugin-id" => plugin_id = Some(it.next().context("--plugin-id に値が必要")?),
+            "--sample-rate" => {
+                sample_rate = it
+                    .next()
+                    .context("--sample-rate に値が必要")?
+                    .parse()
+                    .context("--sample-rate の parse")?
+            }
+            other => bail!("未知の引数: {other}"),
+        }
+    }
+    Ok(Args {
+        shm: shm.context("--shm は必須")?,
+        plugin: plugin.context("--plugin は必須")?,
+        plugin_id,
+        sample_rate,
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn in_order_seqs(last: u64, cur: u64) -> impl Iterator<Item = u64> {
+    last.saturating_add(1)..=cur
+}
+
+#[cfg(target_os = "macos")]
+fn decode_slot_events(records: &[EventRecord], count: u32, sink: &mut Vec<NeutralEvent>) -> u32 {
+    sink.clear();
+    let count = (count as usize)
+        .min(MAX_EVENTS_PER_BLOCK)
+        .min(records.len());
+    let mut failures = 0;
+    for record in &records[..count] {
+        if let Some(event) = record.decode() {
+            sink.push(event);
+        } else {
+            failures += 1;
+        }
+    }
+    failures
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct OutputWriteOutcome {
+    written: usize,
+    spilled: u64,
+    dropped: u64,
+    note_end_dropped: u64,
+}
+
+#[cfg(target_os = "macos")]
+fn write_output_events(
+    window: &mut [EventRecord],
+    output_spill: &mut EventSpillFifo,
+    events: impl Iterator<Item = NeutralEvent>,
+) -> OutputWriteOutcome {
+    let mut outcome = OutputWriteOutcome {
+        written: output_spill.drain_into_window(window),
+        ..Default::default()
+    };
+    for event in events {
+        let record = EventRecord::encode(&event);
+        if outcome.written < window.len() {
+            window[outcome.written] = record;
+            outcome.written += 1;
+        } else if output_spill.push(record) {
+            outcome.spilled += 1;
+        } else {
+            outcome.dropped += 1;
+            if output_spill.take_note_end_dropped() {
+                outcome.note_end_dropped += 1;
+            }
+        }
+    }
+    outcome
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn apply_output_write_outcome(
+    region: *mut SharedRegion,
+    idx: usize,
+    outcome: OutputWriteOutcome,
+) {
+    unsafe {
+        if outcome.spilled != 0 {
+            (*region)
+                .output_event_spilled_count
+                .fetch_add(outcome.spilled, Relaxed);
+        }
+        if outcome.dropped != 0 {
+            (*region)
+                .output_event_dropped_count
+                .fetch_add(outcome.dropped, Relaxed);
+        }
+        if outcome.note_end_dropped != 0 {
+            (*region)
+                .output_note_end_dropped_count
+                .fetch_add(outcome.note_end_dropped, Relaxed);
+        }
+        (*region).output_event_count[idx].store(outcome.written as u32, Relaxed);
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn publish_completed_slot(
+    region: *mut SharedRegion,
+    seq: u64,
+    write_slot: impl FnOnce(*mut SharedRegion),
+) {
+    write_slot(region);
+    let idx = slot_index(seq);
+    unsafe {
+        (*region).seq_tag[idx].store(seq, Release);
+        (*region).seq_done.store(seq, Release);
+    }
+}
+
+/// VST3 accepts concrete MIDI1 values only. Wildcards and out-of-range values are rounded to
+/// zero, matching the conservative fallback used by the VST3 voice-address translation.
+#[cfg(target_os = "macos")]
+fn vst3_channel_pitch(addr: VoiceAddr) -> (i16, i16) {
+    let channel = if (0..=15).contains(&addr.channel) {
+        addr.channel
+    } else {
+        0
+    };
+    let pitch = if (0..=127).contains(&addr.key) {
+        addr.key
+    } else {
+        0
+    };
+    (channel, pitch)
+}
+
+#[cfg(target_os = "macos")]
+fn to_vst3_offset(offset: u32) -> i32 {
+    offset.min(i32::MAX as u32) as i32
+}
+
+#[cfg(target_os = "macos")]
+fn main() -> Result<()> {
+    let args = parse_args()?;
+    let mmap = open_shared(&args.shm).with_context(|| format!("open_shared({:?})", args.shm))?;
+    let region = region_ptr(&mmap);
+    if let Some(plugin_id) = &args.plugin_id {
+        eprintln!("[orbit-vst3-instrument-child] --plugin-id={plugin_id} は VST3 では未使用");
+    }
+    let (mut instrument, _) =
+        Vst3InstrumentProcessor::load(&args.plugin, args.sample_rate as f64, MAX_FRAMES as i32)
+            .with_context(|| format!("load VST3 instrument {:?}", args.plugin))?;
+    unsafe {
+        orbit_audio_sandbox::transport::publish_child_ready(region, false);
+    }
+
+    let mut scratch = vec![0.0; BUF_LEN];
+    let mut event_scratch = Vec::with_capacity(MAX_EVENTS_PER_BLOCK);
+    let mut output_events = Vec::with_capacity(MAX_EVENTS_PER_BLOCK);
+    let mut output_spill = EventSpillFifo::new();
+    let mut process_errors = 0;
+    let mut last = 0;
+    loop {
+        if unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT {
+            break;
+        }
+        let cur = unsafe { (*region).seq_request.load(Acquire) };
+        if cur <= last {
+            std::hint::spin_loop();
+            continue;
+        }
+        for seq in in_order_seqs(last, cur) {
+            let idx = slot_index(seq);
+            let off = slot_offset(seq);
+            let n_frames =
+                unsafe { ((*region).n_frames[idx].load(Relaxed) as usize).min(MAX_FRAMES) };
+            let sample_count = n_frames * CHANNELS;
+            let event_count = unsafe {
+                (*region).input_event_count[idx]
+                    .load(Relaxed)
+                    .min(MAX_EVENTS_PER_BLOCK as u32)
+            };
+            let decode_errors = unsafe {
+                decode_slot_events(
+                    &(*region).input_events[idx],
+                    event_count,
+                    &mut event_scratch,
+                )
+            };
+            if decode_errors != 0 {
+                unsafe {
+                    (*region)
+                        .event_decode_error_count
+                        .fetch_add(decode_errors as u64, Relaxed);
+                }
+            }
+            output_events.clear();
+            for event in &event_scratch {
+                match *event {
+                    NeutralEvent::NoteOn {
+                        sample_offset,
+                        addr,
+                        velocity,
+                        ..
+                    } => {
+                        let (channel, pitch) = vst3_channel_pitch(addr);
+                        instrument.push_note_on(
+                            channel,
+                            pitch,
+                            velocity as f32,
+                            to_vst3_offset(sample_offset),
+                        );
+                    }
+                    NeutralEvent::NoteOff {
+                        sample_offset,
+                        addr,
+                        velocity,
+                    } => {
+                        let (channel, pitch) = vst3_channel_pitch(addr);
+                        instrument.push_note_off(
+                            channel,
+                            pitch,
+                            velocity as f32,
+                            to_vst3_offset(sample_offset),
+                        );
+                        // VST3 has no NOTE_END callback: synthesize it in this same block.
+                        output_events.push(NeutralEvent::NoteEnd {
+                            sample_offset,
+                            addr,
+                        });
+                    }
+                    NeutralEvent::NoteChoke {
+                        sample_offset,
+                        addr,
+                    } => {
+                        let (channel, pitch) = vst3_channel_pitch(addr);
+                        instrument.push_note_off(
+                            channel,
+                            pitch,
+                            0.0,
+                            to_vst3_offset(sample_offset),
+                        );
+                        // Choke likewise terminates the host's matching voice bookkeeping entry.
+                        output_events.push(NeutralEvent::NoteEnd {
+                            sample_offset,
+                            addr,
+                        });
+                    }
+                    _ => unsafe {
+                        (*region).event_decode_error_count.fetch_add(1, Relaxed);
+                    },
+                }
+            }
+            scratch[..sample_count].fill(0.0);
+            if !instrument.process_block(&mut scratch[..sample_count]) {
+                process_errors += 1;
+                unsafe {
+                    (*region).child_process_error_count.fetch_add(1, Relaxed);
+                }
+            }
+            unsafe {
+                publish_completed_slot(region, seq, |region| {
+                    let out_base = std::ptr::addr_of_mut!((*region).output) as *mut f32;
+                    std::ptr::copy_nonoverlapping(
+                        scratch.as_ptr(),
+                        out_base.add(off),
+                        sample_count,
+                    );
+                    let window = std::slice::from_raw_parts_mut(
+                        std::ptr::addr_of_mut!((*region).output_events[idx]) as *mut EventRecord,
+                        MAX_EVENTS_PER_BLOCK,
+                    );
+                    let outcome =
+                        write_output_events(window, &mut output_spill, output_events.drain(..));
+                    apply_output_write_outcome(region, idx, outcome);
+                    (*region).child_processed.fetch_add(1, Relaxed);
+                });
+            }
+        }
+        last = cur.max(last);
+    }
+    if process_errors != 0 {
+        eprintln!(
+            "[orbit-vst3-instrument-child] plugin.process() failed for {process_errors} block(s)"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() -> std::process::ExitCode {
+    eprintln!("orbit-vst3-instrument-child is macOS-only (VST3/CoreFoundation)");
+    std::process::ExitCode::FAILURE
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+    use orbit_audio_sandbox::{VoiceAddr, EVENT_SPILL_CAPACITY};
+
+    fn note_end() -> NeutralEvent {
+        NeutralEvent::NoteEnd {
+            sample_offset: 0,
+            addr: VoiceAddr::WILDCARD,
+        }
+    }
+
+    #[test]
+    fn write_output_events_spills_and_tracks_note_end_drop() {
+        let mut window = vec![EventRecord::encode(&note_end()); MAX_EVENTS_PER_BLOCK];
+        let mut spill = EventSpillFifo::new();
+        let fillers = (0..(MAX_EVENTS_PER_BLOCK + EVENT_SPILL_CAPACITY)).map(|_| note_end());
+        let outcome = write_output_events(
+            &mut window,
+            &mut spill,
+            fillers.chain(std::iter::once(note_end())),
+        );
+        assert_eq!(outcome.written, MAX_EVENTS_PER_BLOCK);
+        assert_eq!(outcome.spilled, EVENT_SPILL_CAPACITY as u64);
+        assert_eq!(outcome.dropped, 1);
+        assert_eq!(outcome.note_end_dropped, 1);
+    }
+
+    #[test]
+    fn wildcard_address_rounds_to_zero() {
+        assert_eq!(vst3_channel_pitch(VoiceAddr::WILDCARD), (0, 0));
+    }
+
+    #[test]
+    fn in_order_sequence_boundaries() {
+        assert_eq!(in_order_seqs(7, 7).collect::<Vec<_>>(), Vec::<u64>::new());
+        assert_eq!(in_order_seqs(7, 9).collect::<Vec<_>>(), vec![8, 9]);
+    }
+}

--- a/rust/crates/orbit-vst3-instrument-child/src/main.rs
+++ b/rust/crates/orbit-vst3-instrument-child/src/main.rs
@@ -175,6 +175,25 @@ fn to_vst3_offset(offset: u32) -> i32 {
     offset.min(i32::MAX as u32) as i32
 }
 
+/// note-off を instrument へ送り、同 addr/sample_offset の synthetic NOTE_END を積む。
+/// VST3 には CLAP の NOTE_END 相当の plugin→host イベントが無いため、child がここで合成して
+/// host の (port,channel,key) voice 簿記を閉じる（NoteOff / NoteChoke 共通・choke は velocity 0）。
+#[cfg(target_os = "macos")]
+fn note_off_and_end(
+    instrument: &mut Vst3InstrumentProcessor,
+    output_events: &mut Vec<NeutralEvent>,
+    addr: VoiceAddr,
+    velocity: f32,
+    sample_offset: u32,
+) {
+    let (channel, pitch) = vst3_channel_pitch(addr);
+    instrument.push_note_off(channel, pitch, velocity, to_vst3_offset(sample_offset));
+    output_events.push(NeutralEvent::NoteEnd {
+        sample_offset,
+        addr,
+    });
+}
+
 #[cfg(target_os = "macos")]
 fn main() -> Result<()> {
     let args = parse_args()?;
@@ -247,41 +266,29 @@ fn main() -> Result<()> {
                             to_vst3_offset(sample_offset),
                         );
                     }
+                    // NoteOff / NoteChoke は同じ形: VST3 note-off を送り、VST3 に無い NOTE_END を
+                    // 同ブロックで合成して host の voice 簿記を閉じる（choke は velocity 0 扱い）。
                     NeutralEvent::NoteOff {
                         sample_offset,
                         addr,
                         velocity,
-                    } => {
-                        let (channel, pitch) = vst3_channel_pitch(addr);
-                        instrument.push_note_off(
-                            channel,
-                            pitch,
-                            velocity as f32,
-                            to_vst3_offset(sample_offset),
-                        );
-                        // VST3 has no NOTE_END callback: synthesize it in this same block.
-                        output_events.push(NeutralEvent::NoteEnd {
-                            sample_offset,
-                            addr,
-                        });
-                    }
+                    } => note_off_and_end(
+                        &mut instrument,
+                        &mut output_events,
+                        addr,
+                        velocity as f32,
+                        sample_offset,
+                    ),
                     NeutralEvent::NoteChoke {
                         sample_offset,
                         addr,
-                    } => {
-                        let (channel, pitch) = vst3_channel_pitch(addr);
-                        instrument.push_note_off(
-                            channel,
-                            pitch,
-                            0.0,
-                            to_vst3_offset(sample_offset),
-                        );
-                        // Choke likewise terminates the host's matching voice bookkeeping entry.
-                        output_events.push(NeutralEvent::NoteEnd {
-                            sample_offset,
-                            addr,
-                        });
-                    }
+                    } => note_off_and_end(
+                        &mut instrument,
+                        &mut output_events,
+                        addr,
+                        0.0,
+                        sample_offset,
+                    ),
                     _ => unsafe {
                         (*region).event_decode_error_count.fetch_add(1, Relaxed);
                     },

--- a/rust/crates/orbit-vst3-instrument-child/src/main.rs
+++ b/rust/crates/orbit-vst3-instrument-child/src/main.rs
@@ -175,23 +175,83 @@ fn to_vst3_offset(offset: u32) -> i32 {
     offset.min(i32::MAX as u32) as i32
 }
 
-/// note-off を instrument へ送り、同 addr/sample_offset の synthetic NOTE_END を積む。
-/// VST3 には CLAP の NOTE_END 相当の plugin→host イベントが無いため、child がここで合成して
-/// host の (port,channel,key) voice 簿記を閉じる（NoteOff / NoteChoke 共通・choke は velocity 0）。
+/// Pure classification of an incoming `NeutralEvent` into the action `main()`'s dispatch loop
+/// should apply. Extracted so the event-routing logic (channel/pitch wildcard rounding, VST3
+/// NOTE_END synthesis for NoteOff/NoteChoke) is unit-testable without a loaded VST3 instrument.
 #[cfg(target_os = "macos")]
-fn note_off_and_end(
-    instrument: &mut Vst3InstrumentProcessor,
-    output_events: &mut Vec<NeutralEvent>,
-    addr: VoiceAddr,
-    velocity: f32,
-    sample_offset: u32,
-) {
-    let (channel, pitch) = vst3_channel_pitch(addr);
-    instrument.push_note_off(channel, pitch, velocity, to_vst3_offset(sample_offset));
-    output_events.push(NeutralEvent::NoteEnd {
-        sample_offset,
-        addr,
-    });
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum EventAction {
+    NoteOn {
+        channel: i16,
+        pitch: i16,
+        velocity: f32,
+        offset: i32,
+    },
+    /// NoteOff / NoteChoke both resolve here: push a VST3 note-off, plus a synthetic `NoteEnd`
+    /// (VST3 has no plugin→host NOTE_END equivalent) so the host can close its voice bookkeeping.
+    NoteOffAndEnd {
+        channel: i16,
+        pitch: i16,
+        velocity: f32,
+        offset: i32,
+        end: NeutralEvent,
+    },
+    /// Unsupported variant: caller must bump `event_decode_error_count`.
+    Unsupported,
+}
+
+#[cfg(target_os = "macos")]
+fn classify_event(event: &NeutralEvent) -> EventAction {
+    match *event {
+        NeutralEvent::NoteOn {
+            sample_offset,
+            addr,
+            velocity,
+            ..
+        } => {
+            let (channel, pitch) = vst3_channel_pitch(addr);
+            EventAction::NoteOn {
+                channel,
+                pitch,
+                velocity: velocity as f32,
+                offset: to_vst3_offset(sample_offset),
+            }
+        }
+        NeutralEvent::NoteOff {
+            sample_offset,
+            addr,
+            velocity,
+        } => {
+            let (channel, pitch) = vst3_channel_pitch(addr);
+            EventAction::NoteOffAndEnd {
+                channel,
+                pitch,
+                velocity: velocity as f32,
+                offset: to_vst3_offset(sample_offset),
+                end: NeutralEvent::NoteEnd {
+                    sample_offset,
+                    addr,
+                },
+            }
+        }
+        NeutralEvent::NoteChoke {
+            sample_offset,
+            addr,
+        } => {
+            let (channel, pitch) = vst3_channel_pitch(addr);
+            EventAction::NoteOffAndEnd {
+                channel,
+                pitch,
+                velocity: 0.0,
+                offset: to_vst3_offset(sample_offset),
+                end: NeutralEvent::NoteEnd {
+                    sample_offset,
+                    addr,
+                },
+            }
+        }
+        _ => EventAction::Unsupported,
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -251,45 +311,26 @@ fn main() -> Result<()> {
             }
             output_events.clear();
             for event in &event_scratch {
-                match *event {
-                    NeutralEvent::NoteOn {
-                        sample_offset,
-                        addr,
+                match classify_event(event) {
+                    EventAction::NoteOn {
+                        channel,
+                        pitch,
                         velocity,
-                        ..
+                        offset,
                     } => {
-                        let (channel, pitch) = vst3_channel_pitch(addr);
-                        instrument.push_note_on(
-                            channel,
-                            pitch,
-                            velocity as f32,
-                            to_vst3_offset(sample_offset),
-                        );
+                        instrument.push_note_on(channel, pitch, velocity, offset);
                     }
-                    // NoteOff / NoteChoke は同じ形: VST3 note-off を送り、VST3 に無い NOTE_END を
-                    // 同ブロックで合成して host の voice 簿記を閉じる（choke は velocity 0 扱い）。
-                    NeutralEvent::NoteOff {
-                        sample_offset,
-                        addr,
+                    EventAction::NoteOffAndEnd {
+                        channel,
+                        pitch,
                         velocity,
-                    } => note_off_and_end(
-                        &mut instrument,
-                        &mut output_events,
-                        addr,
-                        velocity as f32,
-                        sample_offset,
-                    ),
-                    NeutralEvent::NoteChoke {
-                        sample_offset,
-                        addr,
-                    } => note_off_and_end(
-                        &mut instrument,
-                        &mut output_events,
-                        addr,
-                        0.0,
-                        sample_offset,
-                    ),
-                    _ => unsafe {
+                        offset,
+                        end,
+                    } => {
+                        instrument.push_note_off(channel, pitch, velocity, offset);
+                        output_events.push(end);
+                    }
+                    EventAction::Unsupported => unsafe {
                         (*region).event_decode_error_count.fetch_add(1, Relaxed);
                     },
                 }
@@ -324,7 +365,9 @@ fn main() -> Result<()> {
     }
     if process_errors != 0 {
         eprintln!(
-            "[orbit-vst3-instrument-child] plugin.process() failed for {process_errors} block(s)"
+            "[orbit-vst3-instrument-child] plugin.process() failed for {process_errors} block(s); \
+             last tresult={}",
+            instrument.last_process_error()
         );
     }
     Ok(())
@@ -373,5 +416,106 @@ mod tests {
     fn in_order_sequence_boundaries() {
         assert_eq!(in_order_seqs(7, 7).collect::<Vec<_>>(), Vec::<u64>::new());
         assert_eq!(in_order_seqs(7, 9).collect::<Vec<_>>(), vec![8, 9]);
+    }
+
+    fn concrete_addr(channel: i16, key: i16) -> VoiceAddr {
+        VoiceAddr {
+            note_id: -1,
+            port_index: -1,
+            channel,
+            key,
+            _pad: 0,
+        }
+    }
+
+    #[test]
+    fn classify_note_on_maps_channel_pitch_velocity_offset() {
+        let event = NeutralEvent::NoteOn {
+            sample_offset: 42,
+            addr: concrete_addr(3, 60),
+            velocity: 0.5,
+            tuning_cents: 0.0,
+            length_frames: -1,
+        };
+        assert_eq!(
+            classify_event(&event),
+            EventAction::NoteOn {
+                channel: 3,
+                pitch: 60,
+                velocity: 0.5,
+                offset: 42,
+            }
+        );
+    }
+
+    #[test]
+    fn classify_note_on_rounds_wildcard_to_zero() {
+        let event = NeutralEvent::NoteOn {
+            sample_offset: 0,
+            addr: VoiceAddr::WILDCARD,
+            velocity: 1.0,
+            tuning_cents: 0.0,
+            length_frames: -1,
+        };
+        assert_eq!(
+            classify_event(&event),
+            EventAction::NoteOn {
+                channel: 0,
+                pitch: 0,
+                velocity: 1.0,
+                offset: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn classify_note_off_and_choke_yield_matching_note_end() {
+        let addr = concrete_addr(5, 69);
+        let off_event = NeutralEvent::NoteOff {
+            sample_offset: 10,
+            addr,
+            velocity: 0.7,
+        };
+        let choke_event = NeutralEvent::NoteChoke {
+            sample_offset: 10,
+            addr,
+        };
+
+        let expected_end = NeutralEvent::NoteEnd {
+            sample_offset: 10,
+            addr,
+        };
+
+        assert_eq!(
+            classify_event(&off_event),
+            EventAction::NoteOffAndEnd {
+                channel: 5,
+                pitch: 69,
+                velocity: 0.7,
+                offset: 10,
+                end: expected_end,
+            }
+        );
+        assert_eq!(
+            classify_event(&choke_event),
+            EventAction::NoteOffAndEnd {
+                channel: 5,
+                pitch: 69,
+                velocity: 0.0,
+                offset: 10,
+                end: expected_end,
+            }
+        );
+    }
+
+    #[test]
+    fn classify_unsupported_variant_yields_unsupported() {
+        assert_eq!(classify_event(&note_end()), EventAction::Unsupported);
+        let poly_pressure = NeutralEvent::PolyPressure {
+            sample_offset: 0,
+            addr: VoiceAddr::WILDCARD,
+            pressure: 0.0,
+        };
+        assert_eq!(classify_event(&poly_pressure), EventAction::Unsupported);
     }
 }

--- a/rust/crates/orbit-vst3-synth-oracle/Cargo.toml
+++ b/rust/crates/orbit-vst3-synth-oracle/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "orbit-vst3-synth-oracle"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "VST3 monophonic sine synth test-oracle for orbit-vst3-host"
+publish = false
+
+[lib]
+name = "orbit_vst3_synth_oracle"
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+vst3 = "0.3"

--- a/rust/crates/orbit-vst3-synth-oracle/package-oracle.sh
+++ b/rust/crates/orbit-vst3-synth-oracle/package-oracle.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Build and package the known-behavior VST3 instrument oracle for host tests.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workspace_root="$(cd "$here/../.." && pwd)"
+cd "$workspace_root"
+
+profile="${1:-debug}"
+if [ "$profile" = "release" ]; then
+  cargo build -p orbit-vst3-synth-oracle --release >&2
+else
+  cargo build -p orbit-vst3-synth-oracle >&2
+fi
+
+dylib="target/$profile/liborbit_vst3_synth_oracle.dylib"
+[ -f "$dylib" ] || { echo "dylib not found: $dylib" >&2; exit 1; }
+
+bundle="target/vst3-fixtures/SynthOracle.vst3"
+rm -rf "$bundle"
+mkdir -p "$bundle/Contents/MacOS"
+cp "$dylib" "$bundle/Contents/MacOS/SynthOracle"
+printf 'BNDL????' > "$bundle/Contents/PkgInfo"
+cat > "$bundle/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleExecutable</key><string>SynthOracle</string>
+  <key>CFBundleIdentifier</key><string>com.signalcompose.orbitscore.synth-oracle</string>
+  <key>CFBundleName</key><string>SynthOracle</string>
+  <key>CFBundlePackageType</key><string>BNDL</string>
+  <key>CFBundleSignature</key><string>????</string>
+  <key>CFBundleVersion</key><string>0.0.1</string>
+</dict></plist>
+PLIST
+
+echo "$workspace_root/$bundle"

--- a/rust/crates/orbit-vst3-synth-oracle/src/lib.rs
+++ b/rust/crates/orbit-vst3-synth-oracle/src/lib.rs
@@ -1,0 +1,436 @@
+//! Known-behavior VST3 instrument oracle: a monophonic stereo sine synth.
+#![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
+
+use std::cell::Cell;
+use std::f32::consts::TAU;
+use std::ffi::{c_char, c_void, CString};
+use std::{ptr, slice};
+
+use vst3::{uid, Class, ComRef, ComWrapper, Steinberg::Vst::*, Steinberg::*};
+
+const PLUGIN_NAME: &str = "Orbit VST3 Synth Oracle";
+
+fn copy_cstring(src: &str, dst: &mut [c_char]) {
+    let string = CString::new(src).unwrap_or_default();
+    for (source, destination) in string.as_bytes_with_nul().iter().zip(dst.iter_mut()) {
+        *destination = *source as c_char;
+    }
+}
+
+fn copy_wstring(src: &str, dst: &mut [TChar]) {
+    let mut length = 0;
+    for (source, destination) in src.encode_utf16().zip(dst.iter_mut()) {
+        *destination = source as TChar;
+        length += 1;
+    }
+    if let Some(last) = dst.get_mut(length.min(dst.len().saturating_sub(1))) {
+        *last = 0;
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SineVoice {
+    phase: f32,
+    phase_inc: f32,
+    active: bool,
+    key: i16,
+}
+
+impl SineVoice {
+    fn note_on(&mut self, key: i16, sample_rate: f32) {
+        let frequency = 440.0 * 2.0f32.powf((key as f32 - 69.0) / 12.0);
+        self.phase = 0.0;
+        self.phase_inc = TAU * frequency / sample_rate;
+        self.active = true;
+        self.key = key;
+    }
+
+    fn note_off(&mut self, key: i16) {
+        if self.active && self.key == key {
+            self.active = false;
+        }
+    }
+}
+
+struct SynthProcessor {
+    voice: Cell<SineVoice>,
+    sample_rate: Cell<f32>,
+}
+
+impl SynthProcessor {
+    const CID: TUID = uid(0x4D16F7A1, 0xC14B4D4D, 0xA292B0D8, 0xA331C421);
+
+    fn new() -> Self {
+        Self {
+            voice: Cell::new(SineVoice {
+                phase: 0.0,
+                phase_inc: 0.0,
+                active: false,
+                key: 69,
+            }),
+            sample_rate: Cell::new(48_000.0),
+        }
+    }
+}
+
+impl Class for SynthProcessor {
+    type Interfaces = (IComponent, IAudioProcessor);
+}
+
+impl IPluginBaseTrait for SynthProcessor {
+    unsafe fn initialize(&self, _context: *mut FUnknown) -> tresult {
+        kResultOk
+    }
+    unsafe fn terminate(&self) -> tresult {
+        kResultOk
+    }
+}
+
+impl IComponentTrait for SynthProcessor {
+    unsafe fn getControllerClassId(&self, class_id: *mut TUID) -> tresult {
+        *class_id = SynthController::CID;
+        kResultOk
+    }
+    unsafe fn setIoMode(&self, _mode: IoMode) -> tresult {
+        kResultOk
+    }
+    unsafe fn getBusCount(&self, media_type: MediaType, direction: BusDirection) -> i32 {
+        match (media_type as MediaTypes, direction as BusDirections) {
+            (MediaTypes_::kAudio, BusDirections_::kOutput) => 1,
+            (MediaTypes_::kEvent, BusDirections_::kInput) => 1,
+            _ => 0,
+        }
+    }
+    unsafe fn getBusInfo(
+        &self,
+        media_type: MediaType,
+        direction: BusDirection,
+        index: i32,
+        bus: *mut BusInfo,
+    ) -> tresult {
+        if index != 0 || bus.is_null() {
+            return kInvalidArgument;
+        }
+        let bus = &mut *bus;
+        match (media_type as MediaTypes, direction as BusDirections) {
+            (MediaTypes_::kAudio, BusDirections_::kOutput) => {
+                bus.mediaType = MediaTypes_::kAudio as MediaType;
+                bus.direction = BusDirections_::kOutput as BusDirection;
+                bus.channelCount = 2;
+                bus.busType = BusTypes_::kMain as BusType;
+                bus.flags = BusInfo_::BusFlags_::kDefaultActive;
+                copy_wstring("Output", &mut bus.name);
+                kResultOk
+            }
+            (MediaTypes_::kEvent, BusDirections_::kInput) => {
+                bus.mediaType = MediaTypes_::kEvent as MediaType;
+                bus.direction = BusDirections_::kInput as BusDirection;
+                bus.channelCount = 16;
+                bus.busType = BusTypes_::kMain as BusType;
+                bus.flags = BusInfo_::BusFlags_::kDefaultActive;
+                copy_wstring("Events", &mut bus.name);
+                kResultOk
+            }
+            _ => kInvalidArgument,
+        }
+    }
+    unsafe fn getRoutingInfo(
+        &self,
+        _input: *mut RoutingInfo,
+        _output: *mut RoutingInfo,
+    ) -> tresult {
+        kNotImplemented
+    }
+    unsafe fn activateBus(
+        &self,
+        _media: MediaType,
+        _direction: BusDirection,
+        _index: i32,
+        _state: TBool,
+    ) -> tresult {
+        kResultOk
+    }
+    unsafe fn setActive(&self, _state: TBool) -> tresult {
+        kResultOk
+    }
+    unsafe fn setState(&self, _state: *mut IBStream) -> tresult {
+        kResultOk
+    }
+    unsafe fn getState(&self, _state: *mut IBStream) -> tresult {
+        kResultOk
+    }
+}
+
+impl IAudioProcessorTrait for SynthProcessor {
+    unsafe fn setBusArrangements(
+        &self,
+        _inputs: *mut SpeakerArrangement,
+        num_inputs: i32,
+        outputs: *mut SpeakerArrangement,
+        num_outputs: i32,
+    ) -> tresult {
+        if num_inputs == 0 && num_outputs == 1 && *outputs == SpeakerArr::kStereo {
+            kResultTrue
+        } else {
+            kResultFalse
+        }
+    }
+    unsafe fn getBusArrangement(
+        &self,
+        direction: BusDirection,
+        index: i32,
+        arrangement: *mut SpeakerArrangement,
+    ) -> tresult {
+        if direction as BusDirections == BusDirections_::kOutput && index == 0 {
+            *arrangement = SpeakerArr::kStereo;
+            kResultOk
+        } else {
+            kInvalidArgument
+        }
+    }
+    unsafe fn canProcessSampleSize(&self, sample_size: i32) -> tresult {
+        if sample_size as SymbolicSampleSizes == SymbolicSampleSizes_::kSample32 {
+            kResultOk
+        } else {
+            kNotImplemented
+        }
+    }
+    unsafe fn getLatencySamples(&self) -> u32 {
+        0
+    }
+    unsafe fn setupProcessing(&self, setup: *mut ProcessSetup) -> tresult {
+        self.sample_rate.set((*setup).sampleRate as f32);
+        kResultOk
+    }
+    unsafe fn setProcessing(&self, _state: TBool) -> tresult {
+        kResultOk
+    }
+    unsafe fn process(&self, data: *mut ProcessData) -> tresult {
+        let data = &*data;
+        let mut voice = self.voice.get();
+        if data.numOutputs != 1 || data.outputs.is_null() {
+            self.voice.set(voice);
+            return kResultOk;
+        }
+        let output = &mut *data.outputs;
+        if output.numChannels != 2 {
+            self.voice.set(voice);
+            return kResultOk;
+        }
+        let channels = slice::from_raw_parts_mut(output.__field0.channelBuffers32, 2);
+        let frames = data.numSamples.max(0) as usize;
+        let left = slice::from_raw_parts_mut(channels[0], frames);
+        let right = slice::from_raw_parts_mut(channels[1], frames);
+        let events = ComRef::from_raw(data.inputEvents);
+        let event_count = events.map_or(0, |events| events.getEventCount());
+        let mut event_index = 0;
+        for (frame, (left, right)) in left.iter_mut().zip(right.iter_mut()).enumerate() {
+            while event_index < event_count {
+                let mut event: Event = std::mem::zeroed();
+                let Some(events) = events else { break };
+                if events.getEvent(event_index, &mut event) != kResultOk {
+                    event_index += 1;
+                    continue;
+                }
+                if event.sampleOffset > frame as i32 {
+                    break;
+                }
+                match event.r#type as Event_::EventTypes {
+                    Event_::EventTypes_::kNoteOnEvent => {
+                        voice.note_on(event.__field0.noteOn.pitch, self.sample_rate.get())
+                    }
+                    Event_::EventTypes_::kNoteOffEvent => {
+                        voice.note_off(event.__field0.noteOff.pitch)
+                    }
+                    _ => {}
+                }
+                event_index += 1;
+            }
+            let sample = if voice.active {
+                voice.phase.sin() * 0.25
+            } else {
+                0.0
+            };
+            *left = sample;
+            *right = sample;
+            if voice.active {
+                voice.phase = (voice.phase + voice.phase_inc) % TAU;
+            }
+        }
+        self.voice.set(voice);
+        kResultOk
+    }
+    unsafe fn getTailSamples(&self) -> u32 {
+        0
+    }
+}
+
+struct SynthController;
+impl SynthController {
+    const CID: TUID = uid(0x59B9B1A0, 0xA2C244C2, 0xB19FB042, 0x7068E6F1);
+}
+impl Class for SynthController {
+    type Interfaces = (IEditController,);
+}
+impl IPluginBaseTrait for SynthController {
+    unsafe fn initialize(&self, _context: *mut FUnknown) -> tresult {
+        kResultOk
+    }
+    unsafe fn terminate(&self) -> tresult {
+        kResultOk
+    }
+}
+impl IEditControllerTrait for SynthController {
+    unsafe fn setComponentState(&self, _state: *mut IBStream) -> tresult {
+        kResultOk
+    }
+    unsafe fn setState(&self, _state: *mut IBStream) -> tresult {
+        kResultOk
+    }
+    unsafe fn getState(&self, _state: *mut IBStream) -> tresult {
+        kResultOk
+    }
+    unsafe fn getParameterCount(&self) -> i32 {
+        0
+    }
+    unsafe fn getParameterInfo(&self, _index: i32, _info: *mut ParameterInfo) -> tresult {
+        kInvalidArgument
+    }
+    unsafe fn getParamStringByValue(
+        &self,
+        _id: u32,
+        _value: f64,
+        _string: *mut String128,
+    ) -> tresult {
+        kInvalidArgument
+    }
+    unsafe fn getParamValueByString(
+        &self,
+        _id: u32,
+        _string: *mut TChar,
+        _value: *mut f64,
+    ) -> tresult {
+        kInvalidArgument
+    }
+    unsafe fn normalizedParamToPlain(&self, _id: u32, value: f64) -> f64 {
+        value
+    }
+    unsafe fn plainParamToNormalized(&self, _id: u32, value: f64) -> f64 {
+        value
+    }
+    unsafe fn getParamNormalized(&self, _id: u32) -> f64 {
+        0.0
+    }
+    unsafe fn setParamNormalized(&self, _id: u32, _value: f64) -> tresult {
+        kInvalidArgument
+    }
+    unsafe fn setComponentHandler(&self, _handler: *mut IComponentHandler) -> tresult {
+        kResultOk
+    }
+    unsafe fn createView(&self, _name: *const c_char) -> *mut IPlugView {
+        ptr::null_mut()
+    }
+}
+
+struct Factory;
+impl Class for Factory {
+    type Interfaces = (IPluginFactory,);
+}
+impl IPluginFactoryTrait for Factory {
+    unsafe fn getFactoryInfo(&self, info: *mut PFactoryInfo) -> tresult {
+        let info = &mut *info;
+        copy_cstring("Signal compose", &mut info.vendor);
+        copy_cstring("https://signalcompose.com", &mut info.url);
+        copy_cstring("support@signalcompose.com", &mut info.email);
+        info.flags = PFactoryInfo_::FactoryFlags_::kUnicode as int32;
+        kResultOk
+    }
+    unsafe fn countClasses(&self) -> i32 {
+        2
+    }
+    unsafe fn getClassInfo(&self, index: i32, info: *mut PClassInfo) -> tresult {
+        let info = &mut *info;
+        match index {
+            0 => {
+                info.cid = SynthProcessor::CID;
+                info.cardinality = PClassInfo_::ClassCardinality_::kManyInstances as int32;
+                copy_cstring("Audio Module Class", &mut info.category);
+                copy_cstring(PLUGIN_NAME, &mut info.name);
+                kResultOk
+            }
+            1 => {
+                info.cid = SynthController::CID;
+                info.cardinality = PClassInfo_::ClassCardinality_::kManyInstances as int32;
+                copy_cstring("Component Controller Class", &mut info.category);
+                copy_cstring(PLUGIN_NAME, &mut info.name);
+                kResultOk
+            }
+            _ => kInvalidArgument,
+        }
+    }
+    unsafe fn createInstance(
+        &self,
+        cid: FIDString,
+        iid: FIDString,
+        object: *mut *mut c_void,
+    ) -> tresult {
+        let instance = match *(cid as *const TUID) {
+            SynthProcessor::CID => Some(
+                ComWrapper::new(SynthProcessor::new())
+                    .to_com_ptr::<FUnknown>()
+                    .unwrap(),
+            ),
+            SynthController::CID => Some(
+                ComWrapper::new(SynthController)
+                    .to_com_ptr::<FUnknown>()
+                    .unwrap(),
+            ),
+            _ => None,
+        };
+        if let Some(instance) = instance {
+            let pointer = instance.as_ptr();
+            ((*(*pointer).vtbl).queryInterface)(pointer, iid as *mut TUID, object)
+        } else {
+            kInvalidArgument
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+#[no_mangle]
+extern "system" fn InitDll() -> bool {
+    true
+}
+#[cfg(target_os = "windows")]
+#[no_mangle]
+extern "system" fn ExitDll() -> bool {
+    true
+}
+#[cfg(target_os = "macos")]
+#[no_mangle]
+extern "system" fn BundleEntry(_bundle_ref: *mut c_void) -> bool {
+    true
+}
+#[cfg(target_os = "macos")]
+#[no_mangle]
+extern "system" fn BundleExit() -> bool {
+    true
+}
+#[cfg(target_os = "linux")]
+#[no_mangle]
+extern "system" fn ModuleEntry(_library_handle: *mut c_void) -> bool {
+    true
+}
+#[cfg(target_os = "linux")]
+#[no_mangle]
+extern "system" fn ModuleExit() -> bool {
+    true
+}
+
+#[no_mangle]
+extern "system" fn GetPluginFactory() -> *mut IPluginFactory {
+    ComWrapper::new(Factory)
+        .to_com_ptr::<IPluginFactory>()
+        .unwrap()
+        .into_raw()
+}

--- a/scripts/copy-daemon-bin.sh
+++ b/scripts/copy-daemon-bin.sh
@@ -39,7 +39,7 @@
 #
 # Build the release binaries first if you want them bundled:
 #   cd rust && cargo build --release -p orbit-audio-daemon --features outproc-effect,outproc-instrument
-#   cargo build --release -p orbit-clap-effect-child -p orbit-clap-instrument-child
+#   cargo build --release -p orbit-clap-effect-child -p orbit-clap-instrument-child -p orbit-vst3-instrument-child
 
 set -euo pipefail
 
@@ -72,3 +72,4 @@ copy_binary() {
 copy_binary "orbit-audio-daemon"
 copy_binary "orbit-clap-effect-child"
 copy_binary "orbit-clap-instrument-child"
+copy_binary "orbit-vst3-instrument-child"

--- a/tests/core/plugin-instrument.spec.ts
+++ b/tests/core/plugin-instrument.spec.ts
@@ -20,6 +20,21 @@ function makeGlobal(loadPlugin = vi.fn().mockResolvedValue({}), active?: boolean
 }
 
 describe('PluginInstrumentManager', () => {
+  it('accepts VST3 instruments and passes their resolved path to the engine', async () => {
+    const { global, loadPlugin } = makeGlobal()
+    await expect(global.instrument('./synth.vst3', 'synth-id')).resolves.toBe(global)
+    expect(loadPlugin).toHaveBeenCalledWith(
+      path.resolve('/songs/session', 'synth.vst3'),
+      'synth-id',
+      'instrument',
+    )
+  })
+
+  it('continues to reject AU instruments', async () => {
+    const { global } = makeGlobal()
+    await expect(global.instrument('synth.component')).rejects.toThrow('not yet supported')
+  })
+
   it('eagerly loads once and shares concurrent identical declarations', async () => {
     let resolve!: () => void
     const pending = new Promise<void>((r) => (resolve = r))

--- a/tests/core/sequence-instrument.spec.ts
+++ b/tests/core/sequence-instrument.spec.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { Global } from '../../packages/engine/src/core/global'
@@ -54,6 +56,16 @@ describe('Sequence instrument dispatch', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     vi.useRealTimers()
+  })
+
+  it('accepts a VST3 instrument declaration', async () => {
+    const { audio, seq } = harness()
+    await expect(seq.instrument('synth.vst3')).resolves.toBe(seq)
+    expect(audio.loadPlugin).toHaveBeenCalledWith(
+      path.resolve('/songs', 'synth.vst3'),
+      undefined,
+      'instrument',
+    )
   })
 
   it('awaits eager declaration, marks note mode, and resolves degrees to plugin notes', async () => {


### PR DESCRIPTION
Closes #421

## 概要

Epic #424 で確立した CLAP instrument 経路（#427）を VST3 に横展開し、**Pitch DSL が VST3 instrument で鳴る**ところまでを production 化した。単一 PR + Stage ごとのコミット。

## スコープ

**note on/off 経路のみ**。以下は owner 設計セッションへ明示先送り:
- CC → IMidiMapping（罠2）
- per-note expression（罠5）
- tempo / IProcessContext への tempo 供給（罠6・#408）

## Stage 構成

| Stage | コミット | 内容 |
|---|---|---|
| 1 | `25e5360` | `Vst3InstrumentProcessor`（orbit-vst3-host）: instrument 判定・headless controller + connection points・event bus 明示 activate・IEventList note on/off・add-mix process。effect API 不変 |
| 2 | `eb49dcd` | `orbit-vst3-instrument-child` 新 crate: clap 版 transport ミラー + **synthetic NOTE_END**（下記）+ publish_child_ready |
| 3 | `e2605cc` | `orbit-vst3-synth-oracle`（clap-test-synth ミラー・既知振幅 0.25）+ offline テスト + gated テスト3本 |
| 4 | `a09d7fb` | daemon: attach 時の拡張子ベース child 選択 / DSL: `seq.instrument()` の .vst3 受理 / 配布: VST3 child 同梱 |

## 設計判断（確定済み・再議論対象外）

- **synthetic NOTE_END**: VST3 には CLAP の NOTE_END に相当する plugin→host イベントが無い。child が NoteOff/NoteChoke を処理したブロックで同 addr の `NeutralEvent::NoteEnd` を output window へ書き、host の (port,channel,key) 参照カウント簿記は無改変（Fable 確定設計）。
- **child 選択**: デフォルト名の child exe を「同ディレクトリで拡張子に応じて差し替え」る対称・冪等な純関数。明示指定（`ORBIT_INSTRUMENT_CHILD_BIN` / gated の config 直指定）は保持。未知拡張子は reject せず従来どおり CLAP child（CLAP gated は raw .dylib を使うため）。
- effect 側の既存挙動（`ORBIT_EFFECT_FORMAT` env ベース・DSL .vst3 拒否）は不変。

## 受け入れ監査での修正（Codex 委譲分から2点・実機 gated RUN で検出）

1. 拡張子 validation が CLAP gated の raw .dylib attach を破壊 → 未知拡張子を CLAP child へフォールバック
2. child exe 再導出が current_exe 基準でテストハーネスを壊す + retry 後に .clap へ戻らない → 親ディレクトリ基準の対称読み替えに変更（fail-before/pass-after: CLAP gated 0/3 → 3/3）

## 検証

**実機 E2E（DoD）**: .orbs（`global.key("C")` + `seq.instrument("SynthOracle.vst3")` + `play(1,3,5,8)` + `RUN(synth)`）を配布構成 release daemon + cli-audio.js + `ORBIT_CAPTURE_WAV` で実行:
- **VST3: capture peak = 0.25000（厳密一致・synth 既知振幅）**
- CLAP baseline: 同手順で 0.25000（経路パリティ）

**gated（実機・self-run）**:
- VST3 instrument gated 3/3 PASS（post_mix_peak=0.25000・synthetic NOTE_END で probe_live_count 0 復帰・SIGKILL respawn 回復）
- CLAP instrument gated 3/3 PASS（退行なし）

**suite**: cargo workspace build / clippy -D warnings / fmt・daemon unit 54 + protocol 28・npm test 1333 passed / 0 failed

**既知 flake**: orbit-vst3-host offline テストの初回ビルド時に oracle packaging の並行競合で1回 fail することがある（Stage 1 以前からの既存パターン・再実行で安定 green）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu
