### PR TITLE
docs(dsl): sync Plugin Hosting docs with #421/#445 implementation facts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,14 +161,14 @@ git branch --show-current
 ### Project Overview
 **OrbitScore** - Audio-based live coding DSL for modern music production
 - DSL Version: v3.0 (SuperCollider Audio Engine)
-- Test Status: 230 passed, 23 skipped (253 total) = 90.9%
+- Test Status: 1333 passed, 29 skipped (1362 total)
 - Branch Strategy: GitHub Flow (`main` + feature branches)
 
 ### Development Commands
 ```bash
 npm run build            # Build all packages (incremental)
 npm run build:clean      # Clean build (rebuild all files)
-npm test                 # Run all tests (220 tests, 23 skipped)
+npm test                 # Run all tests (1362 tests, 29 skipped)
 npm run dev:engine       # Run engine in development mode
 npm run lint             # ESLint + Prettier
 ```

--- a/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
+++ b/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
@@ -1131,12 +1131,17 @@ piano.comp([1,3,5], [5,7,2]).voicelead()  // composes with §6.3
 >
 > 本節は Issue #425（2026-07-13・owner 設計セッション + Fable 検証）で確定した構文仕様。
 > DSL 疎通は #426（effect・PR #432）/ #427（instrument + Pitch DSL 接続）ともに実装済み。
+> **VST3 instrument hosting は #421（PR #447・2026-07-17 マージ）で実装済み**（`seq.instrument()` が
+> `.vst3` を受理）。VST3 effect 側は child プロセスの READY handshake（#445・PR #446）まで実装済みだが
+> `global.effect()` は引き続き `.clap` のみ受理する。VST3 instrument のスコープは note on/off のみ
+> — CC 制御（IMidiMapping 相当）・per-note expression・tempo 連動（#408）は明示的に先送り。
 > 残るスコープは #428（note timing のサンプル精度化）のみ。
 > Option A/B/C の比較経緯は `docs/development/POST_2.0_VST3_HOSTING_PLAN.md` §6、
 > 決定の記録は Issue #425 / WORK_LOG を参照。
 
-OrbitScore engine（Rust daemon）は CLAP プラグインをホストする配管を持つ
-（effect = PR #397 / instrument = PR #422）。本節はそれを DSL から消費する構文の正本。
+OrbitScore engine（Rust daemon）は CLAP / VST3 プラグインをホストする配管を持つ
+（CLAP effect = PR #397 / CLAP instrument = PR #422 / VST3 instrument = #421 PR #447 /
+VST3 effect child handshake = #445 PR #446）。本節はそれを DSL から消費する構文の正本。
 
 ### PH.1 instrument — `seq.instrument(path[, pluginId])`
 
@@ -1182,8 +1187,12 @@ global.effect("~/plugins/TAL-Reverb-4.clap")   // master bus insert
   （`./` `../` `~/` `/`）と同じ規則。bank 名検索（`global.audioPath()` 相当）はなし。
 - format は**拡張子で判定**: `.clap` → CLAP、`.vst3` → VST3、`.component` → AU。
   verb は format 非依存（format 別 verb は作らない）。
-  **v1 の受理は `.clap` のみ** — `.vst3` / `.component` は構文上予約し
-  「not yet supported」エラーを返す。未知拡張子はエラー。
+  **role 別の受理は非対称**（#421・2026-07-17 実装事実）:
+  - `seq.instrument()`: `.clap` / `.vst3` を受理。`.component` は構文上予約し
+    「not yet supported」エラーを返す。
+  - `global.effect()`: `.clap` のみ受理。`.vst3` / `.component` は構文上予約し
+    「not yet supported」エラーを返す。
+  未知拡張子はいずれの role でもエラー。
 - 第2引数 `pluginId`（optional）: 1 バンドルに複数プラグインが入る場合の指定
   （daemon `LoadPlugin.plugin_id` に対応）。省略時はバンドル先頭のプラグイン。
 
@@ -1345,8 +1354,12 @@ the two time/pitch axes stay orthogonal and consistent with the chop slice-fit v
 - **DAW Plugin**: VST/AU plugin development
 - **Plugin Hosting implementation**: the CLAP effect/instrument hosting *syntax* is finalized
   (#425 — see the Plugin Hosting section above); DSL wiring for effect (#426) and instrument
-  (#427) is implemented. Only sample-accurate note timing (#428) remains outstanding.
-  `.vst3` / `.component` formats are reserved (not yet supported)
+  (#427) is implemented. **VST3 instrument hosting is implemented** (#421 — `seq.instrument()`
+  accepts `.vst3`; PR #447, merged 2026-07-17). VST3 effect hosting is not yet wired into
+  `global.effect()` (the effect child process gained a READY handshake in #445/PR #446, but
+  `.vst3` is still rejected at the `global.effect()` verb). `.component` (AU) remains reserved
+  for both roles (not yet supported). Only sample-accurate note timing (#428) remains
+  outstanding for the implemented paths.
 - **`slice()`**: per-event start/end point selection within a chopped file (#239)
 - **Audio `[ ]` stack / slice layering**: simultaneous audio-layer stacking in the play tree (#238)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,27 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.259 docs: Plugin Hosting docs 同期（#421 / #445 実装事実の反映） #449 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 完了
+**Branch**: `449-docs-plugin-hosting-sync`
+
+DocDD 監査で、#421（VST3 instrument production・PR #447 マージ済）と #445（VST3 effect
+child READY handshake・PR #446 マージ済）の実装事実が docs に反映されていない遅れを検出。
+以下を修正:
+
+- `docs/core/INSTRUCTION_ORBITSCORE_DSL.md`: PH.3 の format 受理表を role 別（instrument =
+  `.clap`/`.vst3`、effect = `.clap` のみ）に更新。Not Yet Implemented セクションと
+  Plugin Hosting 節ヘッダに #421 / #445 の参照と、VST3 instrument の先送りスコープ
+  （CC / per-note expression / tempo #408）を追記。
+- `docs/testing/TESTING_GUIDE.md`: VST3 Instrument Gated Fixture Tests 節を新設
+  （`orbit-vst3-instrument-child` ビルド手順 + gated テストコマンド + oracle 期待値 0.25）。
+- `docs/user/ja/USER_MANUAL.md`: Plugin Hosting（CLAP / VST3）節を新設（ユーザー向け構文・
+  対応フォーマット表）。
+- `CLAUDE.md`: Test Status / npm test コメントのテスト件数を現状（1333 passed, 29 skipped,
+  1362 total）に更新。
+
 ### 6.258 feat(vst3): VST3 instrument production — Pitch DSL が VST3 で鳴る実機 E2E #421 (Jul 16, 2026)
 
 **Date**: 2026-07-16

--- a/docs/testing/TESTING_GUIDE.md
+++ b/docs/testing/TESTING_GUIDE.md
@@ -104,6 +104,31 @@ cargo test -p orbit-clap-host --lib -- --ignored
 fixture dylib が見つからない場合、これらのテストはサイレント skip せず `panic!` で
 loud fail する（build 手順を含むメッセージ付き）。
 
+### Rust: VST3 Instrument Gated Fixture Tests
+
+`orbit-audio-daemon` の out-of-process VST3 instrument テスト（#421）は、実機の output
+device と `orbit-vst3-instrument-child`（VST3 host 用の別プロセス child）を前提とする
+`#[ignore]` 付き gated テスト。synth oracle（既知の音量応答を持つテスト用 VST3 instrument）
+は `orbit-vst3-synth-oracle` の `package-oracle.sh` が自動でビルド・バンドルするため、
+テスト実行前に手動でパッケージングする必要はない。
+
+**事前ビルド**（child プロセスのバイナリ）:
+```bash
+cargo build -p orbit-vst3-instrument-child --manifest-path rust/Cargo.toml
+```
+
+**実行**:
+```bash
+cargo test -p orbit-audio-daemon --features outproc-instrument \
+  --test outproc_instrument_vst3_gated -- --ignored --nocapture --test-threads=1
+```
+
+- 実機 output device 必須（headless CI では実行不可）。
+- synth oracle バンドル（`SynthOracle.vst3`）は `orbit-vst3-synth-oracle/package-oracle.sh`
+  がテスト内部（`package_oracle()`）から呼び出されビルドされる。
+- 期待値: oracle が鳴らす note の `post_mix_peak` が `0.25 ± 0.01`（既知の音量応答）。
+- `--test-threads=1` は実機オーディオデバイスの排他利用のため必須。
+
 ---
 
 ## 🎵 IDE Integration Testing (VS Code / Cursor / Claude Code)

--- a/docs/user/ja/USER_MANUAL.md
+++ b/docs/user/ja/USER_MANUAL.md
@@ -16,8 +16,9 @@
    - 4.6 [音量とステレオ位置](#6-音量とステレオ位置)
    - 4.7 [アンダースコアプレフィックスパターン（DSL v3.0）](#7-アンダースコアプレフィックスパターンdsl-v30)
    - 4.8 [メソッドチェーン](#8-メソッドチェーン)
-5. [よくある間違い](#よくある間違い)
-6. [トラブルシューティング](#トラブルシューティング)
+5. [Plugin Hosting（CLAP / VST3）](#plugin-hostingclap--vst3)
+6. [よくある間違い](#よくある間違い)
+7. [トラブルシューティング](#トラブルシューティング)
 
 ---
 
@@ -578,6 +579,53 @@ var snare = init global.seq
   .gain(-3)
   .pan(20)
 ```
+
+---
+
+## Plugin Hosting（CLAP / VST3）
+
+> 本節は 2.0.0 以降に追加された機能です。詳細な構文仕様は
+> `docs/core/INSTRUCTION_ORBITSCORE_DSL.md` の Plugin Hosting 節を参照してください。
+
+OrbitScore は CLAP / VST3 プラグインをホストして、エフェクト（master bus insert）と
+インストゥルメント（音源）として使うことができます。
+
+### エフェクト: `global.effect()`
+
+```orbitscore
+global.effect("~/plugins/TAL-Reverb-4.clap")
+```
+
+- master bus への単一 insert（全シーケンスに掛かります）
+- v1 では 1 基のみ。**対応フォーマットは `.clap` のみ**
+
+### インストゥルメント: `seq.instrument()`
+
+```orbitscore
+var synth = init global.seq
+synth.instrument("~/plugins/Surge XT.clap")
+// または VST3:
+// synth.instrument("~/plugins/Surge XT.vst3")
+synth.octave(4).vel(100)
+synth.play(1, 3, 5, 0)  // 値は度数（Pitch DSL と同じ）
+```
+
+- `seq.instrument()` を宣言したシーケンスは note シーケンスになり、`play()` の値は
+  度数として解釈されます（`global.key()` の設定が必須）
+- **対応フォーマットは `.clap` と `.vst3` の両方**
+- v1 ではプラグインのインスタンスは 1 つのみ
+
+### LinkAudio との併用不可（v1 制限）
+
+`global.linkAudio()` と Plugin Hosting（effect / instrument のいずれか）は、v1 では
+同時に使用できません。
+
+### 対応フォーマット表（v1 時点）
+
+| Role | `.clap` | `.vst3` | `.component`（AU） |
+|---|---|---|---|
+| `seq.instrument()`（instrument） | ✅ | ✅ | 未対応（予約のみ） |
+| `global.effect()`（effect） | ✅ | 未対応（予約のみ） | 未対応（予約のみ） |
 
 ---
 


### PR DESCRIPTION
## 概要

DocDD 監査で検出した、Plugin Hosting 関連 docs の実装事実との乖離を解消する。

- #421（VST3 instrument production・PR #447・2026-07-17 マージ）: `seq.instrument()` が `.vst3` を受理するようになったが、docs は「v1 受理は `.clap` のみ」のまま
- #445（VST3 effect child READY handshake・PR #446）の反映漏れ
- CLAUDE.md のテスト件数記述が実測（1333 passed, 29 skipped, 1362 total）と乖離

## 変更内容

- `docs/core/INSTRUCTION_ORBITSCORE_DSL.md`
  - PH.3 の format 受理表を role 別に修正（instrument = `.clap`/`.vst3`、effect = `.clap` のみ）
  - Plugin Hosting 節ヘッダ・Not Yet Implemented セクションに #421/#445 参照と、VST3 instrument の先送りスコープ（CC 制御・per-note expression・tempo #408）を追記
- `docs/testing/TESTING_GUIDE.md`
  - VST3 Instrument Gated Fixture Tests 節を新設（`orbit-vst3-instrument-child` ビルド + gated テストコマンド + oracle 期待値）
- `docs/user/ja/USER_MANUAL.md`
  - Plugin Hosting（CLAP / VST3）節を新設（ユーザー向け構文・対応フォーマット表）
- `CLAUDE.md`
  - テスト件数記述を実測値に更新
- `docs/development/WORK_LOG.md`
  - 本作業のエントリ（6.259）を追加

## 検証

- `npm test` 実行済み: 1333 passed, 29 skipped (1362 total) — CLAUDE.md 更新値と一致
- docs のみの変更のため、advisor 判断に基づき full PR レビュー機構（simplify + pr-review-team）は適用せず、内容の事実確認を優先

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)