### PR TITLE
docs(dev-site): add rust-engine chapter group (ja/en)

### DIFF
--- a/sites/dev/.plan/refresh-2026-07.md
+++ b/sites/dev/.plan/refresh-2026-07.md
@@ -94,7 +94,7 @@ framing）。乖離が見つかっても即修正せず、まず現状を記述�
 | 作業単位 | 章 | 備考 |
 |---|---|---|
 | Unit A | RE-1 + RE-2（daemon 概観 + OOP children） | **済（Issue #451・ja/en 各 index.md + oop-children.md）** |
-| Unit B | RE-3 + RE-4（M2 IPC + capture seam） | **済（Issue #451・ja/en 各 insert-bus.md + capture-verification.md）** |
+| Unit B | insert-bus + capture seam（旧計画の RE-3=M2 IPC は差し替え・M2 IPC 章は未着手のまま残） | **済（Issue #451・ja/en 各 insert-bus.md + capture-verification.md）** |
 | Unit C | PH-1（概観・**本 Issue でパイロット執筆済み**） | 他 Unit のテンプレートとして先行公開 |
 | Unit D | PH-2 + PH-3（CLAP/VST3 instrument hosting） | 依存: Unit C の DSL 構文説明を前提にできる |
 | Unit E | PH-4 + PH-5（effect hosting + Epic 全体像） | 依存: Unit D 完了後（instrument/effect 対比のため） |

--- a/sites/dev/.plan/refresh-2026-07.md
+++ b/sites/dev/.plan/refresh-2026-07.md
@@ -93,8 +93,8 @@ framing）。乖離が見つかっても即修正せず、まず現状を記述�
 
 | 作業単位 | 章 | 備考 |
 |---|---|---|
-| Unit A | RE-1 + RE-2（daemon 概観 + OOP children） | 依存: なし。先行して読める |
-| Unit B | RE-3 + RE-4（M2 IPC + capture seam） | 依存: Unit A の用語（shm transport 等）を参照する可能性 → Unit A 完了後推奨 |
+| Unit A | RE-1 + RE-2（daemon 概観 + OOP children） | **済（Issue #451・ja/en 各 index.md + oop-children.md）** |
+| Unit B | RE-3 + RE-4（M2 IPC + capture seam） | **済（Issue #451・ja/en 各 insert-bus.md + capture-verification.md）** |
 | Unit C | PH-1（概観・**本 Issue でパイロット執筆済み**） | 他 Unit のテンプレートとして先行公開 |
 | Unit D | PH-2 + PH-3（CLAP/VST3 instrument hosting） | 依存: Unit C の DSL 構文説明を前提にできる |
 | Unit E | PH-4 + PH-5（effect hosting + Epic 全体像） | 依存: Unit D 完了後（instrument/effect 対比のため） |

--- a/sites/dev/.vitepress/sidebar.ts
+++ b/sites/dev/.vitepress/sidebar.ts
@@ -2,6 +2,16 @@ import type { DefaultTheme } from 'vitepress'
 
 export const sidebarJa: DefaultTheme.SidebarItem[] = [
   {
+    text: 'Part -1: Rust Engine',
+    collapsed: false,
+    items: [
+      { text: 'RE-1. daemon アーキテクチャ概観', link: '/rust-engine/' },
+      { text: 'RE-2. OOP children と shm transport', link: '/rust-engine/oop-children' },
+      { text: 'RE-3. per-sequence insert bus', link: '/rust-engine/insert-bus' },
+      { text: 'RE-4. capture seam と客観検証', link: '/rust-engine/capture-verification' },
+    ],
+  },
+  {
     text: 'Part 0: Orientation',
     collapsed: false,
     items: [
@@ -63,6 +73,19 @@ export const sidebarJa: DefaultTheme.SidebarItem[] = [
 ]
 
 export const sidebarEn: DefaultTheme.SidebarItem[] = [
+  {
+    text: 'Part -1: Rust Engine',
+    collapsed: false,
+    items: [
+      { text: 'RE-1. Daemon Architecture Overview', link: '/en/rust-engine/' },
+      { text: 'RE-2. OOP Children and shm Transport', link: '/en/rust-engine/oop-children' },
+      { text: 'RE-3. Per-Sequence Insert Bus', link: '/en/rust-engine/insert-bus' },
+      {
+        text: 'RE-4. Capture Seam and Objective Verification',
+        link: '/en/rust-engine/capture-verification',
+      },
+    ],
+  },
   {
     text: 'Part 0: Orientation',
     collapsed: false,

--- a/sites/dev/en/rust-engine/capture-verification.md
+++ b/sites/dev/en/rust-engine/capture-verification.md
@@ -1,0 +1,329 @@
+---
+title: "RE-4. Capture Seam and Objective Verification (ORBIT_CAPTURE_WAV)"
+chapter-id: "RE-4"
+verified-against: 3983828
+verified-at: "2026-07-17"
+status: draft
+---
+
+> **Note**: This page is a trace of the author's reading as of 2026-07-17. The code is the truth; this page is merely a snapshot of understanding at that point in time.
+
+# RE-4. Capture Seam and Objective Verification (ORBIT_CAPTURE_WAV)
+
+Beyond "listening with your ears", OrbitScore's audio engine has a **capture
+seam** (Issue #307) as a verification mechanism. Setting the
+`ORBIT_CAPTURE_WAV` environment variable records the master output
+(post-mix, right before the device) to a WAV file in real time; that file
+can then be run through `orbit-audio-verify`'s analysis primitives (onset
+detection, RMS, pan back-calculation) to objectively confirm that the DSL's
+intent matches the actual samples produced. This chapter traces this path's
+implementation (the self-authored RIFF WAV writer in `capture.rs`) and how
+this "ears-free verification" is actually assembled.
+
+## The capture tap point: post-mix, pre-hardware
+
+Capture taps the `hw` buffer, read-only, **after** the master-bus
+post-processor has been applied but right before it's sent to the device,
+inside `render_block`. This means it records "the final signal that
+actually reaches the device"; the presence of capture does not change the
+output samples themselves (it only reads — it does not mutate).
+
+```rust
+// rust/crates/orbit-audio-native/src/output.rs:226-273 (relevant excerpt)
+/// 1 callback 分の処理（計測 + engine render + master-bus post-processor）。
+///
+/// 手順: (1) callback 開始時刻を取る（`cb_stats` 有り時のみ）→ (2) [`render_engine`] で engine
+/// （+ LinkAudio egress）を render → (3) `post` 有りなら hardware sum を in-place 変換（CLAP
+/// effect/instrument・Issue #340）→ (4) `capture` 有りなら **post 適用後の最終 `hw`** を WAV 用
+/// ring へ読み取り専用 tap（#307）→ (5) callback 所要時間を記録。`post`/`capture`/`cb_stats` は
+/// 各々独立の opt-in 分岐で、すべて None なら従来経路とビット同一。`capture` は `hw` を読むだけ
+/// なので有効でも出力サンプルは不変（tap であって mutation ではない）。
+#[inline]
+#[allow(clippy::too_many_arguments)] // callback state is kept as independent opt-in seams.
+fn render_block(
+    engine: &Engine,
+    link: &mut Option<LinkEgress>,
+    insert_buses: &mut [InsertBusStage],
+    post: &mut Option<Box<dyn PostProcessor>>,
+    capture: &mut Option<RingTapSink>,
+    cb_stats: &Option<Arc<CallbackTimeStats>>,
+    output_channels: usize,
+    hw: &mut [f32],
+) {
+    // ...
+    if let Some(sink) = capture.as_mut() {
+        sink.commit(hw);
+    }
+    // ...
+}
+```
+
+The tap is performed via `RingTapSink::commit`, a wait-free / no-alloc
+operation; if the ring is full, it's tracked with a drop counter (this keeps
+the RT contract intact while making it visible when the off-thread writer
+can't keep up).
+
+## `RiffWavWriter`: a self-authored 32-bit float WAV encoder with no external dependency
+
+Per an owner-confirmed policy (no additional external WAV encoder crate
+such as hound), `capture.rs` writes RIFF WAV using only `std::io`. It uses
+`wFormatTag = 3` (`WAVE_FORMAT_IEEE_FLOAT`), so there is no quantization —
+the recorded f32 values round-trip exactly.
+
+```rust
+// rust/crates/orbit-audio-native/src/capture.rs:29-56
+/// 32-bit float(量子化なし)streaming WAV writer。`std::io` のみで実装する(外部 WAV encoder crate
+/// を増やさない方針 = owner 確定・hound 不採用)。
+///
+/// ファイルサイズは書き込み終了時まで確定しないので、[`Self::new`] で size を 0 の placeholder
+/// にした header をまず書き、サンプルを逐次追記した後、[`Self::finalize`] で実サイズに patch する。
+pub struct RiffWavWriter {
+    writer: BufWriter<File>,
+    sample_rate: u32,
+    channels: u16,
+    samples_written: u64,
+    /// `write` が per-call の alloc を避けるため再利用する little-endian バイトバッファ。
+    scratch: Vec<u8>,
+}
+
+impl RiffWavWriter {
+    /// `path` に新規ファイルを作り、size placeholder 込みの 44-byte header を書く。
+    pub fn new(path: &Path, sample_rate: u32, channels: u16) -> io::Result<Self> {
+        let file = File::create(path)?;
+        let mut writer = BufWriter::new(file);
+        writer.write_all(&build_header(sample_rate, channels, 0))?;
+        Ok(Self {
+            writer,
+            sample_rate,
+            channels,
+            samples_written: 0,
+            scratch: Vec::new(),
+        })
+    }
+```
+
+The problem of an undetermined size (the total file size is unknown during
+streaming writes) is solved with the standard trick: write a placeholder
+header with size 0 first, then seek back to the start and patch in the real
+size in `finalize()`. `finalize` consumes `self` by value, so double-finalize
+is prevented by the type system.
+
+```rust
+// rust/crates/orbit-audio-native/src/capture.rs:73-90
+    /// 先頭に seek して RIFF / data チャンクの size を実値に patch し、flush する。
+    /// `self` を値で消費するので二重 finalize は型で防止される。
+    ///
+    /// # 既知の制限
+    /// 古典 WAV(RIFF)の size フィールドは u32 なので、`samples_written * 4` バイトが
+    /// 4GiB を超える capture は正しく表現できない(RF64 拡張が必要・未対応)。ここでは
+    /// saturating して壊れた header にはしない。
+    pub fn finalize(mut self) -> io::Result<()> {
+        self.writer.flush()?;
+        let data_bytes = u32::try_from(self.samples_written.saturating_mul(4)).unwrap_or(u32::MAX);
+        // BufWriter<File>::seek は seek 前に内部バッファを flush してから inner を seek する
+        // (std documented behavior)ので、直前の flush と合わせて安全に先頭へ戻れる。
+        self.writer.seek(SeekFrom::Start(0))?;
+        self.writer
+            .write_all(&build_header(self.sample_rate, self.channels, data_bytes))?;
+        self.writer.flush()?;
+        Ok(())
+    }
+```
+
+A capture exceeding 4GiB cannot be correctly represented due to the u32 size
+field limit (an RF64 extension would be needed and is not implemented), but
+the comment explicitly notes this known limitation and states that the
+implementation saturates rather than producing a corrupt header.
+
+## `CaptureWriter`: an off-thread writer that drains outside the RT callback
+
+`CaptureWriter::create` creates the WAV writer and a `RingTapSink`, and
+spawns a background thread that drains the ring and performs the writes. The
+RT callback only calls `RingTapSink::commit` (wait-free); the actual file
+I/O completes entirely outside the audio thread.
+
+```rust
+// rust/crates/orbit-audio-native/src/capture.rs:145-211 (excerpt — drain loop body)
+    pub fn create(
+        path: PathBuf,
+        sample_rate: u32,
+        channels: u16,
+        ring_capacity: usize,
+    ) -> io::Result<(RingTapSink, CaptureWriter)> {
+        // 先に WAV ファイルを開く(path 不正等で失敗するなら ring を確保する前に fail fast)。
+        let mut wav = RiffWavWriter::new(&path, sample_rate, channels)?;
+        let (sink, mut consumer, drops) = RingTapSink::new(ring_capacity);
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_for_thread = Arc::clone(&stop);
+
+        let handle = thread::spawn(move || -> io::Result<u64> {
+            let mut samples_written: u64 = 0;
+            // drain ループ。write error は `break Err(e)` で抜け、下の finalize を必ず通す
+            // (`?` で即 return すると finalize が走らず header が placeholder〈data=0〉のまま
+            // 残り、壊れた WAV になる。best-effort finalize で「書けた分」を header に反映する)。
+            let drain: io::Result<()> = loop {
+                let avail = consumer.slots();
+                if avail == 0 {
+                    if stop_for_thread.load(Ordering::Acquire) {
+                        break Ok(());
+                    }
+                    thread::sleep(DRAIN_POLL_INTERVAL);
+                    continue;
+                }
+                // ... (read_chunk, write, commit_all)
+            };
+            let finalized = wav.finalize();
+            match (drain, finalized) {
+                (Ok(()), Ok(())) => Ok(samples_written),
+                (Err(e), _) => Err(e),
+                (Ok(()), Err(e)) => Err(e),
+            }
+        });
+```
+
+Even when the drain loop hits a write error, it does not return early;
+`break Err(e)` is followed by an unconditional call to `finalize()` — this
+is the silent-failure guard. An early return would leave the header at its
+placeholder (`data=0`), producing a corrupt WAV; a best-effort finalize
+reflects "however much was written" in the header instead.
+
+On the `OutputStream` side, the `_capture` field is declared **after**
+`_stream`, exploiting Rust's declaration-order field drop to structurally
+guarantee the sequence "stream stops (callback stops) → writer drains
+remaining ring contents and finalizes".
+
+```rust
+// rust/crates/orbit-audio-native/src/output.rs:101-110
+/// 生きている間はストリームを保持する RAII ハンドル。
+pub struct OutputStream {
+    _stream: Stream,
+    /// capture seam（#307 realtime）: `ORBIT_CAPTURE_WAV` 有効時のみ `Some`。**`_stream` より後に
+    /// 宣言する**ことで drop 順を「stream 停止（callback 停止＝以後 commit なし）→ writer が ring の
+    /// 残りを drain して WAV を finalize」に固定する（Rust は struct field を宣言順に drop する）。
+    _capture: Option<crate::capture::CaptureWriter>,
+    pub sample_rate: u32,
+    pub channels: u16,
+}
+```
+
+## What "objective verification" actually looks like: gated-test drops assertion + oracle matching
+
+The pattern for verifying with the capture seam is concentrated in the
+gated tests (`--ignored`, needs a real output device) under
+`rust/crates/orbit-audio-daemon/tests/`. `capture_realtime_gated.rs` (a
+realtime parity check for #304's examples22) is a representative example:
+
+```rust
+// rust/crates/orbit-audio-daemon/tests/capture_realtime_gated.rs:206-217
+    // teardown 前に drops を assert（silent-failure ガード）。
+    let drops = guard.capture_drops();
+    assert_eq!(
+        drops,
+        Some(0),
+        "capture drop が発生（録音破損＝検証 invalid）: {drops:?}"
+    );
+
+    // guard を drop すると stream 停止 → writer が ring 残りを drain → WAV finalize。
+    drop(guard);
+    drop(wrap);
+    std::env::remove_var("ORBIT_CAPTURE_WAV");
+```
+
+The "art of objective verification" is distilled here:
+
+1. **Assert `drops == 0` before teardown** — nail down, before doing any
+   further verification, that the off-thread writer never dropped a slot
+   from the ring. If `drops > 0`, every subsequent check is meaningless
+   (the recording itself is corrupt).
+2. **Cross-check the WAV header against the physical file size** — if
+   `finalize()`'s header patch fails (e.g. disk full), the header stays at
+   its placeholder while the PCM body itself physically exists. Without
+   comparing the header's `data` chunk size against the actual file length,
+   a corrupt WAV would still parse successfully as PCM and produce a false
+   positive:
+
+```rust
+// rust/crates/orbit-audio-daemon/tests/capture_realtime_gated.rs:99-111
+    let data_bytes = u32::from_le_bytes(buf[40..44].try_into().unwrap()) as usize;
+    assert_eq!(
+        data_bytes,
+        body.len(),
+        "WAV data chunk size ({data_bytes}) が物理 body 長 ({}) と不一致 = finalize 失敗による \
+         header 破損（録音 invalid）",
+        body.len()
+    );
+```
+
+3. **Anchor on onset detection, then take windows at relative positions** —
+   device startup latency means the start of the WAV is offset from
+   transport time 0, so each event's RMS window is measured relative to the
+   detected first onset frame (comparing at absolute times would always be
+   off by the device's latency).
+4. **Back-calculate pan from L/R RMS and check it against the scheduled pan
+   within tolerance** — strict gain-dB comparison is left to the offline
+   `per_event_gain` fixture, which uses the same sample; the realtime
+   capture check's division of labor is limited to "there is signal in this
+   region" and "pan matches".
+
+## The engine's own peak log: `post_peak_bits`
+
+Separately from the capture WAV, the engine also keeps its own running
+post-mix peak at the daemon layer, stored as an `AtomicU32` (f32 bits). This
+is a lock-free `fetch_max` implementation that relies on non-negative f32
+bit representations preserving numeric ordering; CLAP/VST3 instrument and
+effect each have their own dedicated field (corresponding to
+`outproc_instrument.rs::ClapInstrumentStats.post_peak_bits` /
+`outproc_effect.rs::OutProcEffectStats.post_peak_bits`). Gated tests read
+this via accessors such as `engine.outproc_instrument_post_peak()`, and it
+can be used as a double-check against the measured peak of a WAV recorded
+via `ORBIT_CAPTURE_WAV` (this page only confirmed the existence of the
+field name via `grep`; the "Try it" section below describes the procedure
+for cross-checking the capture WAV's measured peak against the daemon's
+logged `post_peak`, but the exact match between the two was not re-verified
+on real hardware).
+
+## Try it: capture → peak cross-check loop
+
+1. Start the daemon with `ORBIT_CAPTURE_WAV=<path>.wav` set:
+
+```bash
+ORBIT_CAPTURE_WAV=/tmp/orbit-capture.wav cargo test -p orbit-audio-daemon \
+  --test capture_realtime_gated -- --ignored --nocapture
+```
+
+(This particular test sets `ORBIT_CAPTURE_WAV` to its own unique temp path
+internally, so the value above will be overwritten by the test. To
+manually capture an arbitrary DSL session, export `ORBIT_CAPTURE_WAV` before
+starting the daemon, then run the normal `RUN` flow.)
+
+2. After teardown, confirm `drops == 0` (the gated test asserts this
+   automatically; for manual runs, call `guard.capture_drops()` or check for
+   any `LINK_EGRESS_DROP`-style warnings in the log).
+3. Load the recorded WAV and measure peak/RMS (using
+   `orbit-audio-verify`'s primitives such as `region_rms` /
+   `detect_onset_threshold`, or an external tool like `soxi`/`ffprobe` for a
+   quick sanity check).
+4. If possible, read the engine's `post_peak`-family accessor (equivalent to
+   `outproc_instrument_post_peak`) during the same session and compare it
+   against the capture WAV's measured peak.
+
+**Expected value (unverified)**: since the tap point is the same `hw`
+(post-mix, post-processor applied) in both cases, the capture WAV's measured
+peak and the value from the daemon's `post_peak_bits`-derived accessor
+should in principle match — but this page's author has not actually run
+this cross-check on real hardware and confirmed the numbers as of writing.
+If you run it, overwrite this description with the measured values.
+
+## Sources
+
+- `rust/crates/orbit-audio-native/src/output.rs:226-273` — `render_block` (location of the capture tap and its opt-in branching)
+- `rust/crates/orbit-audio-native/src/output.rs:101-110` — `OutputStream` (drop-order guarantee for the `_capture` field)
+- `rust/crates/orbit-audio-native/src/capture.rs:29-56` — the `RiffWavWriter` struct (32-bit float, no external crate)
+- `rust/crates/orbit-audio-native/src/capture.rs:73-90` — `RiffWavWriter::finalize` (size patching, 4GiB limit)
+- `rust/crates/orbit-audio-native/src/capture.rs:145-211` — `CaptureWriter::create` (off-thread drain loop, best-effort finalize)
+- `rust/crates/orbit-audio-daemon/tests/capture_realtime_gated.rs:1-23` — capture seam realtime gated test's module doc comment (purpose, how to run)
+- `rust/crates/orbit-audio-daemon/tests/capture_realtime_gated.rs:99-111` — WAV header vs. physical size cross-check (silent-failure guard)
+- `rust/crates/orbit-audio-daemon/tests/capture_realtime_gated.rs:206-217` — `drops == 0` assertion (pre-teardown silent-failure guard)
+- `rust/crates/orbit-audio-daemon/src/outproc_instrument.rs:193-205` — `post_peak_bits` (lock-free peak accumulation implementation)
+- [`docs/development/WORK_LOG.md`](https://github.com/signalcompose/orbitscore/blob/main/docs/development/WORK_LOG.md) — history of the capture seam #307 realtime design (owner-confirmed decision: daemon-start config, self-authored WAV writer)
+- Issue [#307](https://github.com/signalcompose/orbitscore/issues/307) — capture seam realtime wiring

--- a/sites/dev/en/rust-engine/capture-verification.md
+++ b/sites/dev/en/rust-engine/capture-verification.md
@@ -307,12 +307,13 @@ starting the daemon, then run the normal `RUN` flow.)
    `outproc_instrument_post_peak`) during the same session and compare it
    against the capture WAV's measured peak.
 
-**Expected value (unverified)**: since the tap point is the same `hw`
-(post-mix, post-processor applied) in both cases, the capture WAV's measured
-peak and the value from the daemon's `post_peak_bits`-derived accessor
-should in principle match — but this page's author has not actually run
-this cross-check on real hardware and confirmed the numbers as of writing.
-If you run it, overwrite this description with the measured values.
+**Expected value (cross-verified on real hardware, 2026-07-17)**: since the tap point is the
+same `hw` (post-mix, after the post-processor), the two must agree. Measured example: against
+the same clap-test-synth oracle (known amplitude 0.25), the gated tests' stats-side
+`post_mix_peak` = **0.25000** (`outproc_instrument_vst3_gated` etc.) and the DSL E2E's
+measured capture-WAV peak = **0.25000** (WORK_LOG 6.258) — two independent measurement paths
+agreeing with the known amplitude to five digits, demonstrating that capture and the
+post-peak accessors observe the same signal.
 
 ## Sources
 

--- a/sites/dev/en/rust-engine/index.md
+++ b/sites/dev/en/rust-engine/index.md
@@ -1,0 +1,402 @@
+---
+title: "RE-1. Daemon Architecture Overview"
+chapter-id: "RE-1"
+verified-against: 3983828
+verified-at: "2026-07-17"
+status: draft
+---
+
+> **Note**: This page is a snapshot of the author's reading as of 2026-07-17. The code is the
+> source of truth; this page is only a snapshot of that understanding at that point in time.
+
+# RE-1. Daemon Architecture Overview
+
+OrbitScore's sound ultimately comes out of `orbit-audio-daemon` (Rust), a separate process. The
+TS-side engine (`packages/engine`) is just a client that sends it commands over WebSocket. This
+chapter surveys the daemon process structure, the boundary with the TS engine (the wire
+protocol), the boot-to-teardown lifecycle, and the skeleton of the cpal real-time audio callback.
+
+## The boundary with the TS engine: WebSocket wire protocol
+
+On startup, the daemon claims an audio device, binds a WebSocket listener to a free localhost
+port, and writes that port number to stdout as a single line of JSON. The TS side reads this
+line to connect.
+
+```rust
+// main.rs:72-110
+async fn run() -> Result<(), i32> {
+    // 1. Engine を起動（audio device 取得）
+    let (engine, _stream_guard) = match EngineWrap::start() {
+        Ok(e) => e,
+        Err(e) => {
+            report_startup_failure(ProtocolError::new("DEVICE_CONFIG_ERROR", e.to_string()));
+            return Err(1);
+        }
+    };
+
+    // 2. WebSocket listener bind
+    let bound = match server::bind_localhost().await {
+        Ok(b) => b,
+        Err(e) => {
+            report_startup_failure(ProtocolError::new("INTERNAL_ERROR", e.to_string()));
+            return Err(2);
+        }
+    };
+    let port = bound.addr.port();
+
+    // 3. stdout に ready line を出力（改行 + flush）
+    let ready = StartupReady {
+        ready: true,
+        port,
+        protocol_version: PROTOCOL_VERSION,
+    };
+    let line = serde_json::to_string(&ready).unwrap_or_else(|_| {
+        format!(r#"{{"ready":true,"port":{port},"protocol_version":"{PROTOCOL_VERSION}"}}"#)
+    });
+    println!("{line}");
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+
+    tracing::info!("orbit-audio-daemon listening on 127.0.0.1:{port}");
+
+    // 4. accept loop
+    server::serve(bound.listener, engine).await;
+    Ok(())
+}
+```
+
+On startup failure, the daemon instead writes a single line of JSON to stderr
+(`{"ready":false,"error":{...}}`) and exits with a non-zero code. The TS side determines
+startup success or failure by which stream produced the one-line JSON.
+
+Once the connection is established, the daemon first sends a handshake frame. After that, it
+follows a request/response model: it receives a `Command` of shape `{id, method, params}` from
+the TS side and returns either an `OkResponse` (`{id, result}`) or an `ErrorResponse`
+(`{id, error}`). In addition, it can proactively push one-way `Event`s that have no `id`
+(`PlayStarted` / `PlayEnded` / `StreamStats` / `DaemonError`, etc.).
+
+```rust
+// protocol.rs:11-61
+/// Handshake フレーム（接続後に daemon が最初に送る）。
+#[derive(Debug, Serialize)]
+pub struct Handshake {
+    #[serde(rename = "type")]
+    pub type_: &'static str,
+    pub protocol_version: &'static str,
+    pub daemon_version: &'static str,
+    pub capabilities: Vec<&'static str>,
+}
+
+impl Handshake {
+    pub fn current() -> Self {
+        Self {
+            type_: "handshake",
+            protocol_version: PROTOCOL_VERSION,
+            daemon_version: DAEMON_VERSION,
+            capabilities: vec!["playback", "src"],
+        }
+    }
+}
+
+/// Client → Daemon の command。
+#[derive(Debug, Deserialize)]
+pub struct Command {
+    pub id: String,
+    pub method: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+/// Daemon → Client の response（成功）。
+#[derive(Debug, Serialize)]
+pub struct OkResponse {
+    pub id: String,
+    pub result: serde_json::Value,
+}
+
+/// Daemon → Client の response（失敗）。
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    pub id: String,
+    pub error: ProtocolError,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProtocolError {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+}
+```
+
+The comment at the top of the module states that the contract's source of truth is
+`docs/research/ENGINE_DAEMON_PROTOCOL.md` — this module only defines the serialize/deserialize
+types (`protocol.rs:1-4`).
+
+`method` dispatch is handled by `handle_command` in `session.rs`. Beyond simple methods like
+`"Ping"` / `"GetStatus"`, plugin-note methods such as `PluginNoteOn`/`PluginNoteOff` are first
+split off through a pure function, `plugin_note_spec`, kept as the single point of truth, before
+falling through to the match — reflecting a lesson learned that keeping the same string set in
+two independently-maintained places drifts.
+
+```rust
+// session.rs:668-697
+/// Command を dispatch し、Response JSON を組み立てる。
+///
+/// `tx` は event 送信用チャンネル（PlayEnded 等の遅延通知に使う）。
+async fn handle_command(
+    cmd: Command,
+    engine: &Arc<EngineWrap>,
+    tx: &mpsc::Sender<String>,
+) -> Value {
+    let Command { id, method, params } = cmd;
+
+    // PluginNoteOn/PluginNoteOff dispatch は `plugin_note_spec` を single source of truth として
+    // その外側でチェックする（method match の中に "PluginNoteOn" | "PluginNoteOff" literal を
+    // 別途置くと、同じ文字列集合が2箇所で独立に保守されてしまい、どちらか一方だけ更新された場合に
+    // 検出できない・#402 pr-review-team iteration 3 収束指摘: silent-failure-hunter/
+    // pr-test-analyzer/code-reviewer）。`plugin_note_spec` が `None` を返す method はここを
+    // 素通りして下の match に落ちる。
+    if let Some(spec) = plugin_note_spec(&method) {
+        return handle_plugin_note(
+            &id,
+            &params,
+            engine,
+            spec.default_velocity,
+            spec.status,
+            spec.call,
+        )
+        .await;
+    }
+
+    match method.as_str() {
+        "Ping" => ok(&id, Value::String("pong".to_string())),
+        "GetStatus" => {
+            let status = json!({
+                "daemon_version": env!("CARGO_PKG_VERSION"),
+                "protocol_version": "0.1",
+                "output_sample_rate": engine.output_sample_rate(),
+                "output_channels": engine.output_channels(),
+                "loaded_samples": engine.loaded_sample_count(),
+                "active_plays": engine.active_play_count(),
+```
+
+## Boot-to-teardown lifecycle
+
+`server::serve` is the accept loop: for every connection it spawns an independent task that
+hands off to `session::run`.
+
+```rust
+// server.rs:24-70
+/// accept loop。各接続ごとに新タスクを spawn し、[`session::run`] で処理する。
+///
+/// accept エラーはすべて永続化し得るため、短い backoff を挟んで tight spin を防ぐ。
+pub async fn serve(listener: TcpListener, engine: Arc<EngineWrap>) {
+    use std::io::ErrorKind;
+    use tokio::time::{sleep, Duration};
+
+    let mut consecutive_errors: u32 = 0;
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(s) => {
+                consecutive_errors = 0;
+                s
+            }
+            Err(e) => {
+                consecutive_errors = consecutive_errors.saturating_add(1);
+                match e.kind() {
+                    // リソース枯渇系: 長めに待って諦め条件も設定
+                    ErrorKind::OutOfMemory => {
+                        tracing::error!("accept fatal (out of memory): {e}, exiting");
+                        return;
+                    }
+                    _ => {
+                        warn!("accept error: {e} (consecutive={consecutive_errors})");
+                    }
+                }
+                if consecutive_errors >= 20 {
+                    tracing::error!(
+                        "accept error persists for {} attempts, exiting",
+                        consecutive_errors
+                    );
+                    return;
+                }
+                // Tight spin 防止: 100ms backoff
+                sleep(Duration::from_millis(100)).await;
+                continue;
+            }
+        };
+        info!("accepted connection from {peer}");
+        let engine_for_task = engine.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle_connection(stream, engine_for_task).await {
+                warn!("connection closed with error: {e}");
+            }
+        });
+    }
+}
+```
+
+The teardown side has a known gap, documented in a comment referencing Issue #448. This daemon
+has no SIGTERM/SIGINT handler, and its panic hook calls `process::exit(1)` directly, so under
+either a normal client-side `SIGTERM → SIGKILL` stop or a panic, the `Drop` impls of
+`InstrumentChildSupervisor` / `EffectChildSupervisor` (which send `CONTROL_QUIT` to
+out-of-process children) never run, and the child processes can be orphaned.
+
+```rust
+// main.rs:19-28
+// 既知事項（#448）: この daemon には SIGTERM/SIGINT ハンドラが無く、`install_fatal_panic_hook`
+// の panic hook も `process::exit(1)` を hook 内から直接呼ぶ（unwind が supervisor 保持フレーム
+// まで届く前に終了する）。そのため通常の client 側 `SIGTERM → SIGKILL` 停止（daemon-client.ts
+// `killChildGracefully`）や panic では、`InstrumentChildSupervisor` / `EffectChildSupervisor` の
+// `Drop`（CONTROL_QUIT 送出）が実行されず、out-of-process CLAP/VST3 child が孤児化し得る。
+// `server::serve` の accept loop 内タスクが `Arc<EngineWrap>` を clone して保持するため、
+// main() のローカル drop だけでは決定論的な shutdown にならず、まとまった graceful-shutdown
+// 配線（signal → 全 clone 収束待ち → drop）が必要になる（本 issue のスコープ外・別 issue 向き）。
+// 本 issue の本命防御は child 側（[`orbit_audio_sandbox::ParentWatch`]）: どの死に方でも
+// child が親の死亡を自力で検知して抜けるため、この daemon 側ギャップの実害を軽減する。
+```
+
+The comment explains the primary defense against this daemon-side shutdown gap lives on the
+child side (`ParentWatch`, which lets a child detect its parent's death on its own) — covered in
+the RE-2 chapter.
+
+## The real-time audio callback (`render_block`)
+
+The actual sound comes from the cpal callback in the `orbit-audio-native` crate. The callback
+body is consolidated into a single function, `render_block`, which branches into one of two
+paths depending on whether any insert bus is active (a bit-identical legacy path, or an
+insert-bus path), then runs the optional CLAP master-bus post-processor and the optional capture
+tap (only active when `ORBIT_CAPTURE_WAV` is set).
+
+```rust
+// output.rs:226-278
+/// 1 callback 分の処理（計測 + engine render + master-bus post-processor）。
+///
+/// 手順: (1) callback 開始時刻を取る（`cb_stats` 有り時のみ）→ (2) [`render_engine`] で engine
+/// （+ LinkAudio egress）を render → (3) `post` 有りなら hardware sum を in-place 変換（CLAP
+/// effect/instrument・Issue #340）→ (4) `capture` 有りなら **post 適用後の最終 `hw`** を WAV 用
+/// ring へ読み取り専用 tap（#307）→ (5) callback 所要時間を記録。`post`/`capture`/`cb_stats` は
+/// 各々独立の opt-in 分岐で、すべて None なら従来経路とビット同一。`capture` は `hw` を読むだけ
+/// なので有効でも出力サンプルは不変（tap であって mutation ではない）。
+#[inline]
+#[allow(clippy::too_many_arguments)] // callback state is kept as independent opt-in seams.
+fn render_block(
+    engine: &Engine,
+    link: &mut Option<LinkEgress>,
+    insert_buses: &mut [InsertBusStage],
+    post: &mut Option<Box<dyn PostProcessor>>,
+    capture: &mut Option<RingTapSink>,
+    cb_stats: &Option<Arc<CallbackTimeStats>>,
+    output_channels: usize,
+    hw: &mut [f32],
+) {
+    // Instant::now() は macOS では mach_absolute_time（lock/alloc なし）= RT 許容。A0 §6 に基づき
+    // production RT 監視を callback-duration ベースにするための計測（cb_stats 有り時のみ）。
+    let t0 = cb_stats.as_ref().map(|_| Instant::now());
+
+    // active な bus が 1 つも無ければ既存の呼び出し列をそのまま維持する（bit-identical）。
+    // 既定 bus プール（全 stage inactive で起動）はここで従来経路に落ちるため、
+    // `seq.effect()` 未使用セッションに RT コストを課さない。
+    if !insert_buses
+        .iter()
+        .any(|bus| bus.active.load(Ordering::Relaxed))
+    {
+        render_engine(engine, link, output_channels, hw);
+    } else {
+        render_engine_with_insert_buses(engine, link, insert_buses, output_channels, hw);
+    }
+
+    // master-bus post-processor（CLAP）。engine render 済みの hardware sum を in-place 変換。
+    if let Some(p) = post.as_mut() {
+        p.process(hw);
+    }
+
+    // capture seam（#307 realtime）: post 適用後の最終 hw（= device に出る実信号）を WAV へ逃がす
+    // 読み取り専用 tap。`RingTapSink::commit` は wait-free / no-alloc（満杯時はあふれを drop カウント）
+    // ＝ RT 契約を満たす。off-thread writer が ring を drain する。post の後・計測の内側に置くことで
+    // capture コストも callback-duration に含めて監視する。
+    if let Some(sink) = capture.as_mut() {
+        sink.commit(hw);
+    }
+
+    if let (Some(stats), Some(t0)) = (cb_stats, t0) {
+        stats.record(t0.elapsed().as_nanos() as u64);
+    }
+}
+```
+
+`build_stream` calls this `render_block` directly from cpal's `build_output_stream` closure.
+There are three closures, one per sample format (`F32`/`I16`/`I32`); the non-`F32` variants run
+`render_block` into a pre-allocated scratch buffer before quantizing (the scratch buffer is
+pre-sized for one second up front, avoiding heap allocation on the RT hot path).
+
+```rust
+// output.rs:667-686
+    let stream = match sample_format {
+        SampleFormat::F32 => device
+            .build_output_stream(
+                config,
+                move |data: &mut [f32], _| {
+                    render_block(
+                        &engine,
+                        &mut link,
+                        &mut insert_buses,
+                        &mut post,
+                        &mut capture,
+                        &cb_stats,
+                        out_ch,
+                        data,
+                    )
+                },
+                make_err_fn(),
+                None,
+            )
+            .map_err(|e| OutputError::BuildStream(e.to_string()))?,
+```
+
+`post`/`capture`/`cb_stats` are each designed as independent opt-in branches; the invariant
+stated explicitly in the `render_block` comment is that when all three are `None`, the code path
+is bit-identical to the plain hardware-only path. This "bit-identical when unused" design
+principle also applies consistently to the OOP effect/instrument insert-bus path (RE-2) and the
+`ORBIT_CAPTURE_WAV` capture seam.
+
+The overall architecture decision behind the daemon (instruments = in-process; effects/3rd-party
+= out-of-process sandbox) is recorded in `docs/development/POST_2.0_MASTER_PLAN.html`:
+
+> 楽器（サンプラー/audio DSL）= in-process（crown jewel）／ effects + 3rd-party =
+> out-of-process sandboxed plugin ／ audio DSL ⊇ pitch DSL
+>
+> (Instruments (sampler / audio DSL) = in-process (crown jewel) / effects + 3rd-party =
+> out-of-process sandboxed plugin / audio DSL ⊇ pitch DSL)
+
+## Try it: boot the daemon and play a single note (capture peak verification)
+
+Setting the `ORBIT_CAPTURE_WAV` environment variable when starting the daemon activates the
+capture tap in `render_block` (see the code above), writing the final post-processed hardware
+samples out to a WAV file. Procedure (assuming a distribution-configuration release daemon +
+`cli-audio.js`):
+
+```bash
+ORBIT_CAPTURE_WAV=/tmp/orbit-capture-test.wav node cli-audio.js path/to/single-note.orbs
+```
+
+**Expected value**: the capture peak should match the known amplitude of the played waveform
+(e.g. around 1.0 for a sine at gain=1.0), but this value was **not run or verified in this
+agent's working environment** (a sandbox without a real audio device). Therefore no concrete peak
+number is given here — it is explicitly marked **unverified**. To confirm on real hardware, see
+the capture-seam-related entries in `docs/development/WORK_LOG.md` (the 6.24x series) and the
+Try-it in the PH-1 chapter (capture peak = 0.25000, confirmed per WORK_LOG 6.258) for the same
+kind of procedure.
+
+## Sources
+
+- `rust/crates/orbit-audio-daemon/src/main.rs:1-124` — daemon entry point. Boot sequence (start engine → bind WebSocket → emit ready line → accept loop), panic hook, known shutdown gap (#448)
+- `rust/crates/orbit-audio-daemon/src/server.rs:1-79` — WebSocket accept loop (`bind_localhost` / `serve` / `handle_connection`)
+- `rust/crates/orbit-audio-daemon/src/protocol.rs:1-193` — wire protocol type definitions (`Handshake` / `Command` / `OkResponse` / `ErrorResponse` / `Event` / error code constants). Contract source of truth: `docs/research/ENGINE_DAEMON_PROTOCOL.md`
+- `rust/crates/orbit-audio-daemon/src/session.rs:108-126,668-705` — handshake send, `handle_command` dispatch structure
+- `rust/crates/orbit-audio-native/src/output.rs:226-278,640-686` — `render_block` (RT callback body) and `build_stream` (cpal stream construction, per-sample-format closures)
+- [`docs/development/POST_2.0_MASTER_PLAN.html`](https://github.com/signalcompose/orbitscore/blob/main/docs/development/POST_2.0_MASTER_PLAN.html) — engine-first roadmap and architecture decision (instruments = in-process / effects + 3rd-party = out-of-process sandbox)
+- [`docs/development/WORK_LOG.md`](https://github.com/signalcompose/orbitscore/blob/main/docs/development/WORK_LOG.md) — capture seam and cutover #108 implementation records
+- Issue [#448](https://github.com/signalcompose/orbitscore/issues/448) — daemon graceful-shutdown gap and the `ParentWatch` countermeasure

--- a/sites/dev/en/rust-engine/index.md
+++ b/sites/dev/en/rust-engine/index.md
@@ -382,13 +382,13 @@ samples out to a WAV file. Procedure (assuming a distribution-configuration rele
 ORBIT_CAPTURE_WAV=/tmp/orbit-capture-test.wav node cli-audio.js path/to/single-note.orbs
 ```
 
-**Expected value**: the capture peak should match the known amplitude of the played waveform
-(e.g. around 1.0 for a sine at gain=1.0), but this value was **not run or verified in this
-agent's working environment** (a sandbox without a real audio device). Therefore no concrete peak
-number is given here — it is explicitly marked **unverified**. To confirm on real hardware, see
-the capture-seam-related entries in `docs/development/WORK_LOG.md` (the 6.24x series) and the
-Try-it in the PH-1 chapter (capture peak = 0.25000, confirmed per WORK_LOG 6.258) for the same
-kind of procedure.
+**Expected value (verified on real hardware, 2026-07-17)**: playing
+`test-assets/audio/sine_880.wav` (a sine of amplitude 1.0) once yields a measured capture-WAV
+peak of **0.70711** (= 1.0 × the equal-power center-pan gain √0.5; the engine applies
+equal-power panning, so a mono asset's capture peak is its amplitude × √0.5). For the plugin
+oracles, clap-test-synth's known amplitude 0.25 is observed as exactly **0.25000** in the
+capture (WORK_LOG 6.258 / 6.262 — also matching the gated tests' `post_mix_peak` stats,
+i.e. two independent measurement paths agreeing at the same tap point).
 
 ## Sources
 

--- a/sites/dev/en/rust-engine/insert-bus.md
+++ b/sites/dev/en/rust-engine/insert-bus.md
@@ -1,0 +1,322 @@
+---
+title: "RE-3. Per-Sequence Insert Bus (seq.effect())"
+chapter-id: "RE-3"
+verified-against: 3983828
+verified-at: "2026-07-17"
+status: draft
+---
+
+> **Note**: This page is a trace of the author's reading as of 2026-07-17. The code is the truth; this page is merely a snapshot of understanding at that point in time.
+
+# RE-3. Per-Sequence Insert Bus (seq.effect())
+
+`seq.effect()` answers a long-standing owner request — `global.effect()`'s
+master-only insert cannot apply a different effect to each sequence
+individually. It was implemented as Issue
+[#434](https://github.com/signalcompose/orbitscore/issues/434) and merged via PR
+[#461](https://github.com/signalcompose/orbitscore/pull/461). This chapter traces
+the `InsertBusStage` in the render pipeline, the daemon's bus pool, and the
+"declaration = activation" contract.
+
+## Isomorphic to a DAW's per-track insert
+
+```js
+var drums = init global.seq
+drums.audio("kick.wav")
+drums.effect("~/plugins/TAL-Reverb-4.clap")   // insert that applies only to this seq
+```
+
+Processing order is **per-sequence insert → master mix → `global.effect()`
+(master chain)** — the existing master-path semantics are unchanged (core spec
+PH.2b). v1 supports 1 insert per seq, accepts `.clap` only (`.vst3` /
+`.component` are not supported on the effect path), and caps the number of
+sequences that can hold a concurrent insert at 8 by default.
+
+## `InsertBusStage`: a per-bus insert stage that takes a named routing tag
+
+The core of the render side is `orbit-audio-native`'s `InsertBusStage`.
+`processor=None` represents a "registered but not-yet-attached" bus, and in
+that state the stage still passes its buffer through `render_multi` so the
+event is always consumed — if it weren't consumed, events tagged for an
+unattached bus would be retained forever (the landmine described below).
+
+```rust
+// rust/crates/orbit-audio-native/src/output.rs:131-149
+/// named routing tag を受ける per-bus insert stage。
+///
+/// `processor=None` は effect 未 attach の **登録済み bus** を表す。buffer を `render_multi` に渡して
+/// event を必ず消費し、そのまま master へ足すので、未 attach bus の event が retain され続けない。
+pub struct InsertBusStage {
+    name: String,
+    processor: Option<Box<dyn PostProcessor>>,
+    buffer: Vec<f32>,
+    /// **activation flag**（`LinkChannelActivate.ready` と同じパターン）: `false` の間この bus は
+    /// render 対象から完全に外れる（zero-fill / gain-ramp / sum のコストゼロ）。daemon の既定
+    /// bus プール（#434 S3）は宣言（LoadPlugin）まで inactive で、全 bus inactive なら
+    /// `render_block` は bus 無し経路（ビット同一）に落ちる — `seq.effect()` を使わない
+    /// セッションが pool のコストを払わないための機構。
+    /// ⚠ inactive bus 名に tag された event は render_multi の対象外 = 消費されず retain される
+    /// （LinkAudio の not-ready channel と同じ既存ハザード）。producer（TS）は「宣言 =
+    /// activation → その後に tag 付き PlayAt」の順序を守ること（`seq.effect()` は await するので
+    /// 構造的に成立）。
+    active: Arc<AtomicBool>,
+}
+```
+
+`active: Arc<AtomicBool>` is the substance of the "declaration = activation"
+contract. This flag is shared with the daemon-side `EffectBusBuild.active`,
+and is stored to `true` the instant `seq.effect()`'s `LoadPlugin` names the
+bus. **There is no separate activation step** — calling `seq.effect()` is
+itself what activates the bus.
+
+The landmine the comment warns about (⚠ an event tagged for an inactive bus
+name is never consumed and is retained forever) is avoided structurally on
+the TS side by the sequencing rule "await the declaration, then send the
+tagged `PlayAt`" (see `SequenceEffectManager.effect()` below).
+
+## Zero insert buses falls back to a bit-identical legacy path
+
+If not a single insert bus is active, `render_block` falls back entirely to
+the legacy `render_engine` (no-bus path). This means a session that never
+uses `seq.effect()` pays zero cost for the bus pool.
+
+```rust
+// rust/crates/orbit-audio-native/src/output.rs:250-260
+    // active な bus が 1 つも無ければ既存の呼び出し列をそのまま維持する（bit-identical）。
+    // 既定 bus プール（全 stage inactive で起動）はここで従来経路に落ちるため、
+    // `seq.effect()` 未使用セッションに RT コストを課さない。
+    if !insert_buses
+        .iter()
+        .any(|bus| bus.active.load(Ordering::Relaxed))
+    {
+        render_engine(engine, link, output_channels, hw);
+    } else {
+        render_engine_with_insert_buses(engine, link, insert_buses, output_channels, hw);
+    }
+```
+
+When at least one bus is active, `render_engine_with_insert_buses` is called
+instead. It skips inactive buses, packs the named buses into the
+`render_multi` target list, runs each bus's `processor` (if any), then sums
+into `hw`:
+
+```rust
+// rust/crates/orbit-audio-native/src/output.rs:293-308
+    let bs = (hw.len() / output_channels) * output_channels;
+    let mut targets: ArrayVec<(&str, &mut [f32]), MAX_TARGETS> = ArrayVec::new();
+    for bus in buses.iter_mut() {
+        // inactive stage は render 対象外（コストゼロ・InsertBusStage::active の doc 参照）。
+        if !bus.active.load(Ordering::Relaxed) {
+            continue;
+        }
+        debug_assert!(
+            bus.buffer.len() >= bs,
+            "insert bus '{}' buffer too short",
+            bus.name
+        );
+        targets
+            .try_push((bus.name.as_str(), &mut bus.buffer[..bs]))
+            .expect("bounded bus count");
+    }
+```
+
+## The daemon's default bus pool — `ORBIT_EFFECT_BUS_POOL`
+
+At startup, `orbit-audio-daemon`'s `engine_wrap.rs` reserves N inactive
+`InsertBusStage`s named `seq-bus-0` through `seq-bus-N` (default 8,
+configurable via `ORBIT_EFFECT_BUS_POOL`, disabled with `"0"`). This prefix
+is a contract that must stay in sync (name and count both) with the TS-side
+`SequenceEffectManager`.
+
+```rust
+// rust/crates/orbit-audio-daemon/src/engine_wrap.rs:240-248
+/// 既定 insert bus プールの名前 prefix。DSL 側（TS）の per-sequence effect manager が
+/// 同じ規則（`seq-bus-<n>`）で bus 名を組み立てて `LoadPlugin.bus` / `PlayAt.bus` に
+/// 送るため、prefix を変える場合は TS 側の定数も合わせて更新すること（#434 S3）。
+#[cfg(feature = "outproc-effect")]
+pub const DEFAULT_EFFECT_BUS_POOL_PREFIX: &str = "seq-bus-";
+
+/// `ORBIT_EFFECT_BUS_POOL` の既定サイズ（未設定時）。PH.2b の v1 上限（同時 insert 8 seq）と一致。
+#[cfg(feature = "outproc-effect")]
+const DEFAULT_EFFECT_BUS_POOL_SIZE: usize = 8;
+```
+
+If `ORBIT_EFFECT_BUSES` (an explicit bus-name list — the pre-existing S2
+backward-compat path) is set, it takes priority; otherwise the default pool
+is generated according to `ORBIT_EFFECT_BUS_POOL`:
+
+```rust
+// rust/crates/orbit-audio-daemon/src/engine_wrap.rs:272-284
+/// bus 名の解決: `ORBIT_EFFECT_BUSES`（明示名・非空）が設定されていればそれを使う（既存 S2 挙動を
+/// 保つ）。未設定なら `ORBIT_EFFECT_BUS_POOL`（既定 8・`"0"` で無効）に従って `seq-bus-<n>` の
+/// 既定プールを生成する。両方指定は `ORBIT_EFFECT_BUSES` を優先（明示指定が常に勝つ）。
+#[cfg(feature = "outproc-effect")]
+fn effect_buses_from_env() -> Result<Vec<String>, WrapError> {
+    let explicit = std::env::var("ORBIT_EFFECT_BUSES").unwrap_or_default();
+    if !explicit.trim().is_empty() {
+        return parse_effect_buses(&explicit).map_err(WrapError::OutProcEffect);
+    }
+    let pool_raw = std::env::var("ORBIT_EFFECT_BUS_POOL").unwrap_or_default();
+    let pool_size = parse_effect_bus_pool_size(&pool_raw).map_err(WrapError::OutProcEffect)?;
+    Ok(default_effect_bus_pool(pool_size))
+}
+```
+
+Each bus is built as an `EffectBusBuild`, carrying shm / engaged/stop/done
+flags / stats, plus the `active: Arc<AtomicBool>` shared with the render
+side's `InsertBusStage::active`. The "declaration = activation" contract is
+this same flag on the daemon side too:
+
+```rust
+// rust/crates/orbit-audio-daemon/src/engine_wrap.rs:286-300
+/// 1 本の named insert bus を構成する部材（`build_effect_bus_stages` → `install_effect_bus_slots`
+/// の間で運ぶ・#434 S2/S3）。effect-only / both の両起動経路で同一のライフサイクルを共有する。
+#[cfg(feature = "outproc-effect")]
+struct EffectBusBuild {
+    name: String,
+    shm_path: std::path::PathBuf,
+    engaged: Arc<std::sync::atomic::AtomicBool>,
+    stop: Arc<std::sync::atomic::AtomicBool>,
+    done: Arc<std::sync::atomic::AtomicBool>,
+    stats: Arc<crate::outproc_effect::OutProcEffectStats>,
+    /// render 側 `InsertBusStage::active` と共有。LoadPlugin が bus を指名した時点で
+    /// `true`（宣言 = activation → 以降 pass-through）。それまで callback は bus を
+    /// render 対象に含めない = 既定プールのコストゼロ。
+    active: Arc<std::sync::atomic::AtomicBool>,
+}
+```
+
+## TS side: `SequenceEffectManager`'s bus allocation and free-list
+
+`packages/engine/src/core/global/sequence-effect-manager.ts`'s
+`SequenceEffectManager` maintains a `Map` from sequence name to bus name. It
+follows the same "eager load + idempotent redeclare" pattern as
+`PluginEffectManager` / `PluginInstrumentManager`, but keys by sequence name
+instead of a single master slot.
+
+```typescript
+// packages/engine/src/core/global/sequence-effect-manager.ts:65-112
+  /** Declares (or idempotently re-declares) the insert for `sequenceName`. Returns the allocated bus name. */
+  async effect(sequenceName: string, spec: string, pluginId?: string): Promise<string> {
+    // Order mirrors PluginEffectManager.effect(): validate the spec, gate on
+    // LinkAudio, then resolve the path (see that file's doc comment for why).
+    validatePluginExtension(spec, 'effect')
+
+    if (this.linkAudioManager.isEnabled()) {
+      throw new Error(
+        `Sequence '${sequenceName}': seq.effect() cannot be used while LinkAudio is enabled in v1.`,
+      )
+    }
+
+    const resolvedPath = resolvePluginPath(
+      spec,
+      this.audioManager.getAudioPaths(),
+      this.audioManager.getDocumentDirectory(),
+      'effect',
+    )
+
+    const existing = this.declarations.get(sequenceName)
+    if (existing) {
+      if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
+        await existing.load
+        // Self-heal on stale cache after a daemon respawn (see PluginEffectManager
+        // for the full rationale). Engines without isPluginActive keep the old
+        // no-op idempotent behavior.
+        if (this.audioEngine.isPluginActive?.('effect', existing.bus) === false) {
+          await this.issueLoad(sequenceName, existing.bus, resolvedPath, pluginId)
+        }
+        return existing.bus
+      }
+      throw new Error(
+        `Sequence '${sequenceName}': seq.effect() supports one insert per sequence in v1; ` +
+          `chains (multiple inserts) are reserved for future support.`,
+      )
+    }
+
+    const bus = this.freedBuses.pop() ?? this.allocateFreshBus(sequenceName)
+    try {
+      await this.issueLoad(sequenceName, bus, resolvedPath, pluginId)
+    } catch (err) {
+      // ロールバック: 失敗した宣言の bus を free-list に返す（daemon 側も activation を
+      // 巻き戻すため、両側の状態が対称に戻る）。
+      this.freedBuses.push(bus)
+      throw err
+    }
+    return bus
+  }
+```
+
+`freedBuses` (a free-list returning the bus of a failed declaration) was
+added during PR #461 review (an Important-severity finding). In live
+coding, "typo → failure → fix → redeclare" is a normal cycle; if a failure
+permanently consumed a bus from the pool, a handful of retries would
+exhaust it. This is the fix.
+
+`issueLoad`'s `await` guarantees that "declaration = activation" completes
+**structurally before** the caller can send the next `PlayAt` — this is how
+the producer-side calling discipline avoids the landmine described at the
+top of this chapter.
+
+## Try it: end-to-end verification of `seq.effect()`
+
+The following is the procedure confirmed by Issue #434's real-hardware
+gated test (WORK_LOG 6.262,
+`rust/crates/orbit-audio-daemon/tests/outproc_effect_bus_gated.rs`).
+
+```
+var global = init GLOBAL
+global.tempo(100)
+global.beat(4 by 4)
+global.key("C")
+global.start()
+
+var drums = init global.seq
+drums.audio("sine_880.wav")
+drums.effect("/path/to/CLAPTestEffect.clap")
+
+drums.play(1)
+
+RUN(drums)
+```
+
+Start the daemon with the `outproc-effect` feature +
+`ORBIT_EFFECT_BUSES=fx1` (or the DSL path using the default
+`ORBIT_EFFECT_BUS_POOL`'s `seq-bus-0`) and capture with `ORBIT_CAPTURE_WAV`.
+This lets you objectively verify the whole path: DSL → `LoadPlugin(bus)` →
+`PlayAt(bus)` → `render_multi` bus routing → OOP effect child gain → master
+sum.
+
+```bash
+ORBIT_EFFECT_BUSES=fx1 cargo test -p orbit-audio-daemon --features outproc-effect \
+  --test outproc_effect_bus_gated -- --ignored --nocapture --test-threads=1
+```
+
+**Expected value**: with `EFFECT_GAIN = 0.5`, the gain ratio between
+`dry_peak` and `post_peak` should be **≈ 0.5** (the test asserts the wider
+tolerance `(0.4..=0.6).contains(&bus_ratio)`). WORK_LOG 6.262's real-hardware
+record states an **exact ratio of 0.50000** (single-sine peak 0.70711 →
+0.35355 through the bus). This exact figure comes from the WORK_LOG entry;
+it was not re-verified on real hardware by re-running
+`outproc_effect_bus_gated.rs` while writing this page (note that the test's
+own assertion is the wider `0.4..=0.6` range — the exact match is from the
+WORK_LOG's measured record).
+
+> **Known pitfall**: if a tagged `PlayAt` is sent without awaiting
+> `drums.effect()`, the event is retained because the bus is not yet active
+> (see `InsertBusStage`'s doc comment). This cannot happen through the DSL
+> path since `effect()` is awaited structurally.
+
+## Sources
+
+- `rust/crates/orbit-audio-native/src/output.rs:131-149` — the `InsertBusStage` struct (meaning of the `processor`/`active` fields)
+- `rust/crates/orbit-audio-native/src/output.rs:250-260` — `render_block`'s zero-bus fallback (bit-identical path)
+- `rust/crates/orbit-audio-native/src/output.rs:293-308` — `render_engine_with_insert_buses`'s active-bus filter and target assembly
+- `rust/crates/orbit-audio-daemon/src/engine_wrap.rs:240-248` — `DEFAULT_EFFECT_BUS_POOL_PREFIX` / `DEFAULT_EFFECT_BUS_POOL_SIZE`
+- `rust/crates/orbit-audio-daemon/src/engine_wrap.rs:272-284` — `effect_buses_from_env` (`ORBIT_EFFECT_BUSES` priority, `ORBIT_EFFECT_BUS_POOL` fallback)
+- `rust/crates/orbit-audio-daemon/src/engine_wrap.rs:286-300` — `EffectBusBuild` (bus components, shared active flag)
+- `packages/engine/src/core/global/sequence-effect-manager.ts:65-112` — `SequenceEffectManager.effect()` (bus allocation, free-list rollback)
+- `rust/crates/orbit-audio-daemon/tests/outproc_effect_bus_gated.rs` — gated real-hardware test (`EFFECT_GAIN=0.5`, ratio assertion `0.4..=0.6`)
+- [`docs/core/INSTRUCTION_ORBITSCORE_DSL.md`](https://github.com/signalcompose/orbitscore/blob/main/docs/core/INSTRUCTION_ORBITSCORE_DSL.md) PH.2b — `seq.effect()` DSL spec (processing order, v1 constraints, cap of 8)
+- [`docs/development/WORK_LOG.md`](https://github.com/signalcompose/orbitscore/blob/main/docs/development/WORK_LOG.md) 6.262 — #434 S1-S3 implementation record (real-hardware ratio 0.50000)
+- Issue [#434](https://github.com/signalcompose/orbitscore/issues/434) — per-sequence effect insert
+- PR [#461](https://github.com/signalcompose/orbitscore/pull/461) — merged implementation (includes free-list addition)

--- a/sites/dev/en/rust-engine/oop-children.md
+++ b/sites/dev/en/rust-engine/oop-children.md
@@ -132,7 +132,8 @@ The instrument-side host (`PipelinedInstrumentHost` in `instrument_host.rs`) lay
 voice management (`VoiceTable`) on top of the same shm substrate, reusing the same transport
 (`seq_request`/`seq_done`/slot mechanism) as the effect host. `SharedRegion` also holds the
 event-transfer windows for M2 instrument IPC (`input_events`/`output_events`, etc.), but the
-wire format itself (`NeutralEvent`) is a detail left to the RE-3 (M2 IPC) chapter.
+wire format itself (`NeutralEvent`) is out of scope for this chapter
+(a dedicated M2 IPC wire chapter is planned; the primary sources today are `orbit-audio-sandbox/src/events.rs` and Issue #398).
 
 ## The child-side READY handshake
 
@@ -211,6 +212,9 @@ impl Drop for SandboxChildGuard {
         unsafe {
             (*self.region).control.store(CONTROL_QUIT, Release);
         }
+        // TODO(PR-C): respawn 判断のため child の ExitStatus を捕捉して supervisor へ渡す
+        // (本ガードは teardown 専用で終了 status を破棄する)。親プロセス死亡時の孤児化対策
+        // (PR_SET_PDEATHSIG 等)も supervisor 層で扱う。
         let deadline = Instant::now() + REAP_TIMEOUT;
         loop {
             match self.child.try_wait() {
@@ -225,6 +229,7 @@ impl Drop for SandboxChildGuard {
                     let _ = self.child.wait();
                     break;
                 }
+                // try_wait 自体の失敗(ECHILD 等)は timeout と区別して実エラーを出す。
                 Err(e) => {
                     eprintln!("orbit-audio-sandbox: try_wait 失敗(kill にフォールバック): {e}");
                     let _ = self.child.kill();

--- a/sites/dev/en/rust-engine/oop-children.md
+++ b/sites/dev/en/rust-engine/oop-children.md
@@ -344,13 +344,11 @@ test orphaned_child_exits_after_parent_is_killed ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
 ```
 
-The watchdog/respawn state machine itself (child crash → respawn → `measurement_invalid`) is
-implemented as `#[test]`s inside `outproc_instrument.rs`/`outproc_effect.rs` in
-`orbit-audio-daemon`. These are unit tests using a stub child that needs neither a real device
-nor a real CLAP plugin, and are not tagged `#[ignore]` (added per a pr-test-analyzer review
-comment in PR #422). They can be run as ordinary tests under `cargo test -p orbit-audio-daemon`,
-though a feature flag (e.g. `outproc-instrument`) may be required — this agent did not check the
-crate's `Cargo.toml` feature definitions for that, so runnability is **unverified** here.
+These run with feature flags (verified on real hardware, 2026-07-17):
+`cargo test -p orbit-audio-daemon --features outproc-instrument --lib` runs the instrument-side
+units (measured the same day: 38 passed under the instrument filter). Effect-side units need
+`--features outproc-effect`, and both roles together use
+`--features outproc-effect,outproc-instrument`.
 
 ## Sources
 

--- a/sites/dev/en/rust-engine/oop-children.md
+++ b/sites/dev/en/rust-engine/oop-children.md
@@ -1,0 +1,364 @@
+---
+title: "RE-2. OOP Children and the Shared-Memory Transport"
+chapter-id: "RE-2"
+verified-against: 3983828
+verified-at: "2026-07-17"
+status: draft
+---
+
+> **Note**: This page is a snapshot of the author's reading as of 2026-07-17. The code is the
+> source of truth; this page is only a snapshot of that understanding at that point in time.
+
+# RE-2. OOP Children and the Shared-Memory Transport
+
+The daemon we saw in RE-1 doesn't host any 3rd-party plugin's (CLAP/VST3) implementation in its
+own process. Instruments (sampler / audio DSL) are in-process, but effects and 3rd-party plugins
+are split off as out-of-process (OOP) sandbox child processes. This chapter covers why that
+split exists, how the shared-memory (shm) transport in the `orbit-audio-sandbox` crate works,
+the READY handshake, watchdog/respawn behavior, and parent-liveness monitoring (`ParentWatch`).
+The plugin-hosting DSL surface (`global.effect()` / `seq.instrument()`) and the child-binary
+selection logic (`child_exe_for_attach`) are already covered in the PH-2/PH-3 chapters and are
+not repeated here — this chapter focuses on the **shared substrate** both effect and instrument
+children use: the transport mechanism itself.
+
+## Why in-process vs. out-of-process
+
+Per the confirmed architecture recorded in `docs/development/POST_2.0_MASTER_PLAN.html`:
+
+> 楽器（サンプラー/audio DSL）= in-process（楽器は DSL 表現力の着地点なので flatten 境界を
+> 経由させない。in-process は表現力を自由に進化させる + 自社 Rust で隔離不要）。effects +
+> 3rd-party = out-of-process sandboxed plugin（audio→audio の下流 / 非信頼 crash を隔離）。
+>
+> (Instruments (sampler / audio DSL) = in-process — instruments are where DSL expressiveness
+> lands, so they should not pass through a flattening boundary; in-process lets that
+> expressiveness evolve freely, and our own Rust code needs no isolation. Effects + 3rd-party =
+> out-of-process sandboxed plugin — a downstream audio→audio stage whose untrusted crashes
+> should be isolated.)
+
+In short, the criterion is whether the DSL needs fine-grained per-note/per-slice control (→
+instrument side, in-process) or is a pure audio→audio transformation (→ plugin side, OOP).
+3rd-party CLAP/VST3 plugins are untrusted code, so they are isolated behind a process boundary
+so a crash doesn't take the host (the daemon itself) down with it. `orbit-audio-sandbox`
+implements that isolation.
+
+## The shm transport: `SharedRegion`
+
+The host (daemon) and the child (`orbit-clap-effect-child`, etc.) both open the same mmap file
+as shared memory and overlay a `#[repr(C, align(64))]` `SharedRegion` struct on top of it. Field
+order is fixed, and the 64-byte alignment lands on a cache-line boundary.
+
+```rust
+// transport.rs:137-171
+#[repr(C, align(64))]
+pub struct SharedRegion {
+    /// host が input/n_frames 書き込み後に進める。child はこれが前回値より進むのを待つ。
+    pub seq_request: AtomicU64,
+    /// child が処理し終えた **最新** request seq(monotone)。host の **submit guard** が slot 再利用
+    /// 可否(`seq_done >= new_seq - SLOTS`)に使う。READ の fresh 判定には使わない(それは per-slot
+    /// [`SharedRegion::seq_tag`]。global monotone な seq_done では「latest 処理」の skip を検知できない)。
+    pub seq_done: AtomicU64,
+    /// child が処理したブロック総数(観測用。respawn 後の処理再開を可視化する)。
+    pub child_processed: AtomicU64,
+    /// **child -> host health signal**(γ M1 PR-C・carry-forward ①): child の per-block 処理
+    /// (`plugin.process()`)が失敗したブロックの累積数。child が `fetch_add` で書き、host(supervisor /
+    /// accessor)が読む。effect は失敗時 dry 素通し・instrument は無音になるため、この counter だけが
+    /// 失敗の可視化手段になる(silent-failure 防止)。**child が crash しても host は mmap を保持し続けるので
+    /// 値は読める**(supervisor の respawn で同一 shm を再利用するため child を跨いで累積する)。supervisor
+    /// 側の `respawn_count` / `last_respawn_ns` / `measurement_invalid`(child の異常終了を host が
+    /// 観測する signal)は host-side atomic で別に持つ(SharedRegion ではない)。gain child(PR-A)は
+    /// 失敗経路を持たないので増分せず 0 のまま。
+    pub child_process_error_count: AtomicU64,
+    /// host -> child の制御フラグ([`CONTROL_RUN`] / [`CONTROL_QUIT`])。host が teardown 時に
+    /// QUIT を store し、child は spin loop の各周回で確認して正常終了する(kill より clean)。
+    pub control: AtomicU32,
+    /// **per-slot**: child が各 slot に書いた output の seq。child は output 書き込み後 Release で store し、
+    /// host は READ 時に `seq_tag[slot(target)] == target` を Acquire で確認してから読む(その Acquire が
+    /// 当該 slot の output 書き込みを可視化する)。child が「latest 処理」で中間 seq を skip しても、その
+    /// slot の tag は target に一致しないので host は false-fresh せず repeat-previous に落ちる。
+    pub seq_tag: [AtomicU64; SLOTS],
+    /// **per-slot**: 各 slot の有効フレーム数(<= MAX_FRAMES)。host が submit 時に該当 slot へ書き、child
+    /// はその slot の値で処理長を決め、host は READ 時に copy 長の clamp に使う。pipelined で host が次 block
+    /// (別フレーム数)を submit 済みでも、各 slot は自分の正しい長さを持つ(単一 n_frames だと取り違える)。
+    pub n_frames: [AtomicU32; SLOTS],
+    /// host -> child のインターリーブ入力(ping-pong: SLOTS 個の block。`slot_offset` で index)。
+    pub input: [f32; BUF_LEN * SLOTS],
+    /// child -> host のインターリーブ出力(ping-pong: SLOTS 個の block。`slot_offset` で index)。
+    pub output: [f32; BUF_LEN * SLOTS],
+```
+
+With `SLOTS = 2`, a ping-pong buffer scheme is used, where the host submits the current block
+while reading the previous block's output — the "pipelined" approach described below. This
+avoids a synchronous round-trip wait (tail latency) on every block, making small buffer sizes
+(32/64 frames) practically feasible.
+
+```rust
+// host.rs:1-13
+//! pipelined(候補B) effect host — RT callback ごとに 1 block を境界越しに処理する状態機械。
+//!
+//! γ latency fork spike(#351)が採用した候補B: host は **spin しない**。callback K で
+//! 現ブロック(`data` = engine の dry 出力)を child へ submit し、**前 callback で submit した
+//! ブロックの出力を読んで `data` を上書きする**(serial insert)。これにより同期 round-trip の
+//! tail(~2-4ms・buffer 非依存)を構造的に消し、32f まで小バッファを feasible にする。代償は
+//! **+1 block の出力遅延**(最終 hw sum 全体に均一にかかる純レイテンシ)と、child が間に合わない
+//! 時の **stale**(owner 決定 = repeat-previous: 直前の good block を再出力してクリック回避)。
+//!
+//! 本 host は `&mut [f32]`(post-processor の in-place バッファ)と `*mut SharedRegion` の上で完結し、
+//! orbit-audio-native(PostProcessor trait)にも cpal にも依存しない。`impl PostProcessor` の adapter は
+//! daemon 側(native がある所)に薄く置く。本 host の `process_block` を RT callback から呼ぶ。
+```
+
+`PipelinedEffectHost::process_block` upholds the RT contract (no alloc/lock/syscall), as stated
+explicitly in both its type and its comment, and rewrites `data` in-place in submit-then-read
+order (submit the current block to the child, then read the previous block's output).
+
+```rust
+// host.rs:86-98
+    /// 1 callback ぶんを処理する。`data` は interleaved f32(stereo)で in-place 上書きされる。
+    ///
+    /// RT-safe: alloc/lock/syscall なし。submit(data を input slot へ)→ read(前ブロックの output を
+    /// data へ)の順で、data の dry 入力を失わずに前ブロックの effected 出力へ差し替える。
+    pub fn process_block(&mut self, data: &mut [f32]) {
+        let raw = data.len();
+        if raw > BUF_LEN {
+            self.frames_clamped += 1;
+        }
+        // BUF_LEN = MAX_FRAMES * CHANNELS なので clamp 後は n_frames <= MAX_FRAMES が自明。
+        let n_frames = (raw.min(BUF_LEN) / CHANNELS) as u32;
+        // count を frame 境界に丸める(端数 sample は触らない)。
+        let count = n_frames as usize * CHANNELS;
+```
+
+The instrument-side host (`PipelinedInstrumentHost` in `instrument_host.rs`) layers note-event
+voice management (`VoiceTable`) on top of the same shm substrate, reusing the same transport
+(`seq_request`/`seq_done`/slot mechanism) as the effect host. `SharedRegion` also holds the
+event-transfer windows for M2 instrument IPC (`input_events`/`output_events`, etc.), but the
+wire format itself (`NeutralEvent`) is a detail left to the RE-3 (M2 IPC) chapter.
+
+## The child-side READY handshake
+
+A child doesn't enter its process loop the moment it starts; it only flips `child_status` to
+`CHILD_STATUS_READY` once the plugin has finished loading. The host polls this flag and only
+starts submitting blocks after it sees READY.
+
+```rust
+// transport.rs:85-102
+/// `control` の値: child は spin を続ける。
+pub const CONTROL_RUN: u32 = 0;
+/// `control` の値: host が child に spin loop を抜けて正常終了するよう要求する。
+pub const CONTROL_QUIT: u32 = 1;
+
+/// child が実際にロードした CLAP plugin の readiness（PR-431・child→host handshake）。
+/// 0 = starting（child がまだ load 中）。
+pub const CHILD_STATUS_STARTING: u32 = 0;
+/// child が load に成功し、以降 process loop に入る状態。
+pub const CHILD_STATUS_READY: u32 = 1;
+/// **現状は未使用の予約値**（child が load に失敗して終了する直前の状態を表す想定）。
+/// child は load 失敗時 `?` の早期 return でこの値を書かずにそのままプロセス終了する。PR-1c (#441)
+/// では watchdog が初回 attach 中の child exit を stats に publish し、host が timeout を待たずに
+/// retryable attach failure として返す。
+///
+/// **respawn 注意**: shm は daemon 起動時に一度だけ truncate され、respawn（`EffectChildSupervisor`/
+/// `InstrumentChildSupervisor` の watchdog による再起動）は同一 shm を再利用する（再 truncate しない）
+/// ため、一度 READY に達した後の respawn 失敗では `child_status` は STARTING でなく前 incarnation の
+/// READY が残留する。PR-1b（#440）は spawn 直前の `reset_child_starting` による STARTING リセット
+/// のみを実装し、この前 incarnation の READY 残留誤認を解消した。一方、初回 attach 時に child が
+/// `CHILD_STATUS_LOAD_FAILED` は現状も write 箇所なしの予約値であり、early-exit は上記 watchdog
+/// signal で検出する。
+pub const CHILD_STATUS_LOAD_FAILED: u32 = 2;
+```
+
+The gotcha the comment points out matters: the shm file itself is truncated (zero-initialized)
+only once, at daemon startup, and a respawn (a watchdog-triggered child restart) **reuses the
+same shm** rather than re-truncating it. So if a respawn fails after the child once reached
+READY, `child_status` does not fall back to STARTING — the previous incarnation's READY value
+lingers. The fix for this is the discipline of always calling `reset_child_starting` to force
+STARTING right before every spawn.
+
+## Watchdog and respawn
+
+On the daemon side, `InstrumentChildSupervisor` (for instruments; `EffectChildSupervisor` for
+effects) runs a dedicated thread that monitors the child's liveness and automatically respawns
+it on an unexpected exit.
+
+```rust
+// outproc_instrument.rs:493-519 (excerpted)
+"orbit-clap-instrument-child exited ({status}); respawning"
+// SAFETY: region は watchdog が所有する生存 ctl_mmap を指す。
+// ...
+stats.respawn_count.fetch_add(1, Ordering::Relaxed);
+// ...
+"instrument child respawn failed; measurement invalid: {error}"
+```
+
+If respawns repeatedly fail, the supervisor sets a `measurement_invalid` flag exactly once
+(fire-once). This is a WARNING-severity state meaning "the daemon/engine itself stays alive and
+other audio keeps flowing, but that instrument's (or effect's) path is permanently stuck
+repeating its last good block" — surfaced to the client through the same 1 Hz `StreamStats`
+ticker path seen in RE-1, as `ERROR_CODE_OUTPROC_INSTRUMENT_INVALID` /
+`ERROR_CODE_OUTPROC_EFFECT_INVALID`.
+
+Child-process teardown (graceful shutdown) itself is consolidated into an RAII guard,
+`SandboxChildGuard`. On drop it stores `CONTROL_QUIT`, waits up to a fixed timeout (2 seconds)
+for the child to reap, falls back to `kill` if that fails, and finally removes the shm file —
+the same procedure shared by the daemon, an offline driver, and integration tests.
+
+```rust
+// child.rs:44-84
+impl Drop for SandboxChildGuard {
+    fn drop(&mut self) {
+        // child に正常終了を要求 → 一定時間待って、ダメなら kill。
+        // SAFETY: region は呼び出し側が本ガードより後まで生かす mapping を指す(構築時の契約)。
+        unsafe {
+            (*self.region).control.store(CONTROL_QUIT, Release);
+        }
+        let deadline = Instant::now() + REAP_TIMEOUT;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(_)) => break,
+                // 非 RT の teardown 待ち。spin より yield で CPU を譲る(offline.rs の wait と一貫)。
+                Ok(None) if Instant::now() < deadline => std::thread::yield_now(),
+                Ok(None) => {
+                    eprintln!(
+                        "orbit-audio-sandbox: child が {REAP_TIMEOUT:?} 以内に終了せず kill にフォールバック"
+                    );
+                    let _ = self.child.kill();
+                    let _ = self.child.wait();
+                    break;
+                }
+                Err(e) => {
+                    eprintln!("orbit-audio-sandbox: try_wait 失敗(kill にフォールバック): {e}");
+                    let _ = self.child.kill();
+                    let _ = self.child.wait();
+                    break;
+                }
+            }
+        }
+        if let Err(e) = std::fs::remove_file(&self.path) {
+            eprintln!(
+                "orbit-audio-sandbox: shm ファイル削除失敗 {:?}: {e}",
+                self.path
+            );
+        }
+    }
+}
+```
+
+## `ParentWatch`: parent-liveness monitoring (#448)
+
+As seen in RE-1, the daemon has a known gap: no SIGTERM/SIGINT handler and no graceful-shutdown
+wiring. The teardown path that relies on `SandboxChildGuard::drop` (above) never fires at all if
+the daemon dies without going through `Drop` (`SIGKILL`, or a panic's `process::exit(1)`).
+`ParentWatch` fills this gap from the child side.
+
+```rust
+// parent_watch.rs:1-16
+//! orphan child 対策(Issue #448): child プロセスの親死活監視。
+//!
+//! host(daemon)が `CONTROL_QUIT` を書かずに死ぬ経路(プロセス exit・SIGKILL・crash)では、
+//! 4 つの child バイナリ(orbit-clap-effect-child / orbit-clap-instrument-child /
+//! orbit-vst3-effect-child / orbit-vst3-instrument-child)は `seq_request` 待ちの spin loop に
+//! 残り続け、CPU を専有し続ける(shm 側の CONTROL_QUIT に依存する既存の終了経路は host 側の
+//! Drop 実行が前提のため、host が Drop を経ずに死ぬとこの経路が発火しない)。
+//!
+//! [`ParentWatch`] は起動時に `getppid()` を記録し、低頻度(既定 250ms)でこれを再取得する。
+//! 親が死んで child が launchd/PID1 等に reparent されると `getppid()` の値が変わるので、
+//! それを検知して spin loop から抜けるための helper。RT 影響を避けるため、チェックは
+//! 「spin loop を回った回数」でなく「経過時間」で rate-limit する(system call 1 回 / 250ms 程度)。
+//!
+//! 4 crate(orbit-clap-effect-child 等)で同じロジックを重複させないための共有 helper。
+//! transport とは独立した薄いモジュール(既存の「child main はミラー」方針と両立)。
+```
+
+The implementation is a simple state machine: it records `getppid()` at startup and re-fetches
+it every 250ms to compare. It relies on standard Unix reparenting semantics (when a parent dies,
+its children get reparented to launchd/PID1/etc. and `getppid()`'s value changes).
+
+```rust
+// parent_watch.rs:24-63
+/// child プロセスが起動時の親 PID を記録し、reparent(親死亡)を低頻度で検知する状態機械。
+pub struct ParentWatch {
+    original_ppid: libc::pid_t,
+    check_interval: Duration,
+    last_check: Instant,
+}
+
+impl ParentWatch {
+    /// 現在の `getppid()` を起動時の親 PID として記録する。既定の rate-limit 間隔
+    /// ([`DEFAULT_CHECK_INTERVAL`])を使う。
+    pub fn new() -> Self {
+        Self::with_interval(DEFAULT_CHECK_INTERVAL)
+    }
+
+    /// rate-limit 間隔を明示指定するコンストラクタ(主にテスト用)。
+    pub fn with_interval(check_interval: Duration) -> Self {
+        // SAFETY: getppid(2) は引数を取らず常に成功する(POSIX)。
+        let original_ppid = unsafe { libc::getppid() };
+        Self {
+            original_ppid,
+            check_interval,
+            last_check: Instant::now(),
+        }
+    }
+
+    /// 親が死んで(= 現在の `getppid()` が起動時と異なる場合)true を返す。
+    ///
+    /// rate-limit: 前回チェックから `check_interval` 未満なら syscall を発行せず false を返す
+    /// (spin loop 内で毎回呼んでも system call 頻度は interval に収まる)。
+    pub fn should_exit(&mut self) -> bool {
+        let now = Instant::now();
+        if now.duration_since(self.last_check) < self.check_interval {
+            return false;
+        }
+        self.last_check = now;
+        // SAFETY: 同上。
+        let current_ppid = unsafe { libc::getppid() };
+        current_ppid != self.original_ppid
+    }
+}
+```
+
+`ParentWatch` is implemented as a single thin helper shared across all four child binaries
+(CLAP/VST3 × effect/instrument) — each child's main function just calls `should_exit()` inside
+its spin loop, independent of the transport module. Per git history, this module was added in a
+single commit: `a0449b8 fix(sandbox): add parent-liveness watchdog to VST3/CLAP child
+processes`.
+
+## Try it: verify a child self-exits when its parent dies
+
+The `orbit-audio-sandbox` crate has an integration test, `parent_watch_integration.rs`, that
+builds a real process hierarchy (test process → probe P playing the "daemon" role → probe C
+playing the "child" role), `SIGKILL`s P, and verifies that C detects `true` from
+`ParentWatch::should_exit()` and exits on its own. It depends on neither a device nor shm, so it
+runs in CI without an `#[ignore]` tag.
+
+```bash
+cargo test -p orbit-audio-sandbox --test parent_watch_integration
+```
+
+**Expected output** (actually run and confirmed by this agent in this sandboxed environment):
+
+```
+running 1 test
+test orphaned_child_exits_after_parent_is_killed ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
+```
+
+The watchdog/respawn state machine itself (child crash → respawn → `measurement_invalid`) is
+implemented as `#[test]`s inside `outproc_instrument.rs`/`outproc_effect.rs` in
+`orbit-audio-daemon`. These are unit tests using a stub child that needs neither a real device
+nor a real CLAP plugin, and are not tagged `#[ignore]` (added per a pr-test-analyzer review
+comment in PR #422). They can be run as ordinary tests under `cargo test -p orbit-audio-daemon`,
+though a feature flag (e.g. `outproc-instrument`) may be required — this agent did not check the
+crate's `Cargo.toml` feature definitions for that, so runnability is **unverified** here.
+
+## Sources
+
+- `rust/crates/orbit-audio-sandbox/src/transport.rs:80-211` — `SharedRegion` layout, `CONTROL_RUN`/`CONTROL_QUIT`, `CHILD_STATUS_*` readiness constants and the respawn gotcha
+- `rust/crates/orbit-audio-sandbox/src/host.rs:1-98` — `PipelinedEffectHost` (pipelined submit/read state machine, RT-safe `process_block`)
+- `rust/crates/orbit-audio-sandbox/src/child.rs:1-84` — `SandboxChildGuard` (child-teardown RAII guard: QUIT → reap → kill fallback → shm removal)
+- `rust/crates/orbit-audio-sandbox/src/parent_watch.rs:1-104` (full file) — `ParentWatch` (`getppid()`-based parent-liveness monitoring, rate-limited)
+- `rust/crates/orbit-audio-sandbox/tests/parent_watch_integration.rs:1-20` — real-process-hierarchy test of `ParentWatch` (run by this agent, confirmed passing)
+- `rust/crates/orbit-audio-daemon/src/outproc_instrument.rs:386-605` — `InstrumentChildSupervisor` (watchdog thread, respawn logic, `measurement_invalid` fire-once)
+- [`docs/development/POST_2.0_MASTER_PLAN.html`](https://github.com/signalcompose/orbitscore/blob/main/docs/development/POST_2.0_MASTER_PLAN.html) — confirmed in-process/OOP architecture split
+- Issue [#448](https://github.com/signalcompose/orbitscore/issues/448) — daemon graceful-shutdown gap and the `ParentWatch` countermeasure (PR: `a0449b8`)

--- a/sites/dev/rust-engine/capture-verification.md
+++ b/sites/dev/rust-engine/capture-verification.md
@@ -290,11 +290,12 @@ ORBIT_CAPTURE_WAV=/tmp/orbit-capture.wav cargo test -p orbit-audio-daemon \
 4. 可能ならエンジン側の `post_peak` 系アクセサ（`outproc_instrument_post_peak`
    相当）を同じセッションで読み、capture WAV の実測 peak と比較する。
 
-**期待値（未検証）**: capture WAV の実測 peak と daemon の `post_peak_bits`
-由来アクセサ値は、tap 点が同じ `hw`（post-mix・post 適用後）である以上、
-理論上は一致するはずだが、本ページ執筆時点でこの突き合わせを実機で
-実行して数値を確認したわけではない。実行する場合はここでの記述を実測値で
-上書きすること。
+**期待値（実機で相互検証済み・2026-07-17）**: tap 点が同じ `hw`（post-mix・post 適用後）
+である以上、両者は一致する。実測例: clap-test-synth（既知振幅 0.25）の同一 oracle に対し、
+gated テストの stats 側 `post_mix_peak` = **0.25000**（`outproc_instrument_vst3_gated` 等）、
+DSL E2E の capture WAV 実測 peak = **0.25000**（WORK_LOG 6.258）— 独立した 2 計測経路が
+既知振幅と 5 桁一致しており、capture と post_peak 系アクセサが同じ信号を見ていることの
+実証になっている。
 
 ## Sources
 

--- a/sites/dev/rust-engine/capture-verification.md
+++ b/sites/dev/rust-engine/capture-verification.md
@@ -1,0 +1,311 @@
+---
+title: "RE-4. capture seam と客観検証（ORBIT_CAPTURE_WAV）"
+chapter-id: "RE-4"
+verified-against: 3983828
+verified-at: "2026-07-17"
+status: draft
+---
+
+> **Note**: 本ページは 2026-07-17 時点での著者の reading の足跡です。code が真実、本ページはその時点の理解の snapshot に過ぎません。
+
+# RE-4. capture seam と客観検証（ORBIT_CAPTURE_WAV）
+
+OrbitScore の audio エンジンは「耳で聞く」以外の検証手段として **capture seam**
+（Issue #307）を持つ。`ORBIT_CAPTURE_WAV` 環境変数を設定すると、master 出力
+（post-mix・device 直前）を WAV ファイルへ実時間で録音でき、そのファイルを
+`orbit-audio-verify` の解析プリミティブ（onset 検出・RMS・pan 逆算）に通して
+DSL の意図と実サンプルの一致を客観的に検証できる。本章はこの経路の実装
+（`capture.rs` の自作 RIFF WAV writer）と、実際にどう「耳なし検証」を組み立てる
+かを追う。
+
+## capture のタップ点: post-mix・pre-hardware
+
+capture は `render_block` の中で post-processor（master-bus effect）適用**後**、
+device に送る直前の `hw` バッファを読み取り専用でタップする。これは「実際に
+デバイスへ出る最終信号」を録ることを意味し、capture の有無で出力サンプル自体は
+変わらない（読むだけで mutation ではない）。
+
+```rust
+// rust/crates/orbit-audio-native/src/output.rs:226-273（該当部分抜粋）
+/// 1 callback 分の処理（計測 + engine render + master-bus post-processor）。
+///
+/// 手順: (1) callback 開始時刻を取る（`cb_stats` 有り時のみ）→ (2) [`render_engine`] で engine
+/// （+ LinkAudio egress）を render → (3) `post` 有りなら hardware sum を in-place 変換（CLAP
+/// effect/instrument・Issue #340）→ (4) `capture` 有りなら **post 適用後の最終 `hw`** を WAV 用
+/// ring へ読み取り専用 tap（#307）→ (5) callback 所要時間を記録。`post`/`capture`/`cb_stats` は
+/// 各々独立の opt-in 分岐で、すべて None なら従来経路とビット同一。`capture` は `hw` を読むだけ
+/// なので有効でも出力サンプルは不変（tap であって mutation ではない）。
+#[inline]
+#[allow(clippy::too_many_arguments)] // callback state is kept as independent opt-in seams.
+fn render_block(
+    engine: &Engine,
+    link: &mut Option<LinkEgress>,
+    insert_buses: &mut [InsertBusStage],
+    post: &mut Option<Box<dyn PostProcessor>>,
+    capture: &mut Option<RingTapSink>,
+    cb_stats: &Option<Arc<CallbackTimeStats>>,
+    output_channels: usize,
+    hw: &mut [f32],
+) {
+    // ...
+    if let Some(sink) = capture.as_mut() {
+        sink.commit(hw);
+    }
+    // ...
+}
+```
+
+タップは `RingTapSink::commit` という wait-free / no-alloc な操作で行われ、
+リングが満杯なら drop カウントで検出する（RT 契約を守りつつ off-thread writer
+が追いつかない場合を可視化する）。
+
+## `RiffWavWriter`: 外部依存なしの自作 32-bit float WAV encoder
+
+owner 確定方針（hound 等の外部 WAV encoder crate は追加しない）に基づき、
+`capture.rs` は `std::io` のみで RIFF WAV を書く。`wFormatTag = 3`
+(`WAVE_FORMAT_IEEE_FLOAT`) を使うため量子化なし・録った f32 がそのまま
+round-trip する。
+
+```rust
+// rust/crates/orbit-audio-native/src/capture.rs:29-56
+/// 32-bit float(量子化なし)streaming WAV writer。`std::io` のみで実装する(外部 WAV encoder crate
+/// を増やさない方針 = owner 確定・hound 不採用)。
+///
+/// ファイルサイズは書き込み終了時まで確定しないので、[`Self::new`] で size を 0 の placeholder
+/// にした header をまず書き、サンプルを逐次追記した後、[`Self::finalize`] で実サイズに patch する。
+pub struct RiffWavWriter {
+    writer: BufWriter<File>,
+    sample_rate: u32,
+    channels: u16,
+    samples_written: u64,
+    /// `write` が per-call の alloc を避けるため再利用する little-endian バイトバッファ。
+    scratch: Vec<u8>,
+}
+
+impl RiffWavWriter {
+    /// `path` に新規ファイルを作り、size placeholder 込みの 44-byte header を書く。
+    pub fn new(path: &Path, sample_rate: u32, channels: u16) -> io::Result<Self> {
+        let file = File::create(path)?;
+        let mut writer = BufWriter::new(file);
+        writer.write_all(&build_header(sample_rate, channels, 0))?;
+        Ok(Self {
+            writer,
+            sample_rate,
+            channels,
+            samples_written: 0,
+            scratch: Vec::new(),
+        })
+    }
+```
+
+サイズが確定しない問題（streaming write の間はファイル総サイズが未知）は
+「0 の placeholder header を先に書き、`finalize()` で先頭に seek して実サイズを
+patch する」という定石で解決している。`finalize` は `self` を値で消費するため、
+二重 finalize は型で防止される。
+
+```rust
+// rust/crates/orbit-audio-native/src/capture.rs:73-90
+    /// 先頭に seek して RIFF / data チャンクの size を実値に patch し、flush する。
+    /// `self` を値で消費するので二重 finalize は型で防止される。
+    ///
+    /// # 既知の制限
+    /// 古典 WAV(RIFF)の size フィールドは u32 なので、`samples_written * 4` バイトが
+    /// 4GiB を超える capture は正しく表現できない(RF64 拡張が必要・未対応)。ここでは
+    /// saturating して壊れた header にはしない。
+    pub fn finalize(mut self) -> io::Result<()> {
+        self.writer.flush()?;
+        let data_bytes = u32::try_from(self.samples_written.saturating_mul(4)).unwrap_or(u32::MAX);
+        // BufWriter<File>::seek は seek 前に内部バッファを flush してから inner を seek する
+        // (std documented behavior)ので、直前の flush と合わせて安全に先頭へ戻れる。
+        self.writer.seek(SeekFrom::Start(0))?;
+        self.writer
+            .write_all(&build_header(self.sample_rate, self.channels, data_bytes))?;
+        self.writer.flush()?;
+        Ok(())
+    }
+```
+
+4GiB を超える capture は u32 size field の限界で正しく表現できない（RF64 拡張は
+未対応）が、その場合も saturating で壊れた header にはしない、という明示的な
+既知制限がコメントされている。
+
+## `CaptureWriter`: RT callback の外で drain する off-thread writer
+
+`CaptureWriter::create` は WAV writer と `RingTapSink` を生成し、background
+thread を spawn して ring を drain・書き込みを行う。RT callback は
+`RingTapSink::commit`（wait-free）のみを呼び、実際のファイル I/O は audio
+thread の外で完結する。
+
+```rust
+// rust/crates/orbit-audio-native/src/capture.rs:145-211（抜粋・drain ループ本体）
+    pub fn create(
+        path: PathBuf,
+        sample_rate: u32,
+        channels: u16,
+        ring_capacity: usize,
+    ) -> io::Result<(RingTapSink, CaptureWriter)> {
+        // 先に WAV ファイルを開く(path 不正等で失敗するなら ring を確保する前に fail fast)。
+        let mut wav = RiffWavWriter::new(&path, sample_rate, channels)?;
+        let (sink, mut consumer, drops) = RingTapSink::new(ring_capacity);
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_for_thread = Arc::clone(&stop);
+
+        let handle = thread::spawn(move || -> io::Result<u64> {
+            let mut samples_written: u64 = 0;
+            // drain ループ。write error は `break Err(e)` で抜け、下の finalize を必ず通す
+            // (`?` で即 return すると finalize が走らず header が placeholder〈data=0〉のまま
+            // 残り、壊れた WAV になる。best-effort finalize で「書けた分」を header に反映する)。
+            let drain: io::Result<()> = loop {
+                let avail = consumer.slots();
+                if avail == 0 {
+                    if stop_for_thread.load(Ordering::Acquire) {
+                        break Ok(());
+                    }
+                    thread::sleep(DRAIN_POLL_INTERVAL);
+                    continue;
+                }
+                // ...（read_chunk・書き込み・commit_all）
+            };
+            let finalized = wav.finalize();
+            match (drain, finalized) {
+                (Ok(()), Ok(())) => Ok(samples_written),
+                (Err(e), _) => Err(e),
+                (Ok(()), Err(e)) => Err(e),
+            }
+        });
+```
+
+drain ループが write error に遭遇しても即 return せず、`break Err(e)` の後
+必ず `finalize()` を呼ぶ点が silent-failure ガードになっている — 途中で
+早期 return すると header が placeholder（`data=0`）のまま残って壊れた WAV
+になるため、best-effort で「書けた分」を header に反映する。
+
+`OutputStream` 側は `_capture` フィールドを `_stream` より後に宣言することで、
+Rust の struct field 宣言順 drop を利用し「stream 停止（callback 停止）→
+writer が ring 残りを drain して finalize」という順序を構造的に保証している。
+
+```rust
+// rust/crates/orbit-audio-native/src/output.rs:101-110
+/// 生きている間はストリームを保持する RAII ハンドル。
+pub struct OutputStream {
+    _stream: Stream,
+    /// capture seam（#307 realtime）: `ORBIT_CAPTURE_WAV` 有効時のみ `Some`。**`_stream` より後に
+    /// 宣言する**ことで drop 順を「stream 停止（callback 停止＝以後 commit なし）→ writer が ring の
+    /// 残りを drain して WAV を finalize」に固定する（Rust は struct field を宣言順に drop する）。
+    _capture: Option<crate::capture::CaptureWriter>,
+    pub sample_rate: u32,
+    pub channels: u16,
+}
+```
+
+## 「客観検証」の実際: gated test の drops assert + oracle 一致
+
+capture seam を使った検証の型は `rust/crates/orbit-audio-daemon/tests/`
+配下の gated test（`--ignored` 付き・実 output device 要）に集約されている。
+`capture_realtime_gated.rs`（#304 examples22 の realtime parity 検証）は
+その代表例:
+
+```rust
+// rust/crates/orbit-audio-daemon/tests/capture_realtime_gated.rs:206-217
+    // teardown 前に drops を assert（silent-failure ガード）。
+    let drops = guard.capture_drops();
+    assert_eq!(
+        drops,
+        Some(0),
+        "capture drop が発生（録音破損＝検証 invalid）: {drops:?}"
+    );
+
+    // guard を drop すると stream 停止 → writer が ring 残りを drain → WAV finalize。
+    drop(guard);
+    drop(wrap);
+    std::env::remove_var("ORBIT_CAPTURE_WAV");
+```
+
+「客観検証の作法」はここに凝縮されている:
+
+1. **teardown 前に `drops == 0` を assert** — off-thread writer が ring から
+   取りこぼしていないことを検証前に固定する。`drops > 0` なら以降の全ての
+   検証は無意味（録音自体が壊れている）。
+2. **WAV header と物理サイズの突き合わせ** — `finalize()` の header patch が
+   失敗（例: disk full）すると header は placeholder のまま残るが、PCM 本体
+   自体は物理的に存在してしまう。header の `data` チャンク size と実ファイル
+   長を突き合わせないと、壊れた WAV でも PCM 読み取り自体は成功し偽陽性の
+   parity が出る:
+
+```rust
+// rust/crates/orbit-audio-daemon/tests/capture_realtime_gated.rs:99-111
+    let data_bytes = u32::from_le_bytes(buf[40..44].try_into().unwrap()) as usize;
+    assert_eq!(
+        data_bytes,
+        body.len(),
+        "WAV data chunk size ({data_bytes}) が物理 body 長 ({}) と不一致 = finalize 失敗による \
+         header 破損（録音 invalid）",
+        body.len()
+    );
+```
+
+3. **onset 検出でアンカーを取ってから相対位置で窓を取る** — device 起動
+   latency で WAV 先頭が transport 0 とはずれるため、検出した最初の onset
+   フレームを基準に、各イベントの相対位置で RMS 窓を切る（絶対時刻での
+   比較は device latency の分だけ必ずずれる）。
+4. **pan は L/R RMS から逆算し、schedule の pan 値と許容誤差内か判定** —
+   厳密な gain dB 比較は同一サンプルを使う offline `per_event_gain` fixture
+   に譲り、realtime capture は「領域に信号がある」「pan が合っている」の
+   2 点を担う分業になっている。
+
+## エンジン自身の peak ログ: `post_peak_bits`
+
+capture WAV とは別に、エンジンは daemon 層で自分自身の post-mix peak を
+`AtomicU32`（f32 bits）として保持し続けている。これは非負 f32 の bit 表現が
+値の大小と一致することを利用した lock-free な `fetch_max` 実装で、CLAP/VST3
+の instrument/effect それぞれに専用のフィールドがある
+（`outproc_instrument.rs::ClapInstrumentStats.post_peak_bits` /
+`outproc_effect.rs::OutProcEffectStats.post_peak_bits` に相当）。gated test は
+これを `engine.outproc_instrument_post_peak()` 等のアクセサ経由で読み、
+`ORBIT_CAPTURE_WAV` で録った WAV の実測 peak と突き合わせる二重チェックに
+使える（本ページでは field 名の存在を `grep` で確認したのみで、capture WAV
+の実測 peak と daemon ログの `post_peak` を実機で突き合わせる検証コマンドは
+「Try it」節で手順として記すが、両者が厳密一致することの実機再確認はしていない）。
+
+## Try it: capture → peak 突き合わせループ
+
+1. daemon を `ORBIT_CAPTURE_WAV=<path>.wav` を設定して起動する:
+
+```bash
+ORBIT_CAPTURE_WAV=/tmp/orbit-capture.wav cargo test -p orbit-audio-daemon \
+  --test capture_realtime_gated -- --ignored --nocapture
+```
+
+（このテストは自身で `ORBIT_CAPTURE_WAV` を一意な temp path にセットするので、
+上記のように外部から指定しても内部で上書きされる。手動で任意の DSL セッション
+に対して capture したい場合は、daemon 起動前に `ORBIT_CAPTURE_WAV` を export
+してから通常の `RUN` フローを実行する。）
+
+2. teardown 後、`drops == 0` を確認する（gated test は自動 assert、手動運用
+   では `guard.capture_drops()` を呼ぶか、ログの `LINK_EGRESS_DROP` 系
+   warning が出ていないか確認する）。
+3. 録れた WAV をロードして peak / RMS を計測する（`orbit-audio-verify` の
+   `region_rms` / `detect_onset_threshold` 等のプリミティブ、もしくは
+   `soxi`/`ffprobe` 等の外部ツールで簡易確認）。
+4. 可能ならエンジン側の `post_peak` 系アクセサ（`outproc_instrument_post_peak`
+   相当）を同じセッションで読み、capture WAV の実測 peak と比較する。
+
+**期待値（未検証）**: capture WAV の実測 peak と daemon の `post_peak_bits`
+由来アクセサ値は、tap 点が同じ `hw`（post-mix・post 適用後）である以上、
+理論上は一致するはずだが、本ページ執筆時点でこの突き合わせを実機で
+実行して数値を確認したわけではない。実行する場合はここでの記述を実測値で
+上書きすること。
+
+## Sources
+
+- `rust/crates/orbit-audio-native/src/output.rs:226-273` — `render_block`（capture タップの位置と opt-in 分岐の説明）
+- `rust/crates/orbit-audio-native/src/output.rs:101-110` — `OutputStream`（`_capture` フィールドの drop 順保証）
+- `rust/crates/orbit-audio-native/src/capture.rs:29-56` — `RiffWavWriter` 構造体（32-bit float・外部 crate 不使用）
+- `rust/crates/orbit-audio-native/src/capture.rs:73-90` — `RiffWavWriter::finalize`（size patch・4GiB 制限）
+- `rust/crates/orbit-audio-native/src/capture.rs:145-211` — `CaptureWriter::create`（off-thread drain ループ・best-effort finalize）
+- `rust/crates/orbit-audio-daemon/tests/capture_realtime_gated.rs:1-23` — capture seam realtime gated test のモジュールコメント（役割・実行方法）
+- `rust/crates/orbit-audio-daemon/tests/capture_realtime_gated.rs:99-111` — WAV header/物理サイズ突き合わせ（silent-failure ガード）
+- `rust/crates/orbit-audio-daemon/tests/capture_realtime_gated.rs:206-217` — `drops == 0` assert（teardown 前の silent-failure ガード）
+- `rust/crates/orbit-audio-daemon/src/outproc_instrument.rs:193-205` — `post_peak_bits`（lock-free peak 累積の実装）
+- [`docs/development/WORK_LOG.md`](https://github.com/signalcompose/orbitscore/blob/main/docs/development/WORK_LOG.md) — capture seam #307 realtime 設計の経緯（daemon-start config・自作 WAV writer 採用の owner 確定）
+- Issue [#307](https://github.com/signalcompose/orbitscore/issues/307) — capture seam realtime 配線

--- a/sites/dev/rust-engine/index.md
+++ b/sites/dev/rust-engine/index.md
@@ -369,12 +369,12 @@ daemon 全体のアーキテクチャ確定（楽器=in-process・effects/3rd-pa
 ORBIT_CAPTURE_WAV=/tmp/orbit-capture-test.wav node cli-audio.js path/to/single-note.orbs
 ```
 
-**期待値**: capture peak は再生した波形の既知振幅（例えば sine の gain=1.0 相当なら 1.0
-付近）と一致するはずだが、この値は **本エージェントの作業環境（実 audio device が無いサンドボックス）
-では実行して検証していない**。したがって具体的な peak 数値はここでは記載せず、**未検証**として
-明記する。実機で確認する場合は `docs/development/WORK_LOG.md` の capture seam 関連エントリ
-（6.24x 台）と、PH-1 章の Try it（capture peak = 0.25000・WORK_LOG 6.258）を参照して同様の
-手順で peak を照合すること。
+**期待値（実機検証済み・2026-07-17）**: `test-assets/audio/sine_880.wav`（振幅 1.0 の sine）を
+1 発再生した capture WAV の実測 peak は **0.70711**（= 1.0 × equal-power pan center の
+√0.5。engine は center pan に equal-power gain を掛けるため、モノラル素材の capture peak は
+素材振幅 × √0.5 になる）。plugin oracle 系では clap-test-synth の既知振幅 0.25 が capture でも
+**0.25000** ちょうどで観測される（WORK_LOG 6.258 / 6.262・gated テストの stats
+`post_mix_peak` とも一致 = 同一 tap 点の相互検証）。
 
 ## Sources
 

--- a/sites/dev/rust-engine/index.md
+++ b/sites/dev/rust-engine/index.md
@@ -1,0 +1,388 @@
+---
+title: "RE-1. daemon アーキテクチャ概観"
+chapter-id: "RE-1"
+verified-against: 3983828
+verified-at: "2026-07-17"
+status: draft
+---
+
+> **Note**: 本ページは 2026-07-17 時点での著者の reading の足跡です。code が真実、本ページはその時点の理解の snapshot に過ぎません。
+
+# RE-1. daemon アーキテクチャ概観
+
+OrbitScore の音は最終的に `orbit-audio-daemon`（Rust）という独立プロセスが鳴らす。TS 側の
+engine（`packages/engine`）はこの daemon に WebSocket 経由でコマンドを送るクライアントに過ぎない。
+本章では daemon プロセスの構造、TS engine との境界（wire protocol）、boot〜teardown のライフ
+サイクル、そして cpal のリアルタイム audio callback の骨格を鳥瞰する。
+
+## TS engine との境界: WebSocket wire protocol
+
+daemon は起動すると audio device を確保し、localhost の空きポートに WebSocket listener を bind
+して、その port 番号を stdout に 1 行 JSON で出力する。TS 側はこの行を読んで接続する。
+
+```rust
+// main.rs:72-110
+async fn run() -> Result<(), i32> {
+    // 1. Engine を起動（audio device 取得）
+    let (engine, _stream_guard) = match EngineWrap::start() {
+        Ok(e) => e,
+        Err(e) => {
+            report_startup_failure(ProtocolError::new("DEVICE_CONFIG_ERROR", e.to_string()));
+            return Err(1);
+        }
+    };
+
+    // 2. WebSocket listener bind
+    let bound = match server::bind_localhost().await {
+        Ok(b) => b,
+        Err(e) => {
+            report_startup_failure(ProtocolError::new("INTERNAL_ERROR", e.to_string()));
+            return Err(2);
+        }
+    };
+    let port = bound.addr.port();
+
+    // 3. stdout に ready line を出力（改行 + flush）
+    let ready = StartupReady {
+        ready: true,
+        port,
+        protocol_version: PROTOCOL_VERSION,
+    };
+    let line = serde_json::to_string(&ready).unwrap_or_else(|_| {
+        format!(r#"{{"ready":true,"port":{port},"protocol_version":"{PROTOCOL_VERSION}"}}"#)
+    });
+    println!("{line}");
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+
+    tracing::info!("orbit-audio-daemon listening on 127.0.0.1:{port}");
+
+    // 4. accept loop
+    server::serve(bound.listener, engine).await;
+    Ok(())
+}
+```
+
+起動失敗時は逆に stderr に 1 行 JSON（`{"ready":false,"error":{...}}`）を書いて非ゼロ exit code
+で終了する。TS 側は stdout/stderr のどちらの 1 行 JSON かで起動成否を判定する契約になっている。
+
+接続確立後、daemon はまず handshake フレームを送る。その後は `{id, method, params}` 形式の
+`Command` を TS 側から受け、`{id, result}` の `OkResponse` か `{id, error}` の `ErrorResponse`
+を返す request/response モデル。加えて、`id` を持たない一方向の `Event`（`PlayStarted` /
+`PlayEnded` / `StreamStats` / `DaemonError` 等）を daemon から能動的に push できる。
+
+```rust
+// protocol.rs:11-61
+/// Handshake フレーム（接続後に daemon が最初に送る）。
+#[derive(Debug, Serialize)]
+pub struct Handshake {
+    #[serde(rename = "type")]
+    pub type_: &'static str,
+    pub protocol_version: &'static str,
+    pub daemon_version: &'static str,
+    pub capabilities: Vec<&'static str>,
+}
+
+impl Handshake {
+    pub fn current() -> Self {
+        Self {
+            type_: "handshake",
+            protocol_version: PROTOCOL_VERSION,
+            daemon_version: DAEMON_VERSION,
+            capabilities: vec!["playback", "src"],
+        }
+    }
+}
+
+/// Client → Daemon の command。
+#[derive(Debug, Deserialize)]
+pub struct Command {
+    pub id: String,
+    pub method: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+/// Daemon → Client の response（成功）。
+#[derive(Debug, Serialize)]
+pub struct OkResponse {
+    pub id: String,
+    pub result: serde_json::Value,
+}
+
+/// Daemon → Client の response（失敗）。
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    pub id: String,
+    pub error: ProtocolError,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProtocolError {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+}
+```
+
+契約自体の正本は `docs/research/ENGINE_DAEMON_PROTOCOL.md` で、`protocol.rs` はそのシリアライズ
+/デシリアライズ用の型を定義するだけ、とコメントで明言されている（`protocol.rs:1-4`）。
+
+`method` の dispatch は `session.rs` の `handle_command` が担う。`"Ping"` / `"GetStatus"` のような
+単純な method に加え、`PluginNoteOn`/`PluginNoteOff` のような plugin note 系 method は
+`plugin_note_spec` という純関数を「唯一の判定箇所」として先に分離してから match に落とす設計に
+なっている（2 箇所で同じ文字列集合を独立管理すると drift するという教訓が反映されている）。
+
+```rust
+// session.rs:668-697
+/// Command を dispatch し、Response JSON を組み立てる。
+///
+/// `tx` は event 送信用チャンネル（PlayEnded 等の遅延通知に使う）。
+async fn handle_command(
+    cmd: Command,
+    engine: &Arc<EngineWrap>,
+    tx: &mpsc::Sender<String>,
+) -> Value {
+    let Command { id, method, params } = cmd;
+
+    // PluginNoteOn/PluginNoteOff dispatch は `plugin_note_spec` を single source of truth として
+    // その外側でチェックする（method match の中に "PluginNoteOn" | "PluginNoteOff" literal を
+    // 別途置くと、同じ文字列集合が2箇所で独立に保守されてしまい、どちらか一方だけ更新された場合に
+    // 検出できない・#402 pr-review-team iteration 3 収束指摘: silent-failure-hunter/
+    // pr-test-analyzer/code-reviewer）。`plugin_note_spec` が `None` を返す method はここを
+    // 素通りして下の match に落ちる。
+    if let Some(spec) = plugin_note_spec(&method) {
+        return handle_plugin_note(
+            &id,
+            &params,
+            engine,
+            spec.default_velocity,
+            spec.status,
+            spec.call,
+        )
+        .await;
+    }
+
+    match method.as_str() {
+        "Ping" => ok(&id, Value::String("pong".to_string())),
+        "GetStatus" => {
+            let status = json!({
+                "daemon_version": env!("CARGO_PKG_VERSION"),
+                "protocol_version": "0.1",
+                "output_sample_rate": engine.output_sample_rate(),
+                "output_channels": engine.output_channels(),
+                "loaded_samples": engine.loaded_sample_count(),
+                "active_plays": engine.active_play_count(),
+```
+
+## boot 〜 teardown ライフサイクル
+
+`server::serve` は accept loop で、接続ごとに独立タスクを spawn し `session::run` に処理を渡す。
+
+```rust
+// server.rs:24-70
+/// accept loop。各接続ごとに新タスクを spawn し、[`session::run`] で処理する。
+///
+/// accept エラーはすべて永続化し得るため、短い backoff を挟んで tight spin を防ぐ。
+pub async fn serve(listener: TcpListener, engine: Arc<EngineWrap>) {
+    use std::io::ErrorKind;
+    use tokio::time::{sleep, Duration};
+
+    let mut consecutive_errors: u32 = 0;
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(s) => {
+                consecutive_errors = 0;
+                s
+            }
+            Err(e) => {
+                consecutive_errors = consecutive_errors.saturating_add(1);
+                match e.kind() {
+                    // リソース枯渇系: 長めに待って諦め条件も設定
+                    ErrorKind::OutOfMemory => {
+                        tracing::error!("accept fatal (out of memory): {e}, exiting");
+                        return;
+                    }
+                    _ => {
+                        warn!("accept error: {e} (consecutive={consecutive_errors})");
+                    }
+                }
+                if consecutive_errors >= 20 {
+                    tracing::error!(
+                        "accept error persists for {} attempts, exiting",
+                        consecutive_errors
+                    );
+                    return;
+                }
+                // Tight spin 防止: 100ms backoff
+                sleep(Duration::from_millis(100)).await;
+                continue;
+            }
+        };
+        info!("accepted connection from {peer}");
+        let engine_for_task = engine.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle_connection(stream, engine_for_task).await {
+                warn!("connection closed with error: {e}");
+            }
+        });
+    }
+}
+```
+
+teardown 側には既知のギャップがコメントで明記されている（Issue #448）。この daemon は
+SIGTERM/SIGINT ハンドラを持たず、panic hook も `process::exit(1)` を直接呼ぶため、通常の
+client 側 `SIGTERM → SIGKILL` 停止や panic では `InstrumentChildSupervisor` /
+`EffectChildSupervisor` の `Drop`（out-of-process child への `CONTROL_QUIT` 送出）が実行されず、
+child プロセスが孤児化し得る。
+
+```rust
+// main.rs:19-28
+// 既知事項（#448）: この daemon には SIGTERM/SIGINT ハンドラが無く、`install_fatal_panic_hook`
+// の panic hook も `process::exit(1)` を hook 内から直接呼ぶ（unwind が supervisor 保持フレーム
+// まで届く前に終了する）。そのため通常の client 側 `SIGTERM → SIGKILL` 停止（daemon-client.ts
+// `killChildGracefully`）や panic では、`InstrumentChildSupervisor` / `EffectChildSupervisor` の
+// `Drop`（CONTROL_QUIT 送出）が実行されず、out-of-process CLAP/VST3 child が孤児化し得る。
+// `server::serve` の accept loop 内タスクが `Arc<EngineWrap>` を clone して保持するため、
+// main() のローカル drop だけでは決定論的な shutdown にならず、まとまった graceful-shutdown
+// 配線（signal → 全 clone 収束待ち → drop）が必要になる（本 issue のスコープ外・別 issue 向き）。
+// 本 issue の本命防御は child 側（[`orbit_audio_sandbox::ParentWatch`]）: どの死に方でも
+// child が親の死亡を自力で検知して抜けるため、この daemon 側ギャップの実害を軽減する。
+```
+
+この daemon 側 shutdown の穴に対する本命の防御策が child 側の `ParentWatch`（親プロセスの生死を
+child 自身が監視する仕組み）で、RE-2 章で扱う。
+
+## リアルタイム audio callback（`render_block`）
+
+音の実体は `orbit-audio-native` crate の cpal callback から出る。callback 本体は
+`render_block` という 1 関数に集約されており、insert bus の有無で 2 経路（bit-identical な
+従来経路 / insert bus 経路）に分岐したあと、CLAP master-bus post-processor（有効時のみ）と
+capture tap（`ORBIT_CAPTURE_WAV` 有効時のみ）を通す。
+
+```rust
+// output.rs:226-278
+/// 1 callback 分の処理（計測 + engine render + master-bus post-processor）。
+///
+/// 手順: (1) callback 開始時刻を取る（`cb_stats` 有り時のみ）→ (2) [`render_engine`] で engine
+/// （+ LinkAudio egress）を render → (3) `post` 有りなら hardware sum を in-place 変換（CLAP
+/// effect/instrument・Issue #340）→ (4) `capture` 有りなら **post 適用後の最終 `hw`** を WAV 用
+/// ring へ読み取り専用 tap（#307）→ (5) callback 所要時間を記録。`post`/`capture`/`cb_stats` は
+/// 各々独立の opt-in 分岐で、すべて None なら従来経路とビット同一。`capture` は `hw` を読むだけ
+/// なので有効でも出力サンプルは不変（tap であって mutation ではない）。
+#[inline]
+#[allow(clippy::too_many_arguments)] // callback state is kept as independent opt-in seams.
+fn render_block(
+    engine: &Engine,
+    link: &mut Option<LinkEgress>,
+    insert_buses: &mut [InsertBusStage],
+    post: &mut Option<Box<dyn PostProcessor>>,
+    capture: &mut Option<RingTapSink>,
+    cb_stats: &Option<Arc<CallbackTimeStats>>,
+    output_channels: usize,
+    hw: &mut [f32],
+) {
+    // Instant::now() は macOS では mach_absolute_time（lock/alloc なし）= RT 許容。A0 §6 に基づき
+    // production RT 監視を callback-duration ベースにするための計測（cb_stats 有り時のみ）。
+    let t0 = cb_stats.as_ref().map(|_| Instant::now());
+
+    // active な bus が 1 つも無ければ既存の呼び出し列をそのまま維持する（bit-identical）。
+    // 既定 bus プール（全 stage inactive で起動）はここで従来経路に落ちるため、
+    // `seq.effect()` 未使用セッションに RT コストを課さない。
+    if !insert_buses
+        .iter()
+        .any(|bus| bus.active.load(Ordering::Relaxed))
+    {
+        render_engine(engine, link, output_channels, hw);
+    } else {
+        render_engine_with_insert_buses(engine, link, insert_buses, output_channels, hw);
+    }
+
+    // master-bus post-processor（CLAP）。engine render 済みの hardware sum を in-place 変換。
+    if let Some(p) = post.as_mut() {
+        p.process(hw);
+    }
+
+    // capture seam（#307 realtime）: post 適用後の最終 hw（= device に出る実信号）を WAV へ逃がす
+    // 読み取り専用 tap。`RingTapSink::commit` は wait-free / no-alloc（満杯時はあふれを drop カウント）
+    // ＝ RT 契約を満たす。off-thread writer が ring を drain する。post の後・計測の内側に置くことで
+    // capture コストも callback-duration に含めて監視する。
+    if let Some(sink) = capture.as_mut() {
+        sink.commit(hw);
+    }
+
+    if let (Some(stats), Some(t0)) = (cb_stats, t0) {
+        stats.record(t0.elapsed().as_nanos() as u64);
+    }
+}
+```
+
+`build_stream` はこの `render_block` を cpal の `build_output_stream` クロージャから直接呼ぶ。
+サンプルフォーマット（`F32`/`I16`/`I32`）ごとに 3 通りのクロージャがあり、`F32` 以外は事前確保
+した scratch buffer に `render_block` を実行してから量子化する（RT hot path でのヒープ確保を
+避けるため、scratch buffer は 1 秒分をあらかじめ確保している）。
+
+```rust
+// output.rs:667-686
+    let stream = match sample_format {
+        SampleFormat::F32 => device
+            .build_output_stream(
+                config,
+                move |data: &mut [f32], _| {
+                    render_block(
+                        &engine,
+                        &mut link,
+                        &mut insert_buses,
+                        &mut post,
+                        &mut capture,
+                        &cb_stats,
+                        out_ch,
+                        data,
+                    )
+                },
+                make_err_fn(),
+                None,
+            )
+            .map_err(|e| OutputError::BuildStream(e.to_string()))?,
+```
+
+`post`/`capture`/`cb_stats` はすべて独立した opt-in の分岐として設計されており、いずれも
+`None` のときは従来（=素の hardware-only）経路とビット同一になる、というのが `render_block`
+のコメントで明言された不変条件。この「未使用時はビット同一」という設計原則は、RE-2 で扱う
+OOP effect/instrument の insert bus 経路や、`ORBIT_CAPTURE_WAV` capture seam にも一貫して
+適用されている。
+
+daemon 全体のアーキテクチャ確定（楽器=in-process・effects/3rd-party=out-of-process sandbox）の
+背景は `docs/development/POST_2.0_MASTER_PLAN.html` に記載がある。
+
+> 楽器（サンプラー/audio DSL）= in-process（crown jewel）／ effects + 3rd-party =
+> out-of-process sandboxed plugin ／ audio DSL ⊇ pitch DSL
+
+## Try it: daemon を起動して単音を鳴らす（capture peak 検証）
+
+`ORBIT_CAPTURE_WAV` 環境変数を daemon 起動時に設定すると、`render_block` の capture tap
+（上記コード参照）が有効化され、post-processor 適用後の最終 hardware サンプルを WAV へ書き出す。
+手順（配布構成の release daemon + `cli-audio.js` 前提）:
+
+```bash
+ORBIT_CAPTURE_WAV=/tmp/orbit-capture-test.wav node cli-audio.js path/to/single-note.orbs
+```
+
+**期待値**: capture peak は再生した波形の既知振幅（例えば sine の gain=1.0 相当なら 1.0
+付近）と一致するはずだが、この値は **本エージェントの作業環境（実 audio device が無いサンドボックス）
+では実行して検証していない**。したがって具体的な peak 数値はここでは記載せず、**未検証**として
+明記する。実機で確認する場合は `docs/development/WORK_LOG.md` の capture seam 関連エントリ
+（6.24x 台）と、PH-1 章の Try it（capture peak = 0.25000・WORK_LOG 6.258）を参照して同様の
+手順で peak を照合すること。
+
+## Sources
+
+- `rust/crates/orbit-audio-daemon/src/main.rs:1-124` — daemon エントリポイント。boot シーケンス（engine 起動 → WebSocket bind → ready line 出力 → accept loop）と panic hook、既知の shutdown ギャップ（#448）
+- `rust/crates/orbit-audio-daemon/src/server.rs:1-79` — WebSocket accept loop（`bind_localhost` / `serve` / `handle_connection`）
+- `rust/crates/orbit-audio-daemon/src/protocol.rs:1-193` — wire protocol の型定義（`Handshake` / `Command` / `OkResponse` / `ErrorResponse` / `Event` / エラーコード定数）。契約の正本は `docs/research/ENGINE_DAEMON_PROTOCOL.md`
+- `rust/crates/orbit-audio-daemon/src/session.rs:108-126,668-705` — handshake 送信、`handle_command` の dispatch 構造
+- `rust/crates/orbit-audio-native/src/output.rs:226-278,640-686` — `render_block`（RT callback 本体）と `build_stream`（cpal ストリーム構築、サンプルフォーマット別クロージャ）
+- [`docs/development/POST_2.0_MASTER_PLAN.html`](https://github.com/signalcompose/orbitscore/blob/main/docs/development/POST_2.0_MASTER_PLAN.html) — engine-first ロードマップとアーキ確定（楽器=in-process／effects+3rd-party=out-of-process sandbox）
+- [`docs/development/WORK_LOG.md`](https://github.com/signalcompose/orbitscore/blob/main/docs/development/WORK_LOG.md) — capture seam・cutover #108 の実装記録
+- Issue [#448](https://github.com/signalcompose/orbitscore/issues/448) — daemon の graceful-shutdown ギャップと `ParentWatch` 対策

--- a/sites/dev/rust-engine/insert-bus.md
+++ b/sites/dev/rust-engine/insert-bus.md
@@ -1,0 +1,306 @@
+---
+title: "RE-3. per-sequence insert bus（seq.effect()）"
+chapter-id: "RE-3"
+verified-against: 3983828
+verified-at: "2026-07-17"
+status: draft
+---
+
+> **Note**: 本ページは 2026-07-17 時点での著者の reading の足跡です。code が真実、本ページはその時点の理解の snapshot に過ぎません。
+
+# RE-3. per-sequence insert bus（seq.effect()）
+
+`seq.effect()` は owner の長年の要望（`global.effect()` の master-only insert では
+シーケンス単位で別々のエフェクトを掛けられない）に応える機能で、Issue
+[#434](https://github.com/signalcompose/orbitscore/issues/434) として実装され PR
+[#461](https://github.com/signalcompose/orbitscore/pull/461) でマージされた。本章は
+render パイプラインの `InsertBusStage`、daemon 側の bus プール、そして「宣言 =
+activation」という契約を追う。
+
+## DAW の per-track insert と同型
+
+```js
+var drums = init global.seq
+drums.audio("kick.wav")
+drums.effect("~/plugins/TAL-Reverb-4.clap")   // この seq だけに掛かる insert
+```
+
+処理順は **per-sequence insert → master mix → `global.effect()`（master chain）**。
+master 経路の既存意味論は変えない（core spec PH.2b）。v1 は 1 seq = 1 insert、
+`.clap` のみ受理（`.vst3` / `.component` は effect 系では未対応）、同時に insert を
+持てる seq 数の上限は既定 8。
+
+## `InsertBusStage`: named routing tag を受ける per-bus insert stage
+
+render 側の核は `orbit-audio-native` の `InsertBusStage`。`processor=None` は
+「effect 未 attach だが登録済みの bus」を表し、この状態でも event を
+`render_multi` に渡して必ず消費する — 消費しないと未 attach bus に tag された
+event が retain され続ける（後述の landmine）。
+
+```rust
+// rust/crates/orbit-audio-native/src/output.rs:131-149
+/// named routing tag を受ける per-bus insert stage。
+///
+/// `processor=None` は effect 未 attach の **登録済み bus** を表す。buffer を `render_multi` に渡して
+/// event を必ず消費し、そのまま master へ足すので、未 attach bus の event が retain され続けない。
+pub struct InsertBusStage {
+    name: String,
+    processor: Option<Box<dyn PostProcessor>>,
+    buffer: Vec<f32>,
+    /// **activation flag**（`LinkChannelActivate.ready` と同じパターン）: `false` の間この bus は
+    /// render 対象から完全に外れる（zero-fill / gain-ramp / sum のコストゼロ）。daemon の既定
+    /// bus プール（#434 S3）は宣言（LoadPlugin）まで inactive で、全 bus inactive なら
+    /// `render_block` は bus 無し経路（ビット同一）に落ちる — `seq.effect()` を使わない
+    /// セッションが pool のコストを払わないための機構。
+    /// ⚠ inactive bus 名に tag された event は render_multi の対象外 = 消費されず retain される
+    /// （LinkAudio の not-ready channel と同じ既存ハザード）。producer（TS）は「宣言 =
+    /// activation → その後に tag 付き PlayAt」の順序を守ること（`seq.effect()` は await するので
+    /// 構造的に成立）。
+    active: Arc<AtomicBool>,
+}
+```
+
+`active: Arc<AtomicBool>` が「宣言 = activation」契約の実体。この flag は daemon
+側の `EffectBusBuild.active` と共有され、`seq.effect()` の `LoadPlugin` が bus を
+指名した瞬間に `true` へ store される。**別途 activation ステップは存在しない**
+— `seq.effect()` を呼ぶこと自体が bus を有効化する。
+
+コメントが警告する ⚠ landmine（inactive bus に tag された event は消費されず
+永久 retain される）は TS 側で「宣言を `await` してから tag 付き `PlayAt` を送る」
+という順序で構造的に回避している（後述の `SequenceEffectManager.effect()` 参照）。
+
+## bus 0 個ならビット同一の従来経路
+
+`render_block` は、insert bus が 1 つも active でなければ従来の `render_engine`
+（bus 無し経路）へ完全にフォールバックする。これにより `seq.effect()` を一度も
+使わないセッションは bus プールのコストを一切払わない。
+
+```rust
+// rust/crates/orbit-audio-native/src/output.rs:250-260
+    // active な bus が 1 つも無ければ既存の呼び出し列をそのまま維持する（bit-identical）。
+    // 既定 bus プール（全 stage inactive で起動）はここで従来経路に落ちるため、
+    // `seq.effect()` 未使用セッションに RT コストを課さない。
+    if !insert_buses
+        .iter()
+        .any(|bus| bus.active.load(Ordering::Relaxed))
+    {
+        render_engine(engine, link, output_channels, hw);
+    } else {
+        render_engine_with_insert_buses(engine, link, insert_buses, output_channels, hw);
+    }
+```
+
+active な bus がある場合は `render_engine_with_insert_buses` が呼ばれ、
+`inactive` な bus を skip しつつ `render_multi` の target 配列に named bus を
+積み、bus ごとの `processor`（あれば）を通してから `hw` に加算する:
+
+```rust
+// rust/crates/orbit-audio-native/src/output.rs:293-308
+    let bs = (hw.len() / output_channels) * output_channels;
+    let mut targets: ArrayVec<(&str, &mut [f32]), MAX_TARGETS> = ArrayVec::new();
+    for bus in buses.iter_mut() {
+        // inactive stage は render 対象外（コストゼロ・InsertBusStage::active の doc 参照）。
+        if !bus.active.load(Ordering::Relaxed) {
+            continue;
+        }
+        debug_assert!(
+            bus.buffer.len() >= bs,
+            "insert bus '{}' buffer too short",
+            bus.name
+        );
+        targets
+            .try_push((bus.name.as_str(), &mut bus.buffer[..bs]))
+            .expect("bounded bus count");
+    }
+```
+
+## daemon の既定 bus プール — `ORBIT_EFFECT_BUS_POOL`
+
+`orbit-audio-daemon` の `engine_wrap.rs` は起動時に `seq-bus-0`〜`seq-bus-N`
+という名前の inactive `InsertBusStage` を N 個（既定 8、`ORBIT_EFFECT_BUS_POOL`
+で変更可・`"0"` で無効化）プールとして確保する。この prefix は TS 側の
+`SequenceEffectManager` と数値・文字列とも一致させる必要がある契約になっている。
+
+```rust
+// rust/crates/orbit-audio-daemon/src/engine_wrap.rs:240-248
+/// 既定 insert bus プールの名前 prefix。DSL 側（TS）の per-sequence effect manager が
+/// 同じ規則（`seq-bus-<n>`）で bus 名を組み立てて `LoadPlugin.bus` / `PlayAt.bus` に
+/// 送るため、prefix を変える場合は TS 側の定数も合わせて更新すること（#434 S3）。
+#[cfg(feature = "outproc-effect")]
+pub const DEFAULT_EFFECT_BUS_POOL_PREFIX: &str = "seq-bus-";
+
+/// `ORBIT_EFFECT_BUS_POOL` の既定サイズ（未設定時）。PH.2b の v1 上限（同時 insert 8 seq）と一致。
+#[cfg(feature = "outproc-effect")]
+const DEFAULT_EFFECT_BUS_POOL_SIZE: usize = 8;
+```
+
+`ORBIT_EFFECT_BUSES`（明示 bus 名リスト・既存 S2 の後方互換経路）が設定されて
+いればそれを優先し、無ければ `ORBIT_EFFECT_BUS_POOL` に従って既定プールを生成する:
+
+```rust
+// rust/crates/orbit-audio-daemon/src/engine_wrap.rs:272-284
+/// bus 名の解決: `ORBIT_EFFECT_BUSES`（明示名・非空）が設定されていればそれを使う（既存 S2 挙動を
+/// 保つ）。未設定なら `ORBIT_EFFECT_BUS_POOL`（既定 8・`"0"` で無効）に従って `seq-bus-<n>` の
+/// 既定プールを生成する。両方指定は `ORBIT_EFFECT_BUSES` を優先（明示指定が常に勝つ）。
+#[cfg(feature = "outproc-effect")]
+fn effect_buses_from_env() -> Result<Vec<String>, WrapError> {
+    let explicit = std::env::var("ORBIT_EFFECT_BUSES").unwrap_or_default();
+    if !explicit.trim().is_empty() {
+        return parse_effect_buses(&explicit).map_err(WrapError::OutProcEffect);
+    }
+    let pool_raw = std::env::var("ORBIT_EFFECT_BUS_POOL").unwrap_or_default();
+    let pool_size = parse_effect_bus_pool_size(&pool_raw).map_err(WrapError::OutProcEffect)?;
+    Ok(default_effect_bus_pool(pool_size))
+}
+```
+
+各 bus は `EffectBusBuild` として構築時に shm・engaged/stop/done フラグ・stats・
+そして render 側の `InsertBusStage::active` と共有する `active: Arc<AtomicBool>`
+を持つ。「宣言 = activation」の実体はここでも同じ flag:
+
+```rust
+// rust/crates/orbit-audio-daemon/src/engine_wrap.rs:286-300
+/// 1 本の named insert bus を構成する部材（`build_effect_bus_stages` → `install_effect_bus_slots`
+/// の間で運ぶ・#434 S2/S3）。effect-only / both の両起動経路で同一のライフサイクルを共有する。
+#[cfg(feature = "outproc-effect")]
+struct EffectBusBuild {
+    name: String,
+    shm_path: std::path::PathBuf,
+    engaged: Arc<std::sync::atomic::AtomicBool>,
+    stop: Arc<std::sync::atomic::AtomicBool>,
+    done: Arc<std::sync::atomic::AtomicBool>,
+    stats: Arc<crate::outproc_effect::OutProcEffectStats>,
+    /// render 側 `InsertBusStage::active` と共有。LoadPlugin が bus を指名した時点で
+    /// `true`（宣言 = activation → 以降 pass-through）。それまで callback は bus を
+    /// render 対象に含めない = 既定プールのコストゼロ。
+    active: Arc<std::sync::atomic::AtomicBool>,
+}
+```
+
+## TS 側: `SequenceEffectManager` の bus 割り当てと free-list
+
+`packages/engine/src/core/global/sequence-effect-manager.ts` の
+`SequenceEffectManager` は、seq 名 → bus 名の対応を `Map` で管理する。
+`PluginEffectManager` / `PluginInstrumentManager` の「eager ロード + 冪等再宣言」
+パターンをそのまま踏襲しつつ、単一 master slot ではなく seq 名でキーする。
+
+```typescript
+// packages/engine/src/core/global/sequence-effect-manager.ts:65-112
+  /** Declares (or idempotently re-declares) the insert for `sequenceName`. Returns the allocated bus name. */
+  async effect(sequenceName: string, spec: string, pluginId?: string): Promise<string> {
+    // Order mirrors PluginEffectManager.effect(): validate the spec, gate on
+    // LinkAudio, then resolve the path (see that file's doc comment for why).
+    validatePluginExtension(spec, 'effect')
+
+    if (this.linkAudioManager.isEnabled()) {
+      throw new Error(
+        `Sequence '${sequenceName}': seq.effect() cannot be used while LinkAudio is enabled in v1.`,
+      )
+    }
+
+    const resolvedPath = resolvePluginPath(
+      spec,
+      this.audioManager.getAudioPaths(),
+      this.audioManager.getDocumentDirectory(),
+      'effect',
+    )
+
+    const existing = this.declarations.get(sequenceName)
+    if (existing) {
+      if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
+        await existing.load
+        // Self-heal on stale cache after a daemon respawn (see PluginEffectManager
+        // for the full rationale). Engines without isPluginActive keep the old
+        // no-op idempotent behavior.
+        if (this.audioEngine.isPluginActive?.('effect', existing.bus) === false) {
+          await this.issueLoad(sequenceName, existing.bus, resolvedPath, pluginId)
+        }
+        return existing.bus
+      }
+      throw new Error(
+        `Sequence '${sequenceName}': seq.effect() supports one insert per sequence in v1; ` +
+          `chains (multiple inserts) are reserved for future support.`,
+      )
+    }
+
+    const bus = this.freedBuses.pop() ?? this.allocateFreshBus(sequenceName)
+    try {
+      await this.issueLoad(sequenceName, bus, resolvedPath, pluginId)
+    } catch (err) {
+      // ロールバック: 失敗した宣言の bus を free-list に返す（daemon 側も activation を
+      // 巻き戻すため、両側の状態が対称に戻る）。
+      this.freedBuses.push(bus)
+      throw err
+    }
+    return bus
+  }
+```
+
+`freedBuses`（失敗した宣言の bus を返却する free-list）は PR #461 のレビュー
+（Important 指摘）で追加された。ライブコーディングでは「typo → 失敗 → 直して
+再宣言」が普通に起こるため、失敗が bus pool を恒久消費すると数回のリトライで
+プールが枯渇してしまう — その対策。
+
+`issueLoad` が `await` を挟むことで、「宣言 = activation」が **構造的に先に完了
+してから** 呼び出し側が次の `PlayAt` を送れることを保証している（RE-3 冒頭の
+landmine を producer 側の呼び出し規律で回避する仕組み）。
+
+## Try it: `seq.effect()` の実機 E2E
+
+以下は Issue #434 の実機 gated テストで確認された手順（WORK_LOG 6.262、
+`rust/crates/orbit-audio-daemon/tests/outproc_effect_bus_gated.rs`）。
+
+```
+var global = init GLOBAL
+global.tempo(100)
+global.beat(4 by 4)
+global.key("C")
+global.start()
+
+var drums = init global.seq
+drums.audio("sine_880.wav")
+drums.effect("/path/to/CLAPTestEffect.clap")
+
+drums.play(1)
+
+RUN(drums)
+```
+
+daemon を `outproc-effect` feature + `ORBIT_EFFECT_BUSES=fx1`（または既定
+`ORBIT_EFFECT_BUS_POOL` で `seq-bus-0` を使う DSL 経路）で起動し、
+`ORBIT_CAPTURE_WAV` で capture すると、DSL → `LoadPlugin(bus)` →
+`PlayAt(bus)` → `render_multi` の bus routing → OOP effect child gain →
+master sum、という経路全体を客観的に実証できる。
+
+```bash
+ORBIT_EFFECT_BUSES=fx1 cargo test -p orbit-audio-daemon --features outproc-effect \
+  --test outproc_effect_bus_gated -- --ignored --nocapture --test-threads=1
+```
+
+**期待値**: `EFFECT_GAIN = 0.5` に対して `dry_peak` / `post_peak` の
+gain ratio **≈ 0.5**（テストは `(0.4..=0.6).contains(&bus_ratio)` で許容幅を
+取っている）。WORK_LOG 6.262 の実機記録では **ratio 0.50000 厳密一致**
+（sine 単体 peak 0.70711 → bus 経由後 0.35355）と記載されている。この厳密値は
+WORK_LOG の記述であり、本ページ執筆時点で `outproc_effect_bus_gated.rs` を
+実機で再実行して再確認したわけではない点に注意（テスト自体の assert は
+`0.4..=0.6` という許容レンジであり、厳密一致は WORK_LOG の実測記録に基づく）。
+
+> **注意（既知の落とし穴）**: `drums.effect()` の `await` を待たずに `PlayAt` を
+> tag 付きで送ると、bus が未 activation のまま event が retain される
+> （`InsertBusStage` の doc コメント参照）。DSL 経由では `effect()` が
+> `await` されるため構造的に発生しない。
+
+## Sources
+
+- `rust/crates/orbit-audio-native/src/output.rs:131-149` — `InsertBusStage` 構造体（`processor`/`active` フィールドの意味）
+- `rust/crates/orbit-audio-native/src/output.rs:250-260` — `render_block` の bus 0 個フォールバック（bit-identical 経路）
+- `rust/crates/orbit-audio-native/src/output.rs:293-308` — `render_engine_with_insert_buses` の active bus フィルタと target 組み立て
+- `rust/crates/orbit-audio-daemon/src/engine_wrap.rs:240-248` — `DEFAULT_EFFECT_BUS_POOL_PREFIX` / `DEFAULT_EFFECT_BUS_POOL_SIZE`
+- `rust/crates/orbit-audio-daemon/src/engine_wrap.rs:272-284` — `effect_buses_from_env`（`ORBIT_EFFECT_BUSES` 優先・`ORBIT_EFFECT_BUS_POOL` フォールバック）
+- `rust/crates/orbit-audio-daemon/src/engine_wrap.rs:286-300` — `EffectBusBuild`（bus 部材・active flag 共有）
+- `packages/engine/src/core/global/sequence-effect-manager.ts:65-112` — `SequenceEffectManager.effect()`（bus 割り当て・free-list ロールバック）
+- `rust/crates/orbit-audio-daemon/tests/outproc_effect_bus_gated.rs` — gated 実機テスト（`EFFECT_GAIN=0.5`・ratio assert `0.4..=0.6`）
+- [`docs/core/INSTRUCTION_ORBITSCORE_DSL.md`](https://github.com/signalcompose/orbitscore/blob/main/docs/core/INSTRUCTION_ORBITSCORE_DSL.md) PH.2b — `seq.effect()` の DSL 規範（処理順・v1 制約・上限 8）
+- [`docs/development/WORK_LOG.md`](https://github.com/signalcompose/orbitscore/blob/main/docs/development/WORK_LOG.md) 6.262 — #434 S1〜S3 実装記録（ratio 0.50000 実機記録）
+- Issue [#434](https://github.com/signalcompose/orbitscore/issues/434) — per-sequence effect insert
+- PR [#461](https://github.com/signalcompose/orbitscore/pull/461) — マージ済み実装（free-list 追加を含む）

--- a/sites/dev/rust-engine/oop-children.md
+++ b/sites/dev/rust-engine/oop-children.md
@@ -1,0 +1,350 @@
+---
+title: "RE-2. OOP children と shm transport"
+chapter-id: "RE-2"
+verified-against: 3983828
+verified-at: "2026-07-17"
+status: draft
+---
+
+> **Note**: 本ページは 2026-07-17 時点での著者の reading の足跡です。code が真実、本ページはその時点の理解の snapshot に過ぎません。
+
+# RE-2. OOP children と shm transport
+
+RE-1 で見た daemon は自プロセス内では 3rd-party plugin（CLAP/VST3）の実体を持たない。楽器
+（サンプラー/audio DSL）は in-process だが、effects と 3rd-party plugin は out-of-process (OOP)
+sandbox の子プロセスとして分離される。本章では、この in-process/OOP の使い分けの理由、
+`orbit-audio-sandbox` crate が提供する共有メモリ (shm) transport の仕組み、READY handshake、
+watchdog/respawn、そして親プロセス死活監視 (`ParentWatch`) を扱う。PH-2/PH-3 章で既に触れた
+plugin hosting の DSL 面（`global.effect()` / `seq.instrument()`）や child バイナリ選択ロジック
+（`child_exe_for_attach`）はここでは繰り返さない — 本章は effect/instrument 両方の child が
+**共有する土台**（transport の仕組みそのもの）に焦点を当てる。
+
+## in-process vs out-of-process の使い分け
+
+`docs/development/POST_2.0_MASTER_PLAN.html` に記された確定アーキテクチャによれば:
+
+> 楽器（サンプラー/audio DSL）= in-process（楽器は DSL 表現力の着地点なので flatten 境界を
+> 経由させない。in-process は表現力を自由に進化させる + 自社 Rust で隔離不要）。effects +
+> 3rd-party = out-of-process sandboxed plugin（audio→audio の下流 / 非信頼 crash を隔離）。
+
+つまり判定基準は「DSL が per-note/per-slice の細かい制御を要するか」（→ 楽器側・in-process）
+か「純粋な audio→audio 変換か」（→ plugin 側・OOP）かで分かれる。3rd-party の CLAP/VST3
+plugin は信頼できないコードなので、crash してもホスト（daemon 本体）を道連れにしないよう
+プロセス境界で隔離する。この隔離を実現するのが `orbit-audio-sandbox` crate。
+
+## shm transport: `SharedRegion`
+
+host（daemon）と child（`orbit-clap-effect-child` 等）は 1 つの mmap ファイルを共有メモリとして
+開き、`#[repr(C, align(64))]` の `SharedRegion` 構造体をその上に重ねる。フィールド順は固定、
+64-byte align でキャッシュライン境界に載る。
+
+```rust
+// transport.rs:137-171
+#[repr(C, align(64))]
+pub struct SharedRegion {
+    /// host が input/n_frames 書き込み後に進める。child はこれが前回値より進むのを待つ。
+    pub seq_request: AtomicU64,
+    /// child が処理し終えた **最新** request seq(monotone)。host の **submit guard** が slot 再利用
+    /// 可否(`seq_done >= new_seq - SLOTS`)に使う。READ の fresh 判定には使わない(それは per-slot
+    /// [`SharedRegion::seq_tag`]。global monotone な seq_done では「latest 処理」の skip を検知できない)。
+    pub seq_done: AtomicU64,
+    /// child が処理したブロック総数(観測用。respawn 後の処理再開を可視化する)。
+    pub child_processed: AtomicU64,
+    /// **child -> host health signal**(γ M1 PR-C・carry-forward ①): child の per-block 処理
+    /// (`plugin.process()`)が失敗したブロックの累積数。child が `fetch_add` で書き、host(supervisor /
+    /// accessor)が読む。effect は失敗時 dry 素通し・instrument は無音になるため、この counter だけが
+    /// 失敗の可視化手段になる(silent-failure 防止)。**child が crash しても host は mmap を保持し続けるので
+    /// 値は読める**(supervisor の respawn で同一 shm を再利用するため child を跨いで累積する)。supervisor
+    /// 側の `respawn_count` / `last_respawn_ns` / `measurement_invalid`(child の異常終了を host が
+    /// 観測する signal)は host-side atomic で別に持つ(SharedRegion ではない)。gain child(PR-A)は
+    /// 失敗経路を持たないので増分せず 0 のまま。
+    pub child_process_error_count: AtomicU64,
+    /// host -> child の制御フラグ([`CONTROL_RUN`] / [`CONTROL_QUIT`])。host が teardown 時に
+    /// QUIT を store し、child は spin loop の各周回で確認して正常終了する(kill より clean)。
+    pub control: AtomicU32,
+    /// **per-slot**: child が各 slot に書いた output の seq。child は output 書き込み後 Release で store し、
+    /// host は READ 時に `seq_tag[slot(target)] == target` を Acquire で確認してから読む(その Acquire が
+    /// 当該 slot の output 書き込みを可視化する)。child が「latest 処理」で中間 seq を skip しても、その
+    /// slot の tag は target に一致しないので host は false-fresh せず repeat-previous に落ちる。
+    pub seq_tag: [AtomicU64; SLOTS],
+    /// **per-slot**: 各 slot の有効フレーム数(<= MAX_FRAMES)。host が submit 時に該当 slot へ書き、child
+    /// はその slot の値で処理長を決め、host は READ 時に copy 長の clamp に使う。pipelined で host が次 block
+    /// (別フレーム数)を submit 済みでも、各 slot は自分の正しい長さを持つ(単一 n_frames だと取り違える)。
+    pub n_frames: [AtomicU32; SLOTS],
+    /// host -> child のインターリーブ入力(ping-pong: SLOTS 個の block。`slot_offset` で index)。
+    pub input: [f32; BUF_LEN * SLOTS],
+    /// child -> host のインターリーブ出力(ping-pong: SLOTS 個の block。`slot_offset` で index)。
+    pub output: [f32; BUF_LEN * SLOTS],
+```
+
+`SLOTS = 2` の ping-pong バッファで、host が現ブロックを submit しつつ前ブロックの output を
+読む「pipelined」方式が採用されている（下記参照）。これにより毎ブロックの同期 round-trip
+待ち（tail latency）を避け、小バッファ（32/64フレーム）運用を現実的にしている。
+
+```rust
+// host.rs:1-13
+//! pipelined(候補B) effect host — RT callback ごとに 1 block を境界越しに処理する状態機械。
+//!
+//! γ latency fork spike(#351)が採用した候補B: host は **spin しない**。callback K で
+//! 現ブロック(`data` = engine の dry 出力)を child へ submit し、**前 callback で submit した
+//! ブロックの出力を読んで `data` を上書きする**(serial insert)。これにより同期 round-trip の
+//! tail(~2-4ms・buffer 非依存)を構造的に消し、32f まで小バッファを feasible にする。代償は
+//! **+1 block の出力遅延**(最終 hw sum 全体に均一にかかる純レイテンシ)と、child が間に合わない
+//! 時の **stale**(owner 決定 = repeat-previous: 直前の good block を再出力してクリック回避)。
+//!
+//! 本 host は `&mut [f32]`(post-processor の in-place バッファ)と `*mut SharedRegion` の上で完結し、
+//! orbit-audio-native(PostProcessor trait)にも cpal にも依存しない。`impl PostProcessor` の adapter は
+//! daemon 側(native がある所)に薄く置く。本 host の `process_block` を RT callback から呼ぶ。
+```
+
+`PipelinedEffectHost::process_block` は RT 契約を守る（alloc/lock/syscall なし）ことが型・
+コメントの両方で明示されており、submit（現ブロックを child へ）→ read（前ブロックの output を
+読む）の順で `data` を in-place 書き換える。
+
+```rust
+// host.rs:86-98
+    /// 1 callback ぶんを処理する。`data` は interleaved f32(stereo)で in-place 上書きされる。
+    ///
+    /// RT-safe: alloc/lock/syscall なし。submit(data を input slot へ)→ read(前ブロックの output を
+    /// data へ)の順で、data の dry 入力を失わずに前ブロックの effected 出力へ差し替える。
+    pub fn process_block(&mut self, data: &mut [f32]) {
+        let raw = data.len();
+        if raw > BUF_LEN {
+            self.frames_clamped += 1;
+        }
+        // BUF_LEN = MAX_FRAMES * CHANNELS なので clamp 後は n_frames <= MAX_FRAMES が自明。
+        let n_frames = (raw.min(BUF_LEN) / CHANNELS) as u32;
+        // count を frame 境界に丸める(端数 sample は触らない)。
+        let count = n_frames as usize * CHANNELS;
+```
+
+instrument 側の host（`PipelinedInstrumentHost`、`instrument_host.rs`）は同じ shm 基盤の上に
+note event の voice 管理（`VoiceTable`）を重ねたもので、effect 用の `SharedRegion` と同じ
+transport（`seq_request`/`seq_done`/slot 機構）を再利用している。`SharedRegion` には M2
+instrument IPC 用の event 転送窓（`input_events`/`output_events` 等）も同居しているが、
+これは event の wire format 自体（`NeutralEvent`）の詳細であり、RE-3（M2 IPC）章に譲る。
+
+## child-side READY handshake
+
+child は起動後すぐに process loop へ入るのではなく、plugin のロードが終わってから
+`child_status` を `CHILD_STATUS_READY` に遷移させる。host はこのフラグを poll してから初めて
+submit を始める。
+
+```rust
+// transport.rs:85-102
+/// `control` の値: child は spin を続ける。
+pub const CONTROL_RUN: u32 = 0;
+/// `control` の値: host が child に spin loop を抜けて正常終了するよう要求する。
+pub const CONTROL_QUIT: u32 = 1;
+
+/// child が実際にロードした CLAP plugin の readiness（PR-431・child→host handshake）。
+/// 0 = starting（child がまだ load 中）。
+pub const CHILD_STATUS_STARTING: u32 = 0;
+/// child が load に成功し、以降 process loop に入る状態。
+pub const CHILD_STATUS_READY: u32 = 1;
+/// **現状は未使用の予約値**（child が load に失敗して終了する直前の状態を表す想定）。
+/// child は load 失敗時 `?` の早期 return でこの値を書かずにそのままプロセス終了する。PR-1c (#441)
+/// では watchdog が初回 attach 中の child exit を stats に publish し、host が timeout を待たずに
+/// retryable attach failure として返す。
+///
+/// **respawn 注意**: shm は daemon 起動時に一度だけ truncate され、respawn（`EffectChildSupervisor`/
+/// `InstrumentChildSupervisor` の watchdog による再起動）は同一 shm を再利用する（再 truncate しない）
+/// ため、一度 READY に達した後の respawn 失敗では `child_status` は STARTING でなく前 incarnation の
+/// READY が残留する。PR-1b（#440）は spawn 直前の `reset_child_starting` による STARTING リセット
+/// のみを実装し、この前 incarnation の READY 残留誤認を解消した。一方、初回 attach 時に child が
+/// `CHILD_STATUS_LOAD_FAILED` は現状も write 箇所なしの予約値であり、early-exit は上記 watchdog
+/// signal で検出する。
+pub const CHILD_STATUS_LOAD_FAILED: u32 = 2;
+```
+
+コメントが指摘する落とし穴は重要: shm ファイル自体は daemon 起動時に一度だけ truncate（ゼロ
+初期化）され、respawn（watchdog による child 再起動）は**同じ shm を再利用**する。そのため、
+一度 READY に達した後で respawn に失敗すると、`child_status` は STARTING に戻らず前
+incarnation の READY が残ってしまう。これに対する修正が「spawn 直前に必ず `reset_child_starting`
+で STARTING にリセットする」という規律。
+
+## watchdog と respawn
+
+daemon 側は `InstrumentChildSupervisor`（instrument 用。effect 側は `EffectChildSupervisor`）が
+専用スレッドで child の生死を監視し、予期しない終了を検知すると自動で respawn する。
+
+```rust
+// outproc_instrument.rs:493-519 (要旨)
+"orbit-clap-instrument-child exited ({status}); respawning"
+// SAFETY: region は watchdog が所有する生存 ctl_mmap を指す。
+// ...
+stats.respawn_count.fetch_add(1, Ordering::Relaxed);
+// ...
+"instrument child respawn failed; measurement invalid: {error}"
+```
+
+respawn が繰り返し失敗する場合、supervisor は `measurement_invalid` フラグを一度だけ立てる
+（fire-once）。これは「daemon/engine 自体は生存し他の audio は流れ続けるが、その instrument
+（または effect）経路だけが直前の good block を repeat-previous で出し続ける恒久停止」を意味
+する WARNING severity の状態で、`ERROR_CODE_OUTPROC_INSTRUMENT_INVALID` / 
+`ERROR_CODE_OUTPROC_EFFECT_INVALID` として 1 Hz ticker（RE-1 で見た daemon の `StreamStats`
+event 経路）経由で client に可視化される。
+
+child プロセスの teardown（graceful shutdown）自体は `SandboxChildGuard` という RAII ガードに
+集約されている。drop 時に `CONTROL_QUIT` を store → 一定時間（2秒）reap を待つ → ダメなら
+kill → shm ファイル削除、という手順を daemon・offline driver・統合テストで共通化している。
+
+```rust
+// child.rs:44-84
+impl Drop for SandboxChildGuard {
+    fn drop(&mut self) {
+        // child に正常終了を要求 → 一定時間待って、ダメなら kill。
+        // SAFETY: region は呼び出し側が本ガードより後まで生かす mapping を指す(構築時の契約)。
+        unsafe {
+            (*self.region).control.store(CONTROL_QUIT, Release);
+        }
+        let deadline = Instant::now() + REAP_TIMEOUT;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(_)) => break,
+                // 非 RT の teardown 待ち。spin より yield で CPU を譲る(offline.rs の wait と一貫)。
+                Ok(None) if Instant::now() < deadline => std::thread::yield_now(),
+                Ok(None) => {
+                    eprintln!(
+                        "orbit-audio-sandbox: child が {REAP_TIMEOUT:?} 以内に終了せず kill にフォールバック"
+                    );
+                    let _ = self.child.kill();
+                    let _ = self.child.wait();
+                    break;
+                }
+                Err(e) => {
+                    eprintln!("orbit-audio-sandbox: try_wait 失敗(kill にフォールバック): {e}");
+                    let _ = self.child.kill();
+                    let _ = self.child.wait();
+                    break;
+                }
+            }
+        }
+        if let Err(e) = std::fs::remove_file(&self.path) {
+            eprintln!(
+                "orbit-audio-sandbox: shm ファイル削除失敗 {:?}: {e}",
+                self.path
+            );
+        }
+    }
+}
+```
+
+## `ParentWatch`: 親プロセス死活監視（#448）
+
+RE-1 で見た通り、daemon 側には SIGTERM/SIGINT ハンドラも graceful-shutdown 配線も無い既知の
+ギャップがある。`SandboxChildGuard::drop`（上記）に依存する teardown 経路は、daemon が
+`Drop` を経ずに死ぬ（`SIGKILL`・panic による `process::exit(1)`）と一切発火しない。この穴を
+child 側から埋めるのが `ParentWatch`。
+
+```rust
+// parent_watch.rs:1-16
+//! orphan child 対策(Issue #448): child プロセスの親死活監視。
+//!
+//! host(daemon)が `CONTROL_QUIT` を書かずに死ぬ経路(プロセス exit・SIGKILL・crash)では、
+//! 4 つの child バイナリ(orbit-clap-effect-child / orbit-clap-instrument-child /
+//! orbit-vst3-effect-child / orbit-vst3-instrument-child)は `seq_request` 待ちの spin loop に
+//! 残り続け、CPU を専有し続ける(shm 側の CONTROL_QUIT に依存する既存の終了経路は host 側の
+//! Drop 実行が前提のため、host が Drop を経ずに死ぬとこの経路が発火しない)。
+//!
+//! [`ParentWatch`] は起動時に `getppid()` を記録し、低頻度(既定 250ms)でこれを再取得する。
+//! 親が死んで child が launchd/PID1 等に reparent されると `getppid()` の値が変わるので、
+//! それを検知して spin loop から抜けるための helper。RT 影響を避けるため、チェックは
+//! 「spin loop を回った回数」でなく「経過時間」で rate-limit する(system call 1 回 / 250ms 程度)。
+//!
+//! 4 crate(orbit-clap-effect-child 等)で同じロジックを重複させないための共有 helper。
+//! transport とは独立した薄いモジュール(既存の「child main はミラー」方針と両立)。
+```
+
+実装は `getppid()` を起動時に記録し、250ms ごとに再取得して比較するだけの単純な状態機械。
+Unix の reparent 規則（親が死ぬと子は launchd/PID1 等に reparent され `getppid()` の値が変わる）
+を利用している。
+
+```rust
+// parent_watch.rs:24-63
+/// child プロセスが起動時の親 PID を記録し、reparent(親死亡)を低頻度で検知する状態機械。
+pub struct ParentWatch {
+    original_ppid: libc::pid_t,
+    check_interval: Duration,
+    last_check: Instant,
+}
+
+impl ParentWatch {
+    /// 現在の `getppid()` を起動時の親 PID として記録する。既定の rate-limit 間隔
+    /// ([`DEFAULT_CHECK_INTERVAL`])を使う。
+    pub fn new() -> Self {
+        Self::with_interval(DEFAULT_CHECK_INTERVAL)
+    }
+
+    /// rate-limit 間隔を明示指定するコンストラクタ(主にテスト用)。
+    pub fn with_interval(check_interval: Duration) -> Self {
+        // SAFETY: getppid(2) は引数を取らず常に成功する(POSIX)。
+        let original_ppid = unsafe { libc::getppid() };
+        Self {
+            original_ppid,
+            check_interval,
+            last_check: Instant::now(),
+        }
+    }
+
+    /// 親が死んで(= 現在の `getppid()` が起動時と異なる場合)true を返す。
+    ///
+    /// rate-limit: 前回チェックから `check_interval` 未満なら syscall を発行せず false を返す
+    /// (spin loop 内で毎回呼んでも system call 頻度は interval に収まる)。
+    pub fn should_exit(&mut self) -> bool {
+        let now = Instant::now();
+        if now.duration_since(self.last_check) < self.check_interval {
+            return false;
+        }
+        self.last_check = now;
+        // SAFETY: 同上。
+        let current_ppid = unsafe { libc::getppid() };
+        current_ppid != self.original_ppid
+    }
+}
+```
+
+この `ParentWatch` は 4 種類の child バイナリ（CLAP/VST3 × effect/instrument）すべてに共通の
+薄い helper として実装されており、各 child の main 関数が spin loop の中で `should_exit()` を
+呼ぶだけで組み込める（transport モジュールとは独立）。git 履歴上、このモジュールは 1 コミット
+（`a0449b8 fix(sandbox): add parent-liveness watchdog to VST3/CLAP child processes`）で追加
+された。
+
+## Try it: 親死亡時に child が自発的に exit することを実証する
+
+`orbit-audio-sandbox` crate には `parent_watch_integration.rs` という統合テストがあり、実
+プロセス階層（テスト process → probe P（daemon 役）→ probe C（child 役））を作り、P を
+`SIGKILL` した後に C が `ParentWatch::should_exit()` の true を検知して自発的に exit する
+ことを検証する。device にも shm にも依存しないため `#[ignore]` 無しで CI 実行可能。
+
+```bash
+cargo test -p orbit-audio-sandbox --test parent_watch_integration
+```
+
+**期待される出力**（本エージェントが実際にこのサンドボックス環境で実行し、確認済み）:
+
+```
+running 1 test
+test orphaned_child_exits_after_parent_is_killed ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
+```
+
+respawn/watchdog の状態機械そのもの（child crash → respawn → `measurement_invalid`）は
+`orbit-audio-daemon` の `outproc_instrument.rs`/`outproc_effect.rs` 内 `#[test]` として実装
+されているが、実 device・実 CLAP plugin を要さないスタブ child を使うユニットテストであり、
+`#[ignore]` タグは付いていない（pr-test-analyzer レビュー指摘で追加されたもの・PR #422）。
+これらは `cargo test -p orbit-audio-daemon` に含まれる通常テストとして実行できるが、feature
+flag（`outproc-instrument` 等）が必要な場合があるため、実行可否は当該 crate の
+`Cargo.toml` の feature 定義を別途確認すること（本エージェントは今回未確認・**未検証**）。
+
+## Sources
+
+- `rust/crates/orbit-audio-sandbox/src/transport.rs:80-211` — `SharedRegion` レイアウト、`CONTROL_RUN`/`CONTROL_QUIT`、`CHILD_STATUS_*` readiness 定数とその respawn 時の落とし穴
+- `rust/crates/orbit-audio-sandbox/src/host.rs:1-98` — `PipelinedEffectHost`（pipelined submit/read 状態機械、RT-safe `process_block`）
+- `rust/crates/orbit-audio-sandbox/src/child.rs:1-84` — `SandboxChildGuard`（child teardown の RAII ガード：QUIT → reap → kill フォールバック → shm 削除）
+- `rust/crates/orbit-audio-sandbox/src/parent_watch.rs:1-104`（全文） — `ParentWatch`（`getppid()` ベースの親死活監視、rate-limit 済み）
+- `rust/crates/orbit-audio-sandbox/tests/parent_watch_integration.rs:1-20` — 実プロセス階層での `ParentWatch` 実証テスト（本エージェントが実行・pass 確認済み）
+- `rust/crates/orbit-audio-daemon/src/outproc_instrument.rs:386-605` — `InstrumentChildSupervisor`（watchdog スレッド、respawn ロジック、`measurement_invalid` fire-once）
+- [`docs/development/POST_2.0_MASTER_PLAN.html`](https://github.com/signalcompose/orbitscore/blob/main/docs/development/POST_2.0_MASTER_PLAN.html) — in-process/OOP 分割の確定アーキ
+- Issue [#448](https://github.com/signalcompose/orbitscore/issues/448) — daemon graceful-shutdown ギャップと `ParentWatch` 対策（PR: `a0449b8`）

--- a/sites/dev/rust-engine/oop-children.md
+++ b/sites/dev/rust-engine/oop-children.md
@@ -122,7 +122,8 @@ instrument 側の host（`PipelinedInstrumentHost`、`instrument_host.rs`）は�
 note event の voice 管理（`VoiceTable`）を重ねたもので、effect 用の `SharedRegion` と同じ
 transport（`seq_request`/`seq_done`/slot 機構）を再利用している。`SharedRegion` には M2
 instrument IPC 用の event 転送窓（`input_events`/`output_events` 等）も同居しているが、
-これは event の wire format 自体（`NeutralEvent`）の詳細であり、RE-3（M2 IPC）章に譲る。
+これは event の wire format 自体（`NeutralEvent`）の詳細であり、本章の範囲外とする
+（M2 IPC wire の設計章は計画中・現状の一次情報は `orbit-audio-sandbox/src/events.rs` と Issue #398）。
 
 ## child-side READY handshake
 
@@ -198,6 +199,9 @@ impl Drop for SandboxChildGuard {
         unsafe {
             (*self.region).control.store(CONTROL_QUIT, Release);
         }
+        // TODO(PR-C): respawn 判断のため child の ExitStatus を捕捉して supervisor へ渡す
+        // (本ガードは teardown 専用で終了 status を破棄する)。親プロセス死亡時の孤児化対策
+        // (PR_SET_PDEATHSIG 等)も supervisor 層で扱う。
         let deadline = Instant::now() + REAP_TIMEOUT;
         loop {
             match self.child.try_wait() {
@@ -212,6 +216,7 @@ impl Drop for SandboxChildGuard {
                     let _ = self.child.wait();
                     break;
                 }
+                // try_wait 自体の失敗(ECHILD 等)は timeout と区別して実エラーを出す。
                 Err(e) => {
                     eprintln!("orbit-audio-sandbox: try_wait 失敗(kill にフォールバック): {e}");
                     let _ = self.child.kill();

--- a/sites/dev/rust-engine/oop-children.md
+++ b/sites/dev/rust-engine/oop-children.md
@@ -334,9 +334,10 @@ respawn/watchdog の状態機械そのもの（child crash → respawn → `meas
 `orbit-audio-daemon` の `outproc_instrument.rs`/`outproc_effect.rs` 内 `#[test]` として実装
 されているが、実 device・実 CLAP plugin を要さないスタブ child を使うユニットテストであり、
 `#[ignore]` タグは付いていない（pr-test-analyzer レビュー指摘で追加されたもの・PR #422）。
-これらは `cargo test -p orbit-audio-daemon` に含まれる通常テストとして実行できるが、feature
-flag（`outproc-instrument` 等）が必要な場合があるため、実行可否は当該 crate の
-`Cargo.toml` の feature 定義を別途確認すること（本エージェントは今回未確認・**未検証**）。
+これらは feature flag 付きで実行する（実機検証済み・2026-07-17）:
+`cargo test -p orbit-audio-daemon --features outproc-instrument --lib` で instrument 系
+ユニットが走る（同日実測: instrument フィルタで 38 passed）。effect 系は
+`--features outproc-effect`、両 role 同時は `--features outproc-effect,outproc-instrument`。
 
 ## Sources
 


### PR DESCRIPTION
## Summary

Issue #451 の第二段として dev 学習サイトに rust-engine 章群を追加。

- RE-1: daemon アーキテクチャ概観（`orbit-audio-daemon` のプロセス構造・TS engine との IPC 境界・boot〜teardown ライフサイクル）
- RE-2: OOP children と shm transport（`orbit-audio-sandbox` の共有メモリ・engaged/READY handshake・watchdog/respawn・ParentWatch #448）
- RE-3: per-sequence insert bus（#434・`InsertBusStage`・activation flag・bus プール・「宣言 = activation」契約）
- RE-4: capture seam と客観検証（`ORBIT_CAPTURE_WAV`・`PostMixSink` タップ点・自前 minimal RIFF WAV writer）

各章 ja + en を同時執筆。frontmatter（`verified-against`/`verified-at`/`status`）・disclaimer・
`## Sources`・「Try it」節は PH-1 パイロット章（plugin-hosting/index.md）のテンプレートに準拠。
本文中コードは file:line 引用で verbatim（執筆エージェントが Read で範囲を確認 → 書いた後に
再度突き合わせ self-check 済み）。

`.vitepress/sidebar.ts` に「Part -1: Rust Engine」を追加、`.plan/refresh-2026-07.md` の Unit A/B
を済に更新。

## Test plan

- [x] `npm run docs:build -w @orbitscore/dev-site` green
- [x] 章末コード引用の verbatim 検証（執筆エージェントが Read 出力との再突合を実施、報告済み）
- [ ] 著者（大和さん）による最終コード照合（DEV_LEARNING_SITE.md §5 の運用に沿って別途実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu