### PR TITLE
feat(engine): seq.effect() — per-sequence plugin effect insert (#434)

### DIFF
--- a/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
+++ b/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
@@ -1178,8 +1178,37 @@ global.effect("~/plugins/TAL-Reverb-4.clap")   // master bus insert
   **異なる path / pluginId での 2 回目の呼び出しはエラー**
   （「v1 は master insert 1 基。チェーンは将来対応」）。
 - 将来拡張（非規範）: 複数回呼び出し = 呼び出し順の直列チェーン（左→右）。
-  per-sequence insert（`seq.effect()`）も将来拡張として予約する — verb 名を共有するため、
-  追加しても構文の非互換は生じない。
+
+### PH.2b per-sequence effect — `seq.effect(path[, pluginId])`（#434）
+
+```js
+var drums = init global.seq
+drums.audio("kick.wav")
+drums.effect("~/plugins/TAL-Reverb-4.clap")   // この seq だけに掛かる insert
+```
+
+- **シーケンス個別の insert**（DAW の per-track insert と同型）。処理順は
+  **per-sequence insert → master mix → `global.effect()`（master chain）** — 既存の
+  master 経路の意味論は不変。
+- v1 は **1 seq = 1 insert**。同一 path + pluginId の再宣言は冪等（no-op・PH.2 と同じ
+  ライブ再評価保護）。異なる path / pluginId での再宣言はエラー。チェーン
+  （複数回呼び出し = 直列）は将来拡張（エンジン内部は順序付きリストで実装済み・
+  DSL 側のガード解放のみ）。
+- **受理フォーマットは effect と同じ**: v1 は `.clap` のみ（`.vst3` / `.component` は
+  instrument と異なり effect 系では未対応）。
+- **エンジン実装（規範）**: `seq.effect()` 宣言はエンジンの **named insert bus** を確保し、
+  当該シーケンスの再生イベントに bus tag を付けてスケジュールする。bus は宣言時点で
+  登録され、**plugin の attach 完了前でも音は素通しで master に届く**（宣言 → attach の
+  間に音が消えたり詰まったりしない）。plugin ロード失敗時も bus は pass-through で残る。
+- **既知の v1 制約（非目標）**: plugin latency 補償（PDC）なし — 複数 seq に latency の
+  異なる insert を掛けると bus 間で位相がずれる。master gain ramp は per-sequence insert の
+  **前**に適用される（DAW の「fader は insert 後」と逆・master unity なら影響なし）。
+  insert を同時に持てるシーケンス数には上限がある（既定 8・エンジンは RT 安全のため
+  bus を起動時にプールとして確保し、宣言時にプールから割り当てる）。上限超過の
+  `seq.effect()` 宣言は明示エラー。
+- LinkAudio との併用不可は PH.5 に従う（`global.effect()` と同じ v1 排他）。
+- **将来予約（非規範）**: aux バス / send-return（pre/post-fader tap・fan-out）は同じ
+  insert bus 基盤の上に実装する（#453・正本 = `POST_2.0_MIXER_DSL_DESIGN.html`）。
 
 ### PH.3 プラグイン識別と format 判定
 
@@ -1344,8 +1373,8 @@ the two time/pitch axes stay orthogonal and consistent with the chop slice-fit v
 - **delay()**: Per-sequence delay effect
 - **reverb()**: Per-sequence reverb effect
 - **filter()**: Per-sequence filter effects
-- **seq.effect()** (per-sequence plugin insert): reserved as a future extension of the
-  Plugin Hosting section — v1 hosts plugin effects on the master bus only (`global.effect()`)
+- **seq.effect()** (per-sequence plugin insert): implemented (#434) — see PH.2b. Chains
+  (multiple inserts per sequence) and aux/send routing (#453) remain future extensions
 
 #### Advanced Features
 - **Composite Meters**: `((3 by 4)(2 by 4))`

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,48 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.262 feat(engine): seq.effect() per-sequence insert — S1〜S3 完走 #434 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 実装・実機 E2E PASS（PR 作成・レビューフローへ）
+**Branch**: `434-per-sequence-effect-insert`
+**Commits**: `42edbc1`(S1) / `2fba667`(S2) / `84c64b5`(spec PH.2b) / `450a7e0`(S3)
+
+owner 最優先要望（mem: owner-wants-seq-effect-per-track）の履行。設計 = Fable main
+（S0 spike + issue #434 コメントに確定記録・owner 指示により advisor 相談なし）。
+実装 = Codex（S1）→ Sonnet xhigh フォールバック（S2b/S3・Codex sandbox EPERM）。
+
+**S0 spike（性能ゲート）**: 64f budget ≈1.33ms に対し 1 OOP effect の callback max
+= 64µs（~4.8%）・stale 0% → per-bus 直列 OOP 成立を実測確認。
+
+**S1（core・挙動不変）**: InsertBusStage（named bus + ordered stages）を render
+パイプラインへ。bus 0 個で bit-identical・**未登録 bus tag の永久 retain landmine 対策**
+（登録 bus は processor 未 attach でも pass-through で event 消費）を fail-before/
+pass-after で固定。LinkAudio 併用時も render_multi 1回。
+
+**S2（daemon N-slot）**: bus id キーの per-bus effect slot 群（専用 shm/child/watchdog/
+stats）・LoadPlugin `bus` param・effect-only/both 両経路・StreamGuard が全 bus guard 保持。
+受け入れ監査で3点修正（attach 中の outproc mutex 長期保持 / gated の計測手段が
+engaged=false 設計と矛盾 / both gated の pipeline 1 ブロック遅延 race）— いずれも
+**実機 RUN が検出**（#445 の教訓の再現）。gated bus 2/2 実機 PASS（**ratio 0.50000**・
+bus 隔離・child 回収）・both/effect gated 退行なし。
+
+**spec 先行（DocDD）**: core spec に **PH.2b** 新設（処理順 = per-seq insert → master mix
+→ global.effect・1 seq 1 insert・bus プール上限 8・PDC 非対応等の v1 制約明記）。
+
+**S3（DSL 配線）**: 既定 bus プール（ORBIT_EFFECT_BUS_POOL・seq-bus-0..7）・PlayAt
+`bus` param（channel と排他）・TS SequenceEffectManager + `Sequence.effect()`（note seq
+は v1 エラー）・insertBus の scheduling 全経路配線。**実装中に respawn 後 plugin
+再ロードの単一キャッシュバグを発見修正**（複数 plugin で最後の1つしか復元されない →
+role:bus キー Map 化）。
+
+**実機 E2E（DoD）**: sine_880.wav を `drums.effect(CLAPTestEffect.clap)` あり/なしで
+capture 比較 → **peak ratio = 0.50000 厳密一致**（0.70711 → 0.35355）。DSL →
+LoadPlugin(bus) → PlayAt(bus) → render_multi bus routing → OOP child gain →
+master sum の全経路を客観実証。
+
+**検証**: 3 feature 構成 lib（67/56/102）・workspace build/clippy/fmt・
+npm test 1354 passed / 0 failed・gated 3 スイート実機 PASS。
 ### 6.260 feat(mcp): dev learning site のローカル配信 + MCP ツール + OrbitStudio 導線 #450 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/packages/engine/src/audio/engine-backend.ts
+++ b/packages/engine/src/audio/engine-backend.ts
@@ -35,6 +35,7 @@ export interface AudioEngineBackend extends Scheduler {
     filePath: string,
     pluginId: string | undefined,
     role: 'effect' | 'instrument',
+    bus?: string,
   ): Promise<PluginLoadResult>
   pluginNoteOn?(key: number, channel: number, velocity: number): Promise<void>
   pluginNoteOff?(key: number, channel: number, velocity?: number): Promise<void>

--- a/packages/engine/src/audio/rust-engine/daemon-client.ts
+++ b/packages/engine/src/audio/rust-engine/daemon-client.ts
@@ -298,6 +298,7 @@ export class DaemonClient extends EventEmitter {
     durationSec = 0,
     rate = 1,
     channel?: string,
+    bus?: string,
   ): Promise<{ playId: string }> {
     const result = await this.request('PlayAt', {
       sample_id: sampleId,
@@ -312,6 +313,9 @@ export class DaemonClient extends EventEmitter {
       rate,
       // channel は LinkAudio ルーティング先（非空の時のみ送る。空/未指定は hardware）。
       ...(channel ? { channel } : {}),
+      // bus は per-sequence insert routing（seq.effect()・PH.2b・#434 S3）。channel と
+      // 同時送出はしない想定（呼び出し側が排他を担保。daemon 側も同時指定を拒否する）。
+      ...(bus ? { bus } : {}),
     })
     return { playId: String(result.play_id) }
   }
@@ -359,11 +363,15 @@ export class DaemonClient extends EventEmitter {
     filePath: string,
     pluginId: string | undefined,
     role: 'effect' | 'instrument',
+    bus?: string,
   ): Promise<PluginLoadResult> {
     const result = await this.request('LoadPlugin', {
       path: filePath,
       ...(pluginId === undefined ? {} : { plugin_id: pluginId }),
       role,
+      // bus は per-sequence insert（'effect' role 専用・#434 S3）。省略時は master slot
+      // （既存の global.effect() / seq.instrument() と後方互換）。
+      ...(bus ? { bus } : {}),
     })
     return {
       pluginId: String(result.plugin_id),

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -285,7 +285,12 @@ export class RustEnginePlayer implements AudioEngineBackend {
    * cache-hit path can detect a stale "success" and re-issue the load instead of
    * silently returning as if the plugin were still active.
    */
-  private pluginActive = false
+  /**
+   * declaration key（`${role}:${bus ?? ''}`）ごとの active 状態。respawn 後の reload が
+   * 一部だけ失敗した場合に、失敗した宣言だけを self-heal 対象にする（#461 review:
+   * 単一 boolean だと健全な宣言まで再ロードされる）。
+   */
+  private readonly pluginActiveByKey = new Map<string, boolean>()
   private clockAnchor: ClockAnchor = { tsMs: 0, daemonSec: 0 }
   /**
    * 直近の StreamStats anchor サンプル列（#389 機構 B・ANCHOR_WINDOW 参照）。
@@ -624,11 +629,11 @@ export class RustEnginePlayer implements AudioEngineBackend {
     try {
       const result = await this.daemon.loadPlugin(filePath, pluginId, role, bus)
       this.loadedPlugins.set(`${role}:${bus ?? ''}`, { filePath, pluginId, role, bus })
-      this.pluginActive = true
+      this.pluginActiveByKey.set(`${role}:${bus ?? ''}`, true)
       return result
     } catch (err) {
       // 失敗時は必ず false（呼び出し元の false-on-entry 保証に依存しない）
-      this.pluginActive = false
+      this.pluginActiveByKey.set(`${role}:${bus ?? ''}`, false)
       if (err instanceof DaemonProtocolError) {
         if (err.code === 'CLAP_UNAVAILABLE') {
           throw new Error(
@@ -649,7 +654,7 @@ export class RustEnginePlayer implements AudioEngineBackend {
       )
       return Promise.resolve()
     }
-    if (!this.pluginActive) {
+    if (this.pluginActiveByKey.get('instrument:') !== true) {
       this.warnOnce(
         'pluginInactive',
         '⚠️  [rust-engine] plugin note-on/off dropped: instrument was not restored after the last daemon respawn — re-run seq.instrument(...) to restore it',
@@ -669,7 +674,7 @@ export class RustEnginePlayer implements AudioEngineBackend {
       )
       return Promise.resolve()
     }
-    if (!this.pluginActive) {
+    if (this.pluginActiveByKey.get('instrument:') !== true) {
       this.warnOnce(
         'pluginInactive',
         '⚠️  [rust-engine] plugin note-on/off dropped: instrument was not restored after the last daemon respawn — re-run seq.instrument(...) to restore it',
@@ -693,13 +698,14 @@ export class RustEnginePlayer implements AudioEngineBackend {
     if (this.loadedPlugins.size === 0) return
     // Reissue every declaration (master effect/instrument + all seq.effect() buses).
     // One entry's failure must not skip the others — each is independent daemon state.
-    let anyFailed = false
-    for (const { filePath, pluginId, role, bus } of this.loadedPlugins.values()) {
+    for (const [key, { filePath, pluginId, role, bus }] of this.loadedPlugins.entries()) {
       try {
         await this.daemon.loadPlugin(filePath, pluginId, role, bus)
+        this.pluginActiveByKey.set(key, true)
       } catch (err) {
-        anyFailed = true
         // Cache entry intentionally remains: a later daemon respawn retries restoration.
+        // per-key の false 化により、self-heal は失敗した宣言だけを再ロードする（#461 review）。
+        this.pluginActiveByKey.set(key, false)
         console.error(
           `❌ [rust-engine] failed to reload plugin after daemon respawn: ${filePath}` +
             (bus ? ` (bus=${bus})` : ''),
@@ -707,12 +713,18 @@ export class RustEnginePlayer implements AudioEngineBackend {
         )
       }
     }
-    this.pluginActive = !anyFailed
   }
 
   /** Whether `loadedPlugin` is actually active in the daemon right now (see field doc). */
-  isPluginActive(): boolean {
-    return this.pluginActive
+  isPluginActive(role?: 'effect' | 'instrument', bus?: string): boolean {
+    // 引数なし = 全宣言が active か（後方互換・boolean AND）。role/bus 指定 = 該当宣言のみ。
+    if (role !== undefined) {
+      return this.pluginActiveByKey.get(`${role}:${bus ?? ''}`) !== false
+    }
+    for (const active of this.pluginActiveByKey.values()) {
+      if (!active) return false
+    }
+    return this.pluginActiveByKey.size > 0
   }
 
   /**

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -85,6 +85,12 @@ export interface ScheduledPlay {
   /** LinkAudio ルーティング先チャンネル名。非空の時のみ daemon の PlayAt へ転送する。 */
   outputChannel?: string
   /**
+   * per-sequence insert bus 名（`seq.effect()`・PH.2b・#434 S3）。非空の時のみ daemon の
+   * PlayAt へ転送する。`outputChannel` と同時に立つことはない（LinkAudio と plugin
+   * hosting は v1 で排他）。
+   */
+  insertBus?: string
+  /**
    * #390 live playhead: 由来する play() 引数のドット結合インデックス（"2"、ネストは
    * 後段で "1.0"）。dispatch 成功時に `[STEP]` marker を stdout へ出すためだけの
    * observational フィールド。timing / 音響には一切影響しない。
@@ -264,14 +270,14 @@ export class RustEnginePlayer implements AudioEngineBackend {
   /** 同一 filepath の並行ロードを直列化する single-flight。 */
   private readonly inflightLoads = new Map<string, Promise<string>>()
   /**
-   * v1 は effect / instrument 共通の単一 plugin slot（各 manager が上流で保証）。
-   * daemon crash 後に同じ role で replay する宣言 intent。
+   * daemon crash 後に replay する宣言 intent。key = `${role}:${bus ?? ''}` — master
+   * effect/instrument はそれぞれ単一 slot（各 manager が上流で保証）、per-sequence
+   * insert（`seq.effect()`・#434 S3）は bus ごとに 1 エントリなので Map で保持する。
    */
-  private loadedPlugin?: {
-    filePath: string
-    pluginId?: string
-    role: 'effect' | 'instrument'
-  }
+  private readonly loadedPlugins = new Map<
+    string,
+    { filePath: string; pluginId?: string; role: 'effect' | 'instrument'; bus?: string }
+  >()
   /**
    * Whether `loadedPlugin` is actually loaded in the daemon right now (silent-failure
    * guard). Set true on a successful `loadPlugin()`/reload, false when a post-respawn
@@ -613,10 +619,11 @@ export class RustEnginePlayer implements AudioEngineBackend {
     filePath: string,
     pluginId: string | undefined,
     role: 'effect' | 'instrument',
+    bus?: string,
   ): Promise<PluginLoadResult> {
     try {
-      const result = await this.daemon.loadPlugin(filePath, pluginId, role)
-      this.loadedPlugin = { filePath, pluginId, role }
+      const result = await this.daemon.loadPlugin(filePath, pluginId, role, bus)
+      this.loadedPlugins.set(`${role}:${bus ?? ''}`, { filePath, pluginId, role, bus })
       this.pluginActive = true
       return result
     } catch (err) {
@@ -683,19 +690,24 @@ export class RustEnginePlayer implements AudioEngineBackend {
    * (see `pluginActive` field doc) and self-heal on the next `effect()` call.
    */
   private async reloadPluginsAfterRespawn(): Promise<void> {
-    if (!this.loadedPlugin) return
-    const { filePath, pluginId, role } = this.loadedPlugin
-    try {
-      await this.daemon.loadPlugin(filePath, pluginId, role)
-      this.pluginActive = true
-    } catch (err) {
-      this.pluginActive = false
-      // Cache entry intentionally remains: a later daemon respawn retries restoration.
-      console.error(
-        `❌ [rust-engine] failed to reload plugin after daemon respawn: ${filePath}`,
-        err,
-      )
+    if (this.loadedPlugins.size === 0) return
+    // Reissue every declaration (master effect/instrument + all seq.effect() buses).
+    // One entry's failure must not skip the others — each is independent daemon state.
+    let anyFailed = false
+    for (const { filePath, pluginId, role, bus } of this.loadedPlugins.values()) {
+      try {
+        await this.daemon.loadPlugin(filePath, pluginId, role, bus)
+      } catch (err) {
+        anyFailed = true
+        // Cache entry intentionally remains: a later daemon respawn retries restoration.
+        console.error(
+          `❌ [rust-engine] failed to reload plugin after daemon respawn: ${filePath}` +
+            (bus ? ` (bus=${bus})` : ''),
+          err,
+        )
+      }
     }
+    this.pluginActive = !anyFailed
   }
 
   /** Whether `loadedPlugin` is actually active in the daemon right now (see field doc). */
@@ -732,13 +744,14 @@ export class RustEnginePlayer implements AudioEngineBackend {
     sequenceName = '',
     outputChannel?: string,
     argPath?: string,
+    insertBus?: string,
   ): void {
     // outputChannel の feature-gap signal は `registerLinkAudioChannel`（`sequence.output()` 経由）が
     // authoritative に出す（A4-2b-2b で egress 配線済み）。scheduleEvent は channel を tag するだけで、
     // 「egress is not wired」の旧 warn は stale なので出さない（egress 有効な daemon では誤誘導になる）。
     // pan は daemon PlayAt で実装済み（#304・equal-power = SC Pan2 一致）。発火時に
     // executePlayback が DSL の -100..100 を daemon の [-1,1] へ変換して送る。
-    this.enqueue({ time, filepath, gainDb, pan, sequenceName, outputChannel, argPath })
+    this.enqueue({ time, filepath, gainDb, pan, sequenceName, outputChannel, argPath, insertBus })
   }
 
   /**
@@ -764,6 +777,7 @@ export class RustEnginePlayer implements AudioEngineBackend {
     sequenceName = '',
     outputChannel?: string,
     argPath?: string,
+    insertBus?: string,
   ): void {
     // outputChannel の feature-gap signal は `registerLinkAudioChannel` が authoritative（上記
     // scheduleEvent と同様・egress 配線済みなので stale な「not wired」warn は出さない）。
@@ -776,6 +790,7 @@ export class RustEnginePlayer implements AudioEngineBackend {
       slice: { index: sliceIndex, total: totalSlices, eventDurationMs },
       outputChannel,
       argPath,
+      insertBus,
     })
   }
 
@@ -932,6 +947,7 @@ export class RustEnginePlayer implements AudioEngineBackend {
       durationSec,
       rate,
       play.outputChannel,
+      play.insertBus,
     )
     // #390 live playhead: emitted only after a successful dispatch (emission-only
     // — no timing / semantics change).

--- a/packages/engine/src/audio/types.ts
+++ b/packages/engine/src/audio/types.ts
@@ -84,7 +84,7 @@ export interface AudioEngine {
    * load instead of returning a false "success". Engines without this method
    * are treated as always-active (no self-heal check performed).
    */
-  isPluginActive?(): boolean
+  isPluginActive?(role?: 'effect' | 'instrument', bus?: string): boolean
 }
 
 /**

--- a/packages/engine/src/audio/types.ts
+++ b/packages/engine/src/audio/types.ts
@@ -61,11 +61,17 @@ export interface AudioEngine {
    */
   setLinkTempo?(bpm: number): Promise<void>
 
-  /** Eagerly load a plugin into the engine's master effect insert. */
+  /**
+   * Eagerly load a plugin into the engine's master effect insert, or (when
+   * `bus` is given) a named per-sequence insert bus (`seq.effect()` — PH.2b /
+   * #434). `bus` is only meaningful for `role: 'effect'`; passing it with
+   * `role: 'instrument'` is a daemon-side error.
+   */
   loadPlugin?(
     filePath: string,
     pluginId: string | undefined,
     role: 'effect' | 'instrument',
+    bus?: string,
   ): Promise<PluginLoadResult>
 
   pluginNoteOn?(key: number, channel: number, velocity: number): Promise<void>

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -24,6 +24,7 @@ import { TransportClock } from './global/transport-clock'
 import { MidiTransportScheduler } from './global/midi-transport-scheduler'
 import { PluginEffectManager } from './global/plugin-effect-manager'
 import { PluginInstrumentManager } from './global/plugin-instrument-manager'
+import { SequenceEffectManager } from './global/sequence-effect-manager'
 
 export class Global {
   // Manager instances for different responsibilities
@@ -37,6 +38,7 @@ export class Global {
   private midiManager: MidiManager
   private pluginEffectManager: PluginEffectManager
   private pluginInstrumentManager: PluginInstrumentManager
+  private sequenceEffectManager: SequenceEffectManager
 
   // Shared transport clock — the single Date.now() origin for both the audio
   // scheduler and the MIDI scheduler, so they stay in sync (§1). MIDI sequences
@@ -65,6 +67,11 @@ export class Global {
     this.audioManager = new AudioManager(audioEngine)
     this.linkAudioManager = new LinkAudioManager()
     this.pluginEffectManager = new PluginEffectManager(
+      audioEngine,
+      this.audioManager,
+      this.linkAudioManager,
+    )
+    this.sequenceEffectManager = new SequenceEffectManager(
       audioEngine,
       this.audioManager,
       this.linkAudioManager,
@@ -246,7 +253,8 @@ export class Global {
   linkAudio(targetSampleRate?: number): this {
     if (
       this.pluginEffectManager.hasDeclaration() ||
-      this.pluginInstrumentManager.hasDeclaration()
+      this.pluginInstrumentManager.hasDeclaration() ||
+      this.sequenceEffectManager.hasAnyDeclaration()
     ) {
       throw new Error(
         'global.linkAudio() cannot be used after plugin hosting has been declared in v1.',
@@ -273,6 +281,14 @@ export class Global {
   async instrument(path: string, pluginId?: string): Promise<this> {
     await this.pluginInstrumentManager.instrument(path, pluginId)
     return this
+  }
+
+  /**
+   * Eagerly load a per-sequence insert plugin for `sequenceName` (`seq.effect()` —
+   * PH.2b / #434 S3). Returns the allocated insert bus name.
+   */
+  async sequenceEffect(sequenceName: string, path: string, pluginId?: string): Promise<string> {
+    return this.sequenceEffectManager.effect(sequenceName, path, pluginId)
   }
 
   /**

--- a/packages/engine/src/core/global/plugin-effect-manager.ts
+++ b/packages/engine/src/core/global/plugin-effect-manager.ts
@@ -53,7 +53,7 @@ export class PluginEffectManager {
         // instead of returning a false "success". Engines without
         // `isPluginActive` (SC backend / plain mocks) keep the old no-op
         // idempotent behavior.
-        if (this.audioEngine.isPluginActive?.() === false) {
+        if (this.audioEngine.isPluginActive?.('effect') === false) {
           await this.issueLoad(resolvedPath, pluginId)
         }
         return

--- a/packages/engine/src/core/global/plugin-instrument-manager.ts
+++ b/packages/engine/src/core/global/plugin-instrument-manager.ts
@@ -40,7 +40,7 @@ export class PluginInstrumentManager {
     if (existing) {
       if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
         await existing.load
-        if (this.audioEngine.isPluginActive?.() === false) {
+        if (this.audioEngine.isPluginActive?.('instrument') === false) {
           await this.issueLoad(resolvedPath, pluginId)
         }
         return

--- a/packages/engine/src/core/global/sequence-effect-manager.ts
+++ b/packages/engine/src/core/global/sequence-effect-manager.ts
@@ -1,0 +1,131 @@
+import type { AudioEngine } from '../../audio/types'
+
+import { AudioManager } from './audio-manager'
+import { LinkAudioManager } from './link-audio-manager'
+import { resolvePluginPath, validatePluginExtension } from './plugin-resolver'
+
+/**
+ * Bus name prefix for the daemon's default per-sequence insert bus pool. Must
+ * match `DEFAULT_EFFECT_BUS_POOL_PREFIX` in
+ * `rust/crates/orbit-audio-daemon/src/engine_wrap.rs` — changing one requires
+ * changing the other (#434 S3).
+ */
+export const SEQUENCE_EFFECT_BUS_PREFIX = 'seq-bus-'
+
+/**
+ * v1 concurrent-insert cap. Must match `DEFAULT_EFFECT_BUS_POOL_SIZE` in
+ * `rust/crates/orbit-audio-daemon/src/engine_wrap.rs` (PH.2b: "同時に持てる
+ * シーケンス数には上限がある（既定 8）").
+ */
+export const SEQUENCE_EFFECT_BUS_POOL_SIZE = 8
+
+interface SeqEffectDeclaration {
+  bus: string
+  resolvedPath: string
+  pluginId?: string
+  load: Promise<void>
+}
+
+/**
+ * Owns the per-sequence insert (`seq.effect()` — PH.2b / #434 S3) declarations:
+ * one bus per sequence, allocated from the daemon's default bus pool
+ * (`seq-bus-0`.."seq-bus-7"). Mirrors `PluginEffectManager` /
+ * `PluginInstrumentManager`'s eager-load + idempotent-redeclare pattern, keyed
+ * by sequence name instead of a single master slot.
+ */
+export class SequenceEffectManager {
+  private readonly declarations = new Map<string, SeqEffectDeclaration>()
+  private nextBusIndex = 0
+
+  constructor(
+    private readonly audioEngine: AudioEngine,
+    private readonly audioManager: AudioManager,
+    private readonly linkAudioManager: LinkAudioManager,
+  ) {}
+
+  hasDeclaration(sequenceName: string): boolean {
+    return this.declarations.has(sequenceName)
+  }
+
+  /** Whether any sequence has declared an insert (used by `Global.linkAudio()`'s v1 exclusion gate). */
+  hasAnyDeclaration(): boolean {
+    return this.declarations.size > 0
+  }
+
+  getBus(sequenceName: string): string | undefined {
+    return this.declarations.get(sequenceName)?.bus
+  }
+
+  /** Declares (or idempotently re-declares) the insert for `sequenceName`. Returns the allocated bus name. */
+  async effect(sequenceName: string, spec: string, pluginId?: string): Promise<string> {
+    // Order mirrors PluginEffectManager.effect(): validate the spec, gate on
+    // LinkAudio, then resolve the path (see that file's doc comment for why).
+    validatePluginExtension(spec, 'effect')
+
+    if (this.linkAudioManager.isEnabled()) {
+      throw new Error(
+        `Sequence '${sequenceName}': seq.effect() cannot be used while LinkAudio is enabled in v1.`,
+      )
+    }
+
+    const resolvedPath = resolvePluginPath(
+      spec,
+      this.audioManager.getAudioPaths(),
+      this.audioManager.getDocumentDirectory(),
+      'effect',
+    )
+
+    const existing = this.declarations.get(sequenceName)
+    if (existing) {
+      if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
+        await existing.load
+        // Self-heal on stale cache after a daemon respawn (see PluginEffectManager
+        // for the full rationale). Engines without isPluginActive keep the old
+        // no-op idempotent behavior.
+        if (this.audioEngine.isPluginActive?.() === false) {
+          await this.issueLoad(sequenceName, existing.bus, resolvedPath, pluginId)
+        }
+        return existing.bus
+      }
+      throw new Error(
+        `Sequence '${sequenceName}': seq.effect() supports one insert per sequence in v1; ` +
+          `chains (multiple inserts) are reserved for future support.`,
+      )
+    }
+
+    if (this.nextBusIndex >= SEQUENCE_EFFECT_BUS_POOL_SIZE) {
+      throw new Error(
+        `Sequence '${sequenceName}': seq.effect() insert bus pool exhausted — v1 supports at ` +
+          `most ${SEQUENCE_EFFECT_BUS_POOL_SIZE} sequences with a concurrent insert.`,
+      )
+    }
+    const bus = `${SEQUENCE_EFFECT_BUS_PREFIX}${this.nextBusIndex}`
+    this.nextBusIndex += 1
+    await this.issueLoad(sequenceName, bus, resolvedPath, pluginId)
+    return bus
+  }
+
+  private async issueLoad(
+    sequenceName: string,
+    bus: string,
+    resolvedPath: string,
+    pluginId: string | undefined,
+  ): Promise<void> {
+    if (!this.audioEngine.loadPlugin) {
+      throw new Error('Plugin hosting requires the Rust engine backend.')
+    }
+    const load = this.audioEngine
+      .loadPlugin(resolvedPath, pluginId, 'effect', bus)
+      .then(() => undefined)
+    const declaration: SeqEffectDeclaration = { bus, resolvedPath, pluginId, load }
+    this.declarations.set(sequenceName, declaration)
+    try {
+      await load
+    } catch (err) {
+      if (this.declarations.get(sequenceName) === declaration) {
+        this.declarations.delete(sequenceName)
+      }
+      throw err
+    }
+  }
+}

--- a/packages/engine/src/core/global/sequence-effect-manager.ts
+++ b/packages/engine/src/core/global/sequence-effect-manager.ts
@@ -36,6 +36,12 @@ interface SeqEffectDeclaration {
 export class SequenceEffectManager {
   private readonly declarations = new Map<string, SeqEffectDeclaration>()
   private nextBusIndex = 0
+  /**
+   * 失敗した宣言から返却された bus 名の free-list。ライブコーディングでは
+   * 「typo → 失敗 → 直して再宣言」が普通に起きるため、失敗が pool を恒久消費すると
+   * 数回のリトライで枯渇する（#461 review Important）。返却された名前を優先的に再利用する。
+   */
+  private freedBuses: string[] = []
 
   constructor(
     private readonly audioEngine: AudioEngine,
@@ -82,7 +88,7 @@ export class SequenceEffectManager {
         // Self-heal on stale cache after a daemon respawn (see PluginEffectManager
         // for the full rationale). Engines without isPluginActive keep the old
         // no-op idempotent behavior.
-        if (this.audioEngine.isPluginActive?.() === false) {
+        if (this.audioEngine.isPluginActive?.('effect', existing.bus) === false) {
           await this.issueLoad(sequenceName, existing.bus, resolvedPath, pluginId)
         }
         return existing.bus
@@ -93,6 +99,19 @@ export class SequenceEffectManager {
       )
     }
 
+    const bus = this.freedBuses.pop() ?? this.allocateFreshBus(sequenceName)
+    try {
+      await this.issueLoad(sequenceName, bus, resolvedPath, pluginId)
+    } catch (err) {
+      // ロールバック: 失敗した宣言の bus を free-list に返す（daemon 側も activation を
+      // 巻き戻すため、両側の状態が対称に戻る）。
+      this.freedBuses.push(bus)
+      throw err
+    }
+    return bus
+  }
+
+  private allocateFreshBus(sequenceName: string): string {
     if (this.nextBusIndex >= SEQUENCE_EFFECT_BUS_POOL_SIZE) {
       throw new Error(
         `Sequence '${sequenceName}': seq.effect() insert bus pool exhausted — v1 supports at ` +
@@ -101,7 +120,6 @@ export class SequenceEffectManager {
     }
     const bus = `${SEQUENCE_EFFECT_BUS_PREFIX}${this.nextBusIndex}`
     this.nextBusIndex += 1
-    await this.issueLoad(sequenceName, bus, resolvedPath, pluginId)
     return bus
   }
 

--- a/packages/engine/src/core/global/types.ts
+++ b/packages/engine/src/core/global/types.ts
@@ -28,6 +28,9 @@ export interface Scheduler {
     sequenceName: string,
     outputChannel?: string,
     argPath?: string,
+    // per-sequence insert bus (seq.effect() — PH.2b / #434 S3). Mutually
+    // exclusive with outputChannel (LinkAudio and plugin hosting are v1-exclusive).
+    insertBus?: string,
   ): void
   scheduleSliceEvent(
     filepath: string,
@@ -40,6 +43,7 @@ export interface Scheduler {
     sequenceName: string,
     outputChannel?: string,
     argPath?: string,
+    insertBus?: string,
   ): void
   /**
    * #390 live playhead: marker-only event for a REST (0) slot — no audio

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -94,6 +94,9 @@ export class Sequence {
   // LinkAudio output channel (only meaningful when Global.linkAudio() is enabled)
   private _outputChannel?: string
 
+  // per-sequence insert bus (only meaningful when seq.effect() was declared — PH.2b / #434 S3)
+  private _insertBus?: string
+
   // MIDI properties (only meaningful when seq.midi() was declared).
   // A MIDI sequence interprets play() values as degrees, not slice numbers.
   private _midiPort?: string // resolved actual port name
@@ -397,6 +400,31 @@ export class Sequence {
 
   isInstrument(): boolean {
     return this._instrumentDeclared
+  }
+
+  /**
+   * Declare a per-sequence insert plugin (`seq.effect()` — PH.2b / #434 S3).
+   * Processed **before** the master mix / `global.effect()` (master chain
+   * semantics are unchanged). Restricted to audio sequences: note sequences
+   * (`seq.midi()` / `seq.instrument()`) play through the plugin-note path or a
+   * MIDI bus, not the audio-event PlayAt path this insert taps, so declaring it
+   * there is a v1 error rather than a silent no-op.
+   */
+  async effect(pluginPath: string, pluginId?: string): Promise<this> {
+    const name = this.stateManager.getName() || 'sequence'
+    if (this.isNoteSequence()) {
+      throw new Error(
+        `Sequence '${name}': seq.effect() is only supported on audio sequences in v1 ` +
+          `(not midi()/instrument() sequences — their playback does not go through the ` +
+          `insert-bus audio path).`,
+      )
+    }
+    this._insertBus = await this.global.sequenceEffect(name, pluginPath, pluginId)
+    return this
+  }
+
+  getInsertBus(): string | undefined {
+    return this._insertBus
   }
 
   isNoteSequence(): boolean {
@@ -1172,6 +1200,7 @@ export class Sequence {
       masterGainDb: this.global.getMasterGainDb(),
       patternDuration: this.getPatternDuration(),
       outputChannel: this.resolveDispatchChannel(),
+      insertBus: this._insertBus,
     })
   }
 
@@ -1253,6 +1282,7 @@ export class Sequence {
       masterGainDb: this.global.getMasterGainDb(),
       patternDuration: this.getPatternDuration(),
       outputChannel: this.resolveDispatchChannel(),
+      insertBus: this._insertBus,
     })
 
     this.stateManager.setPlaying(true)
@@ -1477,6 +1507,7 @@ export class Sequence {
       pan: panState.pan,
       panRandom: panState.panRandom,
       outputChannel: this._outputChannel,
+      insertBus: this._insertBus,
       midiPort: this._midiPort,
       midiChannel: this._midiChannel,
       gate: this._gate,

--- a/packages/engine/src/core/sequence/scheduling/event-scheduler.ts
+++ b/packages/engine/src/core/sequence/scheduling/event-scheduler.ts
@@ -69,6 +69,7 @@ export async function scheduleEvents(options: ScheduleEventsOptions): Promise<vo
     masterGainDb,
     patternDuration,
     outputChannel,
+    insertBus,
   } = options
 
   if (!audioFilePath || !timedEvents || timedEvents.length === 0) {
@@ -106,6 +107,7 @@ export async function scheduleEvents(options: ScheduleEventsOptions): Promise<vo
           sequenceName,
           outputChannel,
           event.argPath,
+          insertBus,
         )
       } else {
         scheduler.scheduleEvent(
@@ -116,6 +118,7 @@ export async function scheduleEvents(options: ScheduleEventsOptions): Promise<vo
           sequenceName,
           outputChannel,
           event.argPath,
+          insertBus,
         )
       }
     } else if (event.sliceNumber === 0 && event.argPath !== undefined) {
@@ -154,6 +157,7 @@ export function scheduleEventsFromTime(options: ScheduleEventsFromTimeOptions): 
     masterGainDb,
     patternDuration,
     outputChannel,
+    insertBus,
   } = options
 
   if (!timedEvents || !audioFilePath) {
@@ -212,6 +216,7 @@ export function scheduleEventsFromTime(options: ScheduleEventsFromTimeOptions): 
             sequenceName,
             outputChannel,
             event.argPath,
+            insertBus,
           )
         } else {
           scheduler.scheduleEvent(
@@ -222,6 +227,7 @@ export function scheduleEventsFromTime(options: ScheduleEventsFromTimeOptions): 
             sequenceName,
             outputChannel,
             event.argPath,
+            insertBus,
           )
         }
       } else if (event.sliceNumber === 0 && event.argPath !== undefined) {

--- a/packages/engine/src/core/sequence/types.ts
+++ b/packages/engine/src/core/sequence/types.ts
@@ -114,6 +114,9 @@ export interface ScheduleEventsOptions {
   // LinkAudio dispatch — set only when Global.linkAudio() is enabled AND the
   // sequence has a channel name from .output(). Absent means hardware bus.
   outputChannel?: string
+  // per-sequence insert bus (seq.effect() — PH.2b / #434 S3). Set only when the
+  // sequence declared an insert. Mutually exclusive with outputChannel.
+  insertBus?: string
 }
 
 /**
@@ -136,4 +139,6 @@ export interface ScheduleEventsFromTimeOptions {
   patternDuration: number
   // LinkAudio dispatch — see ScheduleEventsOptions.outputChannel.
   outputChannel?: string
+  // see ScheduleEventsOptions.insertBus.
+  insertBus?: string
 }

--- a/rust/crates/orbit-audio-core/src/engine.rs
+++ b/rust/crates/orbit-audio-core/src/engine.rs
@@ -117,6 +117,15 @@ impl Engine {
         self.inner.try_lock().ok().map(|s| s.active_count())
     }
 
+    /// 未登録 named target へ tag された event の skip 累計（retain ハザードの観測点・
+    /// `Scheduler::unroutable_event_count` 参照）。ロック競合時は `None`。
+    pub fn unroutable_event_count(&self) -> Option<u64> {
+        self.inner.try_lock().ok().map(|s| {
+            s.unroutable_event_count
+                .load(std::sync::atomic::Ordering::Relaxed)
+        })
+    }
+
     /// マスターゲインを設定する。`ramp_sec` が 0 以下なら即時、正なら線形ランプ。
     ///
     /// 正の `ramp_sec` がサブフレーム相当（例: 1/sample_rate 未満）でも、

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -135,6 +135,12 @@ pub fn resolve_slice_region(
 /// オーディオコールバック内で使うことを想定し、allocation 無しで
 /// フレーム単位のサンプルを取り出せるよう設計している。
 pub struct Scheduler {
+    /// 未登録の named target へ tag された event を skip した累計回数（RT 安全・Relaxed）。
+    /// skip された event は消費されず retain され続ける（`ScheduledSample.channel` doc の
+    /// ハザード）ため、この counter の増加は「宣言前 tag / 名前 typo」の唯一の観測点。
+    /// daemon の 1 Hz ticker が増加を WARNING で surface する（#461 review）。
+    pub unroutable_event_count: std::sync::atomic::AtomicU64,
+
     output_sample_rate: u32,
     output_channels: u16,
     events: Vec<ActiveSample>,
@@ -187,6 +193,7 @@ impl Scheduler {
             output_sample_rate,
             output_channels,
             events: Vec::new(),
+            unroutable_event_count: std::sync::atomic::AtomicU64::new(0),
             cursor_frames: 0,
             global_gain: 1.0,
             target_gain: 1.0,
@@ -378,7 +385,12 @@ impl Scheduler {
                 None => None,
                 Some(name) => match channels.iter().position(|(n, _)| *n == name) {
                     Some(i) => Some(i),
-                    None => continue,
+                    None => {
+                        // 未登録 target: event は消費されない（retain）。観測用 counter のみ更新。
+                        self.unroutable_event_count
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        continue;
+                    }
                 },
             };
             let active = &mut self.events[ev_idx];
@@ -1124,6 +1136,37 @@ mod tests {
     }
 
     // ===== A4-2b-1: render_multi（single-pass multi-buffer）=====
+
+    #[test]
+    fn render_multi_counts_unroutable_tagged_events() {
+        // 未登録 target へ tag された event は skip + retain され、唯一の観測点である
+        // unroutable_event_count が callback ごとに増える（#461 review）。登録済み tag は 0。
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(
+            ScheduledSample::new(0.0, mk_sample_stereo(50)).with_channel(Some("ghost".into())),
+        );
+        let mut hw = vec![0.0f32; 8];
+        let mut empty: [(&str, &mut [f32]); 0] = [];
+        s.render_multi(&mut hw, &mut empty);
+        assert_eq!(
+            s.unroutable_event_count
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+        assert_eq!(s.active_count(), 1, "skip された event は retain される");
+
+        let mut s = Scheduler::new(48_000, 2);
+        s.schedule(ScheduledSample::new(0.0, mk_sample_stereo(50)).with_channel(Some("fx".into())));
+        let mut hw = vec![0.0f32; 8];
+        let mut buf = vec![0.0f32; 8];
+        let mut targets = [("fx", buf.as_mut_slice())];
+        s.render_multi(&mut hw, &mut targets);
+        assert_eq!(
+            s.unroutable_event_count
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0
+        );
+    }
 
     #[test]
     fn render_multi_empty_channels_matches_render() {

--- a/rust/crates/orbit-audio-core/src/scheduler.rs
+++ b/rust/crates/orbit-audio-core/src/scheduler.rs
@@ -23,9 +23,18 @@ pub struct ScheduledSample {
     pub sample: Sample,
     /// Stop 命令での個別停止用識別子。`None` なら停止不可（fire-and-forget）。
     pub play_id: Option<String>,
-    /// 出力先 channel 名（LinkAudio outputChannel・#209）。`None` = 既定（unrouted / hardware
-    /// sum）。同名 channel の event は `Scheduler::render_channel` で加算合成される
-    /// （sum-by-name・DSL §8.1.2）。
+    /// 出力先の named routing tag。`None` = 既定（unrouted / hardware sum）。同名 target の
+    /// event は `render_multi` で加算合成される（sum-by-name・DSL §8.1.2）。
+    ///
+    /// **2つの用途を担う**（wire レベルでは相互排他 — daemon `session.rs` の
+    /// `playat_bus_and_channel_both_set` が両立を拒否する）:
+    /// - LinkAudio outputChannel（#209）— named channel buffer へ egress
+    /// - per-sequence insert bus（#434・PH.2b）— `InsertBusStage` へルーティングし
+    ///   effect 適用後に master へ sum
+    ///
+    /// ⚠ render 対象に存在しない名前へ tag された event は消費されず retain され続ける
+    /// （LinkAudio not-ready channel と insert-bus 未 activation に共通の既存ハザード。
+    /// producer 側が「登録/宣言 → tag」の順序を守ることが前提）。
     pub channel: Option<String>,
 }
 

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -201,6 +201,86 @@ struct OutProcControl {
     cb_stats: Arc<orbit_audio_native::CallbackTimeStats>,
     /// post-boot attach の状態。`StreamGuard` と共有し、supervisor は stream より後に drop する。
     child_slot: Weak<Mutex<ChildSlot>>,
+    /// 起動時に固定した named insert bus の effect slots。master slot は `child_slot` のまま
+    /// 保持し、bus 無し LoadPlugin の後方互換を保つ。
+    bus_slots: HashMap<String, Weak<Mutex<ChildSlot>>>,
+    /// bus 名 → その bus の `OutProcEffectStats`（`outproc_effect_bus_stats` gated 計測用）。
+    /// `bus_slots` と同じキー集合で、child の生死に関わらず統計自体は生存し続けるため強参照。
+    bus_stats: HashMap<String, Arc<crate::outproc_effect::OutProcEffectStats>>,
+}
+
+/// `ORBIT_EFFECT_BUSES` の値を解析する純関数。カンマ区切りの bus 名を trim・空要素除去した上で、
+/// 重複や NUL 文字を含む名前を拒否する。env 直読みを避けることで unit テスト可能にする
+/// （`PluginFormat::from_env_value` / `parse_buffer_frames` と同じ「値渡し純関数 + env 読みラッパー」
+/// の慣習に合わせる）。
+#[cfg(feature = "outproc-effect")]
+fn parse_effect_buses(raw: &str) -> Result<Vec<String>, String> {
+    let mut seen = HashSet::new();
+    raw.split(',')
+        .filter_map(|s| {
+            let s = s.trim();
+            (!s.is_empty()).then(|| s.to_owned())
+        })
+        .map(|bus| {
+            if bus.contains('\0') || !seen.insert(bus.clone()) {
+                Err(format!(
+                    "ORBIT_EFFECT_BUSES contains duplicate or invalid bus '{bus}'"
+                ))
+            } else {
+                Ok(bus)
+            }
+        })
+        .collect()
+}
+
+#[cfg(feature = "outproc-effect")]
+fn effect_buses_from_env() -> Result<Vec<String>, WrapError> {
+    parse_effect_buses(&std::env::var("ORBIT_EFFECT_BUSES").unwrap_or_default())
+        .map_err(WrapError::OutProcEffect)
+}
+
+#[cfg(all(test, feature = "outproc-effect"))]
+mod effect_buses_from_env_tests {
+    use super::parse_effect_buses;
+
+    #[test]
+    fn empty_string_yields_no_buses() {
+        assert_eq!(parse_effect_buses(""), Ok(Vec::new()));
+    }
+
+    #[test]
+    fn whitespace_only_yields_no_buses() {
+        assert_eq!(parse_effect_buses("   "), Ok(Vec::new()));
+    }
+
+    #[test]
+    fn parses_comma_separated_names_and_trims_whitespace() {
+        assert_eq!(
+            parse_effect_buses(" fx1 ,fx2"),
+            Ok(vec!["fx1".to_owned(), "fx2".to_owned()])
+        );
+    }
+
+    #[test]
+    fn skips_empty_elements_between_commas() {
+        assert_eq!(
+            parse_effect_buses("fx1,,fx2,"),
+            Ok(vec!["fx1".to_owned(), "fx2".to_owned()])
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_bus_names() {
+        let error = parse_effect_buses("fx1,fx1").expect_err("duplicate must be rejected");
+        assert!(error.contains("duplicate"), "unexpected message: {error}");
+    }
+
+    #[test]
+    fn rejects_nul_byte_in_bus_name() {
+        let error =
+            parse_effect_buses("fx1,fx\x002").expect_err("NUL byte in name must be rejected");
+        assert!(error.contains("invalid"), "unexpected message: {error}");
+    }
 }
 
 #[cfg(feature = "outproc-instrument")]
@@ -680,6 +760,8 @@ pub struct StreamGuard {
     /// より前に宣言する（clap-host とは feature 排他なので同時には存在しない）。
     #[cfg(feature = "outproc-effect")]
     _outproc_teardown: crate::outproc_effect::OutProcTeardownGuard,
+    #[cfg(feature = "outproc-effect")]
+    _outproc_bus_teardowns: Vec<crate::outproc_effect::OutProcTeardownGuard>,
     /// outproc-instrument: stream 前に audio-thread adapter を quiesce する。
     /// both build における `_outproc_teardown` との相対順序は load-bearing ではない
     /// （各 guard は自 role 専用の requested/done atomic のみを操作し共有状態がない。
@@ -698,6 +780,8 @@ pub struct StreamGuard {
     /// child へ QUIT → reap → shm unlink する。**field 順は load-bearing**: `_stream` より後に宣言する。
     #[cfg(feature = "outproc-effect")]
     _child_guard: Arc<Mutex<ChildSlot>>,
+    #[cfg(feature = "outproc-effect")]
+    _bus_child_guards: Vec<Arc<Mutex<ChildSlot>>>,
     /// both build では同種 guard 間の順序は load-bearing ではない（どちらも stream 停止後）。別々の
     /// child process / shm region を持ち supervisor 間に共有状態が無いため、独立に teardown できる。
     #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
@@ -891,6 +975,36 @@ impl EngineWrap {
         };
         use std::sync::atomic::AtomicBool;
 
+        let bus_names = effect_buses_from_env()?;
+        // Each registered bus owns a complete transport up front.  Attachment is the existing
+        // lock-free `engaged` release-store, so the callback never allocates or locks.
+        let mut bus_builds = Vec::with_capacity(bus_names.len());
+        let mut insert_buses = Vec::with_capacity(bus_names.len());
+        for name in &bus_names {
+            let shm_path = crate::outproc_effect::unique_shm_path();
+            let host = orbit_audio_sandbox::PipelinedEffectHost::from_mmap(
+                orbit_audio_sandbox::create_shared(&shm_path).map_err(|e| {
+                    WrapError::OutProcEffect(format!("create bus shm {shm_path:?}: {e}"))
+                })?,
+            );
+            let engaged = Arc::new(AtomicBool::new(false));
+            let stop = Arc::new(AtomicBool::new(false));
+            let done = Arc::new(AtomicBool::new(false));
+            let stats = OutProcEffectStats::new();
+            insert_buses.push(orbit_audio_native::InsertBusStage::new(
+                name.clone(),
+                Some(Box::new(OutProcEffectPostProcessor::new(
+                    host,
+                    engaged.clone(),
+                    stop.clone(),
+                    done.clone(),
+                    stats.clone(),
+                ))),
+                0,
+            ));
+            bus_builds.push((shm_path, engaged, stop, done, stats));
+        }
+
         // 1. shm 作成 → host mmap（adapter が所有・audio thread）。
         let shm_path = crate::outproc_effect::unique_shm_path();
         let host_mmap = orbit_audio_sandbox::create_shared(&shm_path)
@@ -914,7 +1028,8 @@ impl EngineWrap {
         // 3. cpal stream 起動（ここで device の sample_rate が確定する）。adapter を注入する。
         //    gated stale-rate harness は cfg.buffer_frames に 32/64 を渡し小バッファを要求する。
         let (engine, stream, stream_stats, cb_stats) =
-            orbit_audio_native::start_default_output_with_clap(
+            orbit_audio_native::start_default_output_with_insert_buses_and_post(
+                insert_buses,
                 processor,
                 cfg.buffer_frames,
                 capture_path_from_env(),
@@ -926,7 +1041,7 @@ impl EngineWrap {
         //    control thread から Release store できるようにする。
         let child_slot = Arc::new(Mutex::new(ChildSlot::Empty(ChildLaunch {
             shm_path,
-            child_exe: cfg.child_exe,
+            child_exe: cfg.child_exe.clone(),
             sample_rate,
             stats: stats.clone(),
             engaged,
@@ -945,15 +1060,48 @@ impl EngineWrap {
                 stats,
                 cb_stats,
                 child_slot: Arc::downgrade(&child_slot),
+                bus_slots: HashMap::new(),
+                bus_stats: HashMap::new(),
             });
+
+        let mut bus_slots = HashMap::new();
+        let mut bus_stats = HashMap::new();
+        let mut bus_child_guards = Vec::with_capacity(bus_builds.len());
+        let mut bus_teardowns = Vec::with_capacity(bus_builds.len());
+        for (name, (shm_path, engaged, stop, done, stats)) in bus_names.into_iter().zip(bus_builds)
+        {
+            let slot = Arc::new(Mutex::new(ChildSlot::Empty(ChildLaunch {
+                shm_path,
+                child_exe: cfg.child_exe.clone(),
+                sample_rate,
+                stats: stats.clone(),
+                engaged,
+                cleanup_shm_on_drop: true,
+            })));
+            bus_slots.insert(name.clone(), Arc::downgrade(&slot));
+            bus_stats.insert(name, stats);
+            bus_child_guards.push(slot);
+            bus_teardowns.push(OutProcTeardownGuard::new(stop, done));
+        }
+        {
+            let mut guard = wrap
+                .outproc
+                .lock()
+                .map_err(|_| WrapError::OutProcEffect("outproc mutex poisoned".into()))?;
+            let control = guard.as_mut().expect("outproc control installed");
+            control.bus_slots = bus_slots;
+            control.bus_stats = bus_stats;
+        }
 
         // 7. StreamGuard（field 順 = teardown 順）。
         Ok((
             wrap,
             StreamGuard {
                 _outproc_teardown: OutProcTeardownGuard::new(teardown_requested, teardown_done),
+                _outproc_bus_teardowns: bus_teardowns,
                 _stream: stream,
                 _child_guard: child_slot,
+                _bus_child_guards: bus_child_guards,
             },
         ))
     }
@@ -1102,6 +1250,38 @@ impl EngineWrap {
             effect_cfg.buffer_frames,
             instrument_cfg.buffer_frames,
         )?;
+
+        let bus_names = effect_buses_from_env()?;
+        // 同じ transport 構築を effect-only 経路（`start_outproc_effect_post_boot`）と共有する。
+        // bus 0 個なら `insert_buses` は空 Vec になり、`start_default_output_with_insert_buses_and_post`
+        // は従来の `start_default_output_with_clap` と等価に振る舞う。
+        let mut bus_builds = Vec::with_capacity(bus_names.len());
+        let mut insert_buses = Vec::with_capacity(bus_names.len());
+        for name in &bus_names {
+            let shm_path = crate::outproc_effect::unique_shm_path();
+            let host = orbit_audio_sandbox::PipelinedEffectHost::from_mmap(
+                orbit_audio_sandbox::create_shared(&shm_path).map_err(|e| {
+                    WrapError::OutProcEffect(format!("create bus shm {shm_path:?}: {e}"))
+                })?,
+            );
+            let engaged = Arc::new(AtomicBool::new(false));
+            let stop = Arc::new(AtomicBool::new(false));
+            let done = Arc::new(AtomicBool::new(false));
+            let stats = OutProcEffectStats::new();
+            insert_buses.push(orbit_audio_native::InsertBusStage::new(
+                name.clone(),
+                Some(Box::new(OutProcEffectPostProcessor::new(
+                    host,
+                    engaged.clone(),
+                    stop.clone(),
+                    done.clone(),
+                    stats.clone(),
+                ))),
+                0,
+            ));
+            bus_builds.push((shm_path, engaged, stop, done, stats));
+        }
+
         let effect_shm = crate::outproc_effect::unique_shm_path();
         let effect_host = orbit_audio_sandbox::PipelinedEffectHost::from_mmap(
             orbit_audio_sandbox::create_shared(&effect_shm)
@@ -1143,7 +1323,8 @@ impl EngineWrap {
             ),
         });
         let (engine, stream, stream_stats, effect_cb_stats) =
-            orbit_audio_native::start_default_output_with_clap(
+            orbit_audio_native::start_default_output_with_insert_buses_and_post(
+                insert_buses,
                 processor,
                 buffer_frames,
                 capture_path_from_env(),
@@ -1151,7 +1332,7 @@ impl EngineWrap {
             .map_err(WrapError::Output)?;
         let effect_slot = Arc::new(Mutex::new(ChildSlot::Empty(ChildLaunch {
             shm_path: effect_shm,
-            child_exe: effect_cfg.child_exe,
+            child_exe: effect_cfg.child_exe.clone(),
             sample_rate: stream.sample_rate,
             stats: effect_stats.clone(),
             engaged: effect_engaged,
@@ -1180,6 +1361,8 @@ impl EngineWrap {
                 stats: effect_stats,
                 cb_stats: effect_cb_stats,
                 child_slot: Arc::downgrade(&effect_slot),
+                bus_slots: HashMap::new(),
+                bus_stats: HashMap::new(),
             });
         *wrap.outproc_instrument.lock().map_err(|_| {
             WrapError::OutProcInstrument("outproc instrument mutex poisoned".into())
@@ -1188,16 +1371,48 @@ impl EngineWrap {
             stats: instrument_stats,
             child_slot: Arc::downgrade(&instrument_slot),
         });
+
+        let mut bus_slots = HashMap::new();
+        let mut bus_stats = HashMap::new();
+        let mut bus_child_guards = Vec::with_capacity(bus_builds.len());
+        let mut bus_teardowns = Vec::with_capacity(bus_builds.len());
+        for (name, (shm_path, engaged, stop, done, stats)) in bus_names.into_iter().zip(bus_builds)
+        {
+            let slot = Arc::new(Mutex::new(ChildSlot::Empty(ChildLaunch {
+                shm_path,
+                child_exe: effect_cfg.child_exe.clone(),
+                sample_rate: stream.sample_rate,
+                stats: stats.clone(),
+                engaged,
+                cleanup_shm_on_drop: true,
+            })));
+            bus_slots.insert(name.clone(), Arc::downgrade(&slot));
+            bus_stats.insert(name, stats);
+            bus_child_guards.push(slot);
+            bus_teardowns.push(OutProcTeardownGuard::new(stop, done));
+        }
+        {
+            let mut guard = wrap
+                .outproc
+                .lock()
+                .map_err(|_| WrapError::OutProcEffect("outproc mutex poisoned".into()))?;
+            let control = guard.as_mut().expect("outproc control installed");
+            control.bus_slots = bus_slots;
+            control.bus_stats = bus_stats;
+        }
+
         Ok((
             wrap,
             StreamGuard {
                 _outproc_teardown: OutProcTeardownGuard::new(effect_stop, effect_done),
+                _outproc_bus_teardowns: bus_teardowns,
                 _outproc_instrument_teardown: OutProcInstrumentTeardownGuard::new(
                     instrument_stop,
                     instrument_done,
                 ),
                 _stream: stream,
                 _child_guard: effect_slot,
+                _bus_child_guards: bus_child_guards,
                 _instrument_child_guard: instrument_slot,
             },
         ))
@@ -1367,7 +1582,7 @@ impl EngineWrap {
         plugin_id: Option<String>,
     ) -> Result<LoadedPluginSummary, WrapError> {
         #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
-        return self.load_outproc_effect_plugin(path, plugin_id);
+        return self.load_outproc_effect_plugin(path, plugin_id, None);
         #[cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
         let child_slot = {
             let guard = self
@@ -1413,25 +1628,38 @@ impl EngineWrap {
     }
 
     /// both build で effect slot へ attach する。
-    #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
+    #[cfg(feature = "outproc-effect")]
     pub fn load_outproc_effect_plugin(
         &self,
         path: PathBuf,
         plugin_id: Option<String>,
+        bus: Option<String>,
     ) -> Result<LoadedPluginSummary, WrapError> {
-        let slot = self
-            .outproc
-            .lock()
-            .map_err(|_| WrapError::OutProcEffect("outproc mutex poisoned".into()))?
-            .as_ref()
-            .ok_or_else(|| {
+        // slot の解決だけを lock 下で行い、attach 本体（child spawn + READY poll）前に guard を
+        // 必ず落とす: `outproc` mutex を数百 ms 保持すると 1 Hz health ticker（try_lock）や
+        // stats アクセサと競合する（従来コードも guard は slot 解決の式で即 drop していた）。
+        let slot = {
+            let control_guard = self
+                .outproc
+                .lock()
+                .map_err(|_| WrapError::OutProcEffect("outproc mutex poisoned".into()))?;
+            let control = control_guard.as_ref().ok_or_else(|| {
                 WrapError::OutProcEffectUnavailable(
                     "outproc effect not initialized (test backend has no outproc path)".into(),
                 )
-            })?
-            .child_slot
-            .upgrade()
-            .ok_or_else(|| WrapError::OutProcEffect("outproc effect stream is closed".into()))?;
+            })?;
+            let weak_slot = match bus {
+                Some(bus) => control.bus_slots.get(&bus).ok_or_else(|| {
+                    WrapError::OutProcEffect(format!(
+                        "unknown effect bus '{bus}' (configured by ORBIT_EFFECT_BUSES)"
+                    ))
+                })?,
+                None => &control.child_slot,
+            };
+            weak_slot
+                .upgrade()
+                .ok_or_else(|| WrapError::OutProcEffect("outproc effect stream is closed".into()))?
+        };
         self.load_outproc_plugin_impl::<DefaultOutProcRole>(slot, path, plugin_id)
     }
 
@@ -1977,6 +2205,27 @@ impl EngineWrap {
             Ok(g) => g.as_ref().map(|c| c.stats.snapshot()),
             Err(_) => {
                 tracing::warn!("outproc mutex poisoned; outproc_effect_stats returning None");
+                None
+            }
+        }
+    }
+
+    /// test harness / gated 計測用: 特定の named insert bus（`ORBIT_EFFECT_BUSES`）に attach された
+    /// OOP effect の観測スナップショット。master bus の [`Self::outproc_effect_stats`] と異なり、
+    /// 未知の bus 名 / bus 未起動時は `None`（poison も `None`・warn で区別）。`#[doc(hidden)]`。
+    #[cfg(feature = "outproc-effect")]
+    #[doc(hidden)]
+    pub fn outproc_effect_bus_stats(
+        &self,
+        bus: &str,
+    ) -> Option<crate::outproc_effect::OutProcEffectSnapshot> {
+        match self.outproc.lock() {
+            Ok(g) => g
+                .as_ref()
+                .and_then(|c| c.bus_stats.get(bus))
+                .map(|stats| stats.snapshot()),
+            Err(_) => {
+                tracing::warn!("outproc mutex poisoned; outproc_effect_bus_stats returning None");
                 None
             }
         }
@@ -3832,6 +4081,7 @@ mod outproc_health_tests {
     use crate::backend::StubBackend;
     use crate::outproc_effect::OutProcEffectStats;
     use orbit_audio_native::CallbackTimeStats;
+    use std::collections::HashMap;
     use std::sync::atomic::Ordering;
     use std::sync::{Arc, Mutex, Weak};
 
@@ -3846,6 +4096,8 @@ mod outproc_health_tests {
             stats: stats.clone(),
             cb_stats: CallbackTimeStats::new(),
             child_slot: Weak::new(),
+            bus_slots: HashMap::new(),
+            bus_stats: HashMap::new(),
         });
         (wrap, stats)
     }
@@ -3861,8 +4113,52 @@ mod outproc_health_tests {
             stats,
             cb_stats: CallbackTimeStats::new(),
             child_slot: Arc::downgrade(&child_slot),
+            bus_slots: HashMap::new(),
+            bus_stats: HashMap::new(),
         });
         (wrap, child_slot)
+    }
+
+    #[test]
+    fn load_outproc_effect_plugin_rejects_unknown_bus() {
+        let (wrap, _child_slot) =
+            wrap_with_child_slot(ChildSlot::Closed, OutProcEffectStats::new());
+        let error = wrap
+            .load_outproc_effect_plugin(
+                std::path::PathBuf::from("unused.clap"),
+                None,
+                Some("nope".into()),
+            )
+            .err()
+            .expect("unknown bus must be rejected before touching the master slot");
+        assert_effect_runtime_error_contains(error, "unknown effect bus 'nope'");
+    }
+
+    #[test]
+    fn load_outproc_effect_plugin_routes_known_bus_to_its_own_slot_not_master() {
+        let (wrap, _guard) =
+            EngineWrap::start_with(StubBackend::default()).expect("stub backend start");
+        // master `child_slot` is dropped (Weak::new()), so if the bus lookup fell through to it
+        // this call would fail with "stream is closed" instead of reaching the bus-specific slot.
+        let bus_slot = Arc::new(Mutex::new(ChildSlot::<EffectRole>::Closed));
+        let mut bus_slots = HashMap::new();
+        bus_slots.insert("fx1".to_owned(), Arc::downgrade(&bus_slot));
+        *wrap.outproc.lock().expect("lock outproc for injection") = Some(OutProcControl {
+            stats: OutProcEffectStats::new(),
+            cb_stats: CallbackTimeStats::new(),
+            child_slot: Weak::new(),
+            bus_slots,
+            bus_stats: HashMap::new(),
+        });
+        let error = wrap
+            .load_outproc_effect_plugin(
+                std::path::PathBuf::from("unused.clap"),
+                None,
+                Some("fx1".into()),
+            )
+            .err()
+            .expect("closed bus slot still rejects the load, but past the routing step");
+        assert_effect_runtime_error_contains(error, "closed after an unrecoverable attach failure");
     }
 
     fn assert_effect_runtime_error_contains(error: WrapError, expected: &str) {

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -1750,7 +1750,7 @@ impl EngineWrap {
         // slot の解決だけを lock 下で行い、attach 本体（child spawn + READY poll）前に guard を
         // 必ず落とす: `outproc` mutex を数百 ms 保持すると 1 Hz health ticker（try_lock）や
         // stats アクセサと競合する（従来コードも guard は slot 解決の式で即 drop していた）。
-        let slot = {
+        let (slot, bus_active) = {
             let control_guard = self
                 .outproc
                 .lock()
@@ -1760,7 +1760,7 @@ impl EngineWrap {
                     "outproc effect not initialized (test backend has no outproc path)".into(),
                 )
             })?;
-            let weak_slot = match bus {
+            let (weak_slot, bus_active) = match bus {
                 Some(bus) => {
                     let slot = control.bus_slots.get(&bus).ok_or_else(|| {
                         WrapError::OutProcEffect(format!(
@@ -1770,18 +1770,31 @@ impl EngineWrap {
                     // 宣言 = activation: この store 以降、callback は当該 bus を render 対象に
                     // 含める（attach 完了前は engaged=false の pass-through）。宣言前の bus は
                     // render 対象外 = 既定プールのコストゼロ（InsertBusStage::active の doc 参照）。
-                    if let Some(active) = control.bus_actives.get(&bus) {
+                    // attach 失敗時は下で false に巻き戻す（宣言が生き残らない = pool を汚さない）。
+                    let active = control.bus_actives.get(&bus).cloned();
+                    if let Some(active) = &active {
                         active.store(true, std::sync::atomic::Ordering::Release);
                     }
-                    slot
+                    (slot, active)
                 }
-                None => &control.child_slot,
+                None => (&control.child_slot, None),
             };
-            weak_slot
-                .upgrade()
-                .ok_or_else(|| WrapError::OutProcEffect("outproc effect stream is closed".into()))?
+            (
+                weak_slot.upgrade().ok_or_else(|| {
+                    WrapError::OutProcEffect("outproc effect stream is closed".into())
+                })?,
+                bus_active,
+            )
         };
-        self.load_outproc_plugin_impl::<DefaultOutProcRole>(slot, path, plugin_id)
+        let result = self.load_outproc_plugin_impl::<DefaultOutProcRole>(slot, path, plugin_id);
+        if result.is_err() {
+            // ロールバック: 失敗した宣言の bus を render 対象から外す（TS 側も宣言を破棄して
+            // bus 名を free-list に返すため、Rust/TS の状態が対称に戻る）。
+            if let Some(active) = bus_active {
+                active.store(false, std::sync::atomic::Ordering::Release);
+            }
+        }
+        result
     }
 
     /// both build で instrument slot へ attach する。
@@ -2451,6 +2464,49 @@ impl EngineWrap {
                 (0, 0, false, injected)
             }
         }
+    }
+
+    /// per-bus OOP effect の health を bus 名つきで列挙する（#461 review Critical: bus child の
+    /// crash/respawn/計測無効/frames_clamped が ticker に出ない穴を塞ぐ）。master の
+    /// [`Self::outproc_health`] と同型の tuple を bus ごとに返す。1 tick = 1 try_lock +
+    /// snapshot 群（WouldBlock/Poisoned/未初期化は空 Vec = 次 tick 持ち越し）。
+    #[cfg(feature = "outproc-effect")]
+    pub fn outproc_effect_bus_health(&self) -> Vec<(String, (u64, u64, bool, u64))> {
+        match self.outproc.try_lock() {
+            Ok(g) => g
+                .as_ref()
+                .map(|c| {
+                    c.bus_stats
+                        .iter()
+                        .map(|(name, stats)| {
+                            let s = stats.snapshot();
+                            (
+                                name.clone(),
+                                (
+                                    s.child_process_error_count,
+                                    s.respawn_count,
+                                    s.measurement_invalid,
+                                    s.frames_clamped,
+                                ),
+                            )
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    /// feature 無効ビルド用 stub（ticker 側を cfg なしで書けるようにする）。
+    #[cfg(not(feature = "outproc-effect"))]
+    pub fn outproc_effect_bus_health(&self) -> Vec<(String, (u64, u64, bool, u64))> {
+        Vec::new()
+    }
+
+    /// 未登録 named target へ tag された event の skip 累計（core の retain ハザード観測点・
+    /// `Scheduler::unroutable_event_count`）。lock 競合時は 0（cumulative なので次 tick で回収）。
+    pub fn unroutable_event_count(&self) -> u64 {
+        self.engine.unroutable_event_count().unwrap_or(0)
     }
 
     /// feature `outproc-effect` 無効ビルド用の stub。本番は常に `(0, 0, false, ...)`（control が無い）。
@@ -4283,6 +4339,38 @@ mod outproc_health_tests {
             .err()
             .expect("closed bus slot still rejects the load, but past the routing step");
         assert_effect_runtime_error_contains(error, "closed after an unrecoverable attach failure");
+    }
+
+    #[test]
+    fn load_outproc_effect_plugin_rolls_back_activation_on_failure() {
+        // #461 review Important: attach 失敗後に activation=true が残ると、失敗した宣言が
+        // render path を恒久占有する。失敗で flag が false に戻ることを固定する。
+        let (wrap, _guard) =
+            EngineWrap::start_with(StubBackend::default()).expect("stub backend start");
+        let bus_slot = Arc::new(Mutex::new(ChildSlot::<EffectRole>::Closed));
+        let active = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let mut bus_slots = HashMap::new();
+        bus_slots.insert("fx1".to_owned(), Arc::downgrade(&bus_slot));
+        let mut bus_actives = HashMap::new();
+        bus_actives.insert("fx1".to_owned(), active.clone());
+        *wrap.outproc.lock().expect("lock outproc for injection") = Some(OutProcControl {
+            stats: OutProcEffectStats::new(),
+            cb_stats: CallbackTimeStats::new(),
+            child_slot: Weak::new(),
+            bus_slots,
+            bus_stats: HashMap::new(),
+            bus_actives,
+        });
+        let result = wrap.load_outproc_effect_plugin(
+            std::path::PathBuf::from("unused.clap"),
+            None,
+            Some("fx1".into()),
+        );
+        assert!(result.is_err());
+        assert!(
+            !active.load(std::sync::atomic::Ordering::Acquire),
+            "attach 失敗後は activation がロールバックされること"
+        );
     }
 
     fn assert_effect_runtime_error_contains(error: WrapError, expected: &str) {

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -207,6 +207,10 @@ struct OutProcControl {
     /// bus 名 → その bus の `OutProcEffectStats`（`outproc_effect_bus_stats` gated 計測用）。
     /// `bus_slots` と同じキー集合で、child の生死に関わらず統計自体は生存し続けるため強参照。
     bus_stats: HashMap<String, Arc<crate::outproc_effect::OutProcEffectStats>>,
+    /// bus 名 → render 側 `InsertBusStage::active` と共有する activation flag。LoadPlugin が
+    /// bus を指名した時点で `true`（宣言 = activation）。全 bus inactive の間、callback は
+    /// bus 無し経路（ビット同一）を通る。
+    bus_actives: HashMap<String, Arc<std::sync::atomic::AtomicBool>>,
 }
 
 /// `ORBIT_EFFECT_BUSES` の値を解析する純関数。カンマ区切りの bus 名を trim・空要素除去した上で、
@@ -277,6 +281,109 @@ fn effect_buses_from_env() -> Result<Vec<String>, WrapError> {
     let pool_raw = std::env::var("ORBIT_EFFECT_BUS_POOL").unwrap_or_default();
     let pool_size = parse_effect_bus_pool_size(&pool_raw).map_err(WrapError::OutProcEffect)?;
     Ok(default_effect_bus_pool(pool_size))
+}
+
+/// 1 本の named insert bus を構成する部材（`build_effect_bus_stages` → `install_effect_bus_slots`
+/// の間で運ぶ・#434 S2/S3）。effect-only / both の両起動経路で同一のライフサイクルを共有する。
+#[cfg(feature = "outproc-effect")]
+struct EffectBusBuild {
+    name: String,
+    shm_path: std::path::PathBuf,
+    engaged: Arc<std::sync::atomic::AtomicBool>,
+    stop: Arc<std::sync::atomic::AtomicBool>,
+    done: Arc<std::sync::atomic::AtomicBool>,
+    stats: Arc<crate::outproc_effect::OutProcEffectStats>,
+    /// render 側 `InsertBusStage::active` と共有。LoadPlugin が bus を指名した時点で
+    /// `true`（宣言 = activation → 以降 pass-through）。それまで callback は bus を
+    /// render 対象に含めない = 既定プールのコストゼロ。
+    active: Arc<std::sync::atomic::AtomicBool>,
+}
+
+/// `ORBIT_EFFECT_BUSES` / 既定プールの bus 名から、render 側の `InsertBusStage` 群と
+/// daemon 側の部材（`EffectBusBuild`）を構築する。stage は inactive で生まれ、LoadPlugin
+/// （`load_outproc_effect_plugin` の bus 指定）で activate される。
+#[cfg(feature = "outproc-effect")]
+fn build_effect_bus_stages(
+) -> Result<(Vec<orbit_audio_native::InsertBusStage>, Vec<EffectBusBuild>), WrapError> {
+    use crate::outproc_effect::{OutProcEffectPostProcessor, OutProcEffectStats};
+    use std::sync::atomic::AtomicBool;
+    let names = effect_buses_from_env()?;
+    let mut builds = Vec::with_capacity(names.len());
+    let mut insert_buses = Vec::with_capacity(names.len());
+    for name in names {
+        let shm_path = crate::outproc_effect::unique_shm_path();
+        let host = orbit_audio_sandbox::PipelinedEffectHost::from_mmap(
+            orbit_audio_sandbox::create_shared(&shm_path).map_err(|e| {
+                WrapError::OutProcEffect(format!("create bus shm {shm_path:?}: {e}"))
+            })?,
+        );
+        let engaged = Arc::new(AtomicBool::new(false));
+        let stop = Arc::new(AtomicBool::new(false));
+        let done = Arc::new(AtomicBool::new(false));
+        let active = Arc::new(AtomicBool::new(false));
+        let stats = OutProcEffectStats::new();
+        insert_buses.push(orbit_audio_native::InsertBusStage::with_activation(
+            name.clone(),
+            Some(Box::new(OutProcEffectPostProcessor::new(
+                host,
+                engaged.clone(),
+                stop.clone(),
+                done.clone(),
+                stats.clone(),
+            ))),
+            0,
+            active.clone(),
+        ));
+        builds.push(EffectBusBuild {
+            name,
+            shm_path,
+            engaged,
+            stop,
+            done,
+            stats,
+            active,
+        });
+    }
+    Ok((insert_buses, builds))
+}
+
+/// bus 部材を ChildSlot / 観測 map / StreamGuard 用 guard 群へ展開する（stream 起動後・
+/// sample_rate 確定後に呼ぶ）。返り値: (bus_slots, bus_stats, bus_actives, child_guards, teardowns)。
+#[cfg(feature = "outproc-effect")]
+#[allow(clippy::type_complexity)]
+fn install_effect_bus_slots(
+    builds: Vec<EffectBusBuild>,
+    child_exe: &std::path::Path,
+    sample_rate: u32,
+) -> (
+    HashMap<String, Weak<Mutex<ChildSlot>>>,
+    HashMap<String, Arc<crate::outproc_effect::OutProcEffectStats>>,
+    HashMap<String, Arc<std::sync::atomic::AtomicBool>>,
+    Vec<Arc<Mutex<ChildSlot>>>,
+    Vec<crate::outproc_effect::OutProcTeardownGuard>,
+) {
+    use crate::outproc_effect::OutProcTeardownGuard;
+    let mut bus_slots = HashMap::new();
+    let mut bus_stats = HashMap::new();
+    let mut bus_actives = HashMap::new();
+    let mut child_guards = Vec::with_capacity(builds.len());
+    let mut teardowns = Vec::with_capacity(builds.len());
+    for build in builds {
+        let slot = Arc::new(Mutex::new(ChildSlot::Empty(ChildLaunch {
+            shm_path: build.shm_path,
+            child_exe: child_exe.to_path_buf(),
+            sample_rate,
+            stats: build.stats.clone(),
+            engaged: build.engaged,
+            cleanup_shm_on_drop: true,
+        })));
+        bus_slots.insert(build.name.clone(), Arc::downgrade(&slot));
+        bus_stats.insert(build.name.clone(), build.stats);
+        bus_actives.insert(build.name, build.active);
+        child_guards.push(slot);
+        teardowns.push(OutProcTeardownGuard::new(build.stop, build.done));
+    }
+    (bus_slots, bus_stats, bus_actives, child_guards, teardowns)
 }
 
 #[cfg(all(test, feature = "outproc-effect"))]
@@ -1063,35 +1170,9 @@ impl EngineWrap {
         };
         use std::sync::atomic::AtomicBool;
 
-        let bus_names = effect_buses_from_env()?;
         // Each registered bus owns a complete transport up front.  Attachment is the existing
-        // lock-free `engaged` release-store, so the callback never allocates or locks.
-        let mut bus_builds = Vec::with_capacity(bus_names.len());
-        let mut insert_buses = Vec::with_capacity(bus_names.len());
-        for name in &bus_names {
-            let shm_path = crate::outproc_effect::unique_shm_path();
-            let host = orbit_audio_sandbox::PipelinedEffectHost::from_mmap(
-                orbit_audio_sandbox::create_shared(&shm_path).map_err(|e| {
-                    WrapError::OutProcEffect(format!("create bus shm {shm_path:?}: {e}"))
-                })?,
-            );
-            let engaged = Arc::new(AtomicBool::new(false));
-            let stop = Arc::new(AtomicBool::new(false));
-            let done = Arc::new(AtomicBool::new(false));
-            let stats = OutProcEffectStats::new();
-            insert_buses.push(orbit_audio_native::InsertBusStage::new(
-                name.clone(),
-                Some(Box::new(OutProcEffectPostProcessor::new(
-                    host,
-                    engaged.clone(),
-                    stop.clone(),
-                    done.clone(),
-                    stats.clone(),
-                ))),
-                0,
-            ));
-            bus_builds.push((shm_path, engaged, stop, done, stats));
-        }
+        // lock-free `engaged` release-store（activation は LoadPlugin 時・`EffectBusBuild` doc 参照）。
+        let (insert_buses, bus_builds) = build_effect_bus_stages()?;
 
         // 1. shm 作成 → host mmap（adapter が所有・audio thread）。
         let shm_path = crate::outproc_effect::unique_shm_path();
@@ -1150,27 +1231,11 @@ impl EngineWrap {
                 child_slot: Arc::downgrade(&child_slot),
                 bus_slots: HashMap::new(),
                 bus_stats: HashMap::new(),
+                bus_actives: HashMap::new(),
             });
 
-        let mut bus_slots = HashMap::new();
-        let mut bus_stats = HashMap::new();
-        let mut bus_child_guards = Vec::with_capacity(bus_builds.len());
-        let mut bus_teardowns = Vec::with_capacity(bus_builds.len());
-        for (name, (shm_path, engaged, stop, done, stats)) in bus_names.into_iter().zip(bus_builds)
-        {
-            let slot = Arc::new(Mutex::new(ChildSlot::Empty(ChildLaunch {
-                shm_path,
-                child_exe: cfg.child_exe.clone(),
-                sample_rate,
-                stats: stats.clone(),
-                engaged,
-                cleanup_shm_on_drop: true,
-            })));
-            bus_slots.insert(name.clone(), Arc::downgrade(&slot));
-            bus_stats.insert(name, stats);
-            bus_child_guards.push(slot);
-            bus_teardowns.push(OutProcTeardownGuard::new(stop, done));
-        }
+        let (bus_slots, bus_stats, bus_actives, bus_child_guards, bus_teardowns) =
+            install_effect_bus_slots(bus_builds, &cfg.child_exe, sample_rate);
         {
             let mut guard = wrap
                 .outproc
@@ -1179,6 +1244,7 @@ impl EngineWrap {
             let control = guard.as_mut().expect("outproc control installed");
             control.bus_slots = bus_slots;
             control.bus_stats = bus_stats;
+            control.bus_actives = bus_actives;
         }
 
         // 7. StreamGuard（field 順 = teardown 順）。
@@ -1339,36 +1405,9 @@ impl EngineWrap {
             instrument_cfg.buffer_frames,
         )?;
 
-        let bus_names = effect_buses_from_env()?;
         // 同じ transport 構築を effect-only 経路（`start_outproc_effect_post_boot`）と共有する。
-        // bus 0 個なら `insert_buses` は空 Vec になり、`start_default_output_with_insert_buses_and_post`
-        // は従来の `start_default_output_with_clap` と等価に振る舞う。
-        let mut bus_builds = Vec::with_capacity(bus_names.len());
-        let mut insert_buses = Vec::with_capacity(bus_names.len());
-        for name in &bus_names {
-            let shm_path = crate::outproc_effect::unique_shm_path();
-            let host = orbit_audio_sandbox::PipelinedEffectHost::from_mmap(
-                orbit_audio_sandbox::create_shared(&shm_path).map_err(|e| {
-                    WrapError::OutProcEffect(format!("create bus shm {shm_path:?}: {e}"))
-                })?,
-            );
-            let engaged = Arc::new(AtomicBool::new(false));
-            let stop = Arc::new(AtomicBool::new(false));
-            let done = Arc::new(AtomicBool::new(false));
-            let stats = OutProcEffectStats::new();
-            insert_buses.push(orbit_audio_native::InsertBusStage::new(
-                name.clone(),
-                Some(Box::new(OutProcEffectPostProcessor::new(
-                    host,
-                    engaged.clone(),
-                    stop.clone(),
-                    done.clone(),
-                    stats.clone(),
-                ))),
-                0,
-            ));
-            bus_builds.push((shm_path, engaged, stop, done, stats));
-        }
+        // bus 0 個（または全 bus inactive）なら render は従来経路とビット同一に振る舞う。
+        let (insert_buses, bus_builds) = build_effect_bus_stages()?;
 
         let effect_shm = crate::outproc_effect::unique_shm_path();
         let effect_host = orbit_audio_sandbox::PipelinedEffectHost::from_mmap(
@@ -1451,6 +1490,7 @@ impl EngineWrap {
                 child_slot: Arc::downgrade(&effect_slot),
                 bus_slots: HashMap::new(),
                 bus_stats: HashMap::new(),
+                bus_actives: HashMap::new(),
             });
         *wrap.outproc_instrument.lock().map_err(|_| {
             WrapError::OutProcInstrument("outproc instrument mutex poisoned".into())
@@ -1460,25 +1500,8 @@ impl EngineWrap {
             child_slot: Arc::downgrade(&instrument_slot),
         });
 
-        let mut bus_slots = HashMap::new();
-        let mut bus_stats = HashMap::new();
-        let mut bus_child_guards = Vec::with_capacity(bus_builds.len());
-        let mut bus_teardowns = Vec::with_capacity(bus_builds.len());
-        for (name, (shm_path, engaged, stop, done, stats)) in bus_names.into_iter().zip(bus_builds)
-        {
-            let slot = Arc::new(Mutex::new(ChildSlot::Empty(ChildLaunch {
-                shm_path,
-                child_exe: effect_cfg.child_exe.clone(),
-                sample_rate: stream.sample_rate,
-                stats: stats.clone(),
-                engaged,
-                cleanup_shm_on_drop: true,
-            })));
-            bus_slots.insert(name.clone(), Arc::downgrade(&slot));
-            bus_stats.insert(name, stats);
-            bus_child_guards.push(slot);
-            bus_teardowns.push(OutProcTeardownGuard::new(stop, done));
-        }
+        let (bus_slots, bus_stats, bus_actives, bus_child_guards, bus_teardowns) =
+            install_effect_bus_slots(bus_builds, &effect_cfg.child_exe, stream.sample_rate);
         {
             let mut guard = wrap
                 .outproc
@@ -1487,6 +1510,7 @@ impl EngineWrap {
             let control = guard.as_mut().expect("outproc control installed");
             control.bus_slots = bus_slots;
             control.bus_stats = bus_stats;
+            control.bus_actives = bus_actives;
         }
 
         Ok((
@@ -1737,11 +1761,20 @@ impl EngineWrap {
                 )
             })?;
             let weak_slot = match bus {
-                Some(bus) => control.bus_slots.get(&bus).ok_or_else(|| {
-                    WrapError::OutProcEffect(format!(
-                        "unknown effect bus '{bus}' (configured by ORBIT_EFFECT_BUSES)"
-                    ))
-                })?,
+                Some(bus) => {
+                    let slot = control.bus_slots.get(&bus).ok_or_else(|| {
+                        WrapError::OutProcEffect(format!(
+                            "unknown effect bus '{bus}' (configured by ORBIT_EFFECT_BUSES)"
+                        ))
+                    })?;
+                    // 宣言 = activation: この store 以降、callback は当該 bus を render 対象に
+                    // 含める（attach 完了前は engaged=false の pass-through）。宣言前の bus は
+                    // render 対象外 = 既定プールのコストゼロ（InsertBusStage::active の doc 参照）。
+                    if let Some(active) = control.bus_actives.get(&bus) {
+                        active.store(true, std::sync::atomic::Ordering::Release);
+                    }
+                    slot
+                }
                 None => &control.child_slot,
             };
             weak_slot
@@ -4186,6 +4219,7 @@ mod outproc_health_tests {
             child_slot: Weak::new(),
             bus_slots: HashMap::new(),
             bus_stats: HashMap::new(),
+            bus_actives: HashMap::new(),
         });
         (wrap, stats)
     }
@@ -4203,6 +4237,7 @@ mod outproc_health_tests {
             child_slot: Arc::downgrade(&child_slot),
             bus_slots: HashMap::new(),
             bus_stats: HashMap::new(),
+            bus_actives: HashMap::new(),
         });
         (wrap, child_slot)
     }
@@ -4237,6 +4272,7 @@ mod outproc_health_tests {
             child_slot: Weak::new(),
             bus_slots,
             bus_stats: HashMap::new(),
+            bus_actives: HashMap::new(),
         });
         let error = wrap
             .load_outproc_effect_plugin(

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -233,10 +233,50 @@ fn parse_effect_buses(raw: &str) -> Result<Vec<String>, String> {
         .collect()
 }
 
+/// 既定 insert bus プールの名前 prefix。DSL 側（TS）の per-sequence effect manager が
+/// 同じ規則（`seq-bus-<n>`）で bus 名を組み立てて `LoadPlugin.bus` / `PlayAt.bus` に
+/// 送るため、prefix を変える場合は TS 側の定数も合わせて更新すること（#434 S3）。
+#[cfg(feature = "outproc-effect")]
+pub const DEFAULT_EFFECT_BUS_POOL_PREFIX: &str = "seq-bus-";
+
+/// `ORBIT_EFFECT_BUS_POOL` の既定サイズ（未設定時）。PH.2b の v1 上限（同時 insert 8 seq）と一致。
+#[cfg(feature = "outproc-effect")]
+const DEFAULT_EFFECT_BUS_POOL_SIZE: usize = 8;
+
+/// 既定プール名 `seq-bus-0..N` を生成する純関数。`ORBIT_EFFECT_BUSES`（明示名）が指定されて
+/// いない場合のみ呼ばれる。`pool_size` は `ORBIT_EFFECT_BUS_POOL` の解析結果（既定 8・0 で無効）。
+#[cfg(feature = "outproc-effect")]
+fn default_effect_bus_pool(pool_size: usize) -> Vec<String> {
+    (0..pool_size)
+        .map(|n| format!("{DEFAULT_EFFECT_BUS_POOL_PREFIX}{n}"))
+        .collect()
+}
+
+/// `ORBIT_EFFECT_BUS_POOL` を解析する純関数。空 / 未設定は既定値（8）。`"0"` はプール無効
+/// （明示的な `ORBIT_EFFECT_BUSES` のみ使う後方互換モード）。非数値・負値は起動時エラー。
+#[cfg(feature = "outproc-effect")]
+fn parse_effect_bus_pool_size(raw: &str) -> Result<usize, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(DEFAULT_EFFECT_BUS_POOL_SIZE);
+    }
+    trimmed
+        .parse::<usize>()
+        .map_err(|_| format!("ORBIT_EFFECT_BUS_POOL must be a non-negative integer, got '{raw}'"))
+}
+
+/// bus 名の解決: `ORBIT_EFFECT_BUSES`（明示名・非空）が設定されていればそれを使う（既存 S2 挙動を
+/// 保つ）。未設定なら `ORBIT_EFFECT_BUS_POOL`（既定 8・`"0"` で無効）に従って `seq-bus-<n>` の
+/// 既定プールを生成する。両方指定は `ORBIT_EFFECT_BUSES` を優先（明示指定が常に勝つ）。
 #[cfg(feature = "outproc-effect")]
 fn effect_buses_from_env() -> Result<Vec<String>, WrapError> {
-    parse_effect_buses(&std::env::var("ORBIT_EFFECT_BUSES").unwrap_or_default())
-        .map_err(WrapError::OutProcEffect)
+    let explicit = std::env::var("ORBIT_EFFECT_BUSES").unwrap_or_default();
+    if !explicit.trim().is_empty() {
+        return parse_effect_buses(&explicit).map_err(WrapError::OutProcEffect);
+    }
+    let pool_raw = std::env::var("ORBIT_EFFECT_BUS_POOL").unwrap_or_default();
+    let pool_size = parse_effect_bus_pool_size(&pool_raw).map_err(WrapError::OutProcEffect)?;
+    Ok(default_effect_bus_pool(pool_size))
 }
 
 #[cfg(all(test, feature = "outproc-effect"))]
@@ -280,6 +320,54 @@ mod effect_buses_from_env_tests {
         let error =
             parse_effect_buses("fx1,fx\x002").expect_err("NUL byte in name must be rejected");
         assert!(error.contains("invalid"), "unexpected message: {error}");
+    }
+}
+
+#[cfg(all(test, feature = "outproc-effect"))]
+mod effect_bus_pool_tests {
+    use super::{
+        default_effect_bus_pool, parse_effect_bus_pool_size, DEFAULT_EFFECT_BUS_POOL_SIZE,
+    };
+
+    #[test]
+    fn pool_size_defaults_to_eight_when_unset_or_blank() {
+        assert_eq!(
+            parse_effect_bus_pool_size(""),
+            Ok(DEFAULT_EFFECT_BUS_POOL_SIZE)
+        );
+        assert_eq!(
+            parse_effect_bus_pool_size("   "),
+            Ok(DEFAULT_EFFECT_BUS_POOL_SIZE)
+        );
+    }
+
+    #[test]
+    fn pool_size_zero_disables_the_pool() {
+        assert_eq!(parse_effect_bus_pool_size("0"), Ok(0));
+        assert_eq!(default_effect_bus_pool(0), Vec::<String>::new());
+    }
+
+    #[test]
+    fn pool_size_parses_explicit_count() {
+        assert_eq!(parse_effect_bus_pool_size("3"), Ok(3));
+    }
+
+    #[test]
+    fn pool_size_rejects_non_numeric_or_negative() {
+        assert!(parse_effect_bus_pool_size("abc").is_err());
+        assert!(parse_effect_bus_pool_size("-1").is_err());
+    }
+
+    #[test]
+    fn default_pool_generates_seq_bus_names_in_order() {
+        assert_eq!(
+            default_effect_bus_pool(3),
+            vec![
+                "seq-bus-0".to_string(),
+                "seq-bus-1".to_string(),
+                "seq-bus-2".to_string(),
+            ]
+        );
     }
 }
 

--- a/rust/crates/orbit-audio-daemon/src/protocol.rs
+++ b/rust/crates/orbit-audio-daemon/src/protocol.rs
@@ -151,6 +151,11 @@ pub const ERROR_CODE_OUTPROC_INSTRUMENT_INVALID: &str = "OUTPROC_INSTRUMENT_INVA
 /// だったが daemon health 経路への配線が欠けており、per-note expression 等の未対応イベント消失が
 /// 一切可視化されなかった — silent-failure-hunter 指摘の残余）。
 pub const ERROR_CODE_OUTPROC_INSTRUMENT_EVENT_DECODE: &str = "OUTPROC_INSTRUMENT_EVENT_DECODE";
+/// named routing tag（insert bus / LinkAudio channel）が render 対象に存在せず、event が
+/// 消費されないまま retain され続けている（メモリ増加 + 鳴らない音）。WARNING severity。
+/// core の `Scheduler::unroutable_event_count` を 1 Hz ticker が監視して発火する
+/// （#461 review: 「宣言前 tag / 名前 typo」の唯一の観測点）。
+pub const ERROR_CODE_UNROUTABLE_EVENTS: &str = "UNROUTABLE_EVENTS";
 
 /// Daemon → Client の event（通知、id なし）。
 #[derive(Debug, Serialize)]

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -27,9 +27,9 @@ use crate::protocol::{
     ERROR_CODE_OUTPROC_EFFECT_RESPAWN, ERROR_CODE_OUTPROC_INSTRUMENT_ERROR,
     ERROR_CODE_OUTPROC_INSTRUMENT_EVENT_DECODE, ERROR_CODE_OUTPROC_INSTRUMENT_INVALID,
     ERROR_CODE_OUTPROC_INSTRUMENT_OUTPUT_DROPPED, ERROR_CODE_OUTPROC_INSTRUMENT_RESPAWN,
-    ERROR_CODE_PLUGIN_EVENT_RING_OVERFLOW, ERROR_CODE_STREAM_XRUN, ERROR_SEVERITY_FATAL,
-    ERROR_SEVERITY_WARNING, EVENT_DAEMON_ERROR, EVENT_PLAY_ENDED, EVENT_PLAY_STARTED,
-    EVENT_STREAM_STATS,
+    ERROR_CODE_PLUGIN_EVENT_RING_OVERFLOW, ERROR_CODE_STREAM_XRUN, ERROR_CODE_UNROUTABLE_EVENTS,
+    ERROR_SEVERITY_FATAL, ERROR_SEVERITY_WARNING, EVENT_DAEMON_ERROR, EVENT_PLAY_ENDED,
+    EVENT_PLAY_STARTED, EVENT_STREAM_STATS,
 };
 
 /// writer task のキュー容量。過大に積まれると back pressure をかける。
@@ -143,6 +143,17 @@ pub async fn run(
             let mut last_outproc_errors: u64 = 0;
             let mut last_outproc_respawns: u64 = 0;
             let mut last_outproc_frames_clamped: u64 = 0;
+            // per-bus effect health の watermark（#461 review Critical: bus child の異常が
+            // ticker に出ない穴）。key = bus 名。
+            let mut last_bus_errors: std::collections::HashMap<String, u64> =
+                std::collections::HashMap::new();
+            let mut last_bus_respawns: std::collections::HashMap<String, u64> =
+                std::collections::HashMap::new();
+            let mut bus_invalid_reported: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            let mut last_bus_frames_clamped: std::collections::HashMap<String, u64> =
+                std::collections::HashMap::new();
+            let mut last_unroutable_events: u64 = 0;
             let mut last_outproc_instrument_output_dropped: u64 = 0;
             let mut last_outproc_instrument_errors: u64 = 0;
             let mut last_outproc_instrument_respawns: u64 = 0;
@@ -351,6 +362,94 @@ pub async fn run(
                         break;
                     }
                     last_outproc_frames_clamped = outproc_frames_clamped;
+                }
+
+                // per-bus OOP effect（seq.effect() の insert bus・#434/#461）の health を master と
+                // 同じ 4 signal で surface する。error code は master と共有し、message の bus 名で
+                // 区別する（コード乱発を避ける）。
+                for (bus, (errors, respawns, invalid, clamped)) in
+                    engine.outproc_effect_bus_health()
+                {
+                    let last = last_bus_errors.entry(bus.clone()).or_insert(0);
+                    if errors > *last {
+                        let evt = daemon_error_event(
+                            ERROR_SEVERITY_WARNING,
+                            ERROR_CODE_OUTPROC_EFFECT_ERROR,
+                            format!(
+                                "out-of-process effect child process() failed on bus '{bus}' \
+                                 ({errors} total); that sequence's insert passes dry",
+                            ),
+                        );
+                        if tx.send(to_json_or_fallback(&evt)).await.is_err() {
+                            break;
+                        }
+                        *last = errors;
+                    }
+                    let last = last_bus_respawns.entry(bus.clone()).or_insert(0);
+                    if respawns > *last {
+                        let evt = daemon_error_event(
+                            ERROR_SEVERITY_WARNING,
+                            ERROR_CODE_OUTPROC_EFFECT_RESPAWN,
+                            format!(
+                                "out-of-process effect child crashed and was respawned on bus \
+                                 '{bus}' ({respawns} total); 3rd-party crash isolated",
+                            ),
+                        );
+                        if tx.send(to_json_or_fallback(&evt)).await.is_err() {
+                            break;
+                        }
+                        *last = respawns;
+                    }
+                    if invalid && !bus_invalid_reported.contains(&bus) {
+                        let evt = daemon_error_event(
+                            ERROR_SEVERITY_WARNING,
+                            ERROR_CODE_OUTPROC_EFFECT_INVALID,
+                            format!(
+                                "out-of-process effect supervisor gave up on bus '{bus}' \
+                                 (respawn/try_wait failed); that insert is frozen — restart \
+                                 daemon or fix plugin",
+                            ),
+                        );
+                        if tx.send(to_json_or_fallback(&evt)).await.is_err() {
+                            break;
+                        }
+                        bus_invalid_reported.insert(bus.clone());
+                    }
+                    let last = last_bus_frames_clamped.entry(bus).or_insert(0);
+                    if clamped > *last {
+                        let evt = daemon_error_event(
+                            ERROR_SEVERITY_WARNING,
+                            ERROR_CODE_OUTPROC_EFFECT_FRAMES_CLAMPED,
+                            format!(
+                                "out-of-process effect block exceeded MAX_FRAMES and was \
+                                 clamped on a seq bus ({clamped} total)",
+                            ),
+                        );
+                        if tx.send(to_json_or_fallback(&evt)).await.is_err() {
+                            break;
+                        }
+                        *last = clamped;
+                    }
+                }
+
+                // 未登録 named target（insert bus / LinkAudio channel）へ tag された event の
+                // retain を surface する（#461 review: comment-only だった core のハザードに
+                // 観測点を配線・frames_clamped の前例と同じ「既存 counter → ticker 追配線」）。
+                let unroutable = engine.unroutable_event_count();
+                if unroutable > last_unroutable_events {
+                    let evt = daemon_error_event(
+                        ERROR_SEVERITY_WARNING,
+                        ERROR_CODE_UNROUTABLE_EVENTS,
+                        format!(
+                            "{unroutable} scheduled event(s) are tagged to an unknown \
+                             bus/channel and will never play (declared-before-tag order \
+                             violated, or a name typo); they are retained until Stop",
+                        ),
+                    );
+                    if tx.send(to_json_or_fallback(&evt)).await.is_err() {
+                        break;
+                    }
+                    last_unroutable_events = unroutable;
                 }
 
                 // out-of-process instrument の全 health signal（child-process 系: respawn/計測無効/

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -91,6 +91,14 @@ fn parse_bus_param(params: &Value) -> Result<Option<String>, &'static str> {
     }
 }
 
+/// PlayAt の `bus`（per-sequence insert routing・PH.2b・#434 S3）と `channel`（LinkAudio
+/// routing・#209）の同時指定を検出する純関数。両者は core 上は同じ routing tag フィールド
+/// （`ScheduledSample.channel`）を共有するため、同時指定は意味が一意に決まらず拒否する。
+#[cfg(feature = "outproc-effect")]
+fn playat_bus_and_channel_both_set(bus: &Option<String>, channel: &Option<String>) -> bool {
+    bus.is_some() && channel.is_some()
+}
+
 /// role='instrument' と 'bus' の同時指定を検出する純関数（'bus' は effect 専用）。
 #[cfg(feature = "outproc-instrument")]
 fn bus_param_invalid_for_instrument_role(params: &Value) -> bool {
@@ -859,6 +867,27 @@ async fn handle_command(
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
                 .map(|s| s.to_string());
+            // bus（per-sequence insert routing・PH.2b・#434 S3）。'channel'（LinkAudio）とは
+            // 別 wire param。core の routing tag は単一フィールド（`ScheduledSample.channel`）
+            // を再利用するが、LinkAudio と plugin hosting は v1 で排他ビルドのため
+            // 実運用上どちらか一方しか有効にならない。同時指定は明示エラーで開示する。
+            #[cfg(feature = "outproc-effect")]
+            let bus = match parse_bus_param(&params) {
+                Ok(bus) => bus,
+                Err(message) => return err(&id, ProtocolError::new("MALFORMED_REQUEST", message)),
+            };
+            #[cfg(feature = "outproc-effect")]
+            if playat_bus_and_channel_both_set(&bus, &channel) {
+                return err(
+                    &id,
+                    ProtocolError::new(
+                        "MALFORMED_REQUEST",
+                        "PlayAt 'bus' and 'channel' cannot both be set",
+                    ),
+                );
+            }
+            #[cfg(feature = "outproc-effect")]
+            let channel = bus.or(channel);
             match params.get("sample_id").and_then(|v| v.as_str()) {
                 Some(sid) => match engine.play_at(
                     sid,
@@ -1221,6 +1250,26 @@ mod tests {
         assert!(parse_bus_param(&json!({"bus": ""})).is_err());
         assert!(parse_bus_param(&json!({"bus": "   "})).is_err());
         assert!(parse_bus_param(&json!({"bus": 1})).is_err());
+    }
+
+    // PlayAt の 'bus'（PH.2b insert routing）と 'channel'（LinkAudio routing）は同じ core routing
+    // tag フィールドを共有するため同時指定を拒否する（#434 S3）。
+    #[cfg(feature = "outproc-effect")]
+    #[test]
+    fn playat_bus_and_channel_both_set_flags_only_the_combination() {
+        assert!(playat_bus_and_channel_both_set(
+            &Some("seq-bus-0".to_owned()),
+            &Some("link-ch".to_owned())
+        ));
+        assert!(!playat_bus_and_channel_both_set(
+            &Some("seq-bus-0".to_owned()),
+            &None
+        ));
+        assert!(!playat_bus_and_channel_both_set(
+            &None,
+            &Some("link-ch".to_owned())
+        ));
+        assert!(!playat_bus_and_channel_both_set(&None, &None));
     }
 
     #[cfg(feature = "outproc-instrument")]

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -80,6 +80,23 @@ fn outproc_role_param_is_valid(params: &Value) -> bool {
     )
 }
 
+/// LoadPlugin params から `bus` を取り出す純関数。`None` は無指定（master bus）、`Ok(Some(_))` は
+/// non-empty 文字列。空文字列や非文字列型は `Err` として拒否する。
+#[cfg(feature = "outproc-effect")]
+fn parse_bus_param(params: &Value) -> Result<Option<String>, &'static str> {
+    match params.get("bus") {
+        None => Ok(None),
+        Some(Value::String(bus)) if !bus.trim().is_empty() => Ok(Some(bus.clone())),
+        Some(_) => Err("'bus' must be a non-empty string"),
+    }
+}
+
+/// role='instrument' と 'bus' の同時指定を検出する純関数（'bus' は effect 専用）。
+#[cfg(feature = "outproc-instrument")]
+fn bus_param_invalid_for_instrument_role(params: &Value) -> bool {
+    params.get("role").and_then(Value::as_str) == Some("instrument") && params.get("bus").is_some()
+}
+
 pub async fn run(
     ws: WebSocketStream<TcpStream>,
     engine: Arc<EngineWrap>,
@@ -715,6 +732,23 @@ async fn handle_command(
                     .get("plugin_id")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
+                #[cfg(feature = "outproc-effect")]
+                let bus = match parse_bus_param(&params) {
+                    Ok(bus) => bus,
+                    Err(message) => {
+                        return err(&id, ProtocolError::new("MALFORMED_REQUEST", message))
+                    }
+                };
+                #[cfg(feature = "outproc-instrument")]
+                if bus_param_invalid_for_instrument_role(&params) {
+                    return err(
+                        &id,
+                        ProtocolError::new(
+                            "MALFORMED_REQUEST",
+                            "LoadPlugin bus is only valid for role='effect'",
+                        ),
+                    );
+                }
                 #[cfg(all(feature = "outproc-effect", feature = "outproc-instrument"))]
                 let params_role = params
                     .get("role")
@@ -727,7 +761,7 @@ async fn handle_command(
                         {
                             match params_role.as_deref() {
                                 Some("effect") => {
-                                    engine.load_outproc_effect_plugin(path, plugin_id)
+                                    engine.load_outproc_effect_plugin(path, plugin_id, bus)
                                 }
                                 Some("instrument") => {
                                     engine.load_outproc_instrument_plugin(path, plugin_id)
@@ -739,7 +773,17 @@ async fn handle_command(
                             feature = "outproc-effect",
                             feature = "outproc-instrument"
                         )))]
-                        engine.load_outproc_plugin(path, plugin_id)
+                        #[cfg(feature = "outproc-effect")]
+                        {
+                            engine.load_outproc_effect_plugin(path, plugin_id, bus)
+                        }
+                        #[cfg(all(
+                            feature = "outproc-instrument",
+                            not(feature = "outproc-effect")
+                        ))]
+                        {
+                            engine.load_outproc_plugin(path, plugin_id)
+                        }
                     }
                     #[cfg(not(any(feature = "outproc-effect", feature = "outproc-instrument")))]
                     {
@@ -1164,6 +1208,33 @@ mod tests {
         assert!(outproc_role_param_is_valid(&json!({"role": "instrument"})));
         assert!(!outproc_role_param_is_valid(&json!({"role": "invalid"})));
         assert!(!outproc_role_param_is_valid(&json!({})));
+    }
+
+    #[cfg(feature = "outproc-effect")]
+    #[test]
+    fn parse_bus_param_accepts_absent_and_trims_nothing_but_rejects_blank_or_non_string() {
+        assert_eq!(parse_bus_param(&json!({})), Ok(None));
+        assert_eq!(
+            parse_bus_param(&json!({"bus": "fx1"})),
+            Ok(Some("fx1".to_owned()))
+        );
+        assert!(parse_bus_param(&json!({"bus": ""})).is_err());
+        assert!(parse_bus_param(&json!({"bus": "   "})).is_err());
+        assert!(parse_bus_param(&json!({"bus": 1})).is_err());
+    }
+
+    #[cfg(feature = "outproc-instrument")]
+    #[test]
+    fn bus_param_invalid_for_instrument_role_flags_only_the_combination() {
+        assert!(bus_param_invalid_for_instrument_role(
+            &json!({"role": "instrument", "bus": "fx1"})
+        ));
+        assert!(!bus_param_invalid_for_instrument_role(
+            &json!({"role": "instrument"})
+        ));
+        assert!(!bus_param_invalid_for_instrument_role(
+            &json!({"role": "effect", "bus": "fx1"})
+        ));
     }
 
     // LinkAudio エラーの protocol code 分割を pin（TS は UNAVAILABLE のみ握り潰し RUNTIME は rethrow）。

--- a/rust/crates/orbit-audio-daemon/tests/outproc_both_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_both_gated.rs
@@ -78,7 +78,7 @@ fn both_roles_attach_in_instrument_then_effect_order() {
         .load_outproc_instrument_plugin(synth_path, synth_id)
         .expect("attach test-synth to instrument slot");
     engine
-        .load_outproc_effect_plugin(effect_path, None)
+        .load_outproc_effect_plugin(effect_path, None, None)
         .expect("attach test-effect to effect slot");
 
     engine
@@ -90,10 +90,14 @@ fn both_roles_attach_in_instrument_then_effect_order() {
             .map(|s| s.fresh > 0 && s.probe_live_count > 0)
             .unwrap_or(false)
     });
+    // post_peak まで待つ: OOP effect は SLOTS=2 の pipeline で出力が 1 ブロック遅れる。
+    // fresh/dry だけで先へ進むと、音の最初のブロックを入力した直後（post はまだ
+    // silence-primed の前段出力）に note-off → stats 読みになる race がある（#434 S2 の
+    // 起動位相シフトで顕在化・機構は従来から存在）。
     let effect_fresh = wait_until(Duration::from_secs(3), || {
         engine
             .outproc_effect_stats()
-            .map(|s| s.fresh > 0 && s.dry_peak > 0.01)
+            .map(|s| s.fresh > 0 && s.dry_peak > 0.01 && s.post_peak > 0.01)
             .unwrap_or(false)
     });
     engine

--- a/rust/crates/orbit-audio-daemon/tests/outproc_effect_bus_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_effect_bus_gated.rs
@@ -1,0 +1,215 @@
+//! Issue #434 S2: named insert bus 経由の OOP effect が実機 daemon 上で bus-tagged 再生のみを
+//! 加工し、untagged 再生を素通しすることを検証する gated test（設計・受け入れ監査対応の一部）。
+//!
+//! `outproc_effect_gated.rs`（master-bus 単一 effect）と同じセットアップパターンを踏襲し、bus 対応
+//! 差分のみを追加する:
+//! - master-bus 経路は `ORBIT_EFFECT_BUSES` 未設定（bus 0 個）でも `start_outproc_effect_post_boot` を
+//!   通す。bus 1 個を登録するにはこの env を **プロセス起動前**にセットする必要がある（`from_env` は
+//!   起動時に一度だけ読む）。`std::env::set_var` は他テストと競合するため、本ファイルは
+//!   `--test-threads=1` 前提で実行する（ファイル冒頭のコマンド参照）。
+//! - gain oracle（test-effect .clap・EFFECT_GAIN 定数）を `load_outproc_effect_plugin(path, None,
+//!   Some("fx1"))` で bus "fx1" に直接 LoadPlugin する（`session.rs` の LoadPlugin WS 経路は通さず
+//!   `EngineWrap` を直接叩く）。
+//! - bus tag 付き `play_at(..., Some("fx1".into()))` は "fx1" bus の post-processor（gain oracle）を
+//!   通り、`outproc_effect_bus_stats("fx1")` の `post_peak/dry_peak ≈ EFFECT_GAIN` で検証する。
+//! - bus tag なし（`None`）の再生は bus を経由せず master へ素通しされるので、bus 側 `fresh` カウンタが
+//!   増えないことで確認する。
+//!
+//! 前提（実行前にビルドすること）:
+//!   cargo build -p orbit-clap-effect-child
+//!   cargo build --manifest-path rust-spike/clap-test-effect/Cargo.toml
+//! 実行（bus 用 env を先に固定し、他テストとの set_var 競合を避けるため単一スレッドで実行）:
+//!   ORBIT_EFFECT_BUSES=fx1 cargo test -p orbit-audio-daemon --features outproc-effect \
+//!     --test outproc_effect_bus_gated -- --ignored --nocapture --test-threads=1
+//!
+//! device / dylib / child binary が揃わない env（headless CI 等）では owner へ stop&report（手動 fallback）。
+
+#![cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+
+mod gated_common;
+use gated_common::{child_exe, repo_path, wait_until};
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use orbit_audio_daemon::engine_wrap::EngineWrap;
+use orbit_audio_daemon::outproc_effect::{OutProcEffectConfig, PluginFormat};
+
+/// test-effect が乗算する固定 gain（`outproc_effect_gated.rs` と同一値）。
+const EFFECT_GAIN: f32 = 0.5;
+const BUS_NAME: &str = "fx1";
+
+fn test_effect_dylib() -> PathBuf {
+    repo_path("rust-spike/clap-test-effect/target/debug/libclap_test_effect.dylib")
+}
+
+/// gated 前提を確認して config と音源 path を返す。bus 無し（plugin 未 attach のまま起動 →
+/// bus へ post-boot attach）で `EngineWrap` を起動する。
+fn setup_test() -> (OutProcEffectConfig, PathBuf) {
+    let cfg = OutProcEffectConfig {
+        format: PluginFormat::Clap,
+        child_exe: child_exe("orbit-clap-effect-child"),
+        plugin: None,
+        plugin_id: None,
+        buffer_frames: None,
+    };
+    let dylib = test_effect_dylib();
+    let wav = repo_path("test-assets/audio/sine_440.wav");
+    assert!(
+        dylib.exists(),
+        "test-effect dylib が無い: {} — 先に `cargo build --manifest-path rust-spike/clap-test-effect/Cargo.toml`",
+        dylib.display()
+    );
+    assert!(
+        cfg.child_exe.exists(),
+        "effect child binary が無い: {} — 先に `cargo build -p orbit-clap-effect-child`",
+        cfg.child_exe.display()
+    );
+    assert!(wav.exists(), "音源 WAV が無い: {}", wav.display());
+    (cfg, wav)
+}
+
+fn play_sine(engine: &EngineWrap, wav: &Path, bus: Option<String>) {
+    let sample = engine
+        .load_sample(wav.to_path_buf())
+        .expect("load sine sample");
+    let onset = engine.transport_or_uptime_sec() + 0.1;
+    engine
+        .play_at(&sample.sample_id, onset, 1.0, 0.0, 0.0, 0.0, 1.0, bus)
+        .expect("play sine");
+}
+
+fn gain_ratio(dry_peak: f32, post_peak: f32) -> f32 {
+    if dry_peak > 0.0 {
+        post_peak / dry_peak
+    } else {
+        0.0
+    }
+}
+
+// ── bus-tagged 再生は bus の effect を通り、untagged 再生は素通しする ─────────────────────────
+#[test]
+#[ignore = "#434 S2: needs ORBIT_EFFECT_BUSES=fx1 set before process start + a real output device + built child binary + test-effect dylib (local only)"]
+fn outproc_effect_bus_processes_tagged_playback_and_passes_untagged_through() {
+    assert_eq!(
+        std::env::var("ORBIT_EFFECT_BUSES").as_deref(),
+        Ok(BUS_NAME),
+        "run with `ORBIT_EFFECT_BUSES={BUS_NAME}` set before the test binary starts \
+         (env is read once at `start_outproc_effect_post_boot`, not settable from inside a test)"
+    );
+
+    let (cfg, wav) = setup_test();
+    let (engine, _guard) =
+        EngineWrap::start_outproc_effect_post_boot(cfg).expect("start OOP effect daemon");
+
+    // gain oracle を bus "fx1" に直接 attach（LoadPlugin WS 経路の `bus` param と同じ内部呼び出し）。
+    let dylib = test_effect_dylib();
+    engine
+        .load_outproc_effect_plugin(dylib, None, Some(BUS_NAME.to_owned()))
+        .expect("attach gain oracle to bus");
+
+    // untagged 再生: master へ直行し bus を経由しない。
+    play_sine(&engine, &wav, None);
+    // bus-tagged 再生: bus "fx1" の effect を経由する。
+    play_sine(&engine, &wav, Some(BUS_NAME.to_owned()));
+
+    assert!(
+        wait_until(Duration::from_secs(3), || engine
+            .outproc_effect_bus_stats(BUS_NAME)
+            .map(|s| s.fresh > 0)
+            .unwrap_or(false)),
+        "bus '{BUS_NAME}' が fresh 処理を報告しない（child spawn / bus routing を確認）"
+    );
+    std::thread::sleep(Duration::from_millis(600));
+
+    let bus = engine
+        .outproc_effect_bus_stats(BUS_NAME)
+        .expect("bus stats available");
+    let bus_ratio = gain_ratio(bus.dry_peak, bus.post_peak);
+
+    println!("=== #434 S2 bus routing verdict ===");
+    println!(
+        "bus '{BUS_NAME}': dry_peak={:.5} post_peak={:.5} ratio={:.5} fresh={} (expect ~{EFFECT_GAIN})",
+        bus.dry_peak, bus.post_peak, bus_ratio, bus.fresh
+    );
+    println!("=====================================");
+
+    assert!(!bus.measurement_invalid, "bus の respawn 失敗で計測無効");
+    assert!(
+        bus.dry_peak > 0.01,
+        "bus tagged 再生が bus へ届いていない (dry_peak={:.5})",
+        bus.dry_peak
+    );
+    // serial insert の gain 比。余白は resampling / peak 整列のずれを吸収（理論値 EFFECT_GAIN）。
+    assert!(
+        (0.4..=0.6).contains(&bus_ratio),
+        "bus effect の gain 比が想定外: {bus_ratio:.5}（期待 ~{EFFECT_GAIN}）。\
+         bus routing / attach を確認"
+    );
+    // untagged 再生の「素通し」を master stats では検証できない: master effect slot は
+    // plugin 未 attach（engaged=false）だと安全弁の early return で stats を一切更新しない設計
+    // （outproc_effect.rs の process 冒頭・#431）。そこで bus/master の経路分離は
+    // **bus 側の dry_peak が tagged 再生1本分のピークに一致すること**で検証する:
+    // untagged が誤って bus に流入していれば、同時再生の重なりで dry_peak が
+    // 1本分（sine 1.0 × equal-power √0.5 ≈ 0.707）を有意に超える。
+    // untagged 音の bit-level 素通し自体は orbit-audio-native の unit
+    // （render_block_one_bus_applies_effect_then_sums の untagged 検証）と S3 の
+    // capture E2E が担う。
+    assert!(
+        bus.dry_peak <= 0.75,
+        "bus dry_peak が tagged 1本分を超えている（untagged の bus への漏れ込み疑い）: {:.5}",
+        bus.dry_peak
+    );
+    // _guard drop で teardown（bus / master 両方の watchdog 停止 → QUIT → reap → unlink）。
+    // panic / UB なく完了することを検証。
+}
+
+// ── StreamGuard drop 後、bus child プロセスも master child と同様に回収されること ────────────────
+#[test]
+#[ignore = "#434 S2: needs ORBIT_EFFECT_BUSES=fx1 set before process start + a real output device + built child binary + test-effect dylib (local only)"]
+fn outproc_effect_bus_child_is_reaped_on_stream_guard_drop() {
+    assert_eq!(
+        std::env::var("ORBIT_EFFECT_BUSES").as_deref(),
+        Ok(BUS_NAME),
+        "run with `ORBIT_EFFECT_BUSES={BUS_NAME}` set before the test binary starts"
+    );
+
+    let (cfg, _wav) = setup_test();
+    let (engine, guard) =
+        EngineWrap::start_outproc_effect_post_boot(cfg).expect("start OOP effect daemon");
+    engine
+        .load_outproc_effect_plugin(test_effect_dylib(), None, Some(BUS_NAME.to_owned()))
+        .expect("attach gain oracle to bus");
+
+    let bus_pid = wait_until(Duration::from_secs(3), || {
+        engine
+            .outproc_effect_bus_stats(BUS_NAME)
+            .map(|s| s.current_child_pid != 0)
+            .unwrap_or(false)
+    });
+    assert!(
+        bus_pid,
+        "bus child が起動しなかった（PID が publish されない）"
+    );
+    let pid = engine
+        .outproc_effect_bus_stats(BUS_NAME)
+        .expect("bus stats")
+        .current_child_pid;
+
+    drop(guard);
+    drop(engine);
+
+    // teardown 完了後は child プロセスが存在しない（`kill -0` は生存確認のみで signal を送らない）。
+    let reaped = wait_until(Duration::from_secs(3), || {
+        !std::process::Command::new("kill")
+            .arg("-0")
+            .arg(pid.to_string())
+            .status()
+            .expect("kill -0 実行")
+            .success()
+    });
+    assert!(
+        reaped,
+        "StreamGuard drop 後も bus child (pid {pid}) が生存している（teardown 未完了）"
+    );
+}

--- a/rust/crates/orbit-audio-native/src/lib.rs
+++ b/rust/crates/orbit-audio-native/src/lib.rs
@@ -17,8 +17,9 @@ pub use link_audio_ring::{PostMixSink, RingTapSink};
 pub use loader::{load_sample_from_file, load_sample_resampled, LoaderError};
 pub use output::{
     start_default_output, start_default_output_with_clap, start_default_output_with_insert_buses,
-    start_default_output_with_link_egress, InsertBusStage, LinkChannelActivate, OutputError,
-    OutputStream, StreamStats, StreamStatsSnapshot, MAX_INSERT_BUS_STAGES, MAX_LINK_CHANNELS,
+    start_default_output_with_insert_buses_and_post, start_default_output_with_link_egress,
+    InsertBusStage, LinkChannelActivate, OutputError, OutputStream, StreamStats,
+    StreamStatsSnapshot, MAX_INSERT_BUS_STAGES, MAX_LINK_CHANNELS,
 };
 pub use post_processor::{CallbackTimeSnapshot, CallbackTimeStats, PostProcessor};
 pub use resampler::ResampleError;

--- a/rust/crates/orbit-audio-native/src/lib.rs
+++ b/rust/crates/orbit-audio-native/src/lib.rs
@@ -16,9 +16,9 @@ mod resampler;
 pub use link_audio_ring::{PostMixSink, RingTapSink};
 pub use loader::{load_sample_from_file, load_sample_resampled, LoaderError};
 pub use output::{
-    start_default_output, start_default_output_with_clap, start_default_output_with_link_egress,
-    LinkChannelActivate, OutputError, OutputStream, StreamStats, StreamStatsSnapshot,
-    MAX_LINK_CHANNELS,
+    start_default_output, start_default_output_with_clap, start_default_output_with_insert_buses,
+    start_default_output_with_link_egress, InsertBusStage, LinkChannelActivate, OutputError,
+    OutputStream, StreamStats, StreamStatsSnapshot, MAX_INSERT_BUS_STAGES, MAX_LINK_CHANNELS,
 };
 pub use post_processor::{CallbackTimeSnapshot, CallbackTimeStats, PostProcessor};
 pub use resampler::ResampleError;

--- a/rust/crates/orbit-audio-native/src/output.rs
+++ b/rust/crates/orbit-audio-native/src/output.rs
@@ -484,6 +484,39 @@ pub fn start_default_output_with_insert_buses(
     Ok((engine, stream, stats))
 }
 
+/// per-bus insert と従来の master post-processor を同じ callback に載せる。
+/// bus は master effect より前に処理されるため、instrument add-mix を含む既存 master
+/// 経路の意味論を変えない。
+pub fn start_default_output_with_insert_buses_and_post(
+    insert_buses: Vec<InsertBusStage>,
+    post: Box<dyn PostProcessor>,
+    buffer_frames: Option<u32>,
+    capture_path: Option<PathBuf>,
+) -> Result<
+    (
+        Engine,
+        OutputStream,
+        Arc<StreamStats>,
+        Arc<CallbackTimeStats>,
+    ),
+    OutputError,
+> {
+    if insert_buses.len() > MAX_INSERT_BUS_STAGES {
+        return Err(OutputError::NoConfig(format!(
+            "too many insert bus stages: {} (max {MAX_INSERT_BUS_STAGES})",
+            insert_buses.len()
+        )));
+    }
+    let (engine, stream, stats, cb) =
+        start_output_inner(None, insert_buses, Some(post), buffer_frames, capture_path)?;
+    Ok((
+        engine,
+        stream,
+        stats,
+        cb.expect("post path always creates CallbackTimeStats"),
+    ))
+}
+
 /// `start_default_output` / `_with_link_egress` / `_with_clap` の共通実装。
 /// `link` を渡すと cpal callback に egress 経路を、`post` を渡すと master-bus post-processor を
 /// 組み込む（両方 None なら hardware-only でビット同一）。`post` 有り時のみ callback-duration

--- a/rust/crates/orbit-audio-native/src/output.rs
+++ b/rust/crates/orbit-audio-native/src/output.rs
@@ -124,6 +124,47 @@ impl OutputStream {
 /// channel 数を遥かに上回る値。
 pub const MAX_LINK_CHANNELS: usize = 64;
 
+/// callback が同時に render できる insert bus 数の上限。stage は stream 構築時に固定されるため、
+/// callback では stack 上の `ArrayVec` だけで `render_multi` 引数を組み立てられる。
+pub const MAX_INSERT_BUS_STAGES: usize = 64;
+
+/// named routing tag を受ける per-bus insert stage。
+///
+/// `processor=None` は effect 未 attach の **登録済み bus** を表す。buffer を `render_multi` に渡して
+/// event を必ず消費し、そのまま master へ足すので、未 attach bus の event が retain され続けない。
+pub struct InsertBusStage {
+    name: String,
+    processor: Option<Box<dyn PostProcessor>>,
+    buffer: Vec<f32>,
+}
+
+impl InsertBusStage {
+    /// テストまたは構築側が既知の block 長で stage を作る。通常の stream 起動 seam は device config
+    /// 確定後に必要な buffer を確保するため、ここには 0 を渡してよい。
+    pub fn new(
+        name: impl Into<String>,
+        processor: Option<Box<dyn PostProcessor>>,
+        buffer_len: usize,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            processor,
+            buffer: vec![0.0; buffer_len],
+        }
+    }
+
+    /// effect 未 attach の routing bus を登録する。
+    pub fn unattached(name: impl Into<String>) -> Self {
+        Self::new(name, None, 0)
+    }
+
+    fn ensure_buffer_len(&mut self, len: usize) {
+        if self.buffer.len() < len {
+            self.buffer.resize(len, 0.0);
+        }
+    }
+}
+
 /// LinkAudio channel を RT callback に届けるための activation メッセージ（A4-2b-2）。
 /// control thread が ring 生成・scratch 事前確保まで行い、本構造体を reg-ring 経由で callback へ
 /// 渡す（callback は受け取って pool へ追加するだけ＝RT alloc を避ける）。`sink` は対になる
@@ -167,9 +208,11 @@ fn channel_egress_active(ready: bool, scratch_len: usize, block: usize) -> bool 
 /// 各々独立の opt-in 分岐で、すべて None なら従来経路とビット同一。`capture` は `hw` を読むだけ
 /// なので有効でも出力サンプルは不変（tap であって mutation ではない）。
 #[inline]
+#[allow(clippy::too_many_arguments)] // callback state is kept as independent opt-in seams.
 fn render_block(
     engine: &Engine,
     link: &mut Option<LinkEgress>,
+    insert_buses: &mut [InsertBusStage],
     post: &mut Option<Box<dyn PostProcessor>>,
     capture: &mut Option<RingTapSink>,
     cb_stats: &Option<Arc<CallbackTimeStats>>,
@@ -180,7 +223,12 @@ fn render_block(
     // production RT 監視を callback-duration ベースにするための計測（cb_stats 有り時のみ）。
     let t0 = cb_stats.as_ref().map(|_| Instant::now());
 
-    render_engine(engine, link, output_channels, hw);
+    if insert_buses.is_empty() {
+        // S1 の bus 無し経路は既存の呼び出し列をそのまま維持する（bit-identical）。
+        render_engine(engine, link, output_channels, hw);
+    } else {
+        render_engine_with_insert_buses(engine, link, insert_buses, output_channels, hw);
+    }
 
     // master-bus post-processor（CLAP）。engine render 済みの hardware sum を in-place 変換。
     if let Some(p) = post.as_mut() {
@@ -197,6 +245,69 @@ fn render_block(
 
     if let (Some(stats), Some(t0)) = (cb_stats, t0) {
         stats.record(t0.elapsed().as_nanos() as u64);
+    }
+}
+
+#[inline]
+fn render_engine_with_insert_buses(
+    engine: &Engine,
+    link: &mut Option<LinkEgress>,
+    buses: &mut [InsertBusStage],
+    output_channels: usize,
+    hw: &mut [f32],
+) {
+    // LinkAudio と併用するときも 1 回の render_multi に集約し、transport/gain ramp を一度だけ進める。
+    // bus 名と Link channel 名が重複した場合は bus を先に登録する（S1 は daemon Link 配線を変更しない）。
+    use arrayvec::ArrayVec;
+    const MAX_TARGETS: usize = MAX_INSERT_BUS_STAGES + MAX_LINK_CHANNELS;
+    debug_assert!(buses.len() <= MAX_INSERT_BUS_STAGES);
+    let bs = (hw.len() / output_channels) * output_channels;
+    let mut targets: ArrayVec<(&str, &mut [f32]), MAX_TARGETS> = ArrayVec::new();
+    for bus in buses.iter_mut() {
+        debug_assert!(
+            bus.buffer.len() >= bs,
+            "insert bus '{}' buffer too short",
+            bus.name
+        );
+        targets
+            .try_push((bus.name.as_str(), &mut bus.buffer[..bs]))
+            .expect("bounded bus count");
+    }
+
+    if let Some(le) = link {
+        while let Ok(act) = le.reg_rx.pop() {
+            le.channels.push(act);
+        }
+        for ch in le.channels.iter_mut() {
+            let active =
+                channel_egress_active(ch.ready.load(Ordering::Relaxed), ch.scratch.len(), bs);
+            if active
+                && targets
+                    .try_push((ch.name.as_str(), &mut ch.scratch[..bs]))
+                    .is_err()
+            {
+                debug_assert!(false, "render target pool exceeded configured cap");
+                break;
+            }
+        }
+    }
+    engine.render_multi(hw, &mut targets);
+    drop(targets);
+
+    for bus in buses.iter_mut() {
+        if let Some(processor) = bus.processor.as_mut() {
+            processor.process(&mut bus.buffer[..bs]);
+        }
+        for (dst, src) in hw.iter_mut().zip(&bus.buffer[..bs]) {
+            *dst += *src;
+        }
+    }
+    if let Some(le) = link {
+        for ch in le.channels.iter_mut() {
+            if channel_egress_active(ch.ready.load(Ordering::Relaxed), ch.scratch.len(), bs) {
+                ch.sink.commit(&ch.scratch[..bs]);
+            }
+        }
     }
 }
 
@@ -307,7 +418,8 @@ type OutputInnerStart = (
 /// 既定の出力デバイスを使い、デバイス config に合う [`Engine`] とストリームを
 /// 同時に初期化する（hardware-only）。呼び出し側は config ミスマッチを意識しなくてよい。
 pub fn start_default_output(capture_path: Option<PathBuf>) -> Result<OutputStart, OutputError> {
-    let (engine, stream, stats, _cb) = start_output_inner(None, None, None, capture_path)?;
+    let (engine, stream, stats, _cb) =
+        start_output_inner(None, Vec::new(), None, None, capture_path)?;
     Ok((engine, stream, stats))
 }
 
@@ -324,7 +436,8 @@ pub fn start_default_output_with_link_egress(
         // cap は control が強制するので最大 MAX_LINK_CHANNELS。callback で push のみ・realloc を避ける。
         channels: Vec::with_capacity(MAX_LINK_CHANNELS),
     };
-    let (engine, stream, stats, _cb) = start_output_inner(Some(link), None, None, capture_path)?;
+    let (engine, stream, stats, _cb) =
+        start_output_inner(Some(link), Vec::new(), None, None, capture_path)?;
     Ok((engine, stream, stats, reg_tx))
 }
 
@@ -343,10 +456,32 @@ pub fn start_default_output_with_clap(
     capture_path: Option<PathBuf>,
 ) -> Result<ClapHostStart, OutputError> {
     let (engine, stream, stats, cb) =
-        start_output_inner(None, Some(post), buffer_frames, capture_path)?;
+        start_output_inner(None, Vec::new(), Some(post), buffer_frames, capture_path)?;
     // post=Some の経路では inner が必ず CallbackTimeStats を作る。
     let cb = cb.expect("clap path always creates CallbackTimeStats");
     Ok((engine, stream, stats, cb))
+}
+
+/// per-bus insert stage 付きで出力を起動する。stage の buffer は device config 確定後、callback が
+/// 始まる前に 1 秒分を確保する。`processor=None` の stage は pass-through routing 登録として使える。
+pub fn start_default_output_with_insert_buses(
+    mut insert_buses: Vec<InsertBusStage>,
+    capture_path: Option<PathBuf>,
+) -> Result<OutputStart, OutputError> {
+    if insert_buses.len() > MAX_INSERT_BUS_STAGES {
+        return Err(OutputError::NoConfig(format!(
+            "too many insert bus stages: {} (max {MAX_INSERT_BUS_STAGES})",
+            insert_buses.len()
+        )));
+    }
+    let (engine, stream, stats, _cb) = start_output_inner(
+        None,
+        std::mem::take(&mut insert_buses),
+        None,
+        None,
+        capture_path,
+    )?;
+    Ok((engine, stream, stats))
 }
 
 /// `start_default_output` / `_with_link_egress` / `_with_clap` の共通実装。
@@ -356,6 +491,7 @@ pub fn start_default_output_with_clap(
 /// 計測・通常 None で device 既定）。
 fn start_output_inner(
     link: Option<LinkEgress>,
+    mut insert_buses: Vec<InsertBusStage>,
     post: Option<Box<dyn PostProcessor>>,
     buffer_frames: Option<u32>,
     capture_path: Option<PathBuf>,
@@ -375,6 +511,10 @@ fn start_output_inner(
     }
     let sample_rate = config.sample_rate.0;
     let channels = config.channels;
+    for bus in &mut insert_buses {
+        // callback block は通常これより遥かに短い。RT hot path の resize を構造的に排除する。
+        bus.ensure_buffer_len(sample_rate as usize * channels as usize);
+    }
 
     // capture seam（#307 realtime・A = daemon-start config / whole-stream）: `capture_path` が
     // 与えられたときのみ master 出力（post 適用後の hw）を WAV へ録る tap を差し込む。env 読取りは
@@ -405,6 +545,7 @@ fn start_output_inner(
         engine.clone(),
         stats.clone(),
         link,
+        insert_buses,
         post,
         capture_sink,
         cb_stats.clone(),
@@ -434,6 +575,7 @@ fn build_stream(
     engine: Engine,
     stats: Arc<StreamStats>,
     mut link: Option<LinkEgress>,
+    mut insert_buses: Vec<InsertBusStage>,
     mut post: Option<Box<dyn PostProcessor>>,
     mut capture: Option<RingTapSink>,
     cb_stats: Option<Arc<CallbackTimeStats>>,
@@ -461,6 +603,7 @@ fn build_stream(
                     render_block(
                         &engine,
                         &mut link,
+                        &mut insert_buses,
                         &mut post,
                         &mut capture,
                         &cb_stats,
@@ -486,6 +629,7 @@ fn build_stream(
                         render_block(
                             &engine,
                             &mut link,
+                            &mut insert_buses,
                             &mut post,
                             &mut capture,
                             &cb_stats,
@@ -515,6 +659,7 @@ fn build_stream(
                         render_block(
                             &engine,
                             &mut link,
+                            &mut insert_buses,
                             &mut post,
                             &mut capture,
                             &cb_stats,
@@ -543,6 +688,7 @@ fn build_stream(
                         render_block(
                             &engine,
                             &mut link,
+                            &mut insert_buses,
                             &mut post,
                             &mut capture,
                             &cb_stats,
@@ -572,6 +718,99 @@ fn build_stream(
 mod tests {
     use super::*;
     use cpal::BackendSpecificError;
+
+    #[test]
+    fn render_block_zero_buses_bit_identical() {
+        let sample = orbit_audio_core::Sample::new(vec![0.25; 8], 48_000, 2);
+        let reference = Engine::new(48_000, 2);
+        reference.schedule(0.0, sample.clone()).expect("schedule");
+        let with_buses = Engine::new(48_000, 2);
+        with_buses.schedule(0.0, sample).expect("schedule");
+        let mut expected = vec![0.0; 8];
+        reference.render(&mut expected);
+        let mut buses = Vec::new();
+        let mut actual = vec![0.0; 8];
+        let mut link = None;
+        let mut post = None;
+        let mut capture = None;
+        let cb_stats = None;
+        render_block(
+            &with_buses,
+            &mut link,
+            &mut buses,
+            &mut post,
+            &mut capture,
+            &cb_stats,
+            2,
+            &mut actual,
+        );
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn render_block_one_bus_applies_effect_then_sums() {
+        struct Half;
+        impl PostProcessor for Half {
+            fn process(&mut self, data: &mut [f32]) {
+                for sample in data {
+                    *sample *= 0.5;
+                }
+            }
+        }
+        let engine = Engine::new(48_000, 2);
+        let tagged = orbit_audio_core::Sample::new(vec![2.0; 4], 48_000, 2);
+        engine
+            .schedule_with_play_id(
+                0.0,
+                1.0,
+                0.0,
+                0,
+                0,
+                1.0,
+                Some("fx".into()),
+                "tagged".into(),
+                tagged,
+            )
+            .expect("schedule");
+        let plain = orbit_audio_core::Sample::new(vec![3.0; 4], 48_000, 2);
+        engine.schedule(0.0, plain).expect("schedule");
+        let mut buses = vec![InsertBusStage::new("fx", Some(Box::new(Half)), 4)];
+        let mut hw = vec![0.0; 4];
+        let mut link = None;
+        render_engine_with_insert_buses(&engine, &mut link, &mut buses, 2, &mut hw);
+        // center pan の equal-power gain は √0.5。tagged=2.0×√0.5×0.5、
+        // untagged=3.0×√0.5 なので、両者の sum = 2√2 を値で pin する。
+        assert!(hw
+            .iter()
+            .all(|&sample| (sample - 2.0_f32.sqrt() * 2.0).abs() < 1e-6));
+    }
+
+    #[test]
+    fn tagged_event_with_unattached_bus_still_drops() {
+        let engine = Engine::new(48_000, 2);
+        let sample = orbit_audio_core::Sample::new(vec![1.0; 4], 48_000, 2);
+        engine
+            .schedule_with_play_id(
+                0.0,
+                1.0,
+                0.0,
+                0,
+                0,
+                1.0,
+                Some("dry".into()),
+                "tagged".into(),
+                sample,
+            )
+            .expect("schedule");
+        let mut buses = vec![InsertBusStage::new("dry", None, 4)];
+        let mut hw = vec![0.0; 4];
+        let mut link = None;
+        render_engine_with_insert_buses(&engine, &mut link, &mut buses, 2, &mut hw);
+        assert!(hw
+            .iter()
+            .all(|&sample| (sample - 0.5_f32.sqrt()).abs() < 1e-6));
+        assert_eq!(engine.active_count(), Some(0));
+    }
 
     #[test]
     fn stream_stats_starts_at_zero() {
@@ -710,6 +949,7 @@ mod tests {
         render_block(
             &engine,
             &mut link,
+            &mut [],
             &mut post,
             &mut capture,
             &cb_stats,

--- a/rust/crates/orbit-audio-native/src/output.rs
+++ b/rust/crates/orbit-audio-native/src/output.rs
@@ -136,6 +136,16 @@ pub struct InsertBusStage {
     name: String,
     processor: Option<Box<dyn PostProcessor>>,
     buffer: Vec<f32>,
+    /// **activation flag**（`LinkChannelActivate.ready` と同じパターン）: `false` の間この bus は
+    /// render 対象から完全に外れる（zero-fill / gain-ramp / sum のコストゼロ）。daemon の既定
+    /// bus プール（#434 S3）は宣言（LoadPlugin）まで inactive で、全 bus inactive なら
+    /// `render_block` は bus 無し経路（ビット同一）に落ちる — `seq.effect()` を使わない
+    /// セッションが pool のコストを払わないための機構。
+    /// ⚠ inactive bus 名に tag された event は render_multi の対象外 = 消費されず retain される
+    /// （LinkAudio の not-ready channel と同じ既存ハザード）。producer（TS）は「宣言 =
+    /// activation → その後に tag 付き PlayAt」の順序を守ること（`seq.effect()` は await するので
+    /// 構造的に成立）。
+    active: Arc<AtomicBool>,
 }
 
 impl InsertBusStage {
@@ -146,10 +156,24 @@ impl InsertBusStage {
         processor: Option<Box<dyn PostProcessor>>,
         buffer_len: usize,
     ) -> Self {
+        // 手組み（テスト・明示構成）の stage は生成時から live。遅延 activation が要る
+        // 呼び出し側（daemon の bus プール）は `with_activation` を使う。
+        Self::with_activation(name, processor, buffer_len, Arc::new(AtomicBool::new(true)))
+    }
+
+    /// 共有 activation flag 付きで stage を作る（daemon が LoadPlugin 時に `true` へ release-store
+    /// する用途。flag の所有は呼び出し側と共有）。
+    pub fn with_activation(
+        name: impl Into<String>,
+        processor: Option<Box<dyn PostProcessor>>,
+        buffer_len: usize,
+        active: Arc<AtomicBool>,
+    ) -> Self {
         Self {
             name: name.into(),
             processor,
             buffer: vec![0.0; buffer_len],
+            active,
         }
     }
 
@@ -223,8 +247,13 @@ fn render_block(
     // production RT 監視を callback-duration ベースにするための計測（cb_stats 有り時のみ）。
     let t0 = cb_stats.as_ref().map(|_| Instant::now());
 
-    if insert_buses.is_empty() {
-        // S1 の bus 無し経路は既存の呼び出し列をそのまま維持する（bit-identical）。
+    // active な bus が 1 つも無ければ既存の呼び出し列をそのまま維持する（bit-identical）。
+    // 既定 bus プール（全 stage inactive で起動）はここで従来経路に落ちるため、
+    // `seq.effect()` 未使用セッションに RT コストを課さない。
+    if !insert_buses
+        .iter()
+        .any(|bus| bus.active.load(Ordering::Relaxed))
+    {
         render_engine(engine, link, output_channels, hw);
     } else {
         render_engine_with_insert_buses(engine, link, insert_buses, output_channels, hw);
@@ -264,6 +293,10 @@ fn render_engine_with_insert_buses(
     let bs = (hw.len() / output_channels) * output_channels;
     let mut targets: ArrayVec<(&str, &mut [f32]), MAX_TARGETS> = ArrayVec::new();
     for bus in buses.iter_mut() {
+        // inactive stage は render 対象外（コストゼロ・InsertBusStage::active の doc 参照）。
+        if !bus.active.load(Ordering::Relaxed) {
+            continue;
+        }
         debug_assert!(
             bus.buffer.len() >= bs,
             "insert bus '{}' buffer too short",
@@ -295,6 +328,9 @@ fn render_engine_with_insert_buses(
     drop(targets);
 
     for bus in buses.iter_mut() {
+        if !bus.active.load(Ordering::Relaxed) {
+            continue;
+        }
         if let Some(processor) = bus.processor.as_mut() {
             processor.process(&mut bus.buffer[..bs]);
         }
@@ -762,6 +798,39 @@ mod tests {
         let mut expected = vec![0.0; 8];
         reference.render(&mut expected);
         let mut buses = Vec::new();
+        let mut actual = vec![0.0; 8];
+        let mut link = None;
+        let mut post = None;
+        let mut capture = None;
+        let cb_stats = None;
+        render_block(
+            &with_buses,
+            &mut link,
+            &mut buses,
+            &mut post,
+            &mut capture,
+            &cb_stats,
+            2,
+            &mut actual,
+        );
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn render_block_all_inactive_buses_bit_identical() {
+        // 既定 bus プール（宣言前 = 全 stage inactive）は render_engine 経路に落ち、
+        // bus 無しとビット同一・追加コストゼロであること（#461 efficiency review）。
+        let sample = orbit_audio_core::Sample::new(vec![0.25; 8], 48_000, 2);
+        let reference = Engine::new(48_000, 2);
+        reference.schedule(0.0, sample.clone()).expect("schedule");
+        let with_buses = Engine::new(48_000, 2);
+        with_buses.schedule(0.0, sample).expect("schedule");
+        let mut expected = vec![0.0; 8];
+        reference.render(&mut expected);
+        let mut buses = vec![
+            InsertBusStage::with_activation("seq-bus-0", None, 8, Arc::new(AtomicBool::new(false))),
+            InsertBusStage::with_activation("seq-bus-1", None, 8, Arc::new(AtomicBool::new(false))),
+        ];
         let mut actual = vec![0.0; 8];
         let mut link = None;
         let mut post = None;

--- a/rust/crates/orbit-audio-native/src/output.rs
+++ b/rust/crates/orbit-audio-native/src/output.rs
@@ -850,6 +850,56 @@ mod tests {
     }
 
     #[test]
+    fn activation_flip_mid_stream_takes_effect_without_reconstruction() {
+        // 「宣言 = activation」契約の CI 検証（pr-review-team round 1・test-analyzer C8）:
+        // 同じ Arc<AtomicBool> を flip するだけで、stage の再構築なしに render 対象へ
+        // 入る/外れることを、除外時の bit-identical と適用時の 0.5×gain の両面で pin する。
+        struct Half;
+        impl PostProcessor for Half {
+            fn process(&mut self, data: &mut [f32]) {
+                for sample in data {
+                    *sample *= 0.5;
+                }
+            }
+        }
+        let active = Arc::new(AtomicBool::new(false));
+        let engine = Engine::new(48_000, 2);
+        let tagged = orbit_audio_core::Sample::new(vec![2.0; 16], 48_000, 2);
+        engine
+            .schedule_with_play_id(
+                0.0,
+                1.0,
+                0.0,
+                0,
+                0,
+                1.0,
+                Some("fx".into()),
+                "tagged".into(),
+                tagged,
+            )
+            .expect("schedule");
+        let mut buses = vec![InsertBusStage::with_activation(
+            "fx",
+            Some(Box::new(Half)),
+            4,
+            active.clone(),
+        )];
+        // inactive の間、tagged event は render 対象外（消費されない）で hw は無音。
+        let mut hw = vec![0.0; 4];
+        let mut link = None;
+        render_engine_with_insert_buses(&engine, &mut link, &mut buses, 2, &mut hw);
+        assert!(hw.iter().all(|&sample| sample == 0.0));
+
+        // flip 後、同じ stage オブジェクトのまま effect が適用される。
+        active.store(true, Ordering::Release);
+        let mut hw = vec![0.0; 4];
+        render_engine_with_insert_buses(&engine, &mut link, &mut buses, 2, &mut hw);
+        assert!(hw
+            .iter()
+            .all(|&sample| (sample - 0.5_f32.sqrt()).abs() < 1e-6));
+    }
+
+    #[test]
     fn render_block_one_bus_applies_effect_then_sums() {
         struct Half;
         impl PostProcessor for Half {

--- a/tests/audio/rust-engine/daemon-client.spec.ts
+++ b/tests/audio/rust-engine/daemon-client.spec.ts
@@ -168,6 +168,41 @@ describe('DaemonClient with mock server', () => {
     expect(rec?.params).not.toHaveProperty('channel')
   })
 
+  it('PlayAt bus あり: bus フィールドを params に含める（#434 S3 insert routing）', async () => {
+    const url = await server.start({
+      PlayAt: () => ({ play_id: 'p-bus-1' }),
+    })
+    await client.start({ wsUrlOverride: url })
+    await client.playAt('s-mock-1', 0.0, 0.8, 0, 0, 0, 1, undefined, 'seq-bus-0')
+    const rec = server.received.find((r) => r.method === 'PlayAt')
+    expect(rec?.params.bus).toBe('seq-bus-0')
+    expect(rec?.params).not.toHaveProperty('channel')
+  })
+
+  it('PlayAt bus なし（undefined）: bus フィールドを params から省く', async () => {
+    const url = await server.start({
+      PlayAt: () => ({ play_id: 'p-no-bus-1' }),
+    })
+    await client.start({ wsUrlOverride: url })
+    await client.playAt('s-mock-1', 0.0, 0.8)
+    const rec = server.received.find((r) => r.method === 'PlayAt')
+    expect(rec?.params).not.toHaveProperty('bus')
+  })
+
+  it('LoadPlugin bus あり: bus フィールドを params に含める（#434 S3）', async () => {
+    const url = await server.start({
+      LoadPlugin: () => ({ plugin_id: 'reverb', plugin_name: 'Reverb', note_port_index: 0 }),
+    })
+    await client.start({ wsUrlOverride: url })
+    await client.loadPlugin('/tmp/reverb.clap', undefined, 'effect', 'seq-bus-0')
+    const record = server.received.find((r) => r.method === 'LoadPlugin')
+    expect(record?.params).toEqual({
+      path: '/tmp/reverb.clap',
+      role: 'effect',
+      bus: 'seq-bus-0',
+    })
+  })
+
   it('Stop は status=stopped を true に変換する', async () => {
     const url = await server.start({
       Stop: (params) => {

--- a/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
+++ b/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
@@ -95,7 +95,12 @@ describe('RustEnginePlayer plugin recovery after daemon respawn', () => {
 
     await (player as any).respawnLoop()
 
-    expect(daemon.loadPlugin).toHaveBeenCalledWith('/plugins/echo.clap', 'echo-id', 'effect')
+    expect(daemon.loadPlugin).toHaveBeenCalledWith(
+      '/plugins/echo.clap',
+      'echo-id',
+      'effect',
+      undefined,
+    )
     // C1: a successful reload must flip pluginActive back to true, so
     // PluginEffectManager's self-heal check doesn't mistake this recovery
     // for a still-stale cache.
@@ -128,8 +133,59 @@ describe('RustEnginePlayer plugin recovery after daemon respawn', () => {
       '/plugins/echo.clap',
       'echo-id',
       'instrument',
+      undefined,
     )
     expect(player.isPluginActive()).toBe(true)
+  })
+
+  it('reissues a master effect and a per-sequence insert bus independently (#434 S3)', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    await player.loadPlugin('/plugins/master.clap', undefined, 'effect')
+    await player.loadPlugin('/plugins/reverb.clap', undefined, 'effect', 'seq-bus-0')
+    daemon.loadPlugin.mockClear()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await (player as any).respawnLoop()
+
+    expect(daemon.loadPlugin).toHaveBeenCalledTimes(2)
+    expect(daemon.loadPlugin).toHaveBeenCalledWith(
+      '/plugins/master.clap',
+      undefined,
+      'effect',
+      undefined,
+    )
+    expect(daemon.loadPlugin).toHaveBeenCalledWith(
+      '/plugins/reverb.clap',
+      undefined,
+      'effect',
+      'seq-bus-0',
+    )
+  })
+
+  it('one bus reload failure does not skip reloading the others', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    await player.loadPlugin('/plugins/master.clap', undefined, 'effect')
+    await player.loadPlugin('/plugins/reverb.clap', undefined, 'effect', 'seq-bus-0')
+    daemon.loadPlugin.mockClear()
+    daemon.loadPlugin
+      .mockRejectedValueOnce(new Error('master reload failed'))
+      .mockResolvedValueOnce(ECHO_LOAD_RESULT)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await (player as any).respawnLoop()
+
+    expect(daemon.loadPlugin).toHaveBeenCalledTimes(2)
+    // The failing entry does not prevent the other declaration from reloading.
+    expect(daemon.loadPlugin).toHaveBeenCalledWith(
+      '/plugins/reverb.clap',
+      undefined,
+      'effect',
+      'seq-bus-0',
+    )
+    expect(player.isPluginActive()).toBe(false)
   })
 })
 

--- a/tests/core/event-scheduler-insert-bus.spec.ts
+++ b/tests/core/event-scheduler-insert-bus.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * #434 S3 — seq.effect() per-sequence insert routing.
+ *
+ * `scheduleEvents` / `scheduleEventsFromTime` forward `insertBus` to
+ * `scheduler.scheduleEvent`/`scheduleSliceEvent` as a trailing param, mirroring
+ * the existing `outputChannel` (LinkAudio) wiring. This spec verifies the
+ * wiring at the event-scheduler level, without any audio backend.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Scheduler } from '../../packages/engine/src/core/global/types'
+import {
+  scheduleEvents,
+  scheduleEventsFromTime,
+} from '../../packages/engine/src/core/sequence/scheduling/event-scheduler'
+import type { TimedEvent } from '../../packages/engine/src/timing/calculation/types'
+
+function stubScheduler(): Scheduler & {
+  scheduleEvent: ReturnType<typeof vi.fn>
+  scheduleSliceEvent: ReturnType<typeof vi.fn>
+} {
+  return {
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(),
+    clearSequenceEvents: vi.fn(),
+    reinitializeSequenceTracking: vi.fn(),
+    scheduleEvent: vi.fn(),
+    scheduleSliceEvent: vi.fn(),
+    getAudioDuration: vi.fn(() => 1),
+  }
+}
+
+const ONE_NOTE: TimedEvent[] = [{ sliceNumber: 1, startTime: 0, duration: 250, depth: 0 }]
+
+const BASE_OPTIONS = {
+  audioFilePath: '/audio/kick.wav',
+  gainDb: 0,
+  pan: 0,
+  isMuted: false,
+  sequenceName: 'drum',
+  masterGainDb: 0,
+  patternDuration: 500,
+}
+
+describe('scheduleEvents insertBus wiring (#434 S3)', () => {
+  it('forwards insertBus as the trailing scheduleEvent arg', async () => {
+    const scheduler = stubScheduler()
+    await scheduleEvents({
+      ...BASE_OPTIONS,
+      scheduler,
+      timedEvents: ONE_NOTE,
+      insertBus: 'seq-bus-0',
+    })
+    expect(scheduler.scheduleEvent).toHaveBeenCalledWith(
+      '/audio/kick.wav',
+      0,
+      0,
+      0,
+      'drum',
+      undefined, // outputChannel
+      undefined, // argPath
+      'seq-bus-0',
+    )
+  })
+
+  it('omits insertBus when the sequence has no insert declared', async () => {
+    const scheduler = stubScheduler()
+    await scheduleEvents({ ...BASE_OPTIONS, scheduler, timedEvents: ONE_NOTE })
+    expect(scheduler.scheduleEvent).toHaveBeenCalledWith(
+      '/audio/kick.wav',
+      0,
+      0,
+      0,
+      'drum',
+      undefined,
+      undefined,
+      undefined,
+    )
+  })
+
+  it('forwards insertBus for chopped (scheduleSliceEvent) dispatch too', async () => {
+    const scheduler = stubScheduler()
+    await scheduleEvents({
+      ...BASE_OPTIONS,
+      scheduler,
+      timedEvents: ONE_NOTE,
+      chopDivisions: 4,
+      insertBus: 'seq-bus-1',
+    })
+    expect(scheduler.scheduleSliceEvent).toHaveBeenCalledWith(
+      '/audio/kick.wav',
+      0,
+      1,
+      4,
+      250,
+      0,
+      0,
+      'drum',
+      undefined,
+      undefined,
+      'seq-bus-1',
+    )
+  })
+
+  it('scheduleEventsFromTime also forwards insertBus', () => {
+    const scheduler = stubScheduler()
+    scheduleEventsFromTime({
+      ...BASE_OPTIONS,
+      scheduler,
+      fromTime: -1,
+      timedEvents: ONE_NOTE,
+      insertBus: 'seq-bus-2',
+    })
+    expect(scheduler.scheduleEvent).toHaveBeenCalledWith(
+      '/audio/kick.wav',
+      0,
+      0,
+      0,
+      'drum',
+      undefined,
+      undefined,
+      'seq-bus-2',
+    )
+  })
+})

--- a/tests/core/sequence-effect.spec.ts
+++ b/tests/core/sequence-effect.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * seq.effect() — per-sequence plugin insert (PH.2b / #434 S3).
+ */
+
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Global } from '../../packages/engine/src/core/global'
+import { Sequence } from '../../packages/engine/src/core/sequence'
+import { MidiManager } from '../../packages/engine/src/core/global/midi-manager'
+import type { MidiOutput } from '../../packages/engine/src/midi/midi-output'
+import { SEQUENCE_EFFECT_BUS_POOL_SIZE } from '../../packages/engine/src/core/global/sequence-effect-manager'
+
+const T0 = 1_000_000
+
+function scheduler() {
+  return {
+    isRunning: true,
+    startTime: T0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(),
+    clearSequenceEvents: vi.fn(),
+    reinitializeSequenceTracking: vi.fn(),
+    scheduleEvent: vi.fn(),
+    scheduleSliceEvent: vi.fn(),
+    getAudioDuration: vi.fn(() => 1),
+    getMasterGainDb: () => 0,
+  } as any
+}
+
+function harness(loadPlugin = vi.fn().mockResolvedValue({})) {
+  const audio = scheduler()
+  audio.loadPlugin = loadPlugin
+  const midiOutput: MidiOutput = {
+    ensurePort: vi.fn(() => 'IAC'),
+    noteOn: vi.fn(),
+    noteOff: vi.fn(),
+    pitchBend: vi.fn(),
+    releaseOwner: vi.fn(),
+    panic: vi.fn(),
+    getActiveNotes: vi.fn(() => []),
+    listPorts: vi.fn(() => ['IAC']),
+    closeAll: vi.fn(),
+  }
+  const global = new Global(audio, new MidiManager(() => midiOutput))
+  global.setDocumentDirectory('/songs')
+  const seq = new Sequence(global, audio)
+  seq.setName('drum')
+  return { audio, global, seq, loadPlugin }
+}
+
+describe('Sequence.effect() — per-sequence insert (PH.2b / #434 S3)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(T0)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('allocates the first pool bus and loads via LoadPlugin(role=effect, bus)', async () => {
+    const { seq, loadPlugin } = harness()
+    await expect(seq.effect('./reverb.clap')).resolves.toBe(seq)
+    expect(seq.getInsertBus()).toBe('seq-bus-0')
+    expect(loadPlugin).toHaveBeenCalledWith(
+      path.resolve('/songs', 'reverb.clap'),
+      undefined,
+      'effect',
+      'seq-bus-0',
+    )
+  })
+
+  it('allocates distinct buses per sequence, in declaration order', async () => {
+    const { global, audio } = harness()
+    const seqA = new Sequence(global, audio)
+    seqA.setName('a')
+    const seqB = new Sequence(global, audio)
+    seqB.setName('b')
+    await seqA.effect('./reverb.clap')
+    await seqB.effect('./delay.clap')
+    expect(seqA.getInsertBus()).toBe('seq-bus-0')
+    expect(seqB.getInsertBus()).toBe('seq-bus-1')
+  })
+
+  it('is idempotent on the same path + pluginId (no second LoadPlugin call)', async () => {
+    const { seq, loadPlugin } = harness()
+    await seq.effect('./reverb.clap', 'rev-id')
+    await seq.effect('reverb.clap', 'rev-id')
+    expect(loadPlugin).toHaveBeenCalledTimes(1)
+    expect(seq.getInsertBus()).toBe('seq-bus-0')
+  })
+
+  it('rejects re-declaration with a different path or pluginId', async () => {
+    const { seq, loadPlugin } = harness()
+    await seq.effect('./reverb.clap')
+    await expect(seq.effect('./delay.clap')).rejects.toThrow('one insert per sequence')
+    expect(loadPlugin).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects .vst3 (effect accepts .clap only, unlike seq.instrument())', async () => {
+    const { seq } = harness()
+    await expect(seq.effect('synth.vst3')).rejects.toThrow('not yet supported')
+  })
+
+  it('rejects on note sequences (midi)', async () => {
+    const { seq } = harness()
+    seq.midi('iac', 1)
+    await expect(seq.effect('./reverb.clap')).rejects.toThrow(
+      'seq.effect() is only supported on audio sequences',
+    )
+  })
+
+  it('rejects on note sequences (instrument)', async () => {
+    const { seq } = harness()
+    await seq.instrument('synth.clap')
+    await expect(seq.effect('./reverb.clap')).rejects.toThrow(
+      'seq.effect() is only supported on audio sequences',
+    )
+  })
+
+  it('rejects while LinkAudio is enabled', async () => {
+    const { seq, global } = harness()
+    global.linkAudio()
+    await expect(seq.effect('./reverb.clap')).rejects.toThrow('LinkAudio')
+  })
+
+  it('blocks a later global.linkAudio() once any sequence has declared an insert', async () => {
+    const { seq, global } = harness()
+    await seq.effect('./reverb.clap')
+    expect(() => global.linkAudio()).toThrow('plugin hosting')
+  })
+
+  it('exhausts the pool after the v1 cap and errors with an explicit message', async () => {
+    const { global, loadPlugin } = harness()
+    const seqs: Sequence[] = []
+    for (let i = 0; i < SEQUENCE_EFFECT_BUS_POOL_SIZE; i++) {
+      const s = new Sequence(global, global as any)
+      s.setName(`s${i}`)
+      await s.effect('./reverb.clap')
+      seqs.push(s)
+    }
+    expect(loadPlugin).toHaveBeenCalledTimes(SEQUENCE_EFFECT_BUS_POOL_SIZE)
+    const overflow = new Sequence(global, global as any)
+    overflow.setName('overflow')
+    await expect(overflow.effect('./reverb.clap')).rejects.toThrow('pool exhausted')
+  })
+
+  it('rejects a backend without plugin hosting support', async () => {
+    const audio = scheduler()
+    const global = new Global(audio)
+    global.setDocumentDirectory('/songs')
+    const seq = new Sequence(global, audio)
+    seq.setName('drum')
+    await expect(seq.effect('./reverb.clap')).rejects.toThrow(
+      'Plugin hosting requires the Rust engine backend',
+    )
+  })
+
+  it('dispatches with the allocated bus tagged on PlayAt (via scheduler.scheduleEvent)', async () => {
+    const { audio, global, seq } = harness()
+    vi.spyOn(global, 'resolveAudioSpec').mockReturnValue('/songs/kick.wav')
+    await seq.effect('./reverb.clap')
+    seq.audio('kick.wav')
+    global.start()
+    seq.play(1)
+    await seq.run()
+    await vi.advanceTimersByTimeAsync(600)
+    expect(audio.scheduleEvent).toHaveBeenCalled()
+    const call = audio.scheduleEvent.mock.calls[0]
+    // trailing arg is insertBus
+    expect(call[call.length - 1]).toBe('seq-bus-0')
+  })
+})

--- a/tests/core/sequence-effect.spec.ts
+++ b/tests/core/sequence-effect.spec.ts
@@ -149,6 +149,34 @@ describe('Sequence.effect() — per-sequence insert (PH.2b / #434 S3)', () => {
     await expect(overflow.effect('./reverb.clap')).rejects.toThrow('pool exhausted')
   })
 
+  it('returns a failed declaration bus to the free-list so retries do not exhaust the pool', async () => {
+    // #461 review Important: ライブコーディングの typo → リトライで pool が恒久消費されない。
+    const loadPlugin = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('plugin load failed'))
+      .mockResolvedValue({})
+    const { global } = harness(loadPlugin)
+    const seq = new Sequence(global, global as any)
+    seq.setName('drum')
+    await expect(seq.effect('./typo.clap')).rejects.toThrow('plugin load failed')
+    // 再宣言は失敗で返却された同じ bus 名を再利用する。
+    await seq.effect('./reverb.clap')
+    expect(loadPlugin).toHaveBeenLastCalledWith(
+      expect.stringContaining('reverb.clap'),
+      undefined,
+      'effect',
+      'seq-bus-0',
+    )
+    // 失敗を繰り返しても pool は枯渇しない（cap 回失敗 → なお成功できる）。
+    const failing = vi.fn().mockRejectedValue(new Error('nope'))
+    const { global: g2 } = harness(failing)
+    const s2 = new Sequence(g2, g2 as any)
+    s2.setName('retry')
+    for (let i = 0; i < SEQUENCE_EFFECT_BUS_POOL_SIZE + 2; i++) {
+      await expect(s2.effect('./nope.clap')).rejects.toThrow('nope')
+    }
+  })
+
   it('rejects a backend without plugin hosting support', async () => {
     const audio = scheduler()
     const global = new Global(audio)


### PR DESCRIPTION
Closes #434

## 概要

owner 最優先要望の履行: `seq.effect(path[, pluginId])` — シーケンス個別の plugin insert（DAW の per-track insert と同型）。**spec 先行**（core spec PH.2b・DocDD）+ 4 ステージ実装。

```js
var drums = init global.seq
drums.audio("kick.wav")
drums.effect("~/plugins/TAL-Reverb-4.clap")   // この seq だけに掛かる
```

## ステージ構成

| Stage | コミット | 内容 |
|---|---|---|
| S0 | （spike） | 64f 性能ゲート実測: 1 OOP effect = callback max 64µs（budget の ~4.8%）→ 成立確認 |
| S1 | `42edbc1` | core: InsertBusStage render 経路（bus 0 個で bit-identical・未登録 bus tag の永久 retain landmine 対策） |
| spec | `84c64b5` | core spec **PH.2b** 新設（処理順・v1 制約・bus プール・aux/send #453 予約） |
| S2 | `2fba667` | daemon: N-slot per-bus effect 機構 + LoadPlugin `bus` param（effect-only/both 両経路） |
| S3 | `450a7e0` | DSL: 既定 bus プール（8）+ PlayAt `bus` param + TS SequenceEffectManager + Sequence.effect() |

## 実機検証（客観値）

- **DSL E2E: capture peak ratio = 0.50000 厳密一致**（sine_880.wav・CLAPTestEffect gain 0.5・base 0.70711 → fx 0.35355）
- gated bus 2/2 実機 PASS（bus ratio 0.50000・bus 隔離・StreamGuard drop で child 回収）
- both/effect gated 退行なし（実機 RUN）

## 受け入れ監査で検出・修正した実バグ

1. S2: attach 中の outproc mutex 長期保持 / gated 計測手段の設計矛盾 / both gated の pipeline race（**すべて実機 RUN が検出**）
2. S3: **respawn 後 plugin 再ロードの単一キャッシュバグ**（複数 plugin だと最後の1つしか復元されない）→ role:bus キーの Map 化 + 独立再発行

## v1 制約（spec PH.2b に明記）

1 seq = 1 insert（チェーンは内部実装済み・DSL 解放は将来）/ .clap のみ / bus プール上限 8 / PDC 非対応 / LinkAudio と相互排他 / note sequence（midi/instrument）は対象外

## 後続
- #453 aux/send・#459 sum/group（同じ bus 基盤・グラフモデル兄弟）
- #448 orphan child reap（本セッション中にも再発・優先度上げ推奨）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu