### PR TITLE
feat(vscode): add Activity Bar, webview panel, and walkthrough docs entry points

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,36 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.261 feat(vscode): docs entry point 全部入り（Activity Bar / Webview panel / Walkthrough）#457 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 実装（PR 作成・レビューへ）
+**Branch**: `457-docs-entry-points`
+
+owner 決定「どれもあっても困らない」= #450（status bar + openDevDocs）に加え、学習サイトへの
+入口を全部入りで用意。前提資産（#450・不変）: `orbitscore.openDevDocs` コマンド・MCP HTTP サーバの
+`/orbitscore/dev/` static 配信・status bar `$(book) Docs`。
+
+- **Activity Bar view container**: `contributes.viewsContainers.activitybar` に OrbitScore
+  コンテナ（`media/icon-activitybar.svg`）+ `contributes.views` の Learning view（`viewsWelcome`
+  で 3 ボタン: Open Learning Site (Browser) / Open in Editor / Start the Walkthrough）。
+  TreeView 本実装（章ツリー）は #451（サイト構成確定後）の follow-up と明記
+- **Webview panel**: 新コマンド `orbitscore.openDevDocsPanel` — `vscode.window.createWebviewPanel`
+  で editor タブに `<iframe src="http://127.0.0.1:<port>/orbitscore/dev/">` を全画面表示
+  （CSP で `frame-src http://127.0.0.1:*` を明示・retainContextWhenHidden・シングルトン管理・
+  MCP サーバ未起動時は openDevDocs と同文言でエラー表示）
+- **Walkthrough**: `contributes.walkthroughs` に `orbitscore.learnOrbitScore`（新コマンド
+  `orbitscore.openWalkthrough` から起動）。v1 4 ステップ（Open Learning Site→
+  onCommand:orbitscore.openDevDocs / Start the Engine→onCommand:orbitscore.toggleEngine /
+  Run your first sound→onCommand:orbitscore.runSelection / Explore plugin hosting→
+  completionEvents なし・手動チェック）。ステップ本文は `media/walkthrough/*.md` に
+  日本語+英語併記（package.nls ローカライズより工数が軽いため採用・両言語を1ファイルに集約）
+- **既存導線維持**: status bar / openDevDocs は不変。`.orbs` を開いている時の
+  `editor/title` メニューに `$(book)` ボタン（`orbitscore.openDevDocs`）を追加
+- 検証: `npm run build` green・vscode-extension テスト 130/130・変更 ts ファイル lint クリーン
+- 妥協点: 4番目のステップ（Explore plugin hosting）は `onLink` completionEvent の VS Code 側
+  対応が不確実なため completionEvents を省略し手動チェックに倒した
+
 ### 6.262 feat(engine): seq.effect() per-sequence insert — S1〜S3 完走 #434 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,36 +17,6 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
-### 6.261 feat(vscode): docs entry point 全部入り（Activity Bar / Webview panel / Walkthrough）#457 (Jul 17, 2026)
-
-**Date**: 2026-07-17
-**Status**: ✅ 実装（PR 作成・レビューへ）
-**Branch**: `457-docs-entry-points`
-
-owner 決定「どれもあっても困らない」= #450（status bar + openDevDocs）に加え、学習サイトへの
-入口を全部入りで用意。前提資産（#450・不変）: `orbitscore.openDevDocs` コマンド・MCP HTTP サーバの
-`/orbitscore/dev/` static 配信・status bar `$(book) Docs`。
-
-- **Activity Bar view container**: `contributes.viewsContainers.activitybar` に OrbitScore
-  コンテナ（`media/icon-activitybar.svg`）+ `contributes.views` の Learning view（`viewsWelcome`
-  で 3 ボタン: Open Learning Site (Browser) / Open in Editor / Start the Walkthrough）。
-  TreeView 本実装（章ツリー）は #451（サイト構成確定後）の follow-up と明記
-- **Webview panel**: 新コマンド `orbitscore.openDevDocsPanel` — `vscode.window.createWebviewPanel`
-  で editor タブに `<iframe src="http://127.0.0.1:<port>/orbitscore/dev/">` を全画面表示
-  （CSP で `frame-src http://127.0.0.1:*` を明示・retainContextWhenHidden・シングルトン管理・
-  MCP サーバ未起動時は openDevDocs と同文言でエラー表示）
-- **Walkthrough**: `contributes.walkthroughs` に `orbitscore.learnOrbitScore`（新コマンド
-  `orbitscore.openWalkthrough` から起動）。v1 4 ステップ（Open Learning Site→
-  onCommand:orbitscore.openDevDocs / Start the Engine→onCommand:orbitscore.toggleEngine /
-  Run your first sound→onCommand:orbitscore.runSelection / Explore plugin hosting→
-  completionEvents なし・手動チェック）。ステップ本文は `media/walkthrough/*.md` に
-  日本語+英語併記（package.nls ローカライズより工数が軽いため採用・両言語を1ファイルに集約）
-- **既存導線維持**: status bar / openDevDocs は不変。`.orbs` を開いている時の
-  `editor/title` メニューに `$(book)` ボタン（`orbitscore.openDevDocs`）を追加
-- 検証: `npm run build` green・vscode-extension テスト 130/130・変更 ts ファイル lint クリーン
-- 妥協点: 4番目のステップ（Explore plugin hosting）は `onLink` completionEvent の VS Code 側
-  対応が不確実なため completionEvents を省略し手動チェックに倒した
-
 ### 6.262 feat(engine): seq.effect() per-sequence insert — S1〜S3 完走 #434 (Jul 17, 2026)
 
 **Date**: 2026-07-17
@@ -89,6 +59,36 @@ master sum の全経路を客観実証。
 
 **検証**: 3 feature 構成 lib（67/56/102）・workspace build/clippy/fmt・
 npm test 1354 passed / 0 failed・gated 3 スイート実機 PASS。
+### 6.261 feat(vscode): docs entry point 全部入り（Activity Bar / Webview panel / Walkthrough）#457 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 実装（PR 作成・レビューへ）
+**Branch**: `457-docs-entry-points`
+
+owner 決定「どれもあっても困らない」= #450（status bar + openDevDocs）に加え、学習サイトへの
+入口を全部入りで用意。前提資産（#450・不変）: `orbitscore.openDevDocs` コマンド・MCP HTTP サーバの
+`/orbitscore/dev/` static 配信・status bar `$(book) Docs`。
+
+- **Activity Bar view container**: `contributes.viewsContainers.activitybar` に OrbitScore
+  コンテナ（`media/icon-activitybar.svg`）+ `contributes.views` の Learning view（`viewsWelcome`
+  で 3 ボタン: Open Learning Site (Browser) / Open in Editor / Start the Walkthrough）。
+  TreeView 本実装（章ツリー）は #451（サイト構成確定後）の follow-up と明記
+- **Webview panel**: 新コマンド `orbitscore.openDevDocsPanel` — `vscode.window.createWebviewPanel`
+  で editor タブに `<iframe src="http://127.0.0.1:<port>/orbitscore/dev/">` を全画面表示
+  （CSP で `frame-src http://127.0.0.1:*` を明示・retainContextWhenHidden・シングルトン管理・
+  MCP サーバ未起動時は openDevDocs と同文言でエラー表示）
+- **Walkthrough**: `contributes.walkthroughs` に `orbitscore.learnOrbitScore`（新コマンド
+  `orbitscore.openWalkthrough` から起動）。v1 4 ステップ（Open Learning Site→
+  onCommand:orbitscore.openDevDocs / Start the Engine→onCommand:orbitscore.toggleEngine /
+  Run your first sound→onCommand:orbitscore.runSelection / Explore plugin hosting→
+  completionEvents なし・手動チェック）。ステップ本文は `media/walkthrough/*.md` に
+  日本語+英語併記（package.nls ローカライズより工数が軽いため採用・両言語を1ファイルに集約）
+- **既存導線維持**: status bar / openDevDocs は不変。`.orbs` を開いている時の
+  `editor/title` メニューに `$(book)` ボタン（`orbitscore.openDevDocs`）を追加
+- 検証: `npm run build` green・vscode-extension テスト 130/130・変更 ts ファイル lint クリーン
+- 妥協点: 4番目のステップ（Explore plugin hosting）は `onLink` completionEvent の VS Code 側
+  対応が不確実なため completionEvents を省略し手動チェックに倒した
+
 ### 6.260 feat(mcp): dev learning site のローカル配信 + MCP ツール + OrbitStudio 導線 #450 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/packages/vscode-extension/media/icon-activitybar.svg
+++ b/packages/vscode-extension/media/icon-activitybar.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <path fill="currentColor" d="M2 2.5A1.5 1.5 0 0 1 3.5 1H7a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3.5A1.5 1.5 0 0 1 2 13.5v-11Zm7 -0.5a1 1 0 0 1 1-1h3.5A1.5 1.5 0 0 1 15 2.5v11a1.5 1.5 0 0 1-1.5 1.5H10a1 1 0 0 1-1-1V2Z"/>
+</svg>

--- a/packages/vscode-extension/media/walkthrough/01-open-learning-site.md
+++ b/packages/vscode-extension/media/walkthrough/01-open-learning-site.md
@@ -1,0 +1,15 @@
+# 学習サイトを開く
+
+OrbitScore の開発学習サイトには、DSL・エンジン・プラグインホスティングの解説が章立てでまとまっています。
+右上の「Open Learning Site」ボタン（またはステータスバーの `$(book) Docs`）から開いてください。
+
+サイトを開くとこのステップは自動的に完了します。
+
+---
+
+# Open the Learning Site
+
+The OrbitScore development learning site collects the DSL, engine, and plugin-hosting docs into
+chapters. Open it from the button above (or the `$(book) Docs` item in the status bar).
+
+This step completes automatically once you open the site.

--- a/packages/vscode-extension/media/walkthrough/02-start-engine.md
+++ b/packages/vscode-extension/media/walkthrough/02-start-engine.md
@@ -1,0 +1,15 @@
+# エンジンを起動する
+
+OrbitScore はバンドルされたネイティブ音声エンジン（Rust デーモン）で音を鳴らします。
+上のボタン（またはコマンドパレットの `OrbitScore: Start Engine`）でエンジンを起動してください。
+
+エンジンが起動するとこのステップは自動的に完了します。
+
+---
+
+# Start the Engine
+
+OrbitScore plays sound through its bundled native audio engine (a Rust daemon).
+Start it with the button above (or `OrbitScore: Start Engine` from the Command Palette).
+
+This step completes automatically once the engine starts.

--- a/packages/vscode-extension/media/walkthrough/03-run-first-sound.md
+++ b/packages/vscode-extension/media/walkthrough/03-run-first-sound.md
@@ -1,0 +1,17 @@
+# 最初の音を鳴らす
+
+`examples/01_getting_started.orbs` のような `.orbs` ファイルを開き、`var global = init GLOBAL` から
+`global.start()` までの行を選択して `Cmd+Enter`（またはボタン）で実行します。
+続けて `drum` シーケンスの行も実行すると音が鳴ります。
+
+いずれかの行を実行するとこのステップは自動的に完了します。
+
+---
+
+# Run Your First Sound
+
+Open a `.orbs` file such as `examples/01_getting_started.orbs`, select the lines from
+`var global = init GLOBAL` through `global.start()`, and run them with `Cmd+Enter` (or the button
+above). Then run the `drum` sequence lines to hear sound.
+
+This step completes automatically once you run any selection.

--- a/packages/vscode-extension/media/walkthrough/04-plugin-hosting.md
+++ b/packages/vscode-extension/media/walkthrough/04-plugin-hosting.md
@@ -1,0 +1,21 @@
+# プラグインホスティングを知る
+
+OrbitScore は CLAP / VST3 / AU の楽器・エフェクトをホストできます。詳しくは学習サイトの
+plugin-hosting 章を参照してください。
+
+- ローカル: 学習サイトを開いた上で「plugin-hosting」章に移動
+- オンライン: https://signalcompose.github.io/orbitscore/dev/plugin-hosting/
+
+このステップは手動でチェックしてください（章を読み終えたらチェックボックスを押してください）。
+
+---
+
+# Explore Plugin Hosting
+
+OrbitScore can host CLAP / VST3 / AU instruments and effects. See the plugin-hosting chapter of the
+learning site for details.
+
+- Local: open the learning site, then navigate to the "plugin-hosting" chapter
+- Online: https://signalcompose.github.io/orbitscore/dev/plugin-hosting/
+
+This step has no automatic completion event — check it off manually once you've read the chapter.

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -91,6 +91,102 @@
         "title": "📚 OrbitScore: Open Dev Docs",
         "category": "OrbitScore",
         "icon": "$(book)"
+      },
+      {
+        "command": "orbitscore.openDevDocsPanel",
+        "title": "🖥️ OrbitScore: Open Dev Docs (Editor Tab)",
+        "category": "OrbitScore",
+        "icon": "$(open-preview)"
+      },
+      {
+        "command": "orbitscore.openWalkthrough",
+        "title": "🎓 OrbitScore: Start the Walkthrough",
+        "category": "OrbitScore",
+        "icon": "$(mortar-board)"
+      }
+    ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "orbitscore",
+          "title": "OrbitScore",
+          "icon": "media/icon-activitybar.svg"
+        }
+      ]
+    },
+    "views": {
+      "orbitscore": [
+        {
+          "id": "orbitscore.learningView",
+          "name": "Learning",
+          "visibility": "visible"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "orbitscore.learningView",
+        "contents": "Learn OrbitScore and find your way around the docs.\n[📚 Open Learning Site (Browser)](command:orbitscore.openDevDocs)\n[🖥 Open in Editor](command:orbitscore.openDevDocsPanel)\n[🎓 Start the Walkthrough](command:orbitscore.openWalkthrough)\n\nNote: this welcome view is a placeholder entry point. A full chapter tree (TreeView) is a follow-up once #451 (site structure) is finalized."
+      }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "orbitscore.openDevDocs",
+          "when": "resourceExtname == .orbs",
+          "group": "navigation"
+        }
+      ]
+    },
+    "walkthroughs": [
+      {
+        "id": "orbitscore.learnOrbitScore",
+        "title": "Learn OrbitScore",
+        "description": "Get from zero to your first sound, then explore the engine and plugin hosting.",
+        "icon": "media/icon-activitybar.svg",
+        "steps": [
+          {
+            "id": "openLearningSite",
+            "title": "Open the Learning Site",
+            "description": "Open the OrbitScore development learning site in your browser to see the full documentation.\n[Open Learning Site](command:orbitscore.openDevDocs)",
+            "media": {
+              "markdown": "media/walkthrough/01-open-learning-site.md"
+            },
+            "completionEvents": [
+              "onCommand:orbitscore.openDevDocs"
+            ]
+          },
+          {
+            "id": "startEngine",
+            "title": "Start the Engine",
+            "description": "Start the bundled native audio engine so OrbitScore can play sound.\n[Start Engine](command:orbitscore.toggleEngine)",
+            "media": {
+              "markdown": "media/walkthrough/02-start-engine.md"
+            },
+            "completionEvents": [
+              "onCommand:orbitscore.toggleEngine"
+            ]
+          },
+          {
+            "id": "runFirstSound",
+            "title": "Run Your First Sound",
+            "description": "Open a `.orbs` file, select a line, and run it to hear your first sound.\n[Run Selection](command:orbitscore.runSelection)",
+            "media": {
+              "markdown": "media/walkthrough/03-run-first-sound.md"
+            },
+            "completionEvents": [
+              "onCommand:orbitscore.runSelection"
+            ]
+          },
+          {
+            "id": "explorePluginHosting",
+            "title": "Explore Plugin Hosting",
+            "description": "Learn how OrbitScore hosts CLAP/VST3/AU instruments and effects.\n[Read the Plugin Hosting Chapter](command:orbitscore.openDevDocs)",
+            "media": {
+              "markdown": "media/walkthrough/04-plugin-hosting.md"
+            }
+          }
+        ]
       }
     ],
     "languages": [

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -304,6 +304,12 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('orbitscore.selectAudioDevice', selectAudioDevice),
     vscode.commands.registerCommand('orbitscore.configureFlash', configureFlash),
     vscode.commands.registerCommand('orbitscore.registerMcpServer', registerMcpServer),
+    // viewsWelcome コンテンツは view に provider が登録されて初めて描画される
+    // （空 TreeView で十分 — 章ツリーの本実装は #451 確定後の follow-up）。
+    vscode.window.registerTreeDataProvider('orbitscore.learningView', {
+      getChildren: () => [],
+      getTreeItem: (element: vscode.TreeItem) => element,
+    }),
     vscode.commands.registerCommand('orbitscore.openDevDocs', openDevDocs),
     vscode.commands.registerCommand('orbitscore.openDevDocsPanel', () => openDevDocsPanel(context)),
     vscode.commands.registerCommand('orbitscore.openWalkthrough', openWalkthrough),
@@ -418,15 +424,27 @@ export function deactivate() {
   devDocsPanel = null
 }
 
-async function openDevDocs(): Promise<void> {
+/**
+ * Canonical local URL of the dev learning site, or null (with the shared error
+ * message shown) when the MCP server is not running. Single source for every
+ * entry point (browser command, webview panel) — the site is served at the
+ * VitePress base `/orbitscore/dev/` (mcp-server.ts DOCS_PUBLIC_BASE; `/docs`
+ * is only a redirect kept for muscle memory).
+ */
+function resolveDevDocsUrl(): string | null {
   const port = mcpServerHandle?.port ?? 0
   if (!port) {
     void vscode.window.showErrorMessage(
       'OrbitScore development docs require the MCP server. Set orbitscore.mcpServer.port and enable the MCP server.',
     )
-    return
+    return null
   }
-  const url = `http://127.0.0.1:${port}/docs/`
+  return `http://127.0.0.1:${port}/orbitscore/dev/`
+}
+
+async function openDevDocs(): Promise<void> {
+  const url = resolveDevDocsUrl()
+  if (!url) return
   const opened = await vscode.env.openExternal(vscode.Uri.parse(url))
   if (!opened) {
     outputChannel?.appendLine(`❌ Failed to open development docs at ${url}`)
@@ -441,14 +459,8 @@ async function openDevDocs(): Promise<void> {
  * existing panel instead of creating a duplicate.
  */
 function openDevDocsPanel(context: vscode.ExtensionContext): void {
-  const port = mcpServerHandle?.port ?? 0
-  if (!port) {
-    void vscode.window.showErrorMessage(
-      'OrbitScore development docs require the MCP server. Set orbitscore.mcpServer.port and enable the MCP server.',
-    )
-    return
-  }
-  const url = `http://127.0.0.1:${port}/orbitscore/dev/`
+  const url = resolveDevDocsUrl()
+  if (!url) return
 
   if (devDocsPanel) {
     devDocsPanel.reveal(vscode.ViewColumn.Active)

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -48,6 +48,7 @@ let outputChannel: vscode.OutputChannel | null = null
 let statusBarItem: vscode.StatusBarItem | null = null
 let bundleStatusItem: vscode.StatusBarItem | null = null
 let docsStatusItem: vscode.StatusBarItem | null = null
+let devDocsPanel: vscode.WebviewPanel | null = null
 let isLiveCodingMode: boolean = false
 // Tracks whether `var global = init GLOBAL` has been evaluated in the current engine session.
 // Used to decide if `global.setDocumentDirectory(...)` can be prepended safely.
@@ -304,6 +305,8 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('orbitscore.configureFlash', configureFlash),
     vscode.commands.registerCommand('orbitscore.registerMcpServer', registerMcpServer),
     vscode.commands.registerCommand('orbitscore.openDevDocs', openDevDocs),
+    vscode.commands.registerCommand('orbitscore.openDevDocsPanel', () => openDevDocsPanel(context)),
+    vscode.commands.registerCommand('orbitscore.openWalkthrough', openWalkthrough),
     statusBarItem,
     bundleStatusItem,
     docsStatusItem,
@@ -411,6 +414,8 @@ export function deactivate() {
   statusBarItem?.dispose()
   bundleStatusItem?.dispose()
   docsStatusItem?.dispose()
+  devDocsPanel?.dispose()
+  devDocsPanel = null
 }
 
 async function openDevDocs(): Promise<void> {
@@ -427,6 +432,79 @@ async function openDevDocs(): Promise<void> {
     outputChannel?.appendLine(`❌ Failed to open development docs at ${url}`)
     void vscode.window.showErrorMessage('Could not open the development docs in your browser.')
   }
+}
+
+/**
+ * Open the development docs inside an editor tab via an iframe-wrapped
+ * webview panel, so the site can be read side-by-side with `.orbs` files
+ * without leaving VS Code. Singleton: a second invocation reveals the
+ * existing panel instead of creating a duplicate.
+ */
+function openDevDocsPanel(context: vscode.ExtensionContext): void {
+  const port = mcpServerHandle?.port ?? 0
+  if (!port) {
+    void vscode.window.showErrorMessage(
+      'OrbitScore development docs require the MCP server. Set orbitscore.mcpServer.port and enable the MCP server.',
+    )
+    return
+  }
+  const url = `http://127.0.0.1:${port}/orbitscore/dev/`
+
+  if (devDocsPanel) {
+    devDocsPanel.reveal(vscode.ViewColumn.Active)
+    return
+  }
+
+  devDocsPanel = vscode.window.createWebviewPanel(
+    'orbitscore.devDocsPanel',
+    'OrbitScore Docs',
+    vscode.ViewColumn.Active,
+    {
+      enableScripts: true,
+      retainContextWhenHidden: true,
+    },
+  )
+  devDocsPanel.webview.html = buildDevDocsPanelHtml(url)
+  devDocsPanel.onDidDispose(
+    () => {
+      devDocsPanel = null
+    },
+    null,
+    context.subscriptions,
+  )
+}
+
+function buildDevDocsPanelHtml(url: string): string {
+  const escapedUrl = url.replace(/"/g, '&quot;')
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta
+    http-equiv="Content-Security-Policy"
+    content="default-src 'none'; frame-src http://127.0.0.1:*; style-src 'unsafe-inline';"
+  />
+  <style>
+    html, body { height: 100%; margin: 0; padding: 0; }
+    iframe { width: 100%; height: 100%; border: none; }
+  </style>
+</head>
+<body>
+  <iframe src="${escapedUrl}" title="OrbitScore development docs"></iframe>
+</body>
+</html>`
+}
+
+async function openWalkthrough(): Promise<void> {
+  const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8')) as {
+    publisher: string
+    name: string
+  }
+  const extensionId = `${pkg.publisher}.${pkg.name}`
+  await vscode.commands.executeCommand(
+    'workbench.action.openWalkthrough',
+    `${extensionId}#orbitscore.learnOrbitScore`,
+  )
 }
 
 /**


### PR DESCRIPTION
## 概要

Issue #457（owner 決定「どれもあっても困らない」= 全部入り）の実装。

前提資産（main 済・#450・不変）: `orbitscore.openDevDocs` コマンド（ブラウザで学習サイトを開く）・
MCP HTTP サーバの `/orbitscore/dev/` static 配信・status bar `$(book) Docs`。

## 変更内容

1. **Activity Bar view container**（常設の目立つ入口）
   - `contributes.viewsContainers.activitybar` に OrbitScore コンテナ（`media/icon-activitybar.svg`）
   - Learning view（`viewsWelcome` に3ボタン: Open Learning Site (Browser) / Open in Editor / Start the Walkthrough）
   - TreeView 本実装（章ツリー）は #451（サイト構成確定）後の follow-up とコメントに明記

2. **Webview panel**（エディタ内表示）
   - 新コマンド `orbitscore.openDevDocsPanel`: iframe を張った webview panel を editor タブに表示
   - CSP で `frame-src http://127.0.0.1:*` を明示、`retainContextWhenHidden: true`、シングルトン管理
   - MCP サーバ未起動時は `openDevDocs` と同文言でエラー表示

3. **Walkthrough**（完了条件つき学習ステップ・v1）
   - `contributes.walkthroughs` に `orbitscore.learnOrbitScore`（新コマンド `orbitscore.openWalkthrough` から起動）
   - v1 4ステップ: Open the Learning Site（`onCommand:orbitscore.openDevDocs`）/ Start the Engine
     （`onCommand:orbitscore.toggleEngine`）/ Run your first sound（`onCommand:orbitscore.runSelection`）/
     Explore plugin hosting（completionEvents なし・手動チェック — `onLink` の VS Code 側対応が
     不確実なため妥協）
   - ステップ本文 `media/walkthrough/*.md` は日英併記（package.nls ローカライズより工数が軽いため採用）

4. **既存導線の維持**
   - status bar / `openDevDocs` は不変
   - `.orbs` を開いている時の `editor/title` メニューに `$(book)` ボタンを追加

## 検証

- `npm run build` green
- `tests/vscode-extension` 130/130 passed
- 変更 ts ファイル eslint クリーン
- package.json の `contributes` は JSON 構文チェック + コマンド id の手動整合確認済み

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)