### PR TITLE
feat(mcp): serve dev learning site locally + MCP doc tools + OrbitStudio one-click (#450)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,33 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.260 feat(mcp): dev learning site のローカル配信 + MCP ツール + OrbitStudio 導線 #450 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 実装（PR 作成・レビューへ）
+**Branch**: `450-mcp-dev-docs-serving`
+
+owner 要望「learning site をユーザー/LLM がローカル参照できるように。MCP サーバに
+機能的に組み込み、ブラウザ経由・MCP 経由で見れるように。OrbitStudio からワンクリック」。
+実装 = Codex 委譲 + main の受け入れ監査（base 整合の修正1件）。
+
+- **static 配信**: 拡張内 MCP HTTP サーバ（mcp-server.ts・127.0.0.1）に
+  `sites/dev/.vitepress/dist` の配信を追加。**配信 prefix = SITE_BASE
+  （`/orbitscore/dev/`）と一致させる**（dist 内の asset/ナビ URL は base 絶対
+  パスのため、他 prefix では全 asset が 404 になる — 受け入れ監査で検出し
+  `/docs` は 302 redirect に変更）。path traversal 防御（decode → `..`/`\` 拒否 →
+  resolve 後に root 内検証）・Host-header allowlist は `/mcp` と共通・dist 不在時は
+  503 + ビルドコマンド案内
+- **MCP ツール**: `get_dev_doc(path)`（ソース md を site 相対パスで取得）・
+  `search_dev_docs(query, limit)`（md 全文の case-insensitive 検索・
+  {path,line,excerpt}）。LLM がサイト本文を直接参照できる
+- **OrbitStudio 導線**: `orbitscore.openDevDocs` コマンド + status bar `$(book) Docs`
+  ボタン（MCP サーバ起動時のみ表示・`vscode.env.openExternal`）
+- unit テスト: resolveDocsRoot / resolveDocsFilePath（traversal・%2e%2e）/
+  readDevDoc / searchDevDocs（.vitepress 除外）
+- 検証: npm run build green・vscode-extension テスト 122/122・変更ファイル lint クリーン
+- 関連: #451（サイト内容の 2026-07 追随・日英・E2E 兼用カリキュラム）が別トラックで進行
+
 ### 6.259 docs: Plugin Hosting docs 同期（#421 / #445 実装事実の反映） #449 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -85,6 +85,12 @@
         "title": "🔌 Register Claude Code MCP Server",
         "category": "OrbitScore",
         "icon": "$(plug)"
+      },
+      {
+        "command": "orbitscore.openDevDocs",
+        "title": "📚 OrbitScore: Open Dev Docs",
+        "category": "OrbitScore",
+        "icon": "$(book)"
       }
     ],
     "languages": [

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -47,6 +47,7 @@ let engineProcess: child_process.ChildProcess | null = null
 let outputChannel: vscode.OutputChannel | null = null
 let statusBarItem: vscode.StatusBarItem | null = null
 let bundleStatusItem: vscode.StatusBarItem | null = null
+let docsStatusItem: vscode.StatusBarItem | null = null
 let isLiveCodingMode: boolean = false
 // Tracks whether `var global = init GLOBAL` has been evaluated in the current engine session.
 // Used to decide if `global.setDocumentDirectory(...)` can be prepended safely.
@@ -261,6 +262,13 @@ export async function activate(context: vscode.ExtensionContext) {
   updateBundleStatus()
   bundleStatusItem.show()
 
+  // The development docs are served by the optional MCP server, so this stays
+  // hidden until that server has successfully started.
+  docsStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 98)
+  docsStatusItem.text = '$(book) Docs'
+  docsStatusItem.tooltip = 'Open OrbitScore development docs'
+  docsStatusItem.command = 'orbitscore.openDevDocs'
+
   // Re-evaluate bundle status when user changes the override setting or
   // switches engine kind (#377: kind gates whether scsynth is even resolved).
   context.subscriptions.push(
@@ -295,8 +303,10 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('orbitscore.selectAudioDevice', selectAudioDevice),
     vscode.commands.registerCommand('orbitscore.configureFlash', configureFlash),
     vscode.commands.registerCommand('orbitscore.registerMcpServer', registerMcpServer),
+    vscode.commands.registerCommand('orbitscore.openDevDocs', openDevDocs),
     statusBarItem,
     bundleStatusItem,
+    docsStatusItem,
   )
 
   // Register IntelliSense providers
@@ -377,6 +387,7 @@ export async function activate(context: vscode.ExtensionContext) {
         },
         log: (message) => outputChannel?.appendLine(`🔌 ${message}`),
       })
+      docsStatusItem?.show()
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err)
       outputChannel?.appendLine(`❌ MCP server failed to start on port ${mcpPort}: ${reason}`)
@@ -399,6 +410,18 @@ export function deactivate() {
   outputChannel?.dispose()
   statusBarItem?.dispose()
   bundleStatusItem?.dispose()
+  docsStatusItem?.dispose()
+}
+
+async function openDevDocs(): Promise<void> {
+  const port = mcpServerHandle?.port ?? 0
+  if (!port) {
+    void vscode.window.showErrorMessage(
+      'OrbitScore development docs require the MCP server. Set orbitscore.mcpServer.port and enable the MCP server.',
+    )
+    return
+  }
+  await vscode.env.openExternal(vscode.Uri.parse(`http://127.0.0.1:${port}/docs/`))
 }
 
 /**

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -421,7 +421,12 @@ async function openDevDocs(): Promise<void> {
     )
     return
   }
-  await vscode.env.openExternal(vscode.Uri.parse(`http://127.0.0.1:${port}/docs/`))
+  const url = `http://127.0.0.1:${port}/docs/`
+  const opened = await vscode.env.openExternal(vscode.Uri.parse(url))
+  if (!opened) {
+    outputChannel?.appendLine(`❌ Failed to open development docs at ${url}`)
+    void vscode.window.showErrorMessage('Could not open the development docs in your browser.')
+  }
 }
 
 /**

--- a/packages/vscode-extension/src/mcp-server.ts
+++ b/packages/vscode-extension/src/mcp-server.ts
@@ -292,7 +292,12 @@ export function readDevDoc(sourceRoot: string, relativePath: string): string | n
   if (!filePath || path.extname(filePath) !== '.md' || !fs.existsSync(filePath)) {
     return null
   }
-  return fs.readFileSync(filePath, 'utf8')
+  try {
+    return fs.readFileSync(filePath, 'utf8')
+  } catch {
+    // TOCTOU: the file could vanish (docs rebuild) between existsSync and read.
+    return null
+  }
 }
 
 export interface DevDocSearchMatch {
@@ -312,7 +317,13 @@ export function searchDevDocs(sourceRoot: string, query: string, limit = 10): De
       if (entry.isDirectory()) {
         walk(entryPath)
       } else if (entry.isFile() && path.extname(entry.name) === '.md') {
-        const lines = fs.readFileSync(entryPath, 'utf8').split(/\r?\n/)
+        let lines: string[]
+        try {
+          lines = fs.readFileSync(entryPath, 'utf8').split(/\r?\n/)
+        } catch {
+          // Skip a file that becomes unreadable mid-walk rather than aborting the search.
+          continue
+        }
         for (let index = 0; index < lines.length && matches.length < limit; index += 1) {
           if (lines[index].toLowerCase().includes(needle)) {
             matches.push({
@@ -883,18 +894,34 @@ export async function startOrbitScoreMcpServer(opts: {
           return
         }
         if (!fs.existsSync(docsRoot)) {
+          log(`docs not built — docsRoot missing: ${docsRoot}`)
           res.writeHead(503, { 'content-type': 'text/plain; charset=utf-8' })
           res.end('Development docs are not built. Run npm run docs:build -w @orbitscore/dev-site')
           return
         }
         const filePath = resolveDocsFilePath(docsRoot, pathname.slice(DOCS_PUBLIC_BASE.length))
         if (!filePath || !fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+          log(`docs file not found for pathname: ${pathname}`)
           res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' })
           res.end('Not Found')
           return
         }
-        res.writeHead(200, { 'content-type': contentTypeForDocsFile(filePath) })
-        fs.createReadStream(filePath).pipe(res)
+        const contentType = contentTypeForDocsFile(filePath)
+        if (contentType === 'application/octet-stream') {
+          log(
+            `docs file served with fallback content-type (unknown extension ${path.extname(filePath)}): ${filePath}`,
+          )
+        }
+        res.writeHead(200, { 'content-type': contentType })
+        const stream = fs.createReadStream(filePath)
+        stream.on('error', (err) => {
+          log(`docs file stream error for ${filePath}: ${err}`)
+          if (!res.headersSent) {
+            res.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' })
+          }
+          res.end('Internal Server Error')
+        })
+        stream.pipe(res)
         return
       }
       if (pathname !== '/mcp') {

--- a/packages/vscode-extension/src/mcp-server.ts
+++ b/packages/vscode-extension/src/mcp-server.ts
@@ -240,23 +240,39 @@ export function resolveDocsRoot(baseDir: string): string {
  * Directory URLs (including the root URL) serve their index.html.
  */
 export function resolveDocsFilePath(docsRoot: string, urlPath: string): string | null {
+  return resolveSafePath(docsRoot, urlPath, (decodedPath, relativePath) =>
+    decodedPath.endsWith('/') || !path.extname(relativePath)
+      ? path.join(relativePath, 'index.html')
+      : relativePath,
+  )
+}
+
+/**
+ * Shared traversal guard for every docs path lookup: decode → reject `..`/`\` →
+ * resolve against root → containment check. This is the security boundary for the
+ * locally-bound HTTP server and the MCP doc tools — keep it single-sourced so a
+ * future tightening applies everywhere at once. `mapTarget` lets callers layer
+ * their own URL→file mapping (e.g. directory → index.html) on the decoded path
+ * before resolution; the containment check always runs on the mapped result.
+ */
+function resolveSafePath(
+  root: string,
+  rawPath: string,
+  mapTarget: (decodedPath: string, relativePath: string) => string = (_, relativePath) =>
+    relativePath,
+): string | null {
   let decodedPath: string
   try {
-    decodedPath = decodeURIComponent(urlPath)
+    decodedPath = decodeURIComponent(rawPath)
   } catch {
     return null
   }
   if (decodedPath.includes('\\') || decodedPath.includes('..')) {
     return null
   }
-
   const relativePath = decodedPath.replace(/^\/+/, '')
-  const targetPath =
-    decodedPath.endsWith('/') || !path.extname(relativePath)
-      ? path.join(relativePath, 'index.html')
-      : relativePath
-  const filePath = path.resolve(docsRoot, targetPath)
-  const normalizedRoot = path.resolve(docsRoot)
+  const filePath = path.resolve(root, mapTarget(decodedPath, relativePath))
+  const normalizedRoot = path.resolve(root)
   if (filePath !== normalizedRoot && !filePath.startsWith(`${normalizedRoot}${path.sep}`)) {
     return null
   }
@@ -264,18 +280,11 @@ export function resolveDocsFilePath(docsRoot: string, urlPath: string): string |
 }
 
 function resolvePathWithinRoot(root: string, relativePath: string): string | null {
-  let decodedPath: string
-  try {
-    decodedPath = decodeURIComponent(relativePath)
-  } catch {
-    return null
-  }
-  if (!decodedPath || decodedPath.includes('\\') || decodedPath.includes('..')) {
-    return null
-  }
-  const filePath = path.resolve(root, decodedPath.replace(/^\/+/, ''))
-  const normalizedRoot = path.resolve(root)
-  return filePath.startsWith(`${normalizedRoot}${path.sep}`) ? filePath : null
+  if (!relativePath) return null
+  const filePath = resolveSafePath(root, relativePath)
+  // The bare root is a valid *directory* answer for the docs file server (mapped to
+  // index.html) but never a valid document path for readDevDoc/searchDevDocs.
+  return filePath !== null && filePath !== path.resolve(root) ? filePath : null
 }
 
 export function readDevDoc(sourceRoot: string, relativePath: string): string | null {
@@ -339,9 +348,12 @@ function contentTypeForDocsFile(filePath: string): string {
  * Build a per-session McpServer with the OrbitScore tool surface registered.
  * One instance per MCP session (see `startOrbitScoreMcpServer` for routing).
  */
-function buildServer(version: string, handlers: OrbitScoreToolHandlers): McpServerLike {
+function buildServer(
+  version: string,
+  handlers: OrbitScoreToolHandlers,
+  docsRoot: string,
+): McpServerLike {
   const server = new McpServer({ name: 'orbitscore', version })
-  const docsRoot = resolveDocsRoot(path.resolve(__dirname, '../../..'))
   const docsSourceRoot = path.resolve(docsRoot, '../..')
 
   server.registerTool(
@@ -837,7 +849,7 @@ export async function startOrbitScoreMcpServer(opts: {
         sessions.delete(transport.sessionId)
       }
     }
-    const server = buildServer(version, handlers)
+    const server = buildServer(version, handlers, docsRoot)
     entry.transport = transport
     entry.server = server
     await server.connect(transport)

--- a/packages/vscode-extension/src/mcp-server.ts
+++ b/packages/vscode-extension/src/mcp-server.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'crypto'
+import * as fs from 'fs'
 import * as http from 'http'
+import * as path from 'path'
 
 import type { WavAnalysis } from './wav-analysis'
 
@@ -221,11 +223,126 @@ export interface McpServerHandle {
 }
 
 /**
+ * Public URL prefix the built dev site is served under. Must equal SITE_BASE in
+ * sites/dev/.vitepress/config.ts (minus the trailing slash): the dist's asset and
+ * navigation URLs are absolute under that base, so serving at any other prefix
+ * breaks every asset request.
+ */
+export const DOCS_PUBLIC_BASE = '/orbitscore/dev'
+
+/** Resolve the built VitePress site from a repository/workspace base directory. */
+export function resolveDocsRoot(baseDir: string): string {
+  return path.resolve(baseDir, 'sites/dev/.vitepress/dist')
+}
+
+/**
+ * Resolve a docs-relative URL path without allowing it to escape docsRoot.
+ * Directory URLs (including the root URL) serve their index.html.
+ */
+export function resolveDocsFilePath(docsRoot: string, urlPath: string): string | null {
+  let decodedPath: string
+  try {
+    decodedPath = decodeURIComponent(urlPath)
+  } catch {
+    return null
+  }
+  if (decodedPath.includes('\\') || decodedPath.includes('..')) {
+    return null
+  }
+
+  const relativePath = decodedPath.replace(/^\/+/, '')
+  const targetPath =
+    decodedPath.endsWith('/') || !path.extname(relativePath)
+      ? path.join(relativePath, 'index.html')
+      : relativePath
+  const filePath = path.resolve(docsRoot, targetPath)
+  const normalizedRoot = path.resolve(docsRoot)
+  if (filePath !== normalizedRoot && !filePath.startsWith(`${normalizedRoot}${path.sep}`)) {
+    return null
+  }
+  return filePath
+}
+
+function resolvePathWithinRoot(root: string, relativePath: string): string | null {
+  let decodedPath: string
+  try {
+    decodedPath = decodeURIComponent(relativePath)
+  } catch {
+    return null
+  }
+  if (!decodedPath || decodedPath.includes('\\') || decodedPath.includes('..')) {
+    return null
+  }
+  const filePath = path.resolve(root, decodedPath.replace(/^\/+/, ''))
+  const normalizedRoot = path.resolve(root)
+  return filePath.startsWith(`${normalizedRoot}${path.sep}`) ? filePath : null
+}
+
+export function readDevDoc(sourceRoot: string, relativePath: string): string | null {
+  const filePath = resolvePathWithinRoot(sourceRoot, relativePath)
+  if (!filePath || path.extname(filePath) !== '.md' || !fs.existsSync(filePath)) {
+    return null
+  }
+  return fs.readFileSync(filePath, 'utf8')
+}
+
+export interface DevDocSearchMatch {
+  path: string
+  line: number
+  excerpt: string
+}
+
+export function searchDevDocs(sourceRoot: string, query: string, limit = 10): DevDocSearchMatch[] {
+  if (!query) return []
+  const matches: DevDocSearchMatch[] = []
+  const needle = query.toLowerCase()
+  const walk = (directory: string): void => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (entry.name === '.vitepress' || entry.name === 'node_modules') continue
+      const entryPath = path.join(directory, entry.name)
+      if (entry.isDirectory()) {
+        walk(entryPath)
+      } else if (entry.isFile() && path.extname(entry.name) === '.md') {
+        const lines = fs.readFileSync(entryPath, 'utf8').split(/\r?\n/)
+        for (let index = 0; index < lines.length && matches.length < limit; index += 1) {
+          if (lines[index].toLowerCase().includes(needle)) {
+            matches.push({
+              path: path.relative(sourceRoot, entryPath).split(path.sep).join('/'),
+              line: index + 1,
+              excerpt: lines[index].trim(),
+            })
+          }
+        }
+      }
+      if (matches.length >= limit) return
+    }
+  }
+  if (fs.existsSync(sourceRoot)) walk(sourceRoot)
+  return matches
+}
+
+function contentTypeForDocsFile(filePath: string): string {
+  const types: Record<string, string> = {
+    '.html': 'text/html; charset=utf-8',
+    '.css': 'text/css; charset=utf-8',
+    '.js': 'text/javascript; charset=utf-8',
+    '.json': 'application/json; charset=utf-8',
+    '.svg': 'image/svg+xml',
+    '.png': 'image/png',
+    '.woff2': 'font/woff2',
+    '.ttf': 'font/ttf',
+  }
+  return types[path.extname(filePath).toLowerCase()] ?? 'application/octet-stream'
+}
+
+/**
  * Build a per-session McpServer with the OrbitScore tool surface registered.
  * One instance per MCP session (see `startOrbitScoreMcpServer` for routing).
  */
 function buildServer(version: string, handlers: OrbitScoreToolHandlers): McpServerLike {
   const server = new McpServer({ name: 'orbitscore', version })
+  const docsRoot = resolveDocsRoot(path.resolve(__dirname, '../../..'))
+  const docsSourceRoot = path.resolve(docsRoot, '../..')
 
   server.registerTool(
     'evaluate_orbitscore',
@@ -576,6 +693,46 @@ function buildServer(version: string, handlers: OrbitScoreToolHandlers): McpServ
     },
   )
 
+  server.registerTool(
+    'get_dev_doc',
+    {
+      title: 'Get Dev Doc',
+      description: 'Read a development-site Markdown document by its site-relative path.',
+      inputSchema: {
+        path: z.string().describe('Site-relative Markdown path, e.g. pipeline/text-to-ast.md'),
+      },
+    },
+    async (args) => {
+      const relativePath = typeof args.path === 'string' ? args.path : ''
+      const content = readDevDoc(docsSourceRoot, relativePath)
+      return content === null
+        ? errorResult('development document not found')
+        : { content: [{ type: 'text', text: content }] }
+    },
+  )
+
+  server.registerTool(
+    'search_dev_docs',
+    {
+      title: 'Search Dev Docs',
+      description: 'Search development-site Markdown documents for a case-insensitive substring.',
+      inputSchema: {
+        query: z.string().describe('Text to search for'),
+        limit: z.number().describe('Maximum matches to return (default 10)').optional(),
+      },
+    },
+    async (args) => {
+      const query = typeof args.query === 'string' ? args.query : ''
+      const requestedLimit = typeof args.limit === 'number' ? args.limit : 10
+      const limit = Number.isFinite(requestedLimit) ? Math.max(0, Math.floor(requestedLimit)) : 10
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify(searchDevDocs(docsSourceRoot, query, limit)) },
+        ],
+      }
+    },
+  )
+
   // Optional handler (see OrbitScoreToolHandlers.registerMcpServer): the tool
   // only exists on hosts that can register themselves into Claude Code.
   const registerMcpServer = handlers.registerMcpServer?.bind(handlers)
@@ -649,6 +806,7 @@ export async function startOrbitScoreMcpServer(opts: {
   const { port, version, handlers, log } = opts
 
   const sessions = new Map<string, SessionEntry>()
+  const docsRoot = resolveDocsRoot(path.resolve(__dirname, '../../..'))
 
   // DNS-rebinding protection: the server binds 127.0.0.1, but a malicious page
   // can point its own domain at 127.0.0.1 (short-TTL rebind) and then fetch()
@@ -696,6 +854,37 @@ export async function startOrbitScoreMcpServer(opts: {
         return
       }
       const pathname = (req.url ?? '').split('?')[0]
+      // Human-friendly alias: the VitePress dist is built with SITE_BASE
+      // (`/orbitscore/dev/` — sites/dev/.vitepress/config.ts), so all asset /
+      // navigation URLs inside the built pages are absolute under that base.
+      // Serving the dist at any other prefix would 404 every asset; instead
+      // `/docs` redirects to the canonical base and only the base serves files.
+      if (pathname === '/docs' || pathname === '/docs/') {
+        res.writeHead(302, { Location: `${DOCS_PUBLIC_BASE}/` })
+        res.end()
+        return
+      }
+      if (pathname === DOCS_PUBLIC_BASE || pathname.startsWith(`${DOCS_PUBLIC_BASE}/`)) {
+        if (req.method !== 'GET') {
+          res.writeHead(405, { Allow: 'GET', 'content-type': 'text/plain; charset=utf-8' })
+          res.end('Method Not Allowed')
+          return
+        }
+        if (!fs.existsSync(docsRoot)) {
+          res.writeHead(503, { 'content-type': 'text/plain; charset=utf-8' })
+          res.end('Development docs are not built. Run npm run docs:build -w @orbitscore/dev-site')
+          return
+        }
+        const filePath = resolveDocsFilePath(docsRoot, pathname.slice(DOCS_PUBLIC_BASE.length))
+        if (!filePath || !fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+          res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' })
+          res.end('Not Found')
+          return
+        }
+        res.writeHead(200, { 'content-type': contentTypeForDocsFile(filePath) })
+        fs.createReadStream(filePath).pipe(res)
+        return
+      }
       if (pathname !== '/mcp') {
         res.writeHead(404, { 'content-type': 'application/json' })
         res.end(JSON.stringify({ error: 'not found' }))

--- a/tests/vscode-extension/mcp-server-docs-http.spec.ts
+++ b/tests/vscode-extension/mcp-server-docs-http.spec.ts
@@ -1,0 +1,328 @@
+import * as fs from 'fs'
+import * as http from 'http'
+import * as path from 'path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  startOrbitScoreMcpServer,
+  type OrbitScoreToolHandlers,
+  type McpServerHandle,
+  type CommandResult,
+  type EngineState,
+  type AudioDevicesResult,
+  type FlashConfigResult,
+  type EditorState,
+  type DocumentText,
+  type AnalyzeAudioResult,
+} from '../../packages/vscode-extension/src/mcp-server'
+
+/**
+ * HTTP-level tests for the docs-serving branch of startOrbitScoreMcpServer
+ * (#450 round-1 fix F5, pr-test-analyzer). mcp-server-docs.spec.ts covers the
+ * pure helpers (resolveDocsFilePath / readDevDoc / searchDevDocs) in
+ * isolation; these tests drive the real HTTP handler end to end — redirect,
+ * 404 vs 503, traversal through the live request path, and the MCP tool
+ * round-trip against the actual sites/dev source tree.
+ */
+
+// ── Stub handlers (mirrors mcp-server.spec.ts) ──────────────────────────────
+
+function createStubHandlers(): OrbitScoreToolHandlers {
+  return {
+    evaluate: () => ({ ok: true }),
+    startEngine: () => {
+      const result: CommandResult = { ok: true, message: 'started' }
+      return result
+    },
+    stopEngine: () => {
+      const result: CommandResult = { ok: true, message: 'stopped' }
+      return result
+    },
+    getEngineState: () => {
+      const state: EngineState = { running: true, liveCoding: false }
+      return state
+    },
+    forceKillScsynth: () => {
+      const result: CommandResult = { ok: true }
+      return result
+    },
+    listAudioDevices: () => {
+      const result: AudioDevicesResult = { ok: true, devices: [] }
+      return result
+    },
+    selectAudioDevice: () => {
+      const result: CommandResult = { ok: true }
+      return result
+    },
+    configureFlash: () => {
+      const result: FlashConfigResult = {
+        ok: true,
+        config: { count: 3, duration: 150, color: 'selection', customColor: '#ff6b6b' },
+      }
+      return result
+    },
+    openFile: () => {
+      const result: CommandResult = { ok: true }
+      return result
+    },
+    setSelection: () => {
+      const result: CommandResult = { ok: true }
+      return result
+    },
+    runSelection: () => {
+      const result: CommandResult = { ok: true }
+      return result
+    },
+    editReplace: () => {
+      const result: CommandResult = { ok: true, message: '1' }
+      return result
+    },
+    getEditorState: () => {
+      const state: EditorState = {
+        path: null,
+        languageId: null,
+        cursor: null,
+        selection: null,
+        lineCount: null,
+        isDirty: null,
+      }
+      return state
+    },
+    saveFile: () => {
+      const result: CommandResult = { ok: true, message: 'saved: /tmp/stub.orbs' }
+      return result
+    },
+    getDocumentText: () => {
+      const result: DocumentText = { path: null, text: null }
+      return result
+    },
+    getDiagnostics: () => [],
+    getLog: () => ['[info] log line 1'],
+    analyzeAudio: async () => {
+      const result: AnalyzeAudioResult = {
+        ok: true,
+        analysis: {
+          format: { audioFormat: 3, channels: 2, sampleRate: 48000, bitsPerSample: 32 },
+          frames: 0,
+          durationSec: 0,
+          peak: 0,
+          rms: 0,
+          onsets: [],
+          onsetGaps: [],
+          soundDetected: false,
+        },
+      }
+      return result
+    },
+  }
+}
+
+// ── Server bring-up (ephemeral port, retry on EADDRINUSE) ──────────────────
+
+async function startTestServer(handlers: OrbitScoreToolHandlers): Promise<McpServerHandle> {
+  let lastErr: unknown
+  for (let attempt = 0; attempt < 15; attempt++) {
+    const port = 20000 + Math.floor(Math.random() * 20000)
+    try {
+      return await startOrbitScoreMcpServer({
+        port,
+        version: '0.0.0-test',
+        handlers,
+        log: () => {},
+      })
+    } catch (err) {
+      lastErr = err
+      const code = (err as NodeJS.ErrnoException)?.code
+      if (code !== 'EADDRINUSE') throw err
+    }
+  }
+  throw new Error(`failed to find a free port after 15 attempts: ${String(lastErr)}`)
+}
+
+// ── Raw HTTP / JSON-RPC helpers (mirrors mcp-server.spec.ts) ───────────────
+
+interface RawResponse {
+  status: number
+  headers: http.IncomingHttpHeaders
+  body: string
+}
+
+function getPath(port: number, pathname: string): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: '127.0.0.1', port, path: pathname, method: 'GET' },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (c: Buffer) => chunks.push(c))
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString('utf8'),
+          })
+        })
+      },
+    )
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+function postJson(port: number, body: unknown, sessionId?: string): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    const payload = Buffer.from(JSON.stringify(body))
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      'content-length': String(payload.length),
+    }
+    if (sessionId) headers['mcp-session-id'] = sessionId
+
+    const req = http.request(
+      { hostname: '127.0.0.1', port, path: '/mcp', method: 'POST', headers },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (c: Buffer) => chunks.push(c))
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString('utf8'),
+          })
+        })
+      },
+    )
+    req.on('error', reject)
+    req.end(payload)
+  })
+}
+
+/** initialize → notifications/initialized, returning the session id. */
+async function connectMcpSession(port: number): Promise<string> {
+  const initRes = await postJson(port, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-11-25',
+      capabilities: {},
+      clientInfo: { name: 'mcp-docs-http-test', version: '0.0.1' },
+    },
+  })
+  const sessionId = initRes.headers['mcp-session-id']
+  if (typeof sessionId !== 'string') {
+    throw new Error(`initialize did not return a session id (status ${initRes.status})`)
+  }
+  await postJson(port, { jsonrpc: '2.0', method: 'notifications/initialized' }, sessionId)
+  return sessionId
+}
+
+async function toolsCall(
+  port: number,
+  sessionId: string,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }> {
+  const res = await postJson(
+    port,
+    { jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name, arguments: args } },
+    sessionId,
+  )
+  const parsed = JSON.parse(res.body) as {
+    result: { content: Array<{ type: 'text'; text: string }>; isError?: boolean }
+  }
+  return parsed.result
+}
+
+// docsRoot mirrors resolveDocsRoot's derivation from the server module's own
+// location, so this reliably reflects whether the dist has actually been built.
+const docsDistExists = fs.existsSync(path.resolve(__dirname, '../../sites/dev/.vitepress/dist'))
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('OrbitScore MCP server — docs serving (real HTTP)', () => {
+  let handle: McpServerHandle | undefined
+
+  afterEach(async () => {
+    if (handle) {
+      await handle.dispose()
+      handle = undefined
+    }
+  })
+
+  it('GET /docs redirects to the canonical docs base', async () => {
+    handle = await startTestServer(createStubHandlers())
+    const res = await getPath(handle.port, '/docs')
+
+    expect(res.status).toBe(302)
+    expect(res.headers.location).toBe('/orbitscore/dev/')
+  })
+
+  it('GET /docs/ also redirects to the canonical docs base', async () => {
+    handle = await startTestServer(createStubHandlers())
+    const res = await getPath(handle.port, '/docs/')
+
+    expect(res.status).toBe(302)
+    expect(res.headers.location).toBe('/orbitscore/dev/')
+  })
+
+  if (!docsDistExists) {
+    it('docs not built: GET /orbitscore/dev/ returns 503 mentioning docs:build', async () => {
+      handle = await startTestServer(createStubHandlers())
+      const res = await getPath(handle.port, '/orbitscore/dev/')
+
+      expect(res.status).toBe(503)
+      expect(res.body).toContain('docs:build')
+    })
+  } else {
+    // The dist was built locally (e.g. after `npm run docs:build`) — the 503
+    // branch isn't reachable, so assert the deterministic 404 case instead.
+    it('docs built: a nonexistent page under the docs base returns 404', async () => {
+      handle = await startTestServer(createStubHandlers())
+      const res = await getPath(handle.port, '/orbitscore/dev/does-not-exist-page/')
+
+      expect(res.status).toBe(404)
+    })
+  }
+
+  it('rejects path traversal through the live handler (encoded and literal), never 200', async () => {
+    handle = await startTestServer(createStubHandlers())
+    // Without a built dist, resolution never even reaches the traversal guard
+    // (503 "not built" fires first) — assert the deterministic invariant that
+    // holds in both cases: traversal must never resolve to 200.
+    const expectedStatus = docsDistExists ? 404 : 503
+
+    const encoded = await getPath(handle.port, '/orbitscore/dev/%2e%2e%2fsecret')
+    expect(encoded.status).toBe(expectedStatus)
+
+    const literal = await getPath(handle.port, '/orbitscore/dev/..%2fsecret')
+    expect(literal.status).toBe(expectedStatus)
+  })
+
+  it('MCP get_dev_doc round-trips a real sites/dev document', async () => {
+    handle = await startTestServer(createStubHandlers())
+    const sessionId = await connectMcpSession(handle.port)
+
+    const result = await toolsCall(handle.port, sessionId, 'get_dev_doc', {
+      path: 'glossary.md',
+    })
+
+    expect(result.isError).toBeFalsy()
+    expect(result.content[0]?.text.length).toBeGreaterThan(0)
+  })
+
+  it('MCP search_dev_docs returns a JSON array through the real docsSourceRoot', async () => {
+    handle = await startTestServer(createStubHandlers())
+    const sessionId = await connectMcpSession(handle.port)
+
+    const result = await toolsCall(handle.port, sessionId, 'search_dev_docs', {
+      query: 'OrbitScore',
+      limit: 5,
+    })
+
+    expect(result.isError).toBeFalsy()
+    const matches = JSON.parse(result.content[0]?.text ?? '[]') as unknown[]
+    expect(Array.isArray(matches)).toBe(true)
+  })
+})

--- a/tests/vscode-extension/mcp-server-docs.spec.ts
+++ b/tests/vscode-extension/mcp-server-docs.spec.ts
@@ -50,8 +50,18 @@ describe('development docs helpers', () => {
 
     expect(readDevDoc(root, 'guide/intro.md')).toContain('OrbitScore')
     expect(readDevDoc(root, '../outside.md')).toBeNull()
+    expect(readDevDoc(root, '')).toBeNull()
     expect(searchDevDocs(root, 'SEARCH')).toEqual([
       { path: 'guide/intro.md', line: 2, excerpt: 'OrbitScore search target' },
     ])
+  })
+
+  it('readDevDoc returns null for a file removed after the existsSync check (TOCTOU)', () => {
+    const root = temporaryDirectory()
+    const filePath = path.join(root, 'gone.md')
+    fs.writeFileSync(filePath, '# will be deleted')
+    fs.rmSync(filePath)
+
+    expect(readDevDoc(root, 'gone.md')).toBeNull()
   })
 })

--- a/tests/vscode-extension/mcp-server-docs.spec.ts
+++ b/tests/vscode-extension/mcp-server-docs.spec.ts
@@ -1,0 +1,57 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  readDevDoc,
+  resolveDocsFilePath,
+  resolveDocsRoot,
+  searchDevDocs,
+} from '../../packages/vscode-extension/src/mcp-server'
+
+const temporaryDirectories: string[] = []
+
+function temporaryDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'orbitscore-docs-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('development docs helpers', () => {
+  it('resolves the built docs root from a workspace base directory', () => {
+    expect(resolveDocsRoot('/workspace/orbitscore')).toBe(
+      path.resolve('/workspace/orbitscore/sites/dev/.vitepress/dist'),
+    )
+  })
+
+  it('maps root and directory URLs to index.html and rejects traversal', () => {
+    const root = '/workspace/orbitscore/sites/dev/.vitepress/dist'
+    expect(resolveDocsFilePath(root, '/')).toBe(path.join(root, 'index.html'))
+    expect(resolveDocsFilePath(root, '/guide/')).toBe(path.join(root, 'guide/index.html'))
+    expect(resolveDocsFilePath(root, '/guide/page.html')).toBe(path.join(root, 'guide/page.html'))
+    expect(resolveDocsFilePath(root, '/../secret.html')).toBeNull()
+    expect(resolveDocsFilePath(root, '/%2e%2e/secret.html')).toBeNull()
+  })
+
+  it('reads Markdown and searches it case-insensitively without .vitepress files', () => {
+    const root = temporaryDirectory()
+    fs.mkdirSync(path.join(root, 'guide'), { recursive: true })
+    fs.mkdirSync(path.join(root, '.vitepress'), { recursive: true })
+    fs.writeFileSync(path.join(root, 'guide', 'intro.md'), '# Hello\nOrbitScore search target\n')
+    fs.writeFileSync(path.join(root, '.vitepress', 'hidden.md'), 'search target')
+
+    expect(readDevDoc(root, 'guide/intro.md')).toContain('OrbitScore')
+    expect(readDevDoc(root, '../outside.md')).toBeNull()
+    expect(searchDevDocs(root, 'SEARCH')).toEqual([
+      { path: 'guide/intro.md', line: 2, excerpt: 'OrbitScore search target' },
+    ])
+  })
+})

--- a/tests/vscode-extension/mcp-server-docs.spec.ts
+++ b/tests/vscode-extension/mcp-server-docs.spec.ts
@@ -56,12 +56,32 @@ describe('development docs helpers', () => {
     ])
   })
 
-  it('readDevDoc returns null for a file removed after the existsSync check (TOCTOU)', () => {
+  it('readDevDoc returns null when the read fails after existsSync passed (TOCTOU/EACCES)', () => {
     const root = temporaryDirectory()
-    const filePath = path.join(root, 'gone.md')
-    fs.writeFileSync(filePath, '# will be deleted')
-    fs.rmSync(filePath)
+    const filePath = path.join(root, 'race.md')
+    fs.writeFileSync(filePath, '# racy')
+    // Simulate the check-then-read race with a real fs error: the file exists
+    // (existsSync passes) but the read itself throws EACCES. Without the
+    // try/catch inside readDevDoc this call would throw instead of returning null.
+    fs.chmodSync(filePath, 0o000)
+    try {
+      expect(readDevDoc(root, 'race.md')).toBeNull()
+    } finally {
+      fs.chmodSync(filePath, 0o600)
+    }
+  })
 
-    expect(readDevDoc(root, 'gone.md')).toBeNull()
+  it('searchDevDocs skips an unreadable file instead of aborting the walk', () => {
+    const root = temporaryDirectory()
+    fs.writeFileSync(path.join(root, 'bad.md'), 'search target broken')
+    fs.writeFileSync(path.join(root, 'good.md'), 'search target ok')
+    fs.chmodSync(path.join(root, 'bad.md'), 0o000)
+    try {
+      expect(searchDevDocs(root, 'search target')).toEqual([
+        { path: 'good.md', line: 1, excerpt: 'search target ok' },
+      ])
+    } finally {
+      fs.chmodSync(path.join(root, 'bad.md'), 0o600)
+    }
   })
 })


### PR DESCRIPTION
Closes #450

## 概要

dev ラーニングサイト（sites/dev・VitePress）をユーザー/LLM がローカル参照できるようにする。

## 変更内容

1. **ブラウザ経由**: 拡張内 MCP HTTP サーバ（127.0.0.1:\<port\>）が `sites/dev/.vitepress/dist` を配信。配信 prefix は **SITE_BASE（`/orbitscore/dev/`）と一致**（dist の asset/ナビ URL は base 絶対パスのため。`/docs` は 302 redirect）。path traversal 防御・`/mcp` と共通の Host-header allowlist・dist 不在時は 503 + `npm run docs:build -w @orbitscore/dev-site` の案内
2. **MCP 経由**: `get_dev_doc(path)` / `search_dev_docs(query, limit)` ツール（サイトのソース md を直接参照・検索）
3. **OrbitStudio ワンクリック**: `orbitscore.openDevDocs` コマンド + status bar `$(book) Docs` ボタン（MCP サーバ起動時のみ表示）

## 受け入れ監査での修正（Codex 委譲分から1点）
- `/docs/` 直下配信では VitePress base（`/orbitscore/dev/`）の asset が全 404 になる統合問題 → 配信 prefix を base に一致させ `/docs` を redirect 化

## 検証
- npm run build green・vscode-extension テスト 122/122（新規 unit テスト込み）・変更ファイル lint クリーン
- lint の既存 error（sc-link-audio SDK translations・tsconfig 対象外）は本 PR と無関係

## 関連
- #451: サイト内容の 2026-07 追随（日英・E2E 兼用カリキュラム）— 別トラック進行中
- #388: Agent Bridge MCP（本機能のホスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu