### PR TITLE
docs(dev-site): refresh plan + bilingual plugin-hosting pilot chapter

### DIFF
--- a/docs/development/DEV_LEARNING_SITE.md
+++ b/docs/development/DEV_LEARNING_SITE.md
@@ -59,8 +59,8 @@ skill の Phase 1 (Discovery interview) では audience / scope / language 等�
 | 項目 | 確定値 |
 |---|---|
 | **audience** | self (yamato、実装学習が主目的)。contributor onboarding は副次効果として歓迎 |
-| **content language** | 日本語 only (start)。en は post-ICMC で i18n 追加検討 |
-| **primary source** | own codebase: `packages/engine/src/`、`packages/vscode-extension/src/` |
+| **content language** | **日英バイリンガル必須**（ja ルート + `en/` ツリーを常に同時更新。post-ICMC 先送りの旧方針は撤回・(2026-07-17 owner 指示)） |
+| **primary source** | own codebase: `packages/engine/src/`、`packages/vscode-extension/src/`、`rust/crates/`（rust-engine 移行後） |
 | **scope (含む)** | parser / DSL runtime / scheduler / audio / vscode-extension の **内部実装** |
 | **scope (含まない)** | SuperCollider 内部、Vue 内部、VS Code API 内部 (引用と link に留める) |
 | **voice / tone** | technical-explanatory、sempai 寄り (warmth 中程度)。詳細は STYLE_GUIDE で確定 |
@@ -71,6 +71,8 @@ skill の Phase 1 (Discovery interview) では audience / scope / language 等�
 | **external audit** | advisor で代替 (詳細は §5) |
 | **research depth** | spec-grade (primary source = code 自身、reading 時は逐語引用) |
 | **deploy target** | post-ICMC で GitHub Pages、initial は local-only (`docs:dev`) |
+| **curriculum structure** | **ステップバイステップ構成**。各ステップは実機で再現可能な手順とし、その手順集合が **網羅的 E2E テストのタスクを兼ねる**（learning = E2E 検証の二重役割。(2026-07-17 owner 指示)） |
+| **local delivery** | ローカル配信は **MCP サーバ `/docs/`**（[#450](https://github.com/signalcompose/orbitscore/issues/450)）と **OrbitStudio ワンクリック** の 2 経路（(2026-07-17 owner 指示)） |
 
 ---
 
@@ -203,11 +205,13 @@ cross-LLM-family audit に格上げする選択肢は post-ICMC で検討:
 
 ## 6. Skill Phase 9 — Deployment
 
-- **Initial**: local-only (`docs:dev` で hot reload)。飛行機内などのオフライン作業もこれで足りる
-- **post-ICMC**: GitHub Pages に deploy
-  - URL 案: `signalcompose.github.io/orbitscore-internals/` (or 独自 subdomain)
+**(2026-07-17 owner 指示: 以下は実態に合わせて更新。GitHub Pages は post-ICMC 予定ではなく既に稼働中)**
+
+- **本番**: GitHub Actions `deploy-sites.yml` が `sites/dev/` を build し `https://signalcompose.github.io/orbitscore/dev/` に deploy（`.vitepress/config.ts` の `SITE_BASE = '/orbitscore/dev/'` と一致）
   - 公開範囲: public (OSS なので隠す理由なし、contributor 用途でも有用)
-  - 「個人の学習ノート」 disclaimer は landing page でも明記
+  - 「個人の学習ノート」 disclaimer は landing page (`sites/dev/index.md` / `sites/dev/en/index.md`) で明記
+- **開発時**: local-only (`npm run docs:dev -w @orbitscore/dev-site` で hot reload)。飛行機内などのオフライン作業もこれで足りる
+- **ローカル配信（追加経路・(2026-07-17 owner 指示)）**: MCP サーバ `/docs/`（[#450](https://github.com/signalcompose/orbitscore/issues/450)）経由・OrbitStudio からのワンクリック起動の 2 経路を予定。GitHub Pages 版と並存し、オフライン/エージェント駆動での参照を担う
 
 ---
 

--- a/sites/dev/.plan/refresh-2026-07.md
+++ b/sites/dev/.plan/refresh-2026-07.md
@@ -1,0 +1,129 @@
+# Dev Learning Site Refresh Plan — 2026-07
+
+**Status**: 計画（第一段・Issue [#451](https://github.com/signalcompose/orbitscore/issues/451)）
+**非公開ディレクトリ**: `sites/dev/.plan/` は `srcExclude` 対象外なので `.vitepress/config.ts` の
+`srcExclude` に `.plan/**` を追加してから章の fan-out に着手すること（本ファイル自体が
+VitePress のビルド対象に混入しないようにするための前提条件）。
+
+> 本計画は [`docs/development/DEV_LEARNING_SITE.md`](../../../docs/development/DEV_LEARNING_SITE.md)
+> の 2026-07-17 決定（バイリンガル必須・step-by-step = E2E 検証二重役割・ローカル配信 MCP/OrbitStudio）
+> を実装するための章立てである。決定そのものはそちらが正本。
+
+---
+
+## 1. なぜ今リフレッシュが必要か
+
+既存 5 章群（orientation / pipeline / scheduling / audio / editor + decisions）は 2026-05 時点の
+**TypeScript engine + SuperCollider** 構成を記述しており、以下が完全に欠落している:
+
+- Rust engine（`rust/crates/orbit-audio-daemon` 他）への移行（cutover #108、`57c780f`）
+- OOP（out-of-process）children アーキテクチャ（CLAP/VST3 effect・instrument child、shm transport）
+- M2 IPC event wire（`NeutralEvent` / named tagged union、Issue #398）
+- capture seam（`ORBIT_CAPTURE_WAV`、realtime WAV capture）
+- plugin hosting DSL（`global.effect()` / `seq.instrument()`）と CLAP/VST3 フォーマット対応
+
+2026-07 時点のコードベースの中核（daemon・plugin hosting・M2 IPC）が学習サイトに一切反映されて
+いない。これは DEV_LEARNING_SITE.md §1 が警告する「ブラックボックス債務」がまさに rust-engine
+以降の実装で累積している状態を意味する。
+
+---
+
+## 2. 新章群
+
+### 2.1 rust-engine 章群（`sites/dev/rust-engine/` + `sites/dev/en/rust-engine/`）
+
+| # | 章 | 内容 | 主要ソース |
+|---|---|---|---|
+| RE-1 | daemon アーキテクチャ概観 | `orbit-audio-daemon` のプロセス構造、TS engine との境界（IPC 経由）、boot〜teardown ライフサイクル | `rust/crates/orbit-audio-daemon/src/`、`docs/development/POST_2.0_MASTER_PLAN.html` |
+| RE-2 | OOP children と shm transport | in-process（楽器）vs out-of-process（3rd-party plugin/effect）の使い分け、`orbit-audio-sandbox` の共有メモリ (`PipelinedInstrumentHost`, `open_shared`, `region_ptr`)、watchdog/respawn 供給 | `rust/crates/orbit-audio-sandbox/`、`rust/crates/orbit-audio-daemon/src/outproc_instrument.rs`、`outproc_effect.rs` |
+| RE-3 | M2 IPC event wire | `NeutralEvent` named tagged union 設計（候補A採用の経緯）、note on/off の port/channel/key モデル、`event_decode_error_count` 等の観測ミラー | [[vst3-m2-ipc-wire-design-decision]] 相当の実装 = `rust/crates/orbit-audio-sandbox/src/`、Issue #398 |
+| RE-4 | capture seam | `ORBIT_CAPTURE_WAV`、`PostMixSink`、realtime WAV writer（自前 minimal RIFF）の設計と検証手段 | WORK_LOG 6.24x 台（capture seam 実装回）、`docs/development/POST_2.0_MASTER_PLAN.html` |
+
+### 2.2 plugin-hosting 章群（`sites/dev/plugin-hosting/` + `sites/dev/en/plugin-hosting/`）
+
+| # | 章 | 内容 | 主要ソース |
+|---|---|---|---|
+| PH-1 | **概観（パイロット章・本 Issue で執筆済み）** | DSL 構文（`global.effect` / `seq.instrument`）、フォーマット対応表、OOP hosting の全体像 | `packages/engine/src/core/global/plugin-resolver.ts`、`plugin-instrument-manager.ts`、`plugin-effect-manager.ts` |
+| PH-2 | CLAP instrument hosting | `orbit-clap-instrument-child` の内部、note ring、attach/respawn | `rust/crates/orbit-audio-daemon/src/outproc_instrument.rs`、WORK_LOG 6.25x |
+| PH-3 | VST3 instrument hosting | `Vst3InstrumentProcessor`、NOTE_END 非対称の吸収（synthetic NoteEnd）、child 選択ロジック（`child_exe_for_attach`） | `rust/crates/orbit-vst3-host/`（Stage 1）、`outproc_instrument.rs:106-167`、WORK_LOG 6.258 |
+| PH-4 | effect hosting（CLAP master insert） | `global.effect()` の DoD 配線、LinkAudio との排他 | `packages/engine/src/core/global/plugin-effect-manager.ts`、WORK_LOG 6.256-6.257 |
+| PH-5 | Epic #424 全体像 | effect × instrument 共存、DoD 実機達成の経緯 | WORK_LOG 6.256-6.258、Epic #424 |
+
+---
+
+## 3. Step-by-step チュートリアル trail（= E2E テストタスク）
+
+DEV_LEARNING_SITE.md の新決定「カリキュラム = 実機再現可能な手順の連鎖 = 網羅的 E2E テスト」を
+体現する trail。各章末に「Try it」節を置き、以下の順で積み上げる。実機コマンド・期待客観値は
+執筆時に一次情報（daemon 実行結果・`ORBIT_CAPTURE_WAV` 出力）で検証してから記載する。
+
+| # | Try it | 章 | 期待される客観値（検証必須・未検証は draft のまま明記） |
+|---|---|---|---|
+| 01 | 音を出す（daemon boot → 単音再生） | RE-1 | capture peak が既知振幅と一致（テストトーン相当） |
+| 02 | audio DSL（audio file 再生） | 既存 `audio/` 章の再検証 | 既存章の verified-against 更新（下記 §4） |
+| 03 | Pitch DSL + MIDI 出力 | 既存 v1.1 Pitch DSL 章（未着手なら新設） | note on/off イベント列が期待と一致 |
+| 04 | `seq.instrument("...clap")` | PH-2 | CLAP gated テスト同等の実機 RUN。capture peak = 既知振幅（synth oracle 依存） |
+| 05 | `seq.instrument("SynthOracle.vst3")` | PH-3 | **capture peak = 0.25000**（WORK_LOG 6.258 実機 E2E で確認済みの厳密一致値） |
+| 06 | `global.effect("...clap")` | PH-4 | master insert 適用後の波形差分（未検証・執筆時に一次情報で確定） |
+| 07 | capture 検証（`ORBIT_CAPTURE_WAV` を使った自己検証ループ） | RE-4 | WAV ファイルが生成され、peak 値が daemon ログの `post_peak` と一致 |
+
+**設計原則**: 各 Try it は単独で再現可能なコマンド列（daemon 起動〜.orbs 実行〜capture 確認）とし、
+これを CI/gated テストに転用できる形で書く（learning note と E2E テストタスクの二重利用）。
+
+---
+
+## 4. 既存章の verified-against 更新対象
+
+以下は 2026-05 時点の commit で `verified-against` が固定されており、rust-engine 移行後の実態と
+乖離している可能性が高い。本計画の fan-out で再検証・更新する:
+
+- `sites/dev/orientation/architecture-overview.md`（TS engine 前提の全景図 → rust-engine 反映要）
+- `sites/dev/audio/supercollider.md`（SC 経路は現在も併存するか要確認。daemon 経路との関係を追記）
+- `sites/dev/scheduling/*`（event queue / transport が rust-engine 側でどう扱われるか要確認）
+
+verified-against 更新は「解消」ではなく「drift の document」（DEV_LEARNING_SITE.md §1 の artifact
+framing）。乖離が見つかっても即修正せず、まず現状を記述する。
+
+---
+
+## 5. ja/en 同時執筆の作業単位分割（後続 fan-out 用）
+
+2026-07-17 決定によりバイリンガル必須。1 writing agent = 1 章 = ja + en 両方を同一ターンで担当
+（ja だけ書いて en を後回しにする分割は禁止 — drift を生む）。fan-out 単位:
+
+| 作業単位 | 章 | 備考 |
+|---|---|---|
+| Unit A | RE-1 + RE-2（daemon 概観 + OOP children） | 依存: なし。先行して読める |
+| Unit B | RE-3 + RE-4（M2 IPC + capture seam） | 依存: Unit A の用語（shm transport 等）を参照する可能性 → Unit A 完了後推奨 |
+| Unit C | PH-1（概観・**本 Issue でパイロット執筆済み**） | 他 Unit のテンプレートとして先行公開 |
+| Unit D | PH-2 + PH-3（CLAP/VST3 instrument hosting） | 依存: Unit C の DSL 構文説明を前提にできる |
+| Unit E | PH-4 + PH-5（effect hosting + Epic 全体像） | 依存: Unit D 完了後（instrument/effect 対比のため） |
+| Unit F | Try it trail 07 本（§3）+ 既存章 verified-against 更新（§4） | 全 Unit 完了後、横断で実施 |
+
+各 Unit のディスパッチ時は `.claude/skills/vitepress-learning-site/references/writing-agent-template.md`
+のプロンプト skeleton + DEV_LEARNING_SITE.md §4 の verbatim 規律 + 「ja/en 同時」を明記する。
+
+---
+
+## 6. Sources 候補
+
+- `docs/development/POST_2.0_MASTER_PLAN.html`（rust-engine アーキテクチャの正本）
+- `docs/development/WORK_LOG.md` 6.24x 台（capture seam realtime 配線）〜 6.258（VST3 instrument
+  production）— 特に 6.256（OOP effect × instrument 共存）・6.257（DoD 配線）・6.258（VST3 横展開）
+- `rust/crates/orbit-audio-daemon/src/`（daemon 本体）
+- `rust/crates/orbit-audio-sandbox/src/`（shm transport、M2 IPC event wire 実装）
+- `rust/crates/orbit-vst3-host/`（VST3 host 側、Stage 1）
+- `packages/engine/src/core/global/plugin-resolver.ts`、`plugin-instrument-manager.ts`、
+  `plugin-effect-manager.ts`（DSL 面）
+- Issue #398（M2 IPC wire 設計）、Epic #424（plugin hosting DoD）、Issue #413（本番トラック retarget）、
+  Issue #450（MCP サーバ `/docs/`）
+
+---
+
+## 7. 本計画のスコープ外（第一段では着手しない）
+
+- Pitch DSL v1.1 / Session Log (.orbslog) / WCTM 章群（Epic #224・別トラック。学習サイト章化は
+  WCTM 実装が Stage 3 に進んでから判断）
+- ローカル配信（MCP サーバ `/docs/`・OrbitStudio ワンクリック）の実装自体（Issue #450 側で対応。
+  本計画は章コンテンツのみ）
+- cross-LLM-family audit への格上げ（DEV_LEARNING_SITE.md §5 Future Upgrade のまま未着手）

--- a/sites/dev/.vitepress/config.ts
+++ b/sites/dev/.vitepress/config.ts
@@ -23,6 +23,7 @@ export default withMermaid(
       'en/STYLE_GUIDE.md',
       '**/.audit/**',
       '**/AUDIT_REPORT*.md',
+      '.plan/**',
     ],
 
     // KaTeX CSS は public/katex/ に同梱して local link で読み込む。

--- a/sites/dev/.vitepress/sidebar.ts
+++ b/sites/dev/.vitepress/sidebar.ts
@@ -46,7 +46,12 @@ export const sidebarJa: DefaultTheme.SidebarItem[] = [
     ],
   },
   {
-    text: 'Part V: ADR / Glossary',
+    text: 'Part V: Plugin Hosting',
+    collapsed: false,
+    items: [{ text: 'PH-1. Plugin Hosting 概観', link: '/plugin-hosting/' }],
+  },
+  {
+    text: 'Part VI: ADR / Glossary',
     collapsed: false,
     items: [
       { text: 'ADR-001 SC ベース実装の選択', link: '/decisions/adr-001-supercollider' },
@@ -103,7 +108,12 @@ export const sidebarEn: DefaultTheme.SidebarItem[] = [
     ],
   },
   {
-    text: 'Part V: ADR / Glossary',
+    text: 'Part V: Plugin Hosting',
+    collapsed: false,
+    items: [{ text: 'PH-1. Plugin Hosting Overview', link: '/en/plugin-hosting/' }],
+  },
+  {
+    text: 'Part VI: ADR / Glossary',
     collapsed: false,
     items: [
       {

--- a/sites/dev/en/plugin-hosting/index.md
+++ b/sites/dev/en/plugin-hosting/index.md
@@ -229,10 +229,21 @@ The following is the procedure verified in the real-hardware E2E for Issue #421 
 production), recorded in WORK_LOG 6.258.
 
 ```
+var global = init GLOBAL
+global.tempo(100)
+global.beat(4 by 4)
 global.key("C")
-seq.instrument("SynthOracle.vst3")
-play(1, 3, 5, 8)
-RUN(seq)
+global.start()
+
+var synth = init global.seq
+synth.instrument("/path/to/SynthOracle.vst3")
+synth.octave(4)
+synth.vel(96)
+synth.length(1)
+
+synth.play(1, 3, 5, 8)
+
+RUN(synth)
 ```
 
 Running the distribution-configuration release daemon + `cli-audio.js` with `ORBIT_CAPTURE_WAV`

--- a/sites/dev/en/plugin-hosting/index.md
+++ b/sites/dev/en/plugin-hosting/index.md
@@ -1,0 +1,257 @@
+---
+title: "PH-1. Plugin Hosting Overview"
+chapter-id: "PH-1"
+verified-against: 5b227da
+verified-at: "2026-07-17"
+status: draft
+---
+
+> **Note**: This page is a snapshot of the author's reading as of 2026-07-17. The code is the
+> source of truth; this page is only a snapshot of that understanding at that point in time.
+
+# PH-1. Plugin Hosting Overview
+
+OrbitScore hosts 3rd-party CLAP / VST3 plugins as **sandboxed out-of-process (OOP) children**.
+This chapter surveys the whole picture — DSL syntax, format support matrix, and how OOP hosting
+works. The detailed internals (child-process-side transport, shared-memory layout) are left to
+later chapters (PH-2, PH-3).
+
+## DSL syntax: two hosting surfaces
+
+The OrbitScore DSL splits plugin hosting into two independent surfaces.
+
+- **`global.effect(spec, pluginId?)`** — a master-bus insert (v1 supports exactly one)
+- **`seq.instrument(spec, pluginId?)`** — a per-sequence sound source (v1 supports exactly one instance)
+
+Both share the same "declare → resolve → load" pattern, but differ in which formats they accept.
+
+```typescript
+// plugin-instrument-manager.ts:27-51
+  async instrument(spec: string, pluginId?: string): Promise<void> {
+    validatePluginExtension(spec, 'instrument')
+    if (this.linkAudioManager.isEnabled()) {
+      throw new Error('seq.instrument() cannot be used while LinkAudio is enabled in v1.')
+    }
+
+    const resolvedPath = resolvePluginPath(
+      spec,
+      this.audioManager.getAudioPaths(),
+      this.audioManager.getDocumentDirectory(),
+      'instrument',
+    )
+    const existing = this.declaration
+    if (existing) {
+      if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
+        await existing.load
+        if (this.audioEngine.isPluginActive?.() === false) {
+          await this.issueLoad(resolvedPath, pluginId)
+        }
+        return
+      }
+      throw new Error('seq.instrument() supports one instrument instance in v1.')
+    }
+    await this.issueLoad(resolvedPath, pluginId)
+  }
+```
+
+`global.effect()` is nearly identical in structure, but is careful about ordering in a way that
+matters: extension validation → LinkAudio gate → path resolution, in that order, **on purpose**.
+
+```typescript
+// plugin-effect-manager.ts:27-44
+  async effect(spec: string, pluginId?: string): Promise<void> {
+    // Order is load-bearing: validate the spec, then gate on LinkAudio, and
+    // only then resolve the path. A relative spec with no document context
+    // yet (unsaved file) makes `resolvePluginPath` throw a "cannot resolve"
+    // error; if that ran before the LinkAudio gate, it would mask the more
+    // relevant LinkAudio-conflict error with a confusing resolve failure.
+    validatePluginExtension(spec, 'effect')
+
+    if (this.linkAudioManager.isEnabled()) {
+      throw new Error('global.effect() cannot be used while LinkAudio is enabled in v1.')
+    }
+
+    const resolvedPath = resolvePluginPath(
+      spec,
+      this.audioManager.getAudioPaths(),
+      this.audioManager.getDocumentDirectory(),
+      'effect',
+    )
+```
+
+The comment explains why this ordering is "load-bearing": on an unsaved file (no document
+context yet), a relative spec makes `resolvePluginPath` throw an "unresolvable" error; if that
+ran before the LinkAudio gate, it would mask the more relevant LinkAudio-conflict error behind a
+confusing resolve failure.
+
+Both `PluginInstrumentManager` and `PluginEffectManager` share the constraint that v1 supports
+only a single declaration. Calling with a second, different spec throws explicitly (effect
+chains / multiple instruments are reserved for future support). The
+`isPluginActive?.() === false` self-heal branch guards against a silent failure where a daemon
+respawn leaves the cache thinking the load succeeded while the actual plugin was not restored —
+it re-issues the load instead of returning a false "success".
+
+## Format support matrix
+
+Extension-based validation varies the accepted formats per `PluginRole`.
+
+```typescript
+// plugin-resolver.ts:21-44
+export function resolvePluginPath(
+  spec: string,
+  audioPaths: readonly string[],
+  documentDirectory: string,
+  role: PluginRole,
+): string {
+  validatePluginExtension(spec, role)
+  return resolvePathDirect(spec, audioPaths, documentDirectory)
+}
+
+export type PluginRole = 'effect' | 'instrument'
+
+export function validatePluginExtension(spec: string, role: PluginRole): void {
+  const extension = path.extname(spec).toLowerCase()
+  if (extension === '.clap') return
+  if (extension === '.vst3' && role === 'instrument') return
+  if (extension === '.vst3' || extension === '.component') {
+    throw new Error(
+      `${extension} plugins are not yet supported for ${role} (reserved for future VST3/AU support).`,
+    )
+  }
+  const expected = role === 'instrument' ? '.clap or .vst3' : '.clap'
+  throw new Error(`Unknown plugin extension "${extension || '(none)'}"; expected ${expected}.`)
+}
+```
+
+| Role | `.clap` | `.vst3` | `.component` (AU) |
+|---|---|---|---|
+| `global.effect()` (master insert) | ✅ | ❌ (raises "reserved for future" error) | ❌ |
+| `seq.instrument()` (sound source) | ✅ | ✅ | ❌ |
+
+`.component` (Audio Unit) is unsupported for either role (explicitly rejected as "reserved for
+future"). VST3 is only valid for instrument — this asymmetry reflects that Issue #421 (VST3
+instrument production) shipped only the instrument path so far; VST3 support for effect is a
+separate, unscoped item.
+
+## OOP child process layout
+
+The daemon (`orbit-audio-daemon`) does not host the plugin's actual implementation (CLAP/VST3
+SDK calls) in its own process. Instead it spawns a **dedicated child process** and exchanges
+audio/events over shared memory. Which child to spawn is decided by a pure function keyed off
+the plugin path's extension:
+
+```rust
+// outproc_instrument.rs:106-134
+/// instrument child のフォーマット別デフォルト binary 名。VST3 だけが専用 child を持ち、
+/// それ以外（.clap・raw .dylib CLAP 等）は従来どおり CLAP child が担当する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InstrumentPluginFormat {
+    Clap,
+    Vst3,
+}
+
+impl InstrumentPluginFormat {
+    /// 拡張子 `.vst3`（大文字小文字不問）のみ VST3。**それ以外はすべて Clap** —
+    /// CLAP は VST3 対応前から唯一サポートされていた instrument フォーマットだった
+    /// ため、未知拡張子のフォールバック先として妥当。一例として、CLAP gated テストは
+    /// 未バンドルの raw `.dylib`（clap-test-synth）を attach するため、ここで未知
+    /// 拡張子を reject すると既存経路が壊れる（本ブランチの実機 gated RUN で検出済み）。
+    /// 不正な plugin path の失敗は従来どおり child 側の load エラーとして表面化する。
+    fn from_plugin_path(path: &Path) -> Self {
+        match path.extension().and_then(|extension| extension.to_str()) {
+            Some(extension) if extension.eq_ignore_ascii_case("vst3") => Self::Vst3,
+            _ => Self::Clap,
+        }
+    }
+
+    fn default_child_name(self) -> &'static str {
+        match self {
+            Self::Clap => "orbit-clap-instrument-child",
+            Self::Vst3 => "orbit-vst3-instrument-child",
+        }
+    }
+}
+```
+
+Note that the source code comments above stay in Japanese: they are quoted verbatim from the
+repository per this site's citation discipline (see `STYLE_GUIDE.md` §5-bis) — translating
+inline code comments would break the verbatim guarantee that the code snippet matches the actual
+file byte-for-byte.
+
+The TypeScript-side validation (`validatePluginExtension`) and the Rust-side
+`InstrumentPluginFormat::from_plugin_path` are **not** aligned. TS rejects anything other than
+`.clap`/`.vst3`, while Rust falls back unknown extensions to CLAP. This is an intentional
+asymmetry: the comment explains it exists so the CLAP gated test — which attaches an unbundled
+raw `.dylib` (roughly "no extension") — doesn't break on an existing path.
+
+The child binary selection itself is a symmetric, idempotent pure function that only swaps
+binaries in-place when the current child exe has one of the default names:
+
+```rust
+// outproc_instrument.rs:136-159
+/// attach する plugin の拡張子から instrument child binary を選ぶ（純関数・unit テスト対象）。
+///
+/// - `current_child_exe` の file name がフォーマット別デフォルト名（clap/vst3 child）で
+///   ない場合は**明示指定と見なして触らない**（gated テストの config 直指定・
+///   `ORBIT_INSTRUMENT_CHILD_BIN` override を保護）。
+/// - デフォルト名の場合は**同じディレクトリ**でフォーマットに応じた binary に読み替える。
+///   `current_exe` からの再導出はしない（テストハーネスでは current_exe が
+///   `target/debug/deps/` 配下になり sibling 解決が壊れるため）。retryable attach 失敗で
+///   `ChildLaunch` が再利用されても、毎回この読み替えが走るので .vst3 → .clap の
+///   attach し直しで元の child に戻る（対称・冪等）。
+pub(crate) fn child_exe_for_attach(current_child_exe: &Path, plugin_path: &Path) -> PathBuf {
+    let is_default_name = matches!(
+        current_child_exe.file_name().and_then(|name| name.to_str()),
+        Some("orbit-clap-instrument-child") | Some("orbit-vst3-instrument-child")
+    );
+    if !is_default_name {
+        return current_child_exe.to_path_buf();
+    }
+    let desired = InstrumentPluginFormat::from_plugin_path(plugin_path).default_child_name();
+    match current_child_exe.parent() {
+        Some(dir) => dir.join(desired),
+        None => PathBuf::from(desired),
+    }
+}
+```
+
+The "don't re-derive from `current_exe`" decision is a test-harness compatibility workaround,
+and the "don't touch an explicitly-set custom binary" guard protects gated tests that set the
+child exe directly. Both are covered in more depth in PH-3 (VST3 instrument hosting).
+
+Effect hosting has a corresponding OOP child (`orbit-clap-effect-child` family,
+`outproc_effect.rs`), but since effect currently only supports CLAP, there is no VST3 effect
+child. Effect hosting details are covered in PH-4.
+
+## Try it: play `seq.instrument("SynthOracle.vst3")`
+
+The following is the procedure verified in the real-hardware E2E for Issue #421 (VST3 instrument
+production), recorded in WORK_LOG 6.258.
+
+```
+global.key("C")
+seq.instrument("SynthOracle.vst3")
+play(1, 3, 5, 8)
+RUN(seq)
+```
+
+Running the distribution-configuration release daemon + `cli-audio.js` with `ORBIT_CAPTURE_WAV`
+enabled objectively exercises the whole path: DSL → `LoadPlugin(role=instrument)` →
+extension-based child selection → `orbit-vst3-instrument-child` → note on/off via `IEventList` →
+sine tone → master bus.
+
+**Expected value**: capture peak = **0.25000** (exact match to `SynthOracle`'s known amplitude,
+confirmed on real hardware per WORK_LOG 6.258).
+
+> **Gotcha**: `play()` only buffers the pattern; actually sounding it requires `RUN(seq)` (a
+> recurring "forgot RUN/LOOP" silent-failure pattern already documented in WORK_LOG).
+
+## Sources
+
+- `packages/engine/src/core/global/plugin-resolver.ts:21-44` — `resolvePluginPath` / `validatePluginExtension` (per-role format allowlist logic)
+- `packages/engine/src/core/global/plugin-instrument-manager.ts:27-51` — `PluginInstrumentManager.instrument()`
+- `packages/engine/src/core/global/plugin-effect-manager.ts:27-44` — `PluginEffectManager.effect()` (the load-bearing validation-order comment)
+- `rust/crates/orbit-audio-daemon/src/outproc_instrument.rs:106-167` — `InstrumentPluginFormat` and `child_exe_for_attach` (pure-function per-format child selection)
+- [`docs/development/WORK_LOG.md`](https://github.com/signalcompose/orbitscore/blob/main/docs/development/WORK_LOG.md) 6.258 — VST3 instrument production real-hardware E2E record (capture peak 0.25000)
+- Epic [#424](https://github.com/signalcompose/orbitscore/issues/424) — plugin hosting DoD overview
+- Issue [#421](https://github.com/signalcompose/orbitscore/issues/421) — VST3 instrument production

--- a/sites/dev/plugin-hosting/index.md
+++ b/sites/dev/plugin-hosting/index.md
@@ -1,0 +1,246 @@
+---
+title: "PH-1. Plugin Hosting 概観"
+chapter-id: "PH-1"
+verified-against: 5b227da
+verified-at: "2026-07-17"
+status: draft
+---
+
+> **Note**: 本ページは 2026-07-17 時点での著者の reading の足跡です。code が真実、本ページはその時点の理解の snapshot に過ぎません。
+
+# PH-1. Plugin Hosting 概観
+
+OrbitScore は CLAP / VST3 の 3rd-party プラグインを **sandbox 化された out-of-process (OOP) child**
+としてホストする。本章はその全体像 — DSL 構文、フォーマット対応表、OOP hosting の仕組み — を
+鳥瞰する。詳細な内部実装（child process 側の transport、shm 構造）は後続章 (PH-2, PH-3) に譲る。
+
+## DSL 構文: 2 つの hosting 面
+
+OrbitScore の DSL は plugin hosting を 2 つの独立した面に分ける。
+
+- **`global.effect(spec, pluginId?)`** — マスターバスへの insert（v1 では 1 本のみ）
+- **`seq.instrument(spec, pluginId?)`** — シーケンス単位の音源（v1 では 1 インスタンスのみ）
+
+両者は同じ「宣言 → resolve → load」パターンを共有するが、許容フォーマットが異なる。
+
+```typescript
+// plugin-instrument-manager.ts:27-51
+  async instrument(spec: string, pluginId?: string): Promise<void> {
+    validatePluginExtension(spec, 'instrument')
+    if (this.linkAudioManager.isEnabled()) {
+      throw new Error('seq.instrument() cannot be used while LinkAudio is enabled in v1.')
+    }
+
+    const resolvedPath = resolvePluginPath(
+      spec,
+      this.audioManager.getAudioPaths(),
+      this.audioManager.getDocumentDirectory(),
+      'instrument',
+    )
+    const existing = this.declaration
+    if (existing) {
+      if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
+        await existing.load
+        if (this.audioEngine.isPluginActive?.() === false) {
+          await this.issueLoad(resolvedPath, pluginId)
+        }
+        return
+      }
+      throw new Error('seq.instrument() supports one instrument instance in v1.')
+    }
+    await this.issueLoad(resolvedPath, pluginId)
+  }
+```
+
+`global.effect()` 側は構造がほぼ同一だが、順序に注意が必要な点が異なる: extension validation →
+LinkAudio gate → path resolution、の順を **意図的に** 守っている。
+
+```typescript
+// plugin-effect-manager.ts:27-44
+  async effect(spec: string, pluginId?: string): Promise<void> {
+    // Order is load-bearing: validate the spec, then gate on LinkAudio, and
+    // only then resolve the path. A relative spec with no document context
+    // yet (unsaved file) makes `resolvePluginPath` throw a "cannot resolve"
+    // error; if that ran before the LinkAudio gate, it would mask the more
+    // relevant LinkAudio-conflict error with a confusing resolve failure.
+    validatePluginExtension(spec, 'effect')
+
+    if (this.linkAudioManager.isEnabled()) {
+      throw new Error('global.effect() cannot be used while LinkAudio is enabled in v1.')
+    }
+
+    const resolvedPath = resolvePluginPath(
+      spec,
+      this.audioManager.getAudioPaths(),
+      this.audioManager.getDocumentDirectory(),
+      'effect',
+    )
+```
+
+この順序が「load-bearing」だとコメントが明言している理由は、未保存ファイル（document context
+なし）で spec が相対パスだと `resolvePluginPath` が「解決できない」エラーを投げてしまい、
+それが先に走ると LinkAudio 競合という本質的により重要なエラーがマスクされてしまうため。
+
+`PluginInstrumentManager` / `PluginEffectManager` はいずれも「1 declaration のみ v1 でサポート」
+という制約を共有する。2 本目の異なる spec で呼ぶと明示的にエラーを投げる（effect chain / 複数
+instrument は将来対応として予約されている）。また `isPluginActive?.() === false` の自己修復分岐は、
+daemon 再起動でキャッシュ上は成功扱いのまま実体が復元されていない silent failure を検知して
+再ロードする防御になっている。
+
+## フォーマット対応表
+
+拡張子ベースの validation は `PluginRole` ごとに許容フォーマットを変える。
+
+```typescript
+// plugin-resolver.ts:21-44
+export function resolvePluginPath(
+  spec: string,
+  audioPaths: readonly string[],
+  documentDirectory: string,
+  role: PluginRole,
+): string {
+  validatePluginExtension(spec, role)
+  return resolvePathDirect(spec, audioPaths, documentDirectory)
+}
+
+export type PluginRole = 'effect' | 'instrument'
+
+export function validatePluginExtension(spec: string, role: PluginRole): void {
+  const extension = path.extname(spec).toLowerCase()
+  if (extension === '.clap') return
+  if (extension === '.vst3' && role === 'instrument') return
+  if (extension === '.vst3' || extension === '.component') {
+    throw new Error(
+      `${extension} plugins are not yet supported for ${role} (reserved for future VST3/AU support).`,
+    )
+  }
+  const expected = role === 'instrument' ? '.clap or .vst3' : '.clap'
+  throw new Error(`Unknown plugin extension "${extension || '(none)'}"; expected ${expected}.`)
+}
+```
+
+| Role | `.clap` | `.vst3` | `.component` (AU) |
+|---|---|---|---|
+| `global.effect()`（master insert） | ✅ | ❌（"reserved for future" エラー） | ❌ |
+| `seq.instrument()`（音源） | ✅ | ✅ | ❌ |
+
+`.component` (Audio Unit) はどちらの role でも未対応（"reserved for future" として明示的に
+reject される）。VST3 は instrument でのみ有効 — この非対称は Issue #421（VST3 instrument
+production）で instrument 側のみ先行実装されたことの反映であり、effect 側の VST3 対応は
+別途スコープ。
+
+## OOP child process 構成
+
+daemon (`orbit-audio-daemon`) は plugin の実体（CLAP/VST3 SDK 呼び出し）を自プロセス内に
+持たない。代わりに **専用の子プロセス** を spawn し、共有メモリ (shared memory) 経由で
+audio/event をやり取りする。子プロセスの選択は plugin path の拡張子から決まる純関数で
+行われる:
+
+```rust
+// outproc_instrument.rs:106-134
+/// instrument child のフォーマット別デフォルト binary 名。VST3 だけが専用 child を持ち、
+/// それ以外（.clap・raw .dylib CLAP 等）は従来どおり CLAP child が担当する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InstrumentPluginFormat {
+    Clap,
+    Vst3,
+}
+
+impl InstrumentPluginFormat {
+    /// 拡張子 `.vst3`（大文字小文字不問）のみ VST3。**それ以外はすべて Clap** —
+    /// CLAP は VST3 対応前から唯一サポートされていた instrument フォーマットだった
+    /// ため、未知拡張子のフォールバック先として妥当。一例として、CLAP gated テストは
+    /// 未バンドルの raw `.dylib`（clap-test-synth）を attach するため、ここで未知
+    /// 拡張子を reject すると既存経路が壊れる（本ブランチの実機 gated RUN で検出済み）。
+    /// 不正な plugin path の失敗は従来どおり child 側の load エラーとして表面化する。
+    fn from_plugin_path(path: &Path) -> Self {
+        match path.extension().and_then(|extension| extension.to_str()) {
+            Some(extension) if extension.eq_ignore_ascii_case("vst3") => Self::Vst3,
+            _ => Self::Clap,
+        }
+    }
+
+    fn default_child_name(self) -> &'static str {
+        match self {
+            Self::Clap => "orbit-clap-instrument-child",
+            Self::Vst3 => "orbit-vst3-instrument-child",
+        }
+    }
+}
+```
+
+daemon 側の TypeScript validation (`validatePluginExtension`) と Rust 側の
+`InstrumentPluginFormat::from_plugin_path` は **一致していない** ことに注意。TS 側は
+`.clap`/`.vst3` 以外を reject するが、Rust 側は未知拡張子を CLAP にフォールバックする。
+これは意図的な非対称で、CLAP gated テストが未バンドルの raw `.dylib`（拡張子なし相当）を
+attach する既存経路を壊さないための設計判断だとコメントされている。
+
+child binary の選択自体は、既定名（`orbit-clap-instrument-child` / `orbit-vst3-instrument-child`）
+のときだけ同ディレクトリで読み替える対称・冪等な純関数として実装されている:
+
+```rust
+// outproc_instrument.rs:136-159
+/// attach する plugin の拡張子から instrument child binary を選ぶ（純関数・unit テスト対象）。
+///
+/// - `current_child_exe` の file name がフォーマット別デフォルト名（clap/vst3 child）で
+///   ない場合は**明示指定と見なして触らない**（gated テストの config 直指定・
+///   `ORBIT_INSTRUMENT_CHILD_BIN` override を保護）。
+/// - デフォルト名の場合は**同じディレクトリ**でフォーマットに応じた binary に読み替える。
+///   `current_exe` からの再導出はしない（テストハーネスでは current_exe が
+///   `target/debug/deps/` 配下になり sibling 解決が壊れるため）。retryable attach 失敗で
+///   `ChildLaunch` が再利用されても、毎回この読み替えが走るので .vst3 → .clap の
+///   attach し直しで元の child に戻る（対称・冪等）。
+pub(crate) fn child_exe_for_attach(current_child_exe: &Path, plugin_path: &Path) -> PathBuf {
+    let is_default_name = matches!(
+        current_child_exe.file_name().and_then(|name| name.to_str()),
+        Some("orbit-clap-instrument-child") | Some("orbit-vst3-instrument-child")
+    );
+    if !is_default_name {
+        return current_child_exe.to_path_buf();
+    }
+    let desired = InstrumentPluginFormat::from_plugin_path(plugin_path).default_child_name();
+    match current_child_exe.parent() {
+        Some(dir) => dir.join(desired),
+        None => PathBuf::from(desired),
+    }
+}
+```
+
+「current_exe から再導出しない」判断はテストハーネス互換性のための実装都合であり、
+「明示指定された custom binary は上書きしない」ガードは gated テストの config 直指定を
+壊さないための防御である。この 2 点は PH-3（VST3 instrument hosting）章で詳しく扱う。
+
+effect 側にも対応する OOP child（`orbit-clap-effect-child` 系、`outproc_effect.rs`）が
+存在するが、現時点で effect は CLAP のみ対応のため VST3 child は無い。effect 側の詳細は
+PH-4 章に譲る。
+
+## Try it: `seq.instrument("SynthOracle.vst3")` を鳴らす
+
+以下は Issue #421（VST3 instrument production）の実機 E2E で実証済みの手順（WORK_LOG 6.258）。
+
+```
+global.key("C")
+seq.instrument("SynthOracle.vst3")
+play(1, 3, 5, 8)
+RUN(seq)
+```
+
+配布構成の release daemon + `cli-audio.js` を `ORBIT_CAPTURE_WAV` 有効で実行すると、
+DSL → `LoadPlugin(role=instrument)` → 拡張子ベースの child 選択 → `orbit-vst3-instrument-child`
+→ `IEventList` 経由の note on/off → sine 発音 → master bus、という経路全体が客観的に実証できる。
+
+**期待値**: capture peak = **0.25000**（`SynthOracle` の既知振幅との厳密一致。WORK_LOG 6.258
+で実機確認済み）。
+
+> **注意（既知の落とし穴）**: `play()` はパターンの buffering のみを行い、実際の発音には
+> `RUN(seq)` が必要（WORK_LOG に既出の「RUN/LOOP 忘れ」silent 失敗パターン）。
+
+## Sources
+
+- `packages/engine/src/core/global/plugin-resolver.ts:21-44` — `resolvePluginPath` / `validatePluginExtension`（role 別フォーマット許容ロジック）
+- `packages/engine/src/core/global/plugin-instrument-manager.ts:27-51` — `PluginInstrumentManager.instrument()`
+- `packages/engine/src/core/global/plugin-effect-manager.ts:27-44` — `PluginEffectManager.effect()`（validation 順序の load-bearing コメント）
+- `rust/crates/orbit-audio-daemon/src/outproc_instrument.rs:106-167` — `InstrumentPluginFormat` と `child_exe_for_attach`（フォーマット別 child 選択の純関数）
+- [`docs/development/WORK_LOG.md`](https://github.com/signalcompose/orbitscore/blob/main/docs/development/WORK_LOG.md) 6.258 — VST3 instrument production の実機 E2E 記録（capture peak 0.25000）
+- Epic [#424](https://github.com/signalcompose/orbitscore/issues/424) — plugin hosting DoD 全体像
+- Issue [#421](https://github.com/signalcompose/orbitscore/issues/421) — VST3 instrument production

--- a/sites/dev/plugin-hosting/index.md
+++ b/sites/dev/plugin-hosting/index.md
@@ -219,10 +219,21 @@ PH-4 章に譲る。
 以下は Issue #421（VST3 instrument production）の実機 E2E で実証済みの手順（WORK_LOG 6.258）。
 
 ```
+var global = init GLOBAL
+global.tempo(100)
+global.beat(4 by 4)
 global.key("C")
-seq.instrument("SynthOracle.vst3")
-play(1, 3, 5, 8)
-RUN(seq)
+global.start()
+
+var synth = init global.seq
+synth.instrument("/path/to/SynthOracle.vst3")
+synth.octave(4)
+synth.vel(96)
+synth.length(1)
+
+synth.play(1, 3, 5, 8)
+
+RUN(synth)
 ```
 
 配布構成の release daemon + `cli-audio.js` を `ORBIT_CAPTURE_WAV` 有効で実行すると、


### PR DESCRIPTION
## 概要

Issue #451 の第一段。dev ラーニングサイト最新化に向けて以下を実施:

- `docs/development/DEV_LEARNING_SITE.md` の決定表を 2026-07-17 owner 指示に合わせて改訂
  （日英バイリンガル必須化・step-by-step = E2E 検証二重役割・ローカル配信 MCP/OrbitStudio・
  §6 Deployment の実態反映）
- `sites/dev/.plan/refresh-2026-07.md` に 2026-07 時点の実装（rust-engine・plugin hosting）
  に追随する新章計画を追加（非公開ディレクトリ、`srcExclude` に `.plan/**` を追加）
- パイロット章 `sites/dev/plugin-hosting/index.md`（ja）+ `sites/dev/en/plugin-hosting/index.md`（en）
  を追加。DSL 構文・フォーマット対応表・OOP child process 構成・Try it 実機手順
  （`seq.instrument("SynthOracle.vst3")`、期待値 capture peak 0.25000）
- `.vitepress/sidebar.ts` に ja/en 両方の新章エントリを追加

## 検証

- `npm run docs:build`: green
- パイロット章の全コードブロックを一次ソース（`plugin-resolver.ts` / `plugin-instrument-manager.ts` /
  `plugin-effect-manager.ts` / `outproc_instrument.rs`）と byte-for-byte diff で照合し一致確認済み
- `npm test`: 1333 passed / 29 skipped（worktree の node_modules に `uuid` が未インストールだった
  ため `npm install` で補完してから実行）

## 変更ファイル

- `docs/development/DEV_LEARNING_SITE.md`
- `sites/dev/.plan/refresh-2026-07.md`（新規）
- `sites/dev/plugin-hosting/index.md`（新規）
- `sites/dev/en/plugin-hosting/index.md`（新規）
- `sites/dev/.vitepress/config.ts`
- `sites/dev/.vitepress/sidebar.ts`

Refs #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)