### PR TITLE
fix(sandbox): add parent-liveness watchdog to VST3/CLAP child processes

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -945,6 +945,7 @@ name = "orbit-audio-sandbox"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "libc",
  "memmap2",
 ]
 

--- a/rust/crates/orbit-audio-daemon/src/main.rs
+++ b/rust/crates/orbit-audio-daemon/src/main.rs
@@ -16,6 +16,16 @@ use orbit_audio_daemon::protocol::{
 use orbit_audio_daemon::server;
 use serde_json::json;
 
+// 既知事項（#448）: この daemon には SIGTERM/SIGINT ハンドラが無く、`install_fatal_panic_hook`
+// の panic hook も `process::exit(1)` を hook 内から直接呼ぶ（unwind が supervisor 保持フレーム
+// まで届く前に終了する）。そのため通常の client 側 `SIGTERM → SIGKILL` 停止（daemon-client.ts
+// `killChildGracefully`）や panic では、`InstrumentChildSupervisor` / `EffectChildSupervisor` の
+// `Drop`（CONTROL_QUIT 送出）が実行されず、out-of-process CLAP/VST3 child が孤児化し得る。
+// `server::serve` の accept loop 内タスクが `Arc<EngineWrap>` を clone して保持するため、
+// main() のローカル drop だけでは決定論的な shutdown にならず、まとまった graceful-shutdown
+// 配線（signal → 全 clone 収束待ち → drop）が必要になる（本 issue のスコープ外・別 issue 向き）。
+// 本 issue の本命防御は child 側（[`orbit_audio_sandbox::ParentWatch`]）: どの死に方でも
+// child が親の死亡を自力で検知して抜けるため、この daemon 側ギャップの実害を軽減する。
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() {
     tracing_subscriber::fmt()

--- a/rust/crates/orbit-audio-sandbox/Cargo.toml
+++ b/rust/crates/orbit-audio-sandbox/Cargo.toml
@@ -31,6 +31,9 @@ name = "orbit_audio_sandbox"
 memmap2 = "0.9"
 # gain child binary の引数 parse / エラー伝播用(lib 本体は使わない)。MIT/Apache-2.0。
 anyhow = "1"
+# child プロセスの親死活監視(#448 orphan 対策)用 getppid(2) FFI。MIT/Apache-2.0。
+# 4 child crate(orbit-clap-effect-child 等)から共有する src/parent_watch.rs でのみ使用。
+libc = "0.2"
 
 # 親子で同一 SharedRegion レイアウトを共有する gain child(PR-A の parity 相手)。
 # clack 非依存(実 CLAP effect child は PR-B の別 crate)。
@@ -41,3 +44,9 @@ path = "src/bin/sandbox-effect-child.rs"
 [[bin]]
 name = "sandbox-instrument-child"
 path = "src/bin/sandbox-instrument-child.rs"
+
+# テスト専用ヘルパー(#448 orphan 対策の実プロセス reparent 実証用)。
+# tests/parent_watch_integration.rs から spawn される。
+[[bin]]
+name = "parent-watch-probe"
+path = "src/bin/parent-watch-probe.rs"

--- a/rust/crates/orbit-audio-sandbox/src/bin/parent-watch-probe.rs
+++ b/rust/crates/orbit-audio-sandbox/src/bin/parent-watch-probe.rs
@@ -1,0 +1,59 @@
+//! parent-watch-probe — テスト専用の小さなヘルパー。実プロセス階層で
+//! [`orbit_audio_sandbox::ParentWatch`] の reparent 検知を実証する
+//! (tests/parent_watch_integration.rs から spawn される)。
+//!
+//! サブコマンド:
+//!   spawn-and-wait <marker_path>   自分の子として `watch-parent <marker_path>` を spawn し、
+//!                                  そのまま SIGKILL で殺されるまで sleep する（=「親(daemon)役」）。
+//!   watch-parent <marker_path>     [`ParentWatch`] で自分の親（上記プロセス）の死活を監視し、
+//!                                  検知したら marker ファイルへ "EXITED" と書いて exit する
+//!                                  （=「child 役」。実 child バイナリと同じ検知ロジックを使う）。
+
+use std::env;
+use std::fs;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use orbit_audio_sandbox::ParentWatch;
+
+fn main() {
+    let mut args = env::args().skip(1);
+    match args.next().as_deref() {
+        Some("spawn-and-wait") => {
+            let marker = args.next().expect("marker_path required");
+            let self_exe = env::current_exe().expect("current_exe");
+            // 意図的に wait() しない: この probe は SIGKILL で強制終了させる想定(#448 の再現)。
+            // wait() すると SIGKILL 後にこのプロセス自体が残った子を reap する機会がなくなり
+            // テストの意図(reparent 検知)と無関係な zombie-processes lint が出るが、テスト側で
+            // 検証対象(C の exit)を確認した後は OS が孤児プロセスを reap する。
+            #[allow(clippy::zombie_processes)]
+            let _child = Command::new(self_exe)
+                .arg("watch-parent")
+                .arg(&marker)
+                .spawn()
+                .expect("spawn watch-parent child");
+            // 親(このプロセス)は SIGKILL されるまで sleep するだけ。
+            loop {
+                std::thread::sleep(Duration::from_secs(3600));
+            }
+        }
+        Some("watch-parent") => {
+            let marker = args.next().expect("marker_path required");
+            fs::write(&marker, format!("STARTED:{}", std::process::id())).expect("write marker");
+            let mut watch = ParentWatch::with_interval(Duration::from_millis(20));
+            let deadline = Instant::now() + Duration::from_secs(10);
+            loop {
+                if watch.should_exit() {
+                    fs::write(&marker, "EXITED").expect("write marker");
+                    return;
+                }
+                if Instant::now() > deadline {
+                    fs::write(&marker, "TIMED_OUT").expect("write marker");
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
+        other => panic!("unknown subcommand: {other:?}"),
+    }
+}

--- a/rust/crates/orbit-audio-sandbox/src/lib.rs
+++ b/rust/crates/orbit-audio-sandbox/src/lib.rs
@@ -21,6 +21,7 @@ pub mod events;
 pub mod host;
 mod instrument_host;
 pub mod offline;
+pub mod parent_watch;
 pub mod transport;
 
 pub use child::SandboxChildGuard;
@@ -40,6 +41,7 @@ pub use offline::{
     max_abs_diff, render_in_process_gain, render_through_child_sync,
     render_through_child_sync_with_options, ChildStats, RenderOptions,
 };
+pub use parent_watch::{ParentWatch, DEFAULT_CHECK_INTERVAL};
 pub use transport::{
     create_shared, open_shared, region_ptr, slot_index, slot_offset, SharedRegion,
     TransportContext, BUF_LEN, CHANNELS, CONTROL_QUIT, CONTROL_RUN, MAX_EVENTS_PER_BLOCK,

--- a/rust/crates/orbit-audio-sandbox/src/parent_watch.rs
+++ b/rust/crates/orbit-audio-sandbox/src/parent_watch.rs
@@ -1,0 +1,104 @@
+//! orphan child 対策(Issue #448): child プロセスの親死活監視。
+//!
+//! host(daemon)が `CONTROL_QUIT` を書かずに死ぬ経路(プロセス exit・SIGKILL・crash)では、
+//! 4 つの child バイナリ(orbit-clap-effect-child / orbit-clap-instrument-child /
+//! orbit-vst3-effect-child / orbit-vst3-instrument-child)は `seq_request` 待ちの spin loop に
+//! 残り続け、CPU を専有し続ける(shm 側の CONTROL_QUIT に依存する既存の終了経路は host 側の
+//! Drop 実行が前提のため、host が Drop を経ずに死ぬとこの経路が発火しない)。
+//!
+//! [`ParentWatch`] は起動時に `getppid()` を記録し、低頻度(既定 250ms)でこれを再取得する。
+//! 親が死んで child が launchd/PID1 等に reparent されると `getppid()` の値が変わるので、
+//! それを検知して spin loop から抜けるための helper。RT 影響を避けるため、チェックは
+//! 「spin loop を回った回数」でなく「経過時間」で rate-limit する(system call 1 回 / 250ms 程度)。
+//!
+//! 4 crate(orbit-clap-effect-child 等)で同じロジックを重複させないための共有 helper。
+//! transport とは独立した薄いモジュール(既存の「child main はミラー」方針と両立)。
+
+#![allow(unsafe_code)]
+
+use std::time::{Duration, Instant};
+
+/// [`ParentWatch::should_exit`] のデフォルト rate-limit 間隔。
+pub const DEFAULT_CHECK_INTERVAL: Duration = Duration::from_millis(250);
+
+/// child プロセスが起動時の親 PID を記録し、reparent(親死亡)を低頻度で検知する状態機械。
+pub struct ParentWatch {
+    original_ppid: libc::pid_t,
+    check_interval: Duration,
+    last_check: Instant,
+}
+
+impl ParentWatch {
+    /// 現在の `getppid()` を起動時の親 PID として記録する。既定の rate-limit 間隔
+    /// ([`DEFAULT_CHECK_INTERVAL`])を使う。
+    pub fn new() -> Self {
+        Self::with_interval(DEFAULT_CHECK_INTERVAL)
+    }
+
+    /// rate-limit 間隔を明示指定するコンストラクタ(主にテスト用)。
+    pub fn with_interval(check_interval: Duration) -> Self {
+        // SAFETY: getppid(2) は引数を取らず常に成功する(POSIX)。
+        let original_ppid = unsafe { libc::getppid() };
+        Self {
+            original_ppid,
+            check_interval,
+            last_check: Instant::now(),
+        }
+    }
+
+    /// 親が死んで(= 現在の `getppid()` が起動時と異なる場合)true を返す。
+    ///
+    /// rate-limit: 前回チェックから `check_interval` 未満なら syscall を発行せず false を返す
+    /// (spin loop 内で毎回呼んでも system call 頻度は interval に収まる)。
+    pub fn should_exit(&mut self) -> bool {
+        let now = Instant::now();
+        if now.duration_since(self.last_check) < self.check_interval {
+            return false;
+        }
+        self.last_check = now;
+        // SAFETY: 同上。
+        let current_ppid = unsafe { libc::getppid() };
+        current_ppid != self.original_ppid
+    }
+}
+
+impl Default for ParentWatch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    #[test]
+    fn does_not_fire_while_ppid_unchanged() {
+        let mut watch = ParentWatch::with_interval(Duration::from_millis(1));
+        thread::sleep(Duration::from_millis(5));
+        // このテストプロセスの親(テストランナー)は生きているので発火しないはず。
+        assert!(!watch.should_exit());
+    }
+
+    #[test]
+    fn rate_limits_syscall_checks() {
+        let mut watch = ParentWatch::with_interval(Duration::from_secs(10));
+        // 間隔未満の連続呼び出しは syscall を発行せず false を返し続ける
+        // (ppid が変わっていたとしても検知しないのが rate-limit の定義)。
+        for _ in 0..1000 {
+            assert!(!watch.should_exit());
+        }
+    }
+
+    #[test]
+    fn fires_after_ppid_changes() {
+        // 実プロセスの reparent を起こさずに、`original_ppid` を意図的に不一致な値へ
+        // 差し替えることで「ppid が変わったら true を返す」分岐を検証する
+        // (実プロセスの reparent 経路は orbit-audio-sandbox の統合テストで実証する)。
+        let mut watch = ParentWatch::with_interval(Duration::from_millis(1));
+        watch.original_ppid = -1; // 現実には取り得ない pid
+        thread::sleep(Duration::from_millis(5));
+        assert!(watch.should_exit());
+    }
+}

--- a/rust/crates/orbit-audio-sandbox/tests/parent_watch_integration.rs
+++ b/rust/crates/orbit-audio-sandbox/tests/parent_watch_integration.rs
@@ -1,0 +1,80 @@
+//! #448 実証テスト: 実プロセス階層で `ParentWatch` の reparent 検知を確認する。
+//!
+//! `orbit-clap-effect-child` 等の実 child バイナリを直接使うと CLAP plugin の用意が要るため、
+//! `parent-watch-probe`（テスト専用ヘルパー・[`ParentWatch`] を実 child と同じロジックで使う）で
+//! 3 プロセス階層を作る:
+//!   test process
+//!     └─ P = `parent-watch-probe spawn-and-wait <marker>`（「daemon」役。SIGKILL で殺す）
+//!          └─ C = `parent-watch-probe watch-parent <marker>`（「child」役。P の死活を監視）
+//!
+//! P を SIGKILL すると、C の `getppid()` が変わり（launchd/PID1 へ reparent）、
+//! `ParentWatch::should_exit()` が true を返して C が自発的に exit する。これは daemon が
+//! `CONTROL_QUIT` を書かずに死ぬ経路（プロセス exit・SIGKILL・crash）で child が spin-loop に
+//! 取り残されないことの直接的な証拠になる。
+//!
+//! device 非依存(shm も使わない)なので `#[ignore]` なしで CI 実行可能。
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn probe_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_parent-watch-probe"))
+}
+
+#[test]
+fn orphaned_child_exits_after_parent_is_killed() {
+    let marker = std::env::temp_dir().join(format!(
+        "orbit-parent-watch-probe-{}.marker",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&marker);
+
+    let mut parent = Command::new(probe_exe())
+        .arg("spawn-and-wait")
+        .arg(&marker)
+        .spawn()
+        .expect("spawn parent probe");
+
+    // C(watch-parent)が起動して marker に STARTED を書くまで待つ。
+    let started_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(content) = std::fs::read_to_string(&marker) {
+            if content.starts_with("STARTED") {
+                break;
+            }
+        }
+        assert!(
+            Instant::now() < started_deadline,
+            "watch-parent child が時間内に起動しなかった"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // P を SIGKILL する（daemon が CONTROL_QUIT を書かずに死ぬ経路の再現）。
+    // std::process::Child::kill() は SIGKILL を送る(unix)。
+    parent.kill().expect("kill parent probe");
+    let _ = parent.wait();
+
+    // C が reparent を検知して EXITED を書くまで待つ(P kill 後、数秒以内が期待値)。
+    let exited_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(content) = std::fs::read_to_string(&marker) {
+            if content == "EXITED" {
+                break;
+            }
+            assert_ne!(
+                content, "TIMED_OUT",
+                "watch-parent child が ParentWatch の内部 timeout(10s)で exit した \
+                 (reparent を検知できなかった)"
+            );
+        }
+        assert!(
+            Instant::now() < exited_deadline,
+            "watch-parent child が親死亡を検知して exit するまでの時間内に終了しなかった"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    let _ = std::fs::remove_file(&marker);
+}

--- a/rust/crates/orbit-clap-effect-child/src/main.rs
+++ b/rust/crates/orbit-clap-effect-child/src/main.rs
@@ -25,7 +25,8 @@ use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 use anyhow::{bail, Context, Result};
 use orbit_audio_sandbox::{
-    open_shared, region_ptr, slot_index, slot_offset, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_FRAMES,
+    open_shared, region_ptr, slot_index, slot_offset, ParentWatch, BUF_LEN, CHANNELS, CONTROL_QUIT,
+    MAX_FRAMES,
 };
 use orbit_clap_host::ClapEffectProcessor;
 
@@ -96,10 +97,17 @@ fn main() -> Result<()> {
     let mut process_errors: u64 = 0;
 
     let mut last: u64 = 0;
+    // orphan 対策（#448）: host（daemon）が CONTROL_QUIT を書かずに死ぬ経路（プロセス exit・
+    // SIGKILL・crash）でも spin loop を抜けられるよう、親死活を低頻度で監視する。
+    let mut parent_watch = ParentWatch::new();
     loop {
         // host からの正常終了要求。一回限りの flag なので Relaxed で十分（PR-A gain child と同様）。
         // SAFETY: region は host が REGION_BYTES に truncate 済みの共有ファイルを指す（map 後不変）。
         if unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT {
+            break;
+        }
+        if parent_watch.should_exit() {
+            eprintln!("[orbit-clap-effect-child] 親プロセス死亡を検知、終了する");
             break;
         }
         // SAFETY: 同上（region は有効）。seq_request の Acquire は host SUBMIT の Release と

--- a/rust/crates/orbit-clap-instrument-child/src/main.rs
+++ b/rust/crates/orbit-clap-instrument-child/src/main.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 use anyhow::{bail, Context, Result};
 use orbit_audio_sandbox::{
     open_shared, region_ptr, slot_index, slot_offset, EventRecord, EventSpillFifo, NeutralEvent,
-    SharedRegion, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_EVENTS_PER_BLOCK, MAX_FRAMES,
+    ParentWatch, SharedRegion, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_EVENTS_PER_BLOCK, MAX_FRAMES,
 };
 use orbit_clap_host::{push_neutral_event, ClapInstrumentProcessor, EventBuffer};
 
@@ -194,9 +194,16 @@ fn main() -> Result<()> {
     // historical seq up to the current `seq_request` (no resume-point handshake exists yet).
     // Tracked in #418.
     let mut last = 0u64;
+    // orphan 対策(#448): host(daemon)が CONTROL_QUIT を書かずに死ぬ経路(プロセス exit・
+    // SIGKILL・crash)でも spin loop を抜けられるよう、親死活を低頻度で監視する。
+    let mut parent_watch = ParentWatch::new();
 
     loop {
         if unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT {
+            break;
+        }
+        if parent_watch.should_exit() {
+            eprintln!("[orbit-clap-instrument-child] 親プロセス死亡を検知、終了する");
             break;
         }
         let cur = unsafe { (*region).seq_request.load(Acquire) };

--- a/rust/crates/orbit-vst3-effect-child/src/main.rs
+++ b/rust/crates/orbit-vst3-effect-child/src/main.rs
@@ -22,7 +22,8 @@ use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 use anyhow::{bail, Context, Result};
 #[cfg(target_os = "macos")]
 use orbit_audio_sandbox::{
-    open_shared, region_ptr, slot_index, slot_offset, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_FRAMES,
+    open_shared, region_ptr, slot_index, slot_offset, ParentWatch, BUF_LEN, CHANNELS, CONTROL_QUIT,
+    MAX_FRAMES,
 };
 #[cfg(target_os = "macos")]
 use orbit_vst3_host::Vst3EffectProcessor;
@@ -93,8 +94,15 @@ fn main() -> Result<()> {
     let mut process_errors: u64 = 0;
 
     let mut last: u64 = 0;
+    // orphan 対策(#448): host(daemon)が CONTROL_QUIT を書かずに死ぬ経路(プロセス exit・
+    // SIGKILL・crash)でも spin loop を抜けられるよう、親死活を低頻度で監視する。
+    let mut parent_watch = ParentWatch::new();
     loop {
         if unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT {
+            break;
+        }
+        if parent_watch.should_exit() {
+            eprintln!("[orbit-vst3-effect-child] 親プロセス死亡を検知、終了する");
             break;
         }
         let cur = unsafe { (*region).seq_request.load(Acquire) };

--- a/rust/crates/orbit-vst3-instrument-child/src/main.rs
+++ b/rust/crates/orbit-vst3-instrument-child/src/main.rs
@@ -12,7 +12,8 @@ use anyhow::{bail, Context, Result};
 #[cfg(target_os = "macos")]
 use orbit_audio_sandbox::{
     open_shared, region_ptr, slot_index, slot_offset, EventRecord, EventSpillFifo, NeutralEvent,
-    SharedRegion, VoiceAddr, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_EVENTS_PER_BLOCK, MAX_FRAMES,
+    ParentWatch, SharedRegion, VoiceAddr, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_EVENTS_PER_BLOCK,
+    MAX_FRAMES,
 };
 #[cfg(target_os = "macos")]
 use orbit_vst3_host::Vst3InstrumentProcessor;
@@ -275,8 +276,15 @@ fn main() -> Result<()> {
     let mut output_spill = EventSpillFifo::new();
     let mut process_errors = 0;
     let mut last = 0;
+    // orphan 対策(#448): host(daemon)が CONTROL_QUIT を書かずに死ぬ経路(プロセス exit・
+    // SIGKILL・crash)でも spin loop を抜けられるよう、親死活を低頻度で監視する。
+    let mut parent_watch = ParentWatch::new();
     loop {
         if unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT {
+            break;
+        }
+        if parent_watch.should_exit() {
+            eprintln!("[orbit-vst3-instrument-child] 親プロセス死亡を検知、終了する");
             break;
         }
         let cur = unsafe { (*region).seq_request.load(Acquire) };


### PR DESCRIPTION
## 概要

Issue #448 の恒久対策。daemon が `CONTROL_QUIT` を書かずに死ぬ経路（プロセス exit・SIGKILL・crash）で、`orbit-clap-{effect,instrument}-child` / `orbit-vst3-{effect,instrument}-child` が `seq_request` 待ちの spin-loop に取り残され、1 体あたり CPU ~90% を専有し続ける問題を修正する。

## 変更内容

- `orbit-audio-sandbox` に `ParentWatch` helper を新設（`src/parent_watch.rs`）。起動時に `getppid()` を記録し、spin loop 内で ~250ms 間隔（rate-limit 済み）で再取得。値が変わった（親死亡で launchd/PID1 等へ reparent）ら `true` を返す。
- 4 crate（`orbit-clap-effect-child` / `orbit-clap-instrument-child` / `orbit-vst3-effect-child` / `orbit-vst3-instrument-child`）の main loop から共有し、既存の `CONTROL_QUIT` チェックと同じ `break` 経路で抜ける。
- `getppid(2)` FFI 用に `libc = "0.2"`（MIT/Apache-2.0）を `orbit-audio-sandbox` の依存に追加。
- `orbit-audio-daemon/src/main.rs` に既知事項コメントを追加: この daemon には SIGTERM/SIGINT ハンドラが無く、panic hook も `process::exit(1)` を hook 内から直接呼ぶため、通常の client 側停止（SIGTERM→SIGKILL）や panic では supervisor の `Drop`（`CONTROL_QUIT` 送出）が実行されない。accept loop 内タスクが `Arc<EngineWrap>` を clone するため、graceful shutdown の配線は本 issue のスコープ外（別 issue 向き）と判断し、child 側の自力検知（`ParentWatch`）を本命防御とした。

## テスト

- `parent_watch.rs` に unit test 3 件（rate-limit・ppid 不変時 false・ppid 変化時 true）。
- 実証テスト `tests/parent_watch_integration.rs`: テスト専用ヘルパー `parent-watch-probe` で「daemon 役プロセス P → child 役プロセス C（ParentWatch で P を監視）」の 3 階層プロセスを実際に作り、P を SIGKILL した後 C が数百 ms 以内に自発的に exit することを確認（device 不要・`#[ignore]` なしで CI 実行可能）。
- `cargo build --workspace` / `cargo test -p orbit-audio-sandbox` / `cargo test -p orbit-audio-daemon` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo fmt --check` すべて green。
- `pre-push` の `cargo deny check` も通過済み。

## テスト計画

- [x] `cargo build --workspace`
- [x] `cargo test -p orbit-audio-sandbox`（新規 `parent_watch_integration.rs` 含む）
- [x] `cargo test -p orbit-audio-daemon`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] gated 実機での orphan 再現確認（既存の実機シナリオで daemon kill 後に child が残らないこと）はレビュー後に owner が実施

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu