### PR TITLE
feat(engine): mixer graph — sum/group + aux/send from core to DSL (#459, #453)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,41 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.263 feat(engine): mixer graph — sum/aux/send を DSL まで完走 #459/#453 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 実装・実機 E2E 済み（PR 作成・レビューフローへ）
+**Branch**: `459-mixer-graph-impl`
+**Commits**: M0 spec = PR #466（マージ済・MX.1-MX.5）/ M1 `3029545` / M2 `95d3fc9` / M3 `7b70b1b`
+
+#434 の insert bus 基盤の上に DAW ミキサー構造（group/send-return）を実装。
+設計 = Fable main（issue #459 コメントが決定記録・fan-out は event 複製でなく
+bus 処理段の copy 加算 = render_multi 無変更が核）。実装 = Sonnet xhigh ×3 + main 監査。
+
+**M1（core）**: InsertBusStage に output_target/sends・validate_bus_topology
+（前方参照のみ = 配列順がトポロジカル順・ネスト/循環が構造的に不可）・
+is_render_target 分離（member だけ active な sum が中継点として生きる）。
+closed-form unit（sum ×0.5・send dry+wet ×0.75）・既存テスト無変更 green。
+
+**M2（daemon）**: BusKind（Insert/Sum/Aux）プール・実行時 routing の atomic overlay
+（routing_override + 全後方 slot 事前確保の send_gain_overrides = RT は Relaxed load のみ）・
+SetBusRouting protocol（前方参照 + kind + 有限 gain を non-RT 検証・部分適用なし）。
+**実機 gated: insert→sum→aux カスケード全段厳密半減 0.70711→0.35355→0.17678→0.08839**。
+
+**M3（DSL）**: MixerManager（global.sum()/aux()・ハンドル .effect()）・
+seq.output()（sum 解決 + insert 未宣言時の pass-through 自動確保）・
+seq.send()（累積・全状態冪等再送）・set_bus_routing での activation・
+parser に裸 sum()/aux() 受理。
+
+**実機 E2E（DSL・capture）**:
+- **sum oracle: peak 0.35355 厳密一致**
+- **aux oracle: 窓解析で send 実効を実証** — 第1窓 0.7071（dry のみ・wet は OOP
+  pipeline 1 block 遅延）→ 定常 0.4965（dry+位相シフト wet の干渉）。素朴期待値
+  1.06 との差 = **MX.5 の既知制約（PDC なし）の実観測**（spec と実挙動が一致）
+
+**検証**: npm test 1397 / rust 3構成 80/56/115 / gated（mixer 新設 + bus/both 退行なし・
+実機）/ clippy --all-targets / fmt。
+
 ### 6.262 feat(engine): seq.effect() per-sequence insert — S1〜S3 完走 #434 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/packages/engine/src/audio/rust-engine/daemon-client.ts
+++ b/packages/engine/src/audio/rust-engine/daemon-client.ts
@@ -380,6 +380,24 @@ export class DaemonClient extends EventEmitter {
     }
   }
 
+  /**
+   * Runtime mixer bus routing change (MX.4, #459/#453 M3): (re)sets `seqBus`'s output
+   * target (sum) and/or send gains (aux). `output: undefined` means "leave untouched" —
+   * translated to omitting the field so the daemon's `parse_set_bus_routing_params`
+   * treats it as `None` and does not touch the existing override.
+   */
+  async setBusRouting(
+    seqBus: string,
+    output: string | undefined,
+    sends: { bus: string; gain: number }[],
+  ): Promise<void> {
+    await this.request('SetBusRouting', {
+      seq_bus: seqBus,
+      ...(output === undefined ? {} : { output }),
+      sends,
+    })
+  }
+
   pluginNoteOn(key: number, channel: number, velocity: number): Promise<void> {
     return this.request('PluginNoteOn', { key, channel, velocity }) as unknown as Promise<void>
   }

--- a/packages/engine/src/audio/rust-engine/protocol-types.ts
+++ b/packages/engine/src/audio/rust-engine/protocol-types.ts
@@ -18,6 +18,10 @@ export interface HandshakeFrame {
 export type CommandMethod =
   | 'LoadSample'
   | 'LoadPlugin'
+  // ランタイムの mixer bus routing 変更（MX.4・#459/#453 M3）: seq_bus の output(sum)/
+  // sends(aux) を非 RT で書き換える。daemon が feature `outproc-effect` 無効ビルドなら
+  // OUTPROC_EFFECT_UNAVAILABLE を返す。
+  | 'SetBusRouting'
   | 'PluginNoteOn'
   | 'PluginNoteOff'
   | 'UnloadSample'

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -615,6 +615,21 @@ export class RustEnginePlayer implements AudioEngineBackend {
   }
 
   /**
+   * Runtime mixer bus routing change (MX.4, #459/#453 M3). Unlike LinkAudio channel
+   * registration, there is no hardware-bus fallback for a missing sum/aux target — the
+   * daemon-side error (e.g. `UNSUPPORTED` on a non-`outproc-effect` build, or a kind/order
+   * violation) is a real failure and propagates unchanged to the caller (`Sequence`'s
+   * `output()`/`send()`, which log it via `console.warn` — see that file).
+   */
+  async setBusRouting(
+    seqBus: string,
+    output: string | undefined,
+    sends: { bus: string; gain: number }[],
+  ): Promise<void> {
+    await this.daemon.setBusRouting(seqBus, output, sends)
+  }
+
+  /**
    * Loads a plugin into the daemon's master effect insert. Converts daemon-side
    * `DaemonProtocolError`s into operator-actionable messages (CLAP_UNAVAILABLE →
    * build hint, other codes → generic wrap); non-protocol errors pass through

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -291,6 +291,15 @@ export class RustEnginePlayer implements AudioEngineBackend {
    * 単一 boolean だと健全な宣言まで再ロードされる）。
    */
   private readonly pluginActiveByKey = new Map<string, boolean>()
+  /**
+   * seq bus ごとの「最後に意図した routing」（MX.4 M3）。daemon respawn 後に
+   * `reapplyBusRoutingAfterRespawn` が全 entry を再発行する（新 daemon の routing atomics は
+   * 既定値に戻るため、replay しないと sum/aux routing が silent に素通しへ戻る）。
+   */
+  private readonly busRoutings = new Map<
+    string,
+    { output: string | undefined; sends: { bus: string; gain: number }[] }
+  >()
   private clockAnchor: ClockAnchor = { tsMs: 0, daemonSec: 0 }
   /**
    * 直近の StreamStats anchor サンプル列（#389 機構 B・ANCHOR_WINDOW 参照）。
@@ -516,6 +525,7 @@ export class RustEnginePlayer implements AudioEngineBackend {
           // エントリは ws close の reject で各自の .finally が既に delete 済み。
           this.sampleIds.clear()
           await this.reloadPluginsAfterRespawn()
+          await this.reapplyBusRoutingAfterRespawn()
           console.warn(
             `✅ [rust-engine] daemon respawned and session re-established (attempt ${attempt}/${MAX_RESPAWN_ATTEMPTS}).`,
           )
@@ -626,7 +636,42 @@ export class RustEnginePlayer implements AudioEngineBackend {
     output: string | undefined,
     sends: { bus: string; gain: number }[],
   ): Promise<void> {
-    await this.daemon.setBusRouting(seqBus, output, sends)
+    // Intent-first cache: transport failures (daemon mid-respawn, socket drop) keep the
+    // intended routing so `reapplyBusRoutingAfterRespawn` restores it on the next daemon.
+    // A definitive daemon-side rejection means the daemon state did NOT change, so the
+    // cache reverts — otherwise every later respawn would replay a known-bad request.
+    const prev = this.busRoutings.get(seqBus)
+    this.busRoutings.set(seqBus, { output, sends })
+    try {
+      await this.daemon.setBusRouting(seqBus, output, sends)
+    } catch (err) {
+      if (err instanceof DaemonProtocolError) {
+        if (prev) this.busRoutings.set(seqBus, prev)
+        else this.busRoutings.delete(seqBus)
+      }
+      throw err
+    }
+  }
+
+  /**
+   * Re-issues the last intended `SetBusRouting` per seq bus after a daemon respawn — the
+   * new daemon process starts with all `routing_override`/send atomics at their defaults,
+   * so without this replay every sum/aux routing silently reverts to plain per-sequence
+   * output (audio quietly goes to the wrong place). Mirrors `reloadPluginsAfterRespawn`:
+   * per-entry independent failure handling, and a failure must not fail the respawn itself.
+   */
+  private async reapplyBusRoutingAfterRespawn(): Promise<void> {
+    for (const [seqBus, { output, sends }] of this.busRoutings.entries()) {
+      try {
+        await this.daemon.setBusRouting(seqBus, output, sends)
+      } catch (err) {
+        // Cache entry intentionally remains: a later daemon respawn retries restoration.
+        console.error(
+          `❌ [rust-engine] failed to restore bus routing after daemon respawn (bus=${seqBus})`,
+          err,
+        )
+      }
+    }
   }
 
   /**

--- a/packages/engine/src/audio/types.ts
+++ b/packages/engine/src/audio/types.ts
@@ -85,6 +85,21 @@ export interface AudioEngine {
    * are treated as always-active (no self-heal check performed).
    */
   isPluginActive?(role?: 'effect' | 'instrument', bus?: string): boolean
+
+  /**
+   * Runtime mixer routing (MX.4, #459/#453 M3): (re)sets `seqBus`'s output target (a sum
+   * bus) and/or send gains (to aux buses). `output: undefined` leaves the existing output
+   * target untouched (daemon-side semantics — there is no way to explicitly clear it back
+   * to the hardware bus in v1). `sends` is the FULL current send list for `seqBus` — callers
+   * must re-send previously-set sends alongside a new one (the daemon only touches the
+   * enumerated entries, so a shorter list does not clear the others, but callers should still
+   * pass the complete set to keep engine state and TS-side state visibly in sync).
+   */
+  setBusRouting?(
+    seqBus: string,
+    output: string | undefined,
+    sends: { bus: string; gain: number }[],
+  ): Promise<void>
 }
 
 /**

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -25,6 +25,7 @@ import { MidiTransportScheduler } from './global/midi-transport-scheduler'
 import { PluginEffectManager } from './global/plugin-effect-manager'
 import { PluginInstrumentManager } from './global/plugin-instrument-manager'
 import { SequenceEffectManager } from './global/sequence-effect-manager'
+import { MixerManager, MixerBusHandle } from './global/mixer-manager'
 
 export class Global {
   // Manager instances for different responsibilities
@@ -39,6 +40,7 @@ export class Global {
   private pluginEffectManager: PluginEffectManager
   private pluginInstrumentManager: PluginInstrumentManager
   private sequenceEffectManager: SequenceEffectManager
+  private mixerManager: MixerManager
 
   // Shared transport clock — the single Date.now() origin for both the audio
   // scheduler and the MIDI scheduler, so they stay in sync (§1). MIDI sequences
@@ -76,6 +78,7 @@ export class Global {
       this.audioManager,
       this.linkAudioManager,
     )
+    this.mixerManager = new MixerManager(audioEngine, this.audioManager, this.linkAudioManager)
     this.quantizeManager = new QuantizeManager()
     this.midiManager = midiManager ?? new MidiManager()
     this.midiManager.setPluginOutputFactory(() => new PluginNoteOutput(audioEngine))
@@ -254,7 +257,8 @@ export class Global {
     if (
       this.pluginEffectManager.hasDeclaration() ||
       this.pluginInstrumentManager.hasDeclaration() ||
-      this.sequenceEffectManager.hasAnyDeclaration()
+      this.sequenceEffectManager.hasAnyDeclaration() ||
+      this.mixerManager.hasAnyDeclaration()
     ) {
       throw new Error(
         'global.linkAudio() cannot be used after plugin hosting has been declared in v1.',
@@ -289,6 +293,51 @@ export class Global {
    */
   async sequenceEffect(sequenceName: string, path: string, pluginId?: string): Promise<string> {
     return this.sequenceEffectManager.effect(sequenceName, path, pluginId)
+  }
+
+  /**
+   * Ensures a per-sequence bus is allocated without loading a plugin (MX.4/#459/#453 M3):
+   * used by `Sequence.output()`/`.send()` when `seq.effect()` was not declared, so
+   * `SetBusRouting` has a source bus to reference. @internal
+   */
+  ensureSequenceInsertBus(sequenceName: string): string {
+    return this.sequenceEffectManager.ensureBus(sequenceName)
+  }
+
+  /** Declares (or idempotently re-declares) a sum/group bus (MX.2, #459/#453 M3). */
+  sum(name: string): MixerBusHandle {
+    return this.mixerManager.sum(name)
+  }
+
+  /** Declares (or idempotently re-declares) an aux/return bus (MX.3, #459/#453 M3). */
+  aux(name: string): MixerBusHandle {
+    return this.mixerManager.aux(name)
+  }
+
+  /** Resolves a declared sum bus name to its allocated bus, or undefined if undeclared. @internal */
+  resolveSumBus(name: string): string | undefined {
+    return this.mixerManager.resolveSum(name)
+  }
+
+  /** Resolves a declared aux bus name to its allocated bus, or undefined if undeclared. @internal */
+  resolveAuxBus(name: string): string | undefined {
+    return this.mixerManager.resolveAux(name)
+  }
+
+  /**
+   * Issues (or re-issues) `SetBusRouting` for `seqBus` (MX.4/#459/#453 M3). `output` /
+   * `sends` should be the sequence's FULL current routing state — see
+   * `AudioEngine.setBusRouting`'s doc comment for why. @internal
+   */
+  async setBusRouting(
+    seqBus: string,
+    output: string | undefined,
+    sends: { bus: string; gain: number }[],
+  ): Promise<void> {
+    if (!this.audioEngine.setBusRouting) {
+      throw new Error('Mixer bus routing requires the Rust engine backend.')
+    }
+    await this.audioEngine.setBusRouting(seqBus, output, sends)
   }
 
   /**

--- a/packages/engine/src/core/global/mixer-manager.ts
+++ b/packages/engine/src/core/global/mixer-manager.ts
@@ -1,0 +1,206 @@
+import type { AudioEngine } from '../../audio/types'
+
+import { AudioManager } from './audio-manager'
+import { LinkAudioManager } from './link-audio-manager'
+import { resolvePluginPath, validatePluginExtension } from './plugin-resolver'
+
+/**
+ * `sum-bus-<n>` / `aux-bus-<n>` default pool prefixes. Must match
+ * `DEFAULT_SUM_BUS_POOL_PREFIX` / `DEFAULT_AUX_BUS_POOL_PREFIX` in
+ * `rust/crates/orbit-audio-daemon/src/engine_wrap.rs` (MX.4, #459/#453 M3) — changing
+ * one requires changing the other.
+ */
+export const SUM_BUS_PREFIX = 'sum-bus-'
+export const AUX_BUS_PREFIX = 'aux-bus-'
+
+/**
+ * v1 cap: at most 4 sum buses and 4 aux buses concurrently declared. Must match
+ * `DEFAULT_SUM_BUS_POOL_SIZE` / `DEFAULT_AUX_BUS_POOL_SIZE` in `engine_wrap.rs`.
+ */
+export const MIXER_BUS_POOL_SIZE = 4
+
+type MixerKind = 'sum' | 'aux'
+
+interface MixerBusDeclaration {
+  bus: string
+}
+
+interface MixerInsertDeclaration {
+  resolvedPath: string
+  pluginId?: string
+  load: Promise<void>
+}
+
+/** Returned by `global.sum(name)` / `global.aux(name)` and the bare `sum(name)` / `aux(name)` reference. */
+export interface MixerBusHandle {
+  readonly bus: string
+  /** Declares (or idempotently re-declares) the bus's own insert (MX.2/MX.3: v1 one insert). */
+  effect(path: string, pluginId?: string): Promise<MixerBusHandle>
+}
+
+/**
+ * Owns `global.sum(name)` / `global.aux(name)` declarations (MX.2/MX.3, #459/#453 M3): one
+ * bus per declared name, allocated from the daemon's default sum/aux bus pools
+ * (`sum-bus-0..3` / `aux-bus-0..3`). Mirrors `SequenceEffectManager`'s eager-load +
+ * idempotent-redeclare pattern, but keyed by declared name in two independent namespaces
+ * (sum vs. aux) instead of by sequence name.
+ *
+ * The bus's own insert (`sum("drum").effect(...)`) reuses the SAME `LoadPlugin` endpoint
+ * as `seq.effect()` (`role: 'effect', bus: <name>`) — the daemon does not distinguish insert
+ * vs. sum vs. aux kind when attaching a plugin to a bus (only `SetBusRouting` enforces kind),
+ * so no new engine-side wiring is needed for this half of M3.
+ */
+export class MixerManager {
+  private readonly sumBuses = new Map<string, MixerBusDeclaration>()
+  private readonly auxBuses = new Map<string, MixerBusDeclaration>()
+  private readonly sumInserts = new Map<string, MixerInsertDeclaration>() // keyed by bus name
+  private readonly auxInserts = new Map<string, MixerInsertDeclaration>() // keyed by bus name
+  private nextSumIndex = 0
+  private nextAuxIndex = 0
+  // Mirrors SequenceEffectManager's free-list rationale (#461 review Important): a failed
+  // declaration must not permanently consume a pool slot.
+  private freedSumBuses: string[] = []
+  private freedAuxBuses: string[] = []
+
+  constructor(
+    private readonly audioEngine: AudioEngine,
+    private readonly audioManager: AudioManager,
+    private readonly linkAudioManager: LinkAudioManager,
+  ) {}
+
+  /** Whether any sum or aux bus has been declared (used by `Global.linkAudio()`'s v1 exclusion gate). */
+  hasAnyDeclaration(): boolean {
+    return this.sumBuses.size > 0 || this.auxBuses.size > 0
+  }
+
+  /** Declares (or idempotently re-declares) a sum/group bus. MX.2: sum nesting is not supported in v1. */
+  sum(name: string): MixerBusHandle {
+    return this.declareBus('sum', name)
+  }
+
+  /** Declares (or idempotently re-declares) an aux/return bus. */
+  aux(name: string): MixerBusHandle {
+    return this.declareBus('aux', name)
+  }
+
+  /** Resolves a declared sum bus name to its allocated bus, or undefined if undeclared. */
+  resolveSum(name: string): string | undefined {
+    return this.sumBuses.get(name)?.bus
+  }
+
+  /** Resolves a declared aux bus name to its allocated bus, or undefined if undeclared. */
+  resolveAux(name: string): string | undefined {
+    return this.auxBuses.get(name)?.bus
+  }
+
+  private declareBus(kind: MixerKind, name: string): MixerBusHandle {
+    if (!name || !name.trim()) {
+      throw new Error(`global.${kind}(name) requires a non-empty name.`)
+    }
+    if (this.linkAudioManager.isEnabled()) {
+      throw new Error(`global.${kind}() cannot be used while LinkAudio is enabled in v1.`)
+    }
+
+    const buses = kind === 'sum' ? this.sumBuses : this.auxBuses
+    let declaration = buses.get(name)
+    if (!declaration) {
+      const freed = kind === 'sum' ? this.freedSumBuses : this.freedAuxBuses
+      const bus = freed.pop() ?? this.allocateFreshBus(kind, name)
+      declaration = { bus }
+      buses.set(name, declaration)
+    }
+    return this.makeHandle(kind, name, declaration.bus)
+  }
+
+  private allocateFreshBus(kind: MixerKind, name: string): string {
+    const index = kind === 'sum' ? this.nextSumIndex : this.nextAuxIndex
+    if (index >= MIXER_BUS_POOL_SIZE) {
+      throw new Error(
+        `global.${kind}("${name}"): ${kind} bus pool exhausted — v1 supports at most ` +
+          `${MIXER_BUS_POOL_SIZE} concurrent ${kind} buses.`,
+      )
+    }
+    if (kind === 'sum') {
+      this.nextSumIndex += 1
+      return `${SUM_BUS_PREFIX}${index}`
+    }
+    this.nextAuxIndex += 1
+    return `${AUX_BUS_PREFIX}${index}`
+  }
+
+  private makeHandle(kind: MixerKind, name: string, bus: string): MixerBusHandle {
+    return {
+      bus,
+      effect: (path: string, pluginId?: string) => this.effectFor(kind, name, bus, path, pluginId),
+    }
+  }
+
+  private async effectFor(
+    kind: MixerKind,
+    name: string,
+    bus: string,
+    spec: string,
+    pluginId: string | undefined,
+  ): Promise<MixerBusHandle> {
+    // Order mirrors PluginEffectManager.effect() / SequenceEffectManager.effect(): validate
+    // the spec, gate on LinkAudio (declaration order can't produce this in practice since
+    // declareBus() already gated, but a respawn/reload path could re-run effect() alone),
+    // then resolve the path.
+    validatePluginExtension(spec, 'effect')
+
+    if (this.linkAudioManager.isEnabled()) {
+      throw new Error(
+        `${kind}("${name}").effect() cannot be used while LinkAudio is enabled in v1.`,
+      )
+    }
+
+    const resolvedPath = resolvePluginPath(
+      spec,
+      this.audioManager.getAudioPaths(),
+      this.audioManager.getDocumentDirectory(),
+      'effect',
+    )
+
+    const inserts = kind === 'sum' ? this.sumInserts : this.auxInserts
+    const existing = inserts.get(bus)
+    if (existing) {
+      if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
+        await existing.load
+        if (this.audioEngine.isPluginActive?.('effect', bus) === false) {
+          await this.issueLoad(kind, bus, resolvedPath, pluginId)
+        }
+        return this.makeHandle(kind, name, bus)
+      }
+      throw new Error(
+        `${kind}("${name}").effect() supports one insert per bus in v1; chains (multiple ` +
+          `inserts) are reserved for future support.`,
+      )
+    }
+
+    await this.issueLoad(kind, bus, resolvedPath, pluginId)
+    return this.makeHandle(kind, name, bus)
+  }
+
+  private async issueLoad(
+    kind: MixerKind,
+    bus: string,
+    resolvedPath: string,
+    pluginId: string | undefined,
+  ): Promise<void> {
+    if (!this.audioEngine.loadPlugin) {
+      throw new Error('Plugin hosting requires the Rust engine backend.')
+    }
+    const inserts = kind === 'sum' ? this.sumInserts : this.auxInserts
+    const load = this.audioEngine
+      .loadPlugin(resolvedPath, pluginId, 'effect', bus)
+      .then(() => undefined)
+    const declaration: MixerInsertDeclaration = { resolvedPath, pluginId, load }
+    inserts.set(bus, declaration)
+    try {
+      await load
+    } catch (err) {
+      if (inserts.get(bus) === declaration) inserts.delete(bus)
+      throw err
+    }
+  }
+}

--- a/packages/engine/src/core/global/sequence-effect-manager.ts
+++ b/packages/engine/src/core/global/sequence-effect-manager.ts
@@ -21,7 +21,9 @@ export const SEQUENCE_EFFECT_BUS_POOL_SIZE = 8
 
 interface SeqEffectDeclaration {
   bus: string
-  resolvedPath: string
+  // undefined = passthrough-only (bus allocated via `ensureBus()`, no plugin loaded yet —
+  // MX.4/#459/#453 M3: `seq.output()`/`seq.send()` on a sequence without `seq.effect()`).
+  resolvedPath?: string
   pluginId?: string
   load: Promise<void>
 }
@@ -62,6 +64,23 @@ export class SequenceEffectManager {
     return this.declarations.get(sequenceName)?.bus
   }
 
+  /**
+   * Ensures a per-sequence bus is allocated WITHOUT loading a plugin into it (MX.4/#459/#453
+   * M3): `seq.output(sum)` / `seq.send(aux, gain)` need a bus to route from even when
+   * `seq.effect()` was never declared (a "pass-through insert" — DAW-style track with no
+   * insert plugin but still a routable channel). Idempotent — returns the existing bus
+   * whether it is a passthrough-only allocation or already has a real insert loaded via
+   * `effect()`. If `effect()` is called later for the same sequence, it upgrades this same
+   * bus in place instead of allocating a second one (see `effect()` below).
+   */
+  ensureBus(sequenceName: string): string {
+    const existing = this.declarations.get(sequenceName)
+    if (existing) return existing.bus
+    const bus = this.freedBuses.pop() ?? this.allocateFreshBus(sequenceName)
+    this.declarations.set(sequenceName, { bus, load: Promise.resolve() })
+    return bus
+  }
+
   /** Declares (or idempotently re-declares) the insert for `sequenceName`. Returns the allocated bus name. */
   async effect(sequenceName: string, spec: string, pluginId?: string): Promise<string> {
     // Order mirrors PluginEffectManager.effect(): validate the spec, gate on
@@ -82,7 +101,9 @@ export class SequenceEffectManager {
     )
 
     const existing = this.declarations.get(sequenceName)
-    if (existing) {
+    // A passthrough-only declaration (from ensureBus(), no resolvedPath yet) is not a real
+    // insert — upgrade it in place instead of treating it as an existing insert declaration.
+    if (existing && existing.resolvedPath !== undefined) {
       if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
         await existing.load
         // Self-heal on stale cache after a daemon respawn (see PluginEffectManager
@@ -99,13 +120,21 @@ export class SequenceEffectManager {
       )
     }
 
-    const bus = this.freedBuses.pop() ?? this.allocateFreshBus(sequenceName)
+    const wasPassthrough = existing !== undefined
+    const bus = existing?.bus ?? this.freedBuses.pop() ?? this.allocateFreshBus(sequenceName)
     try {
       await this.issueLoad(sequenceName, bus, resolvedPath, pluginId)
     } catch (err) {
-      // ロールバック: 失敗した宣言の bus を free-list に返す（daemon 側も activation を
-      // 巻き戻すため、両側の状態が対称に戻る）。
-      this.freedBuses.push(bus)
+      if (wasPassthrough) {
+        // ロールバック: passthrough から昇格しようとして失敗した場合は bus を pool に
+        // 戻さず、passthrough 状態に戻す（seq.output()/seq.send() の routing がまだその
+        // bus を参照しているため — bus 自体は生き続ける必要がある）。
+        this.declarations.set(sequenceName, { bus, load: Promise.resolve() })
+      } else {
+        // 新規割当が失敗した場合は free-list に返す（daemon 側も activation を巻き戻す
+        // ため、両側の状態が対称に戻る）。
+        this.freedBuses.push(bus)
+      }
       throw err
     }
     return bus

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -94,8 +94,15 @@ export class Sequence {
   // LinkAudio output channel (only meaningful when Global.linkAudio() is enabled)
   private _outputChannel?: string
 
-  // per-sequence insert bus (only meaningful when seq.effect() was declared — PH.2b / #434 S3)
+  // per-sequence insert bus (only meaningful when seq.effect() was declared — PH.2b / #434 S3;
+  // or auto-allocated by `output()`/`send()` targeting a sum/aux bus — MX.4 / #459/#453 M3)
   private _insertBus?: string
+
+  // MX.4/#459/#453 M3: the sum bus target for `SetBusRouting` (set by `output(sumName)`),
+  // and the accumulated aux sends (set by `send(auxName, amount)`). Kept so every
+  // `SetBusRouting` re-issue carries the FULL current routing state (idempotent re-send).
+  private _sumOutputBus?: string
+  private readonly _auxSends = new Map<string, number>()
 
   // MIDI properties (only meaningful when seq.midi() was declared).
   // A MIDI sequence interprets play() values as degrees, not slice numbers.
@@ -295,24 +302,41 @@ export class Sequence {
   }
 
   /**
-   * Set the LinkAudio output channel name for this sequence.
+   * Set the LinkAudio output channel name for this sequence, OR (MX.2, #459/#453 M3) route
+   * this sequence's per-seq insert bus to a declared sum/group bus.
    *
-   * Effective only when `Global.linkAudio()` was declared earlier in the same
-   * .orbs file. Without that declaration the assignment is recorded but the
-   * sequence still routes through the hardware bus, and a runtime warning is
-   * emitted on each call when LinkAudio mode is not enabled. Multiple sequences
-   * sharing the same channel name are summed by the SC plugin.
+   * Name resolution (MX.2): if `channelName` matches a `global.sum(name)` declaration, this
+   * routes to that group bus via `SetBusRouting` (v1 mutual exclusion with LinkAudio means
+   * only one of the two branches below can ever apply). Otherwise, the existing LinkAudio
+   * egress-channel behavior applies unchanged: effective only when `Global.linkAudio()` was
+   * declared earlier in the same .orbs file; without that declaration the assignment is
+   * recorded but the sequence still routes through the hardware bus, and a runtime warning
+   * is emitted. Multiple sequences sharing the same channel name are summed by the SC plugin.
    *
-   * Channel changes take effect at the next scheduling cycle; in-flight loop
-   * iterations are not rewritten (no `seamlessParameterUpdate` — channel
-   * switching mid-loop is a separate feature, planned for Step 3.4).
+   * Channel/routing changes take effect at the next scheduling cycle; in-flight loop
+   * iterations are not rewritten (no `seamlessParameterUpdate` — mid-loop switching is a
+   * separate feature, planned for Step 3.4).
    */
   output(channelName: string): this {
+    const name = this.stateManager.getName() || 'sequence'
     if (!channelName || !channelName.trim()) {
-      throw new Error(
-        `Sequence '${this.stateManager.getName() || 'sequence'}': output(channelName) requires a non-empty channel name.`,
-      )
+      throw new Error(`Sequence '${name}': output(channelName) requires a non-empty channel name.`)
     }
+
+    const sumBus = this.global.resolveSumBus(channelName)
+    if (sumBus) {
+      if (this.isNoteSequence()) {
+        throw new Error(
+          `Sequence '${name}': output("${channelName}") to a sum bus is only supported on ` +
+            `audio sequences in v1 (not midi()/instrument() sequences).`,
+        )
+      }
+      this._insertBus = this._insertBus ?? this.global.ensureSequenceInsertBus(name)
+      this._sumOutputBus = sumBus
+      this.syncBusRouting()
+      return this
+    }
+
     this._outputChannel = channelName
     if (this.global.isLinkAudioEnabled()) {
       // Eagerly register the channel with the plugin so its source appears in
@@ -321,13 +345,13 @@ export class Sequence {
       // the dispatch path re-registers idempotently if this races the boot.
       this.audioEngine.registerLinkAudioChannel?.(channelName)?.catch((err) => {
         console.warn(
-          `⚠️  ${this.stateManager.getName() || 'sequence'}.output("${channelName}"): ` +
+          `⚠️  ${name}.output("${channelName}"): ` +
             `eager LinkAudio channel registration failed (will retry on playback): ${err}`,
         )
       })
     } else {
       console.warn(
-        `⚠️  ${this.stateManager.getName() || 'sequence'}.output("${channelName}") ` +
+        `⚠️  ${name}.output("${channelName}") ` +
           `was called without 'global.linkAudio()'. The channel name is recorded ` +
           `but will not take effect until LinkAudio mode is declared.`,
       )
@@ -337,6 +361,60 @@ export class Sequence {
 
   getOutputChannel(): string | undefined {
     return this._outputChannel
+  }
+
+  /**
+   * Add a send to a declared aux/return bus (MX.3, #459/#453 M3). Post-fader fixed (after
+   * this sequence's own insert, if any). Multiple sends fan out (repeated calls with
+   * different `auxName` accumulate; the same `auxName` overwrites its gain). Audio
+   * sequences only (mirrors `seq.effect()` / sum-routing restriction).
+   */
+  send(auxName: string, amount: number): this {
+    const name = this.stateManager.getName() || 'sequence'
+    if (!auxName || !auxName.trim()) {
+      throw new Error(`Sequence '${name}': send(auxName, amount) requires a non-empty aux name.`)
+    }
+    if (this.isNoteSequence()) {
+      throw new Error(
+        `Sequence '${name}': send() is only supported on audio sequences in v1 (not ` +
+          `midi()/instrument() sequences).`,
+      )
+    }
+    const auxBus = this.global.resolveAuxBus(auxName)
+    if (!auxBus) {
+      throw new Error(
+        `Sequence '${name}': send("${auxName}", ...) references an undeclared aux bus. ` +
+          `Call global.aux("${auxName}") first.`,
+      )
+    }
+    if (!Number.isFinite(amount)) {
+      throw new Error(`Sequence '${name}': send("${auxName}", ${amount}) gain must be finite.`)
+    }
+
+    this._insertBus = this._insertBus ?? this.global.ensureSequenceInsertBus(name)
+    this._auxSends.set(auxBus, amount)
+    this.syncBusRouting()
+    return this
+  }
+
+  /**
+   * Re-issues `SetBusRouting` with the FULL current routing state (output + all sends) for
+   * this sequence's insert bus (MX.4/#459/#453 M3). Fire-and-forget + best-effort, mirroring
+   * `output()`'s eager LinkAudio registration: a failed push must not break the synchronous
+   * `.method().method()` chaining contract these calls share with the rest of the DSL.
+   */
+  private syncBusRouting(): void {
+    if (!this._insertBus) return
+    const bus = this._insertBus
+    const sends = Array.from(this._auxSends.entries()).map(([sendBus, gain]) => ({
+      bus: sendBus,
+      gain,
+    }))
+    void this.global.setBusRouting(bus, this._sumOutputBus, sends).catch((err) => {
+      console.warn(
+        `⚠️  ${this.stateManager.getName() || 'sequence'}: SetBusRouting(${bus}) failed: ${err}`,
+      )
+    })
   }
 
   /**

--- a/packages/engine/src/core/sequence.ts
+++ b/packages/engine/src/core/sequence.ts
@@ -7,6 +7,7 @@
 import * as path from 'path'
 
 import { AudioEngine } from '../audio/types'
+import { DaemonProtocolError } from '../audio/rust-engine/errors'
 import { PlayElement, RandomValue } from '../parser/audio-parser'
 import { resolveDegree } from '../midi/degree-resolution'
 import { resolveChords, cloneElement } from '../midi/chord/resolve-chords'
@@ -103,6 +104,11 @@ export class Sequence {
   // `SetBusRouting` re-issue carries the FULL current routing state (idempotent re-send).
   private _sumOutputBus?: string
   private readonly _auxSends = new Map<string, number>()
+  /**
+   * 直近の `syncBusRouting` が失敗し、TS 側の routing 宣言と daemon の実 routing が乖離して
+   * いる可能性がある状態（true の間）。再生開始時（dispatch 前）に検知して全量再送する。
+   */
+  private _busRoutingStale = false
 
   // MIDI properties (only meaningful when seq.midi() was declared).
   // A MIDI sequence interprets play() values as degrees, not slice numbers.
@@ -410,11 +416,31 @@ export class Sequence {
       bus: sendBus,
       gain,
     }))
-    void this.global.setBusRouting(bus, this._sumOutputBus, sends).catch((err) => {
-      console.warn(
-        `⚠️  ${this.stateManager.getName() || 'sequence'}: SetBusRouting(${bus}) failed: ${err}`,
-      )
-    })
+    void this.global.setBusRouting(bus, this._sumOutputBus, sends).then(
+      () => {
+        this._busRoutingStale = false
+      },
+      (err) => {
+        // 失敗＝TS 側の宣言（_sumOutputBus/_auxSends）と daemon の実 routing が乖離した状態。
+        // stale フラグを立て、次の routing 呼び出しまたは再生開始時に全量再送で自己修復する
+        // （`pluginActiveByKey` の self-heal と同じ形）。
+        this._busRoutingStale = true
+        const name = this.stateManager.getName() || 'sequence'
+        if (err instanceof DaemonProtocolError) {
+          // daemon 側の決定的な拒否（kind/順序違反・非 outproc-effect ビルドの UNSUPPORTED 等）。
+          // 再送しても同じ結果＝スクリプト側の修正が必要なので、actionable な error で出す。
+          console.error(
+            `❌ ${name}: SetBusRouting(${bus}) was rejected — routing was NOT applied. ` +
+              `Fix the declaration and re-run .output()/.send(): ${err.message}`,
+          )
+        } else {
+          console.warn(
+            `⚠️  ${name}: SetBusRouting(${bus}) failed (transient) — ` +
+              `will re-sync on the next routing call or playback start: ${err}`,
+          )
+        }
+      },
+    )
   }
 
   /**
@@ -1384,6 +1410,9 @@ export class Sequence {
     this.validateMidiDispatch() // eager root + degree validation (same rationale)
     this.applyVoiceLeading() // §6.3 (C1): deterministic auto voice-leading annotation
     this.validateNonMidiDispatch() // eager `[ ]`-in-audio rejection (§10-5)
+    // 直近の SetBusRouting が失敗していたら、音が出る前に全量再送で自己修復する
+    // （transient 失敗の回復経路。決定的拒否は再送しても同じ error log が出るだけで無害）。
+    if (this._busRoutingStale) this.syncBusRouting()
 
     const prepared = await preparePlayback({
       sequenceName: this.stateManager.getName(),
@@ -1428,6 +1457,9 @@ export class Sequence {
     this.validateMidiDispatch() // eager root + degree validation (same rationale)
     this.applyVoiceLeading() // §6.3 (C1): deterministic auto voice-leading annotation
     this.validateNonMidiDispatch() // eager `[ ]`-in-audio rejection (§10-5)
+    // 直近の SetBusRouting が失敗していたら、音が出る前に全量再送で自己修復する
+    // （transient 失敗の回復経路。決定的拒否は再送しても同じ error log が出るだけで無害）。
+    if (this._busRoutingStale) this.syncBusRouting()
 
     const prepared = await preparePlayback({
       sequenceName: this.stateManager.getName(),

--- a/packages/engine/src/interpreter/process-statement.ts
+++ b/packages/engine/src/interpreter/process-statement.ts
@@ -12,6 +12,7 @@ import {
   PatternBinding,
   ModeBinding,
   ImportStatement,
+  MixerHandleStatement,
 } from '../parser/audio-parser'
 
 import { InterpreterState } from './types'
@@ -69,6 +70,9 @@ export async function processStatement(
     case 'mode_binding':
       processModeBinding(statement, state)
       break
+    case 'mixer_handle':
+      await processMixerHandleStatement(statement, state)
+      break
     default:
       // TypeScript should prevent this, but handle gracefully at runtime
       console.warn(`Unknown statement type: ${(statement as any).type}`)
@@ -125,6 +129,28 @@ function processModeBinding(statement: ModeBinding, state: InterpreterState): vo
     statement.lattice,
     statement.period,
   )
+}
+
+/**
+ * Process a bare `sum("name")` / `aux("name")` reference (MX.2/MX.3, #459/#453 M3):
+ * `global.sum(name)`/`global.aux(name)` is a `GlobalStatement` (target-prefixed), but this
+ * bare form has no `global`-variable prefix — it always operates on `state.currentGlobal`
+ * (mirrors `import chords` / the chord-binding handlers above).
+ */
+async function processMixerHandleStatement(
+  statement: MixerHandleStatement,
+  state: InterpreterState,
+): Promise<void> {
+  const global = requireGlobal(state, `${statement.kind}("${statement.name}")`)
+  if (!global) return
+
+  let result: any = await callMethod(global, statement.kind, [statement.name])
+
+  if (statement.chain) {
+    for (const chainedCall of statement.chain) {
+      result = await callMethod(result, chainedCall.method, chainedCall.args)
+    }
+  }
 }
 
 /**

--- a/packages/engine/src/parser/audio-parser.ts
+++ b/packages/engine/src/parser/audio-parser.ts
@@ -29,6 +29,7 @@ export type {
   PatternBinding,
   ModeBinding,
   ImportStatement,
+  MixerHandleStatement,
   MethodChain,
   RandomValue,
   PlayElement,

--- a/packages/engine/src/parser/parse-statement.ts
+++ b/packages/engine/src/parser/parse-statement.ts
@@ -342,6 +342,17 @@ export class StatementParser {
 
     this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
 
+    // Bare `sum("drum")` / `aux("rev")` reference (MX.2/MX.3, #459/#453 M3): no `.method`
+    // dot — the identifier itself is called directly, then (optionally) chained, e.g.
+    // `sum("drum").effect("GlueComp.clap")`. Must be checked before the DOT requirement
+    // below since this form has no dot after the target identifier.
+    if (
+      (target === 'sum' || target === 'aux') &&
+      ParserUtils.current(this.tokens, this.pos).type === 'LPAREN'
+    ) {
+      return this.parseMixerHandleReference(target)
+    }
+
     if (ParserUtils.current(this.tokens, this.pos).type !== 'DOT') {
       // Identifier without method call (invalid syntax, skip it)
       return { statement: null, newPos: this.pos }
@@ -455,6 +466,33 @@ export class StatementParser {
       result.chain = chain
     }
 
+    return { statement: result, newPos: this.pos }
+  }
+
+  /**
+   * Parse a bare `sum("name")` / `aux("name")` reference (MX.2/MX.3, #459/#453 M3):
+   * `kind("name")[.method(args)[.method(args)...]]`. Reconciliation key is the name —
+   * this always resolves against the SAME sum/aux declared via `global.sum(name)` /
+   * `global.aux(name)` (a plain `GlobalStatement`), never a new one.
+   */
+  private parseMixerHandleReference(kind: 'sum' | 'aux'): {
+    statement: Statement
+    newPos: number
+  } {
+    const argsResult = this.parseArguments()
+    this.pos = argsResult.newPos
+    if (argsResult.args.length !== 1 || typeof argsResult.args[0] !== 'string') {
+      throw new Error(`${kind}(name) requires exactly one string argument (the bus name).`)
+    }
+    const name = argsResult.args[0]
+
+    this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
+    const chain = this.parseMethodChain()
+
+    const result: any = { type: 'mixer_handle', kind, name }
+    if (chain.length > 0) {
+      result.chain = chain
+    }
     return { statement: result, newPos: this.pos }
   }
 

--- a/packages/engine/src/parser/types.ts
+++ b/packages/engine/src/parser/types.ts
@@ -70,6 +70,22 @@ export type Statement =
   | PatternBinding
   | ModeBinding
   | ImportStatement
+  | MixerHandleStatement
+
+/**
+ * Bare `sum("drum")` / `aux("rev")` reference (MX.2/MX.3, #459/#453 M3) — used to add the
+ * group/return bus's own insert: `sum("drum").effect("GlueComp.clap")`. Distinct from
+ * `global.sum(name)` / `global.aux(name)` (the declaration form, parsed as a plain
+ * `GlobalStatement`): this bare form has no `global`-variable prefix, so there is no
+ * `target` to resolve against `state.globals` — it always operates on `state.currentGlobal`
+ * (§ interpreter `requireGlobal`, mirrors `import chords` / chord bindings).
+ */
+export type MixerHandleStatement = {
+  type: 'mixer_handle'
+  kind: 'sum' | 'aux'
+  name: string
+  chain?: MethodChain[]
+}
 
 /**
  * `var NAME = [ ... ]` — a chord-value binding (§6, bare `[ ]` literal, decision #48).

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -341,23 +341,35 @@ fn parse_named_bus_pool_size(env_name: &str, raw: &str, default: usize) -> Resul
 /// `ORBIT_SUM_BUS_POOL`（既定 4）から `sum-bus-0..N-1` の既定プール名を組み立てる。
 #[cfg(feature = "outproc-effect")]
 fn sum_bus_pool_from_env() -> Result<Vec<String>, WrapError> {
-    let raw = std::env::var("ORBIT_SUM_BUS_POOL").unwrap_or_default();
-    let n = parse_named_bus_pool_size("ORBIT_SUM_BUS_POOL", &raw, DEFAULT_SUM_BUS_POOL_SIZE)
-        .map_err(WrapError::OutProcEffect)?;
-    Ok((0..n)
-        .map(|i| format!("{DEFAULT_SUM_BUS_POOL_PREFIX}{i}"))
-        .collect())
+    named_bus_pool_from_env(
+        "ORBIT_SUM_BUS_POOL",
+        DEFAULT_SUM_BUS_POOL_SIZE,
+        DEFAULT_SUM_BUS_POOL_PREFIX,
+    )
 }
 
 /// `ORBIT_AUX_BUS_POOL`（既定 4）から `aux-bus-0..N-1` の既定プール名を組み立てる。
 #[cfg(feature = "outproc-effect")]
 fn aux_bus_pool_from_env() -> Result<Vec<String>, WrapError> {
-    let raw = std::env::var("ORBIT_AUX_BUS_POOL").unwrap_or_default();
-    let n = parse_named_bus_pool_size("ORBIT_AUX_BUS_POOL", &raw, DEFAULT_AUX_BUS_POOL_SIZE)
+    named_bus_pool_from_env(
+        "ORBIT_AUX_BUS_POOL",
+        DEFAULT_AUX_BUS_POOL_SIZE,
+        DEFAULT_AUX_BUS_POOL_PREFIX,
+    )
+}
+
+/// env 名 + 既定サイズ + prefix から `<prefix>0..N-1` の既定プール名を組み立てる共通体
+/// （/simplify: sum/aux の同一実装を単一化・命名スキーム変更時のドリフト防止）。
+#[cfg(feature = "outproc-effect")]
+fn named_bus_pool_from_env(
+    env_name: &str,
+    default_size: usize,
+    prefix: &str,
+) -> Result<Vec<String>, WrapError> {
+    let raw = std::env::var(env_name).unwrap_or_default();
+    let n = parse_named_bus_pool_size(env_name, &raw, default_size)
         .map_err(WrapError::OutProcEffect)?;
-    Ok((0..n)
-        .map(|i| format!("{DEFAULT_AUX_BUS_POOL_PREFIX}{i}"))
-        .collect())
+    Ok((0..n).map(|i| format!("{prefix}{i}")).collect())
 }
 
 /// 1 本の named bus stage（insert/sum/aux 共通）を構成する部材（`build_effect_bus_stages` →

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -791,6 +791,46 @@ mod set_bus_routing_tests {
         let message = format!("{error:?}");
         assert!(message.contains("unknown bus"), "{message}");
     }
+
+    /// M3（#459/#453）: `SetBusRouting` は参照された bus（seq_bus 自身・output 先・send 先）を
+    /// activation する（`LoadPlugin` 未実行の pass-through bus でも routing が render 対象になる）。
+    #[test]
+    fn set_bus_routing_activates_seq_bus_and_referenced_targets() {
+        let wrap = wrap_with_three_stage_topology();
+        let seq_active = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let sum_active = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let aux_active = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        {
+            let mut guard = wrap.outproc.lock().unwrap();
+            let control = guard.as_mut().unwrap();
+            control
+                .bus_actives
+                .insert("seq-bus-0".to_owned(), seq_active.clone());
+            control
+                .bus_actives
+                .insert("sum-bus-0".to_owned(), sum_active.clone());
+            control
+                .bus_actives
+                .insert("aux-bus-0".to_owned(), aux_active.clone());
+        }
+
+        wrap.set_bus_routing(
+            "seq-bus-0",
+            Some("sum-bus-0"),
+            &[("aux-bus-0".to_owned(), 0.5)],
+        )
+        .expect("routing with output + send must be accepted");
+
+        assert!(seq_active.load(Ordering::Acquire), "seq_bus must activate");
+        assert!(
+            sum_active.load(Ordering::Acquire),
+            "output target must activate"
+        );
+        assert!(
+            aux_active.load(Ordering::Acquire),
+            "send target must activate"
+        );
+    }
 }
 
 #[cfg(feature = "outproc-instrument")]
@@ -2247,6 +2287,20 @@ impl EngineWrap {
                     ))
                 })?;
                 slot.store(gain.to_bits(), Ordering::Relaxed);
+            }
+        }
+
+        // 4. activation（M3・#459/#453）: `SetBusRouting` は `LoadPlugin` と同じ activation 機構を
+        //    共有する（MX.4）。plugin 未ロードの pass-through bus（insert 未宣言の seq が
+        //    `seq.output`/`seq.send` だけを持つケース）でも routing が生きるよう、参照された bus
+        //    （seq_bus 自身・output 先・send 先）を render 対象に含める。既に active な bus への
+        //    再 store は無害（RT 経路は bool load のみ）。
+        for name in std::iter::once(seq_bus)
+            .chain(output)
+            .chain(sends.iter().map(|(name, _)| name.as_str()))
+        {
+            if let Some(active) = control.bus_actives.get(name) {
+                active.store(true, Ordering::Release);
             }
         }
         Ok(())

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -6,6 +6,8 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+#[cfg(feature = "outproc-effect")]
+use std::sync::atomic::{AtomicU32, AtomicUsize};
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
 use std::sync::MutexGuard;
 #[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
@@ -211,6 +213,17 @@ struct OutProcControl {
     /// bus を指名した時点で `true`（宣言 = activation）。全 bus inactive の間、callback は
     /// bus 無し経路（ビット同一）を通る。
     bus_actives: HashMap<String, Arc<std::sync::atomic::AtomicBool>>,
+    /// bus 名 → kind（M2・#459/#453）。`SetBusRouting` の検証（output は sum のみ・send 先は
+    /// aux のみ許可・MX.4）に使う。
+    bus_kinds: HashMap<String, BusKind>,
+    /// bus 名 → stage 配列内の絶対 index（M2）。forward-only（後方参照のみ・MX.4）の検証に使う。
+    bus_index: HashMap<String, usize>,
+    /// bus 名 → render 側 `InsertBusStage::routing_override` と共有する atomic ハンドル（M2）。
+    /// `SetBusRouting` がここを書き換えて output target を実行時に切替える。
+    bus_routing: HashMap<String, Arc<AtomicUsize>>,
+    /// bus 名 → render 側 `InsertBusStage::send_gain_overrides` と共有する atomic ハンドル群
+    /// （M2・index k = 「この bus の絶対 index + 1 + k」への send gain）。
+    bus_sends: HashMap<String, Vec<Arc<AtomicU32>>>,
 }
 
 /// `ORBIT_EFFECT_BUSES` の値を解析する純関数。カンマ区切りの bus 名を trim・空要素除去した上で、
@@ -283,11 +296,77 @@ fn effect_buses_from_env() -> Result<Vec<String>, WrapError> {
     Ok(default_effect_bus_pool(pool_size))
 }
 
-/// 1 本の named insert bus を構成する部材（`build_effect_bus_stages` → `install_effect_bus_slots`
-/// の間で運ぶ・#434 S2/S3）。effect-only / both の両起動経路で同一のライフサイクルを共有する。
+/// bus のグラフ上の役割（#459/#453 M2）。`insert` = 既存の per-seq effect bus（PH.2b・#434）・
+/// `sum` = 複数 insert の合流点（`seq.output(sum)`）・`aux` = post-fader send 先（`seq.send(aux, gain)`）。
+/// 名前 prefix（`seq-bus-`/`sum-bus-`/`aux-bus-`）からも判別できるが、`SetBusRouting` の検証
+/// （output は sum のみ・send 先は aux のみ許可・MX.4）を prefix 文字列比較に依存させないため、
+/// 構築時に確定した値として明示的に持つ。
+#[cfg(feature = "outproc-effect")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BusKind {
+    Insert,
+    Sum,
+    Aux,
+}
+
+/// `sum-bus-<n>` 既定プールの名前 prefix。TS 側 `seq.output(sum)` が同じ規則で名前を組み立てる
+/// （M3 で配線予定）。
+#[cfg(feature = "outproc-effect")]
+pub const DEFAULT_SUM_BUS_POOL_PREFIX: &str = "sum-bus-";
+/// `aux-bus-<n>` 既定プールの名前 prefix。TS 側 `seq.send(aux, gain)` が同じ規則で名前を組み立てる
+/// （M3 で配線予定）。
+#[cfg(feature = "outproc-effect")]
+pub const DEFAULT_AUX_BUS_POOL_PREFIX: &str = "aux-bus-";
+/// `ORBIT_SUM_BUS_POOL` の既定サイズ（未設定時）。
+#[cfg(feature = "outproc-effect")]
+const DEFAULT_SUM_BUS_POOL_SIZE: usize = 4;
+/// `ORBIT_AUX_BUS_POOL` の既定サイズ（未設定時）。
+#[cfg(feature = "outproc-effect")]
+const DEFAULT_AUX_BUS_POOL_SIZE: usize = 4;
+
+/// `ORBIT_SUM_BUS_POOL` / `ORBIT_AUX_BUS_POOL` に共通のプールサイズ解析（`parse_effect_bus_pool_size`
+/// と同じ規則: 空 = 既定値・非数値/負値はエラー）。env 名をメッセージに含めるため呼び出し側が
+/// 渡す（`ORBIT_EFFECT_BUS_POOL` 用の既存関数と重複させない）。
+#[cfg(feature = "outproc-effect")]
+fn parse_named_bus_pool_size(env_name: &str, raw: &str, default: usize) -> Result<usize, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(default);
+    }
+    trimmed
+        .parse::<usize>()
+        .map_err(|_| format!("{env_name} must be a non-negative integer, got '{raw}'"))
+}
+
+/// `ORBIT_SUM_BUS_POOL`（既定 4）から `sum-bus-0..N-1` の既定プール名を組み立てる。
+#[cfg(feature = "outproc-effect")]
+fn sum_bus_pool_from_env() -> Result<Vec<String>, WrapError> {
+    let raw = std::env::var("ORBIT_SUM_BUS_POOL").unwrap_or_default();
+    let n = parse_named_bus_pool_size("ORBIT_SUM_BUS_POOL", &raw, DEFAULT_SUM_BUS_POOL_SIZE)
+        .map_err(WrapError::OutProcEffect)?;
+    Ok((0..n)
+        .map(|i| format!("{DEFAULT_SUM_BUS_POOL_PREFIX}{i}"))
+        .collect())
+}
+
+/// `ORBIT_AUX_BUS_POOL`（既定 4）から `aux-bus-0..N-1` の既定プール名を組み立てる。
+#[cfg(feature = "outproc-effect")]
+fn aux_bus_pool_from_env() -> Result<Vec<String>, WrapError> {
+    let raw = std::env::var("ORBIT_AUX_BUS_POOL").unwrap_or_default();
+    let n = parse_named_bus_pool_size("ORBIT_AUX_BUS_POOL", &raw, DEFAULT_AUX_BUS_POOL_SIZE)
+        .map_err(WrapError::OutProcEffect)?;
+    Ok((0..n)
+        .map(|i| format!("{DEFAULT_AUX_BUS_POOL_PREFIX}{i}"))
+        .collect())
+}
+
+/// 1 本の named bus stage（insert/sum/aux 共通）を構成する部材（`build_effect_bus_stages` →
+/// `install_effect_bus_slots` の間で運ぶ・#434 S2/S3・M2 で kind/routing を追加）。
+/// effect-only / both の両起動経路で同一のライフサイクルを共有する。
 #[cfg(feature = "outproc-effect")]
 struct EffectBusBuild {
     name: String,
+    kind: BusKind,
     shm_path: std::path::PathBuf,
     engaged: Arc<std::sync::atomic::AtomicBool>,
     stop: Arc<std::sync::atomic::AtomicBool>,
@@ -297,20 +376,47 @@ struct EffectBusBuild {
     /// `true`（宣言 = activation → 以降 pass-through）。それまで callback は bus を
     /// render 対象に含めない = 既定プールのコストゼロ。
     active: Arc<std::sync::atomic::AtomicBool>,
+    /// render 側 `InsertBusStage::routing_override` と共有（M2）。`SetBusRouting` が
+    /// control 側からこの Arc を書き換えて実行時に output target を切替える。
+    routing_override: Arc<AtomicUsize>,
+    /// render 側 `InsertBusStage::send_gain_overrides` と共有（M2・index k = 「この stage の
+    /// 絶対 index + 1 + k」への send gain）。`SetBusRouting` が該当 index の Arc を書き換える。
+    send_gain_overrides: Vec<Arc<AtomicU32>>,
 }
 
-/// `ORBIT_EFFECT_BUSES` / 既定プールの bus 名から、render 側の `InsertBusStage` 群と
-/// daemon 側の部材（`EffectBusBuild`）を構築する。stage は inactive で生まれ、LoadPlugin
-/// （`load_outproc_effect_plugin` の bus 指定）で activate される。
+/// `ORBIT_EFFECT_BUSES`/`ORBIT_EFFECT_BUS_POOL`（insert）+ `ORBIT_SUM_BUS_POOL`（sum）+
+/// `ORBIT_AUX_BUS_POOL`（aux）の bus 名から、render 側の `InsertBusStage` 群と daemon 側の部材
+/// （`EffectBusBuild`）を構築する。**stage 配列の並びは `[insert…, sum…, aux…]` に固定**する
+/// （MX.4: insert → sum/aux への forward-only 参照が常に構築可能になるよう、insert を先頭に
+/// 置く）。stage は inactive で生まれ、LoadPlugin（`load_outproc_effect_plugin` の bus 指定）
+/// で activate される。sum/aux stage も同じ `OutProcEffectPostProcessor` 機構（PH.2b）で
+/// 自前の insert chain を持てる（M2 で明示解禁）。
 #[cfg(feature = "outproc-effect")]
 fn build_effect_bus_stages(
 ) -> Result<(Vec<orbit_audio_native::InsertBusStage>, Vec<EffectBusBuild>), WrapError> {
     use crate::outproc_effect::{OutProcEffectPostProcessor, OutProcEffectStats};
     use std::sync::atomic::AtomicBool;
-    let names = effect_buses_from_env()?;
-    let mut builds = Vec::with_capacity(names.len());
-    let mut insert_buses = Vec::with_capacity(names.len());
-    for name in names {
+
+    let insert_names = effect_buses_from_env()?;
+    let sum_names = sum_bus_pool_from_env()?;
+    let aux_names = aux_bus_pool_from_env()?;
+    let named: Vec<(String, BusKind)> = insert_names
+        .into_iter()
+        .map(|n| (n, BusKind::Insert))
+        .chain(sum_names.into_iter().map(|n| (n, BusKind::Sum)))
+        .chain(aux_names.into_iter().map(|n| (n, BusKind::Aux)))
+        .collect();
+    let total = named.len();
+    if total > orbit_audio_native::MAX_INSERT_BUS_STAGES {
+        return Err(WrapError::OutProcEffect(format!(
+            "too many bus stages: {total} (insert+sum+aux, max {})",
+            orbit_audio_native::MAX_INSERT_BUS_STAGES
+        )));
+    }
+
+    let mut builds = Vec::with_capacity(total);
+    let mut insert_buses = Vec::with_capacity(total);
+    for (index, (name, kind)) in named.into_iter().enumerate() {
         let shm_path = crate::outproc_effect::unique_shm_path();
         let host = orbit_audio_sandbox::PipelinedEffectHost::from_mmap(
             orbit_audio_sandbox::create_shared(&shm_path).map_err(|e| {
@@ -322,33 +428,46 @@ fn build_effect_bus_stages(
         let done = Arc::new(AtomicBool::new(false));
         let active = Arc::new(AtomicBool::new(false));
         let stats = OutProcEffectStats::new();
-        insert_buses.push(orbit_audio_native::InsertBusStage::with_activation(
-            name.clone(),
-            Some(Box::new(OutProcEffectPostProcessor::new(
-                host,
-                engaged.clone(),
-                stop.clone(),
-                done.clone(),
-                stats.clone(),
-            ))),
-            0,
-            active.clone(),
-        ));
+        let routing_override = Arc::new(AtomicUsize::new(0));
+        // この stage より後ろの全 stage 分の send gain スロットを構築時に確保する（v1 の設計判断:
+        // `SetBusRouting` は既存スロットへの書き込みのみ・実行時に Vec を伸長しない）。
+        let send_gain_overrides: Vec<Arc<AtomicU32>> = (0..(total - index - 1))
+            .map(|_| Arc::new(AtomicU32::new(0)))
+            .collect();
+        insert_buses.push(
+            orbit_audio_native::InsertBusStage::with_activation(
+                name.clone(),
+                Some(Box::new(OutProcEffectPostProcessor::new(
+                    host,
+                    engaged.clone(),
+                    stop.clone(),
+                    done.clone(),
+                    stats.clone(),
+                ))),
+                0,
+                active.clone(),
+            )
+            .with_routing_overrides(routing_override.clone(), send_gain_overrides.clone()),
+        );
         builds.push(EffectBusBuild {
             name,
+            kind,
             shm_path,
             engaged,
             stop,
             done,
             stats,
             active,
+            routing_override,
+            send_gain_overrides,
         });
     }
     Ok((insert_buses, builds))
 }
 
-/// bus 部材を ChildSlot / 観測 map / StreamGuard 用 guard 群へ展開する（stream 起動後・
-/// sample_rate 確定後に呼ぶ）。返り値: (bus_slots, bus_stats, bus_actives, child_guards, teardowns)。
+/// bus 部材を ChildSlot / 観測 map / routing map / StreamGuard 用 guard 群へ展開する（stream 起動後・
+/// sample_rate 確定後に呼ぶ）。返り値: (bus_slots, bus_stats, bus_actives, bus_kinds, bus_index,
+/// bus_routing, bus_sends, child_guards, teardowns)。
 #[cfg(feature = "outproc-effect")]
 #[allow(clippy::type_complexity)]
 fn install_effect_bus_slots(
@@ -359,6 +478,10 @@ fn install_effect_bus_slots(
     HashMap<String, Weak<Mutex<ChildSlot>>>,
     HashMap<String, Arc<crate::outproc_effect::OutProcEffectStats>>,
     HashMap<String, Arc<std::sync::atomic::AtomicBool>>,
+    HashMap<String, BusKind>,
+    HashMap<String, usize>,
+    HashMap<String, Arc<AtomicUsize>>,
+    HashMap<String, Vec<Arc<AtomicU32>>>,
     Vec<Arc<Mutex<ChildSlot>>>,
     Vec<crate::outproc_effect::OutProcTeardownGuard>,
 ) {
@@ -366,9 +489,13 @@ fn install_effect_bus_slots(
     let mut bus_slots = HashMap::new();
     let mut bus_stats = HashMap::new();
     let mut bus_actives = HashMap::new();
+    let mut bus_kinds = HashMap::new();
+    let mut bus_index = HashMap::new();
+    let mut bus_routing = HashMap::new();
+    let mut bus_sends = HashMap::new();
     let mut child_guards = Vec::with_capacity(builds.len());
     let mut teardowns = Vec::with_capacity(builds.len());
-    for build in builds {
+    for (index, build) in builds.into_iter().enumerate() {
         let slot = Arc::new(Mutex::new(ChildSlot::Empty(ChildLaunch {
             shm_path: build.shm_path,
             child_exe: child_exe.to_path_buf(),
@@ -379,11 +506,25 @@ fn install_effect_bus_slots(
         })));
         bus_slots.insert(build.name.clone(), Arc::downgrade(&slot));
         bus_stats.insert(build.name.clone(), build.stats);
-        bus_actives.insert(build.name, build.active);
+        bus_actives.insert(build.name.clone(), build.active);
+        bus_kinds.insert(build.name.clone(), build.kind);
+        bus_index.insert(build.name.clone(), index);
+        bus_routing.insert(build.name.clone(), build.routing_override);
+        bus_sends.insert(build.name, build.send_gain_overrides);
         child_guards.push(slot);
         teardowns.push(OutProcTeardownGuard::new(build.stop, build.done));
     }
-    (bus_slots, bus_stats, bus_actives, child_guards, teardowns)
+    (
+        bus_slots,
+        bus_stats,
+        bus_actives,
+        bus_kinds,
+        bus_index,
+        bus_routing,
+        bus_sends,
+        child_guards,
+        teardowns,
+    )
 }
 
 #[cfg(all(test, feature = "outproc-effect"))]
@@ -475,6 +616,180 @@ mod effect_bus_pool_tests {
                 "seq-bus-2".to_string(),
             ]
         );
+    }
+}
+
+/// M2（#459/#453）: sum/aux プール名生成・`SetBusRouting` の検証規則の unit テスト。
+#[cfg(all(test, feature = "outproc-effect"))]
+mod named_bus_pool_tests {
+    use super::{
+        aux_bus_pool_from_env, parse_named_bus_pool_size, sum_bus_pool_from_env,
+        DEFAULT_AUX_BUS_POOL_SIZE, DEFAULT_SUM_BUS_POOL_SIZE,
+    };
+
+    #[test]
+    fn pool_size_defaults_when_unset_or_blank() {
+        assert_eq!(
+            parse_named_bus_pool_size("X", "", 4),
+            Ok(DEFAULT_SUM_BUS_POOL_SIZE)
+        );
+        assert_eq!(parse_named_bus_pool_size("X", "  ", 4), Ok(4));
+    }
+
+    #[test]
+    fn pool_size_rejects_non_numeric() {
+        let error = parse_named_bus_pool_size("ORBIT_SUM_BUS_POOL", "abc", 4)
+            .expect_err("non-numeric must be rejected");
+        assert!(error.contains("ORBIT_SUM_BUS_POOL"), "{error}");
+    }
+
+    #[test]
+    fn sum_pool_generates_default_four_names() {
+        // env は他テストと並行するプロセス内 global mutable state なので、明示的に空文字へ戻す
+        // （unset だと他テストの残留値を拾いうる・#434 系の既存慣習に合わせる）。
+        std::env::set_var("ORBIT_SUM_BUS_POOL", "");
+        let names = sum_bus_pool_from_env().expect("default sum pool");
+        assert_eq!(names.len(), DEFAULT_SUM_BUS_POOL_SIZE);
+        assert_eq!(names[0], "sum-bus-0");
+        std::env::remove_var("ORBIT_SUM_BUS_POOL");
+    }
+
+    #[test]
+    fn aux_pool_generates_default_four_names() {
+        std::env::set_var("ORBIT_AUX_BUS_POOL", "");
+        let names = aux_bus_pool_from_env().expect("default aux pool");
+        assert_eq!(names.len(), DEFAULT_AUX_BUS_POOL_SIZE);
+        assert_eq!(names[0], "aux-bus-0");
+        std::env::remove_var("ORBIT_AUX_BUS_POOL");
+    }
+}
+
+/// `EngineWrap::set_bus_routing` の検証規則を stub backend + 手組み `OutProcControl` で
+/// 直接 exercise する unit テスト（M2・#459/#453）。real child は不要（bus_index/bus_kinds/
+/// bus_routing/bus_sends だけを検証する経路のため）。
+#[cfg(all(test, feature = "outproc-effect"))]
+mod set_bus_routing_tests {
+    use super::{AtomicU32, AtomicUsize, BusKind, EngineWrap, Ordering, OutProcControl, Weak};
+    use crate::backend::StubBackend;
+    use crate::outproc_effect::OutProcEffectStats;
+    use orbit_audio_native::CallbackTimeStats;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    /// stage 配列 `[seq-bus-0 (Insert), sum-bus-0 (Sum), aux-bus-0 (Aux)]` を模した
+    /// `OutProcControl` を注入する（native stage 自体は起動しない・routing 検証のみが対象）。
+    fn wrap_with_three_stage_topology() -> Arc<EngineWrap> {
+        let (wrap, _guard) =
+            EngineWrap::start_with(StubBackend::default()).expect("stub backend start");
+        let mut bus_index = HashMap::new();
+        bus_index.insert("seq-bus-0".to_owned(), 0usize);
+        bus_index.insert("sum-bus-0".to_owned(), 1usize);
+        bus_index.insert("aux-bus-0".to_owned(), 2usize);
+        let mut bus_kinds = HashMap::new();
+        bus_kinds.insert("seq-bus-0".to_owned(), BusKind::Insert);
+        bus_kinds.insert("sum-bus-0".to_owned(), BusKind::Sum);
+        bus_kinds.insert("aux-bus-0".to_owned(), BusKind::Aux);
+        let mut bus_routing = HashMap::new();
+        bus_routing.insert("seq-bus-0".to_owned(), Arc::new(AtomicUsize::new(0)));
+        let mut bus_sends = HashMap::new();
+        // seq-bus-0 (index 0) has 2 later stages (index 1, 2) => 2 send slots.
+        bus_sends.insert(
+            "seq-bus-0".to_owned(),
+            vec![Arc::new(AtomicU32::new(0)), Arc::new(AtomicU32::new(0))],
+        );
+        *wrap.outproc.lock().expect("lock outproc for injection") = Some(OutProcControl {
+            stats: OutProcEffectStats::new(),
+            cb_stats: CallbackTimeStats::new(),
+            child_slot: Weak::new(),
+            bus_slots: HashMap::new(),
+            bus_stats: HashMap::new(),
+            bus_actives: HashMap::new(),
+            bus_kinds,
+            bus_index,
+            bus_routing,
+            bus_sends,
+        });
+        wrap
+    }
+
+    #[test]
+    fn output_to_sum_bus_stores_encoded_target_on_the_routing_atomic() {
+        let wrap = wrap_with_three_stage_topology();
+        wrap.set_bus_routing("seq-bus-0", Some("sum-bus-0"), &[])
+            .expect("sum output must be accepted");
+        let guard = wrap.outproc.lock().unwrap();
+        let routing = guard
+            .as_ref()
+            .unwrap()
+            .bus_routing
+            .get("seq-bus-0")
+            .unwrap();
+        // encoding: n = target_index + 2 (see native InsertBusStage doc).
+        assert_eq!(routing.load(Ordering::Relaxed), 1 + 2);
+    }
+
+    #[test]
+    fn output_to_insert_bus_is_rejected_kind_mismatch() {
+        let wrap = wrap_with_three_stage_topology();
+        let error = wrap
+            .set_bus_routing("seq-bus-0", Some("aux-bus-0"), &[])
+            .expect_err("output to an aux bus must be rejected (output requires sum kind)");
+        let message = format!("{error:?}");
+        assert!(message.contains("must be a sum bus"), "{message}");
+    }
+
+    #[test]
+    fn output_to_earlier_or_equal_index_is_rejected() {
+        let wrap = wrap_with_three_stage_topology();
+        let error = wrap
+            .set_bus_routing("sum-bus-0", Some("seq-bus-0"), &[])
+            .expect_err("backward reference must be rejected");
+        let message = format!("{error:?}");
+        assert!(message.contains("later stage"), "{message}");
+    }
+
+    #[test]
+    fn send_to_aux_bus_stores_gain_bits_on_the_correct_slot() {
+        let wrap = wrap_with_three_stage_topology();
+        wrap.set_bus_routing("seq-bus-0", None, &[("aux-bus-0".to_owned(), 0.75)])
+            .expect("send to an aux bus must be accepted");
+        let guard = wrap.outproc.lock().unwrap();
+        let sends = guard.as_ref().unwrap().bus_sends.get("seq-bus-0").unwrap();
+        // aux-bus-0 is at absolute index 2; seq-bus-0 is at index 0 => slot k = 2 - 0 - 1 = 1.
+        let gain = f32::from_bits(sends[1].load(Ordering::Relaxed));
+        assert_eq!(gain, 0.75);
+        // The untouched slot (sum-bus-0, k=0) must remain disabled.
+        assert_eq!(f32::from_bits(sends[0].load(Ordering::Relaxed)), 0.0);
+    }
+
+    #[test]
+    fn send_to_sum_bus_is_rejected_kind_mismatch() {
+        let wrap = wrap_with_three_stage_topology();
+        let error = wrap
+            .set_bus_routing("seq-bus-0", None, &[("sum-bus-0".to_owned(), 0.5)])
+            .expect_err("send to a sum bus must be rejected (send requires aux kind)");
+        let message = format!("{error:?}");
+        assert!(message.contains("must be an aux bus"), "{message}");
+    }
+
+    #[test]
+    fn non_finite_gain_is_rejected() {
+        let wrap = wrap_with_three_stage_topology();
+        let error = wrap
+            .set_bus_routing("seq-bus-0", None, &[("aux-bus-0".to_owned(), f32::NAN)])
+            .expect_err("NaN gain must be rejected");
+        let message = format!("{error:?}");
+        assert!(message.contains("finite"), "{message}");
+    }
+
+    #[test]
+    fn unknown_bus_name_is_rejected() {
+        let wrap = wrap_with_three_stage_topology();
+        let error = wrap
+            .set_bus_routing("nope", None, &[])
+            .expect_err("unknown seq_bus must be rejected");
+        let message = format!("{error:?}");
+        assert!(message.contains("unknown bus"), "{message}");
     }
 }
 
@@ -1232,10 +1547,23 @@ impl EngineWrap {
                 bus_slots: HashMap::new(),
                 bus_stats: HashMap::new(),
                 bus_actives: HashMap::new(),
+                bus_kinds: HashMap::new(),
+                bus_index: HashMap::new(),
+                bus_routing: HashMap::new(),
+                bus_sends: HashMap::new(),
             });
 
-        let (bus_slots, bus_stats, bus_actives, bus_child_guards, bus_teardowns) =
-            install_effect_bus_slots(bus_builds, &cfg.child_exe, sample_rate);
+        let (
+            bus_slots,
+            bus_stats,
+            bus_actives,
+            bus_kinds,
+            bus_index,
+            bus_routing,
+            bus_sends,
+            bus_child_guards,
+            bus_teardowns,
+        ) = install_effect_bus_slots(bus_builds, &cfg.child_exe, sample_rate);
         {
             let mut guard = wrap
                 .outproc
@@ -1245,6 +1573,10 @@ impl EngineWrap {
             control.bus_slots = bus_slots;
             control.bus_stats = bus_stats;
             control.bus_actives = bus_actives;
+            control.bus_kinds = bus_kinds;
+            control.bus_index = bus_index;
+            control.bus_routing = bus_routing;
+            control.bus_sends = bus_sends;
         }
 
         // 7. StreamGuard（field 順 = teardown 順）。
@@ -1491,6 +1823,10 @@ impl EngineWrap {
                 bus_slots: HashMap::new(),
                 bus_stats: HashMap::new(),
                 bus_actives: HashMap::new(),
+                bus_kinds: HashMap::new(),
+                bus_index: HashMap::new(),
+                bus_routing: HashMap::new(),
+                bus_sends: HashMap::new(),
             });
         *wrap.outproc_instrument.lock().map_err(|_| {
             WrapError::OutProcInstrument("outproc instrument mutex poisoned".into())
@@ -1500,8 +1836,17 @@ impl EngineWrap {
             child_slot: Arc::downgrade(&instrument_slot),
         });
 
-        let (bus_slots, bus_stats, bus_actives, bus_child_guards, bus_teardowns) =
-            install_effect_bus_slots(bus_builds, &effect_cfg.child_exe, stream.sample_rate);
+        let (
+            bus_slots,
+            bus_stats,
+            bus_actives,
+            bus_kinds,
+            bus_index,
+            bus_routing,
+            bus_sends,
+            bus_child_guards,
+            bus_teardowns,
+        ) = install_effect_bus_slots(bus_builds, &effect_cfg.child_exe, stream.sample_rate);
         {
             let mut guard = wrap
                 .outproc
@@ -1511,6 +1856,10 @@ impl EngineWrap {
             control.bus_slots = bus_slots;
             control.bus_stats = bus_stats;
             control.bus_actives = bus_actives;
+            control.bus_kinds = bus_kinds;
+            control.bus_index = bus_index;
+            control.bus_routing = bus_routing;
+            control.bus_sends = bus_sends;
         }
 
         Ok((
@@ -1795,6 +2144,112 @@ impl EngineWrap {
             }
         }
         result
+    }
+
+    /// 実行時ルーティング切替（#459/#453 M2）: `seq_bus` の output target / send gain を非 RT で
+    /// 書き換える。**forward-only（MX.4）と kind 制約（output は sum のみ・send 先は aux のみ）を
+    /// ここで検証してから atomic に反映する**（RT callback は検証済みの値を load するだけ）。
+    ///
+    /// - `output = Some(name)`: `name` は `sum` kind かつ `seq_bus` より後ろの index でなければ
+    ///   ならない。それ以外はエラーで拒否し、既存の routing_override には触れない（部分適用しない）。
+    /// - `output = None`: output target には触れない（既存の override をそのまま保つ。明示的に
+    ///   `Master` へ戻す操作は v1 のスコープ外・将来 `output = Some("master")` 等の予約語で拡張しうる）。
+    /// - `sends`: 列挙された `(name, gain)` のみを反映する（列挙されていない既存 send には触れない）。
+    ///   `name` は `aux` kind かつ `seq_bus` より後ろの index でなければならない。`gain` は有限
+    ///   （NaN/Inf 拒否）。1 件でも検証に失敗したら **どの send も反映しない**（部分適用しない）。
+    #[cfg(feature = "outproc-effect")]
+    pub fn set_bus_routing(
+        &self,
+        seq_bus: &str,
+        output: Option<&str>,
+        sends: &[(String, f32)],
+    ) -> Result<(), WrapError> {
+        let guard = self
+            .outproc
+            .lock()
+            .map_err(|_| WrapError::OutProcEffect("outproc mutex poisoned".into()))?;
+        let control = guard.as_ref().ok_or_else(|| {
+            WrapError::OutProcEffectUnavailable(
+                "outproc effect not initialized (test backend has no outproc path)".into(),
+            )
+        })?;
+
+        let seq_index = *control
+            .bus_index
+            .get(seq_bus)
+            .ok_or_else(|| WrapError::OutProcEffect(format!("unknown bus '{seq_bus}'")))?;
+
+        // 1. output target を検証（反映はまだしない・部分適用を避ける）。
+        let resolved_output = match output {
+            Some(name) => {
+                let target_index = *control.bus_index.get(name).ok_or_else(|| {
+                    WrapError::OutProcEffect(format!("SetBusRouting output: unknown bus '{name}'"))
+                })?;
+                if target_index <= seq_index {
+                    return Err(WrapError::OutProcEffect(format!(
+                        "SetBusRouting output '{name}' (index {target_index}) must be a later stage than '{seq_bus}' (index {seq_index})"
+                    )));
+                }
+                if control.bus_kinds.get(name) != Some(&BusKind::Sum) {
+                    return Err(WrapError::OutProcEffect(format!(
+                        "SetBusRouting output '{name}' must be a sum bus"
+                    )));
+                }
+                Some(target_index)
+            }
+            None => None,
+        };
+
+        // 2. sends を検証（同上・1 件でも失敗したら全体を拒否）。
+        let mut resolved_sends = Vec::with_capacity(sends.len());
+        for (name, gain) in sends {
+            if !gain.is_finite() {
+                return Err(WrapError::OutProcEffect(format!(
+                    "SetBusRouting send '{name}' gain must be finite, got {gain}"
+                )));
+            }
+            let target_index = *control.bus_index.get(name).ok_or_else(|| {
+                WrapError::OutProcEffect(format!("SetBusRouting send: unknown bus '{name}'"))
+            })?;
+            if target_index <= seq_index {
+                return Err(WrapError::OutProcEffect(format!(
+                    "SetBusRouting send '{name}' (index {target_index}) must be a later stage than '{seq_bus}' (index {seq_index})"
+                )));
+            }
+            if control.bus_kinds.get(name) != Some(&BusKind::Aux) {
+                return Err(WrapError::OutProcEffect(format!(
+                    "SetBusRouting send '{name}' must be an aux bus"
+                )));
+            }
+            resolved_sends.push((target_index, *gain));
+        }
+
+        // 3. 検証済みの値だけを atomic へ反映する。
+        if let Some(target_index) = resolved_output {
+            let routing = control.bus_routing.get(seq_bus).ok_or_else(|| {
+                WrapError::OutProcEffect(format!("bus '{seq_bus}' has no routing handle"))
+            })?;
+            // エンコード: 0=override 無し・1=Master・n>=2 => Bus(n-2)（native `InsertBusStage`
+            // doc 参照）。
+            routing.store(target_index + 2, Ordering::Relaxed);
+        }
+        if !resolved_sends.is_empty() {
+            let send_slots = control.bus_sends.get(seq_bus).ok_or_else(|| {
+                WrapError::OutProcEffect(format!("bus '{seq_bus}' has no send slots"))
+            })?;
+            for (target_index, gain) in resolved_sends {
+                // slot k は絶対 index `seq_index + 1 + k` を指す（構築時の割当・build_effect_bus_stages
+                // doc 参照）ので k = target_index - seq_index - 1。
+                let k = target_index - seq_index - 1;
+                let slot = send_slots.get(k).ok_or_else(|| {
+                    WrapError::OutProcEffect(format!(
+                        "bus '{seq_bus}' has no send slot for target index {target_index}"
+                    ))
+                })?;
+                slot.store(gain.to_bits(), Ordering::Relaxed);
+            }
+        }
+        Ok(())
     }
 
     /// both build で instrument slot へ attach する。
@@ -4276,6 +4731,10 @@ mod outproc_health_tests {
             bus_slots: HashMap::new(),
             bus_stats: HashMap::new(),
             bus_actives: HashMap::new(),
+            bus_kinds: HashMap::new(),
+            bus_index: HashMap::new(),
+            bus_routing: HashMap::new(),
+            bus_sends: HashMap::new(),
         });
         (wrap, stats)
     }
@@ -4294,6 +4753,10 @@ mod outproc_health_tests {
             bus_slots: HashMap::new(),
             bus_stats: HashMap::new(),
             bus_actives: HashMap::new(),
+            bus_kinds: HashMap::new(),
+            bus_index: HashMap::new(),
+            bus_routing: HashMap::new(),
+            bus_sends: HashMap::new(),
         });
         (wrap, child_slot)
     }
@@ -4329,6 +4792,10 @@ mod outproc_health_tests {
             bus_slots,
             bus_stats: HashMap::new(),
             bus_actives: HashMap::new(),
+            bus_kinds: HashMap::new(),
+            bus_index: HashMap::new(),
+            bus_routing: HashMap::new(),
+            bus_sends: HashMap::new(),
         });
         let error = wrap
             .load_outproc_effect_plugin(
@@ -4360,6 +4827,10 @@ mod outproc_health_tests {
             bus_slots,
             bus_stats: HashMap::new(),
             bus_actives,
+            bus_kinds: HashMap::new(),
+            bus_index: HashMap::new(),
+            bus_routing: HashMap::new(),
+            bus_sends: HashMap::new(),
         });
         let result = wrap.load_outproc_effect_plugin(
             std::path::PathBuf::from("unused.clap"),

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -91,6 +91,46 @@ fn parse_bus_param(params: &Value) -> Result<Option<String>, &'static str> {
     }
 }
 
+/// `SetBusRouting` params から `(seq_bus, output, sends)` を取り出す純関数（#459/#453 M2）。
+/// - `seq_bus`: 必須の非空文字列。
+/// - `output`: 省略/`null` = `None`（output target には触れない）。非空文字列以外は拒否。
+/// - `sends`: 省略/`null` = 空配列。`[{bus: string, gain: number}]` の配列以外・要素の型不正は拒否。
+#[cfg(feature = "outproc-effect")]
+#[allow(clippy::type_complexity)]
+fn parse_set_bus_routing_params(
+    params: &Value,
+) -> Result<(String, Option<String>, Vec<(String, f32)>), &'static str> {
+    let seq_bus = match params.get("seq_bus") {
+        Some(Value::String(s)) if !s.trim().is_empty() => s.clone(),
+        _ => return Err("'seq_bus' must be a non-empty string"),
+    };
+    let output = match params.get("output") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(s)) if !s.trim().is_empty() => Some(s.clone()),
+        _ => return Err("'output' must be a non-empty string or null"),
+    };
+    let sends = match params.get("sends") {
+        None | Some(Value::Null) => Vec::new(),
+        Some(Value::Array(items)) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                let bus = match item.get("bus") {
+                    Some(Value::String(s)) if !s.trim().is_empty() => s.clone(),
+                    _ => return Err("'sends[].bus' must be a non-empty string"),
+                };
+                let gain = match item.get("gain").and_then(Value::as_f64) {
+                    Some(g) => g as f32,
+                    None => return Err("'sends[].gain' must be a number"),
+                };
+                out.push((bus, gain));
+            }
+            out
+        }
+        _ => return Err("'sends' must be an array"),
+    };
+    Ok((seq_bus, output, sends))
+}
+
 /// PlayAt の `bus`（per-sequence insert routing・PH.2b・#434 S3）と `channel`（LinkAudio
 /// routing・#209）の同時指定を検出する純関数。両者は core 上は同じ routing tag フィールド
 /// （`ScheduledSample.channel`）を共有するため、同時指定は意味が一意に決まらず拒否する。
@@ -1073,6 +1113,27 @@ async fn handle_command(
                 Err(e) => err(&id, wrap_err_to_protocol(&e)),
             }
         }
+        // 実行時 mixer routing 切替（#459/#453 M2）: sum bus への output / aux bus への send を
+        // 非 RT で設定する。`SetBusRouting` は `outproc-effect` feature 専用（insert/sum/aux bus
+        // 機構自体がその feature の産物・`build_effect_bus_stages` 参照）。
+        #[cfg(feature = "outproc-effect")]
+        "SetBusRouting" => match parse_set_bus_routing_params(&params) {
+            Ok((seq_bus, output, sends)) => {
+                match engine.set_bus_routing(&seq_bus, output.as_deref(), &sends) {
+                    Ok(()) => ok(&id, json!({"status": "accepted"})),
+                    Err(e) => err(&id, wrap_err_to_protocol(&e)),
+                }
+            }
+            Err(message) => err(&id, ProtocolError::new("MALFORMED_REQUEST", message)),
+        },
+        #[cfg(not(feature = "outproc-effect"))]
+        "SetBusRouting" => err(
+            &id,
+            ProtocolError::new(
+                "UNSUPPORTED",
+                "SetBusRouting requires the outproc-effect build (mixer bus graph)",
+            ),
+        ),
         // gated な fault 注入（recovery floor / #300 の kill-test 専用・単一動作なので unit コマンド）。
         // ORBIT_DAEMON_ALLOW_FAULT_INJECTION=1 のときだけ受理する（既定では出荷時に無効）。
         // daemon を panic させ、main.rs の panic hook 経由で stderr に DaemonError を出し exit(1)

--- a/rust/crates/orbit-audio-daemon/tests/outproc_mixer_bus_gated.rs
+++ b/rust/crates/orbit-audio-daemon/tests/outproc_mixer_bus_gated.rs
@@ -1,0 +1,202 @@
+//! Issue #459/#453 M2: mixer graph（insert + sum + aux）を実機 daemon 上で組み合わせ、
+//! `SetBusRouting`（`EngineWrap::set_bus_routing`）で実行時に配線した経路が gain oracle を通じて
+//! 検証できることを確認する gated test（骨格・#459/#453 M2 の依頼元が実機 RUN を担当する）。
+//!
+//! セットアップ:
+//! - insert bus 1 個（`ORBIT_EFFECT_BUSES=seq-bus-0`）・sum bus 1 個（`ORBIT_SUM_BUS_POOL=1` →
+//!   `sum-bus-0`）・aux bus 1 個（`ORBIT_AUX_BUS_POOL=1` → `aux-bus-0`）を起動前に env 固定する
+//!   （`outproc_effect_bus_gated.rs` と同じ制約: env は `build_effect_bus_stages` が起動時に一度
+//!   だけ読むため、プロセス起動前に固定し `--test-threads=1` で実行する）。
+//! - 各 bus に gain oracle（test-effect .clap・`EFFECT_GAIN` 定数）を `load_outproc_effect_plugin`
+//!   で attach する。
+//! - `engine.set_bus_routing("seq-bus-0", Some("sum-bus-0"), &[("aux-bus-0".into(), 0.5)])` で
+//!   insert bus の output を sum へ、send を aux へ実行時に配線する（M2 の核心 = `SetBusRouting` が
+//!   非 RT で atomic を書き換え、次 callback から反映される・`orbit_audio_native::output` の
+//!   `routing_override_retargets_output_from_master_to_bus_on_next_callback` /
+//!   `send_gain_override_applies_from_the_correct_slot_on_next_callback` unit test と対になる
+//!   実機検証）。
+//! - closed-form oracle: insert bus 通過後の gain は `EFFECT_GAIN`（0.5）。sum bus 通過後は
+//!   さらに `EFFECT_GAIN` を掛けた `EFFECT_GAIN^2 = 0.25`（sum 自身にも gain oracle を attach する
+//!   ため）。aux 経由の send は insert 後・send gain（0.5）適用後にさらに aux 自身の gain oracle を
+//!   経由するので `EFFECT_GAIN * 0.5 * EFFECT_GAIN = 0.125`。
+//!
+//! 前提（実行前にビルドすること）:
+//!   cargo build -p orbit-clap-effect-child
+//!   cargo build --manifest-path rust-spike/clap-test-effect/Cargo.toml
+//! 実行（bus 用 env を先に固定し、他テストとの set_var 競合を避けるため単一スレッドで実行）:
+//!   ORBIT_EFFECT_BUSES=seq-bus-0 ORBIT_SUM_BUS_POOL=1 ORBIT_AUX_BUS_POOL=1 \
+//!     cargo test -p orbit-audio-daemon --features outproc-effect \
+//!     --test outproc_mixer_bus_gated -- --ignored --nocapture --test-threads=1
+//!
+//! device / dylib / child binary が揃わない env（headless CI 等）では owner へ stop&report
+//! （手動 fallback）。本ファイルは #459/#453 M2 の依頼で **compile まで**を成功条件とし、実機
+//! RUN 自体は依頼元が行う。
+
+#![cfg(all(feature = "outproc-effect", not(feature = "outproc-instrument")))]
+
+mod gated_common;
+use gated_common::{child_exe, repo_path, wait_until};
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use orbit_audio_daemon::engine_wrap::EngineWrap;
+use orbit_audio_daemon::outproc_effect::{OutProcEffectConfig, PluginFormat};
+
+/// test-effect が乗算する固定 gain（`outproc_effect_bus_gated.rs` と同一値）。
+const EFFECT_GAIN: f32 = 0.5;
+const SEQ_BUS: &str = "seq-bus-0";
+const SUM_BUS: &str = "sum-bus-0";
+const AUX_BUS: &str = "aux-bus-0";
+
+fn test_effect_dylib() -> PathBuf {
+    repo_path("rust-spike/clap-test-effect/target/debug/libclap_test_effect.dylib")
+}
+
+fn setup_test() -> (OutProcEffectConfig, PathBuf) {
+    let cfg = OutProcEffectConfig {
+        format: PluginFormat::Clap,
+        child_exe: child_exe("orbit-clap-effect-child"),
+        plugin: None,
+        plugin_id: None,
+        buffer_frames: None,
+    };
+    let dylib = test_effect_dylib();
+    let wav = repo_path("test-assets/audio/sine_440.wav");
+    assert!(
+        dylib.exists(),
+        "test-effect dylib が無い: {} — 先に `cargo build --manifest-path rust-spike/clap-test-effect/Cargo.toml`",
+        dylib.display()
+    );
+    assert!(
+        cfg.child_exe.exists(),
+        "effect child binary が無い: {} — 先に `cargo build -p orbit-clap-effect-child`",
+        cfg.child_exe.display()
+    );
+    assert!(wav.exists(), "音源 WAV が無い: {}", wav.display());
+    (cfg, wav)
+}
+
+fn assert_env(name: &str, expected: &str) {
+    assert_eq!(
+        std::env::var(name).as_deref(),
+        Ok(expected),
+        "run with `{name}={expected}` set before the test binary starts \
+         (env is read once at `build_effect_bus_stages`, not settable from inside a test)"
+    );
+}
+
+// ── insert → sum(output) / aux(send) の実行時配線が gain oracle の closed-form に一致する ──────
+#[test]
+#[ignore = "#459/#453 M2: needs ORBIT_EFFECT_BUSES=seq-bus-0 ORBIT_SUM_BUS_POOL=1 ORBIT_AUX_BUS_POOL=1 set before process start + a real output device + built child binary + test-effect dylib (local only)"]
+fn set_bus_routing_wires_insert_to_sum_output_and_aux_send() {
+    assert_env("ORBIT_EFFECT_BUSES", SEQ_BUS);
+    assert_env("ORBIT_SUM_BUS_POOL", "1");
+    assert_env("ORBIT_AUX_BUS_POOL", "1");
+
+    let (cfg, wav) = setup_test();
+    let (engine, _guard) =
+        EngineWrap::start_outproc_effect_post_boot(cfg).expect("start OOP effect daemon");
+
+    let dylib = test_effect_dylib();
+    for bus in [SEQ_BUS, SUM_BUS, AUX_BUS] {
+        engine
+            .load_outproc_effect_plugin(dylib.clone(), None, Some(bus.to_owned()))
+            .unwrap_or_else(|e| panic!("attach gain oracle to bus '{bus}': {e}"));
+    }
+
+    // M2 の核心: 非 RT で insert(seq-bus-0) の output を sum(sum-bus-0) へ、send を aux(aux-bus-0)
+    // へ実行時に配線する。
+    engine
+        .set_bus_routing(SEQ_BUS, Some(SUM_BUS), &[(AUX_BUS.to_owned(), 0.5)])
+        .expect("SetBusRouting must accept sum output + aux send");
+
+    let sample = engine.load_sample(wav).expect("load sine sample");
+    let onset = engine.transport_or_uptime_sec() + 0.1;
+    engine
+        .play_at(
+            &sample.sample_id,
+            onset,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            Some(SEQ_BUS.to_owned()),
+        )
+        .expect("play sine tagged to seq-bus-0");
+
+    assert!(
+        wait_until(Duration::from_secs(3), || engine
+            .outproc_effect_bus_stats(SUM_BUS)
+            .map(|s| s.fresh > 0)
+            .unwrap_or(false)),
+        "sum bus '{SUM_BUS}' が fresh 処理を報告しない（routing / attach を確認）"
+    );
+    std::thread::sleep(Duration::from_millis(600));
+
+    let seq_stats = engine
+        .outproc_effect_bus_stats(SEQ_BUS)
+        .expect("seq bus stats available");
+    let sum_stats = engine
+        .outproc_effect_bus_stats(SUM_BUS)
+        .expect("sum bus stats available");
+    let aux_stats = engine
+        .outproc_effect_bus_stats(AUX_BUS)
+        .expect("aux bus stats available");
+
+    println!("=== #459/#453 M2 mixer routing verdict ===");
+    println!(
+        "seq: dry={:.5} post={:.5} | sum: dry={:.5} post={:.5} | aux: dry={:.5} post={:.5}",
+        seq_stats.dry_peak,
+        seq_stats.post_peak,
+        sum_stats.dry_peak,
+        sum_stats.post_peak,
+        aux_stats.dry_peak,
+        aux_stats.post_peak,
+    );
+    println!("============================================");
+
+    assert!(
+        !seq_stats.measurement_invalid,
+        "seq bus の respawn 失敗で計測無効"
+    );
+    assert!(
+        !sum_stats.measurement_invalid,
+        "sum bus の respawn 失敗で計測無効"
+    );
+    assert!(
+        !aux_stats.measurement_invalid,
+        "aux bus の respawn 失敗で計測無効"
+    );
+
+    // closed-form oracle: sum は insert(gain)×sum(gain) = EFFECT_GAIN^2。aux は
+    // insert(gain)×send(0.5)×aux(gain) = EFFECT_GAIN × 0.5 × EFFECT_GAIN。
+    let expected_sum_ratio = EFFECT_GAIN * EFFECT_GAIN;
+    let expected_aux_ratio = EFFECT_GAIN * 0.5 * EFFECT_GAIN;
+    let sum_ratio = if sum_stats.dry_peak > 0.0 {
+        sum_stats.post_peak / sum_stats.dry_peak
+    } else {
+        0.0
+    };
+    // sum bus の dry_peak は「sum に流れ込んだ (insert 後の) signal」なので、seq bus 自体の
+    // post_peak/dry_peak 比（= EFFECT_GAIN 単体）とは別に、直接 hardware sum 経路の比較として
+    // sum_stats.post_peak と seq_stats.dry_peak（元の raw playback peak）の比で
+    // `expected_sum_ratio` を検証する（余白は resampling / peak 整列のずれを吸収）。
+    let _ = sum_ratio; // 参考値として算出のみ（実機オラクルの主判定は次行）。
+    assert!(
+        seq_stats.dry_peak > 0.01,
+        "insert bus に音が届いていない (dry_peak={:.5})",
+        seq_stats.dry_peak
+    );
+    assert!(
+        (expected_sum_ratio - 0.1..=expected_sum_ratio + 0.1)
+            .contains(&(sum_stats.post_peak / seq_stats.dry_peak.max(1e-6))),
+        "sum 経路の gain 比が想定外（期待 ~{expected_sum_ratio:.5}）"
+    );
+    assert!(
+        (expected_aux_ratio - 0.1..=expected_aux_ratio + 0.1)
+            .contains(&(aux_stats.post_peak / seq_stats.dry_peak.max(1e-6))),
+        "aux send 経路の gain 比が想定外（期待 ~{expected_aux_ratio:.5}）"
+    );
+}

--- a/rust/crates/orbit-audio-native/src/lib.rs
+++ b/rust/crates/orbit-audio-native/src/lib.rs
@@ -18,8 +18,8 @@ pub use loader::{load_sample_from_file, load_sample_resampled, LoaderError};
 pub use output::{
     start_default_output, start_default_output_with_clap, start_default_output_with_insert_buses,
     start_default_output_with_insert_buses_and_post, start_default_output_with_link_egress,
-    InsertBusStage, LinkChannelActivate, OutputError, OutputStream, StreamStats,
-    StreamStatsSnapshot, MAX_INSERT_BUS_STAGES, MAX_LINK_CHANNELS,
+    BusSend, BusTarget, InsertBusStage, LinkChannelActivate, OutputError, OutputStream,
+    StreamStats, StreamStatsSnapshot, MAX_INSERT_BUS_STAGES, MAX_LINK_CHANNELS,
 };
 pub use post_processor::{CallbackTimeSnapshot, CallbackTimeStats, PostProcessor};
 pub use resampler::ResampleError;

--- a/rust/crates/orbit-audio-native/src/output.rs
+++ b/rust/crates/orbit-audio-native/src/output.rs
@@ -409,6 +409,26 @@ fn render_engine_with_insert_buses(
         .map(|bus| bus.active.load(Ordering::Relaxed))
         .collect();
 
+    // M2 routing atomics も callback 冒頭で 1 回だけ snapshot する。marking pass と post-loop が
+    // 同じ atomic を別々に load すると、callback 途中に `SetBusRouting` が挟まった場合に
+    // 「marking が見た合流先 j」と「accumulation が書く合流先 j'」が食い違い、zero-fill されて
+    // いない buffer へ加算 → 次に render target になった block で前分が一括流出（pop）する。
+    // snapshot を両パスで共有すれば 1 callback 内の view は常に一貫する。
+    let effective_targets: ArrayVec<BusTarget, MAX_INSERT_BUS_STAGES> =
+        buses.iter().map(effective_output_target).collect();
+    let send_override_gains: ArrayVec<
+        ArrayVec<f32, { MAX_INSERT_BUS_STAGES - 1 }>,
+        MAX_INSERT_BUS_STAGES,
+    > = buses
+        .iter()
+        .map(|bus| {
+            bus.send_gain_overrides
+                .iter()
+                .map(|g| f32::from_bits(g.load(Ordering::Relaxed)))
+                .collect()
+        })
+        .collect();
+
     // is_render_target（MX.4）: 「event tag を受けるか」（active）と「グラフの中継点として
     // 生きるか」（他の active stage の output_target/sends から参照されるか）を分離する。
     // 後者だけが true の stage（例: 未 declare の sum bus に active な member が output している）
@@ -419,7 +439,7 @@ fn render_engine_with_insert_buses(
         if !active_flags[i] {
             continue;
         }
-        if let BusTarget::Bus(j) = effective_output_target(bus) {
+        if let BusTarget::Bus(j) = effective_targets[i] {
             render_targets[j] = true;
         }
         for send in &bus.sends {
@@ -427,8 +447,8 @@ fn render_engine_with_insert_buses(
         }
         // M2: 実行時 send override も render target 判定に加える（override が非ゼロ gain の間、
         // 合流先 stage を post-loop の zero-fill/processor 対象に含める必要がある）。
-        for (k, gain) in bus.send_gain_overrides.iter().enumerate() {
-            if f32::from_bits(gain.load(Ordering::Relaxed)) != 0.0 {
+        for (k, gain) in send_override_gains[i].iter().enumerate() {
+            if *gain != 0.0 {
                 render_targets[i + 1 + k] = true;
             }
         }
@@ -492,7 +512,7 @@ fn render_engine_with_insert_buses(
         let (left, right) = buses.split_at_mut(i + 1);
         let src_stage = &left[i];
 
-        match effective_output_target(src_stage) {
+        match effective_targets[i] {
             BusTarget::Master => {
                 for (dst, s) in hw.iter_mut().zip(&src_stage.buffer[..bs]) {
                     *dst += *s;
@@ -511,9 +531,9 @@ fn render_engine_with_insert_buses(
                 *d += *s * send.gain;
             }
         }
-        // M2: 実行時 send override（`SetBusRouting`）。gain=0.0 は無効（分岐で skip・RT はロードのみ）。
-        for (k, gain_atomic) in src_stage.send_gain_overrides.iter().enumerate() {
-            let gain = f32::from_bits(gain_atomic.load(Ordering::Relaxed));
+        // M2: 実行時 send override（`SetBusRouting`）。gain=0.0 は無効（分岐で skip）。
+        // 冒頭 snapshot（send_override_gains）を使い marking pass と同じ値で加算する。
+        for (k, gain) in send_override_gains[i].iter().copied().enumerate() {
             if gain == 0.0 {
                 continue;
             }

--- a/rust/crates/orbit-audio-native/src/output.rs
+++ b/rust/crates/orbit-audio-native/src/output.rs
@@ -128,10 +128,32 @@ pub const MAX_LINK_CHANNELS: usize = 64;
 /// callback では stack 上の `ArrayVec` だけで `render_multi` 引数を組み立てられる。
 pub const MAX_INSERT_BUS_STAGES: usize = 64;
 
-/// named routing tag を受ける per-bus insert stage。
+/// mixer graph（#459/#453 MX.1-MX.5）における stage の出力先。**stages 配列内の index** で指す
+/// （配列順 = トポロジカル順という MX.4 の不変条件を、型ではなく構築時検証で担保する）。
+/// `Master` は既定（従来の「hw へ加算」のみの経路とビット同一）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BusTarget {
+    /// hardware sum へ加算する（従来の唯一の経路）。
+    #[default]
+    Master,
+    /// 自分より **後ろ**（配列 index が大きい）の stage へ copy 加算する（sum への合流）。
+    Bus(usize),
+}
+
+/// post-insert の signal を copy 加算する send（aux への並列タップ・MX.3）。post-fader 固定
+/// （v1・pre/post 切替は将来拡張）。`target` は `sends` を持つ stage 自身より**後ろ**の index。
+#[derive(Debug, Clone, Copy)]
+pub struct BusSend {
+    pub target: usize,
+    pub gain: f32,
+}
+
+/// named routing tag を受ける per-bus insert stage。sum/aux を含む mixer graph の1ノード
+/// （#459/#453・MX.1-MX.5）。
 ///
 /// `processor=None` は effect 未 attach の **登録済み bus** を表す。buffer を `render_multi` に渡して
-/// event を必ず消費し、そのまま master へ足すので、未 attach bus の event が retain され続けない。
+/// event を必ず消費し、そのまま `output_target` へ足すので、未 attach bus の event が retain され
+/// 続けない。
 pub struct InsertBusStage {
     name: String,
     processor: Option<Box<dyn PostProcessor>>,
@@ -146,6 +168,10 @@ pub struct InsertBusStage {
     /// activation → その後に tag 付き PlayAt」の順序を守ること（`seq.effect()` は await するので
     /// 構造的に成立）。
     active: Arc<AtomicBool>,
+    /// この stage の insert 適用後 buffer を最終的にどこへ足すか（既定 `Master` = 従来経路）。
+    output_target: BusTarget,
+    /// post-insert の buffer を copy 加算する先（既定空 = 従来経路）。MX.3 の send/aux。
+    sends: Vec<BusSend>,
 }
 
 impl InsertBusStage {
@@ -174,6 +200,8 @@ impl InsertBusStage {
             processor,
             buffer: vec![0.0; buffer_len],
             active,
+            output_target: BusTarget::default(),
+            sends: Vec::new(),
         }
     }
 
@@ -182,11 +210,50 @@ impl InsertBusStage {
         Self::new(name, None, 0)
     }
 
+    /// この stage の出力先を指定する（既定 `Master`）。sum の member や sum→master 以外の合流に
+    /// 使う（MX.1）。target index の妥当性（自分より後ろ）は構築 API 側で検証する。
+    pub fn with_output_target(mut self, target: BusTarget) -> Self {
+        self.output_target = target;
+        self
+    }
+
+    /// 複数の send（aux/return への post-fader copy・MX.3）を指定する（既定空）。
+    pub fn with_sends(mut self, sends: Vec<BusSend>) -> Self {
+        self.sends = sends;
+        self
+    }
+
     fn ensure_buffer_len(&mut self, len: usize) {
         if self.buffer.len() < len {
             self.buffer.resize(len, 0.0);
         }
     }
+}
+
+/// `insert_buses` の `output_target`/`sends` が MX.4 のトポロジカル不変条件（配列順で後方参照
+/// のみ）を満たすか検証する。stage i の target/send が `<= i` を指すと、render 時に
+/// `split_at_mut` で解決できない（前方参照 or 自己参照は sum のネスト・循環に相当し v1 で禁止・
+/// MX.2）。構築 API の入口（`start_default_output_with_insert_buses*`）でのみ呼ぶ。
+fn validate_bus_topology(stages: &[InsertBusStage]) -> Result<(), OutputError> {
+    for (i, stage) in stages.iter().enumerate() {
+        if let BusTarget::Bus(target) = stage.output_target {
+            if target <= i || target >= stages.len() {
+                return Err(OutputError::NoConfig(format!(
+                    "insert bus '{}' (index {i}) output_target Bus({target}) must be a later stage",
+                    stage.name
+                )));
+            }
+        }
+        for send in &stage.sends {
+            if send.target <= i || send.target >= stages.len() {
+                return Err(OutputError::NoConfig(format!(
+                    "insert bus '{}' (index {i}) send target {} must be a later stage",
+                    stage.name, send.target
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// LinkAudio channel を RT callback に届けるための activation メッセージ（A4-2b-2）。
@@ -291,10 +358,40 @@ fn render_engine_with_insert_buses(
     const MAX_TARGETS: usize = MAX_INSERT_BUS_STAGES + MAX_LINK_CHANNELS;
     debug_assert!(buses.len() <= MAX_INSERT_BUS_STAGES);
     let bs = (hw.len() / output_channels) * output_channels;
+
+    // active フラグを 1 回だけ atomic load して使い回す（RT: 同じ判定を何度も load しない）。
+    let active_flags: ArrayVec<bool, MAX_INSERT_BUS_STAGES> = buses
+        .iter()
+        .map(|bus| bus.active.load(Ordering::Relaxed))
+        .collect();
+
+    // is_render_target（MX.4）: 「event tag を受けるか」（active）と「グラフの中継点として
+    // 生きるか」（他の active stage の output_target/sends から参照されるか）を分離する。
+    // 後者だけが true の stage（例: 未 declare の sum bus に active な member が output している）
+    // も、buffer を zero-fill し post-loop で処理しないと合流先が前 block のゴミを持ち越す。
+    let mut render_targets: ArrayVec<bool, MAX_INSERT_BUS_STAGES> =
+        active_flags.iter().copied().collect();
+    for (i, bus) in buses.iter().enumerate() {
+        if !active_flags[i] {
+            continue;
+        }
+        if let BusTarget::Bus(j) = bus.output_target {
+            render_targets[j] = true;
+        }
+        for send in &bus.sends {
+            render_targets[send.target] = true;
+        }
+    }
+
     let mut targets: ArrayVec<(&str, &mut [f32]), MAX_TARGETS> = ArrayVec::new();
-    for bus in buses.iter_mut() {
-        // inactive stage は render 対象外（コストゼロ・InsertBusStage::active の doc 参照）。
-        if !bus.active.load(Ordering::Relaxed) {
+    for (i, bus) in buses.iter_mut().enumerate() {
+        if !active_flags[i] {
+            // inactive stage は render_multi のタグ対象外（コストゼロ・event tag 契約は変えない・
+            // InsertBusStage::active の doc 参照）。ただし render_target なら render_multi を
+            // 通らないので、代わりにここで手動 zero-fill する（post-loop が読む前提を守る）。
+            if render_targets[i] {
+                bus.buffer[..bs].fill(0.0);
+            }
             continue;
         }
         debug_assert!(
@@ -327,17 +424,44 @@ fn render_engine_with_insert_buses(
     engine.render_multi(hw, &mut targets);
     drop(targets);
 
-    for bus in buses.iter_mut() {
-        if !bus.active.load(Ordering::Relaxed) {
+    // post-loop: 配列順（= トポロジカル順・MX.4）で is_render_target な stage を処理する。
+    // stage i の output_target/send は必ず i より後ろを指す（構築時 validate_bus_topology で
+    // 検証済み）ので、`split_at_mut(i + 1)` で「i を含む左」と「i より後ろの右」に安全に分割できる
+    // （sum のネスト・循環は構造的に発生しない）。
+    for i in 0..buses.len() {
+        if !render_targets[i] {
             continue;
         }
-        if let Some(processor) = bus.processor.as_mut() {
-            processor.process(&mut bus.buffer[..bs]);
+        if active_flags[i] {
+            if let Some(processor) = buses[i].processor.as_mut() {
+                processor.process(&mut buses[i].buffer[..bs]);
+            }
         }
-        for (dst, src) in hw.iter_mut().zip(&bus.buffer[..bs]) {
-            *dst += *src;
+
+        let (left, right) = buses.split_at_mut(i + 1);
+        let src_stage = &left[i];
+
+        match src_stage.output_target {
+            BusTarget::Master => {
+                for (dst, s) in hw.iter_mut().zip(&src_stage.buffer[..bs]) {
+                    *dst += *s;
+                }
+            }
+            BusTarget::Bus(j) => {
+                let dst_buf = &mut right[j - i - 1].buffer[..bs];
+                for (d, s) in dst_buf.iter_mut().zip(&src_stage.buffer[..bs]) {
+                    *d += *s;
+                }
+            }
+        }
+        for send in &src_stage.sends {
+            let dst_buf = &mut right[send.target - i - 1].buffer[..bs];
+            for (d, s) in dst_buf.iter_mut().zip(&src_stage.buffer[..bs]) {
+                *d += *s * send.gain;
+            }
         }
     }
+
     if let Some(le) = link {
         for ch in le.channels.iter_mut() {
             if channel_egress_active(ch.ready.load(Ordering::Relaxed), ch.scratch.len(), bs) {
@@ -510,6 +634,7 @@ pub fn start_default_output_with_insert_buses(
             insert_buses.len()
         )));
     }
+    validate_bus_topology(&insert_buses)?;
     let (engine, stream, stats, _cb) = start_output_inner(
         None,
         std::mem::take(&mut insert_buses),
@@ -543,6 +668,7 @@ pub fn start_default_output_with_insert_buses_and_post(
             insert_buses.len()
         )));
     }
+    validate_bus_topology(&insert_buses)?;
     let (engine, stream, stats, cb) =
         start_output_inner(None, insert_buses, Some(post), buffer_frames, capture_path)?;
     Ok((
@@ -962,6 +1088,155 @@ mod tests {
             .iter()
             .all(|&sample| (sample - 0.5_f32.sqrt()).abs() < 1e-6));
         assert_eq!(engine.active_count(), Some(0));
+    }
+
+    // #459/#453 M1: mixer graph (sum/aux) 拡張の必須テスト群。既存の per-seq insert のみの構成
+    // （output_target=Master・sends 空）が上の既存テスト群でそのまま green であることをもって
+    // 「既定構成の挙動不変」を担保する（明示的な回帰確認）。
+
+    #[test]
+    fn sum_bus_chains_member_output_before_master() {
+        // stage0 "kick"（processor None・output_target=Bus(1) = drum sum へ）
+        // stage1 "drum"（sum・0.5×gain processor・output_target 既定 Master）
+        struct Half;
+        impl PostProcessor for Half {
+            fn process(&mut self, data: &mut [f32]) {
+                for sample in data {
+                    *sample *= 0.5;
+                }
+            }
+        }
+        let engine = Engine::new(48_000, 2);
+        let tagged = orbit_audio_core::Sample::new(vec![2.0; 4], 48_000, 2);
+        engine
+            .schedule_with_play_id(
+                0.0,
+                1.0,
+                0.0,
+                0,
+                0,
+                1.0,
+                Some("kick".into()),
+                "tagged".into(),
+                tagged,
+            )
+            .expect("schedule");
+        let mut buses = vec![
+            InsertBusStage::new("kick", None, 4).with_output_target(BusTarget::Bus(1)),
+            InsertBusStage::new("drum", Some(Box::new(Half)), 4),
+        ];
+        let mut hw = vec![0.0; 4];
+        let mut link = None;
+        render_engine_with_insert_buses(&engine, &mut link, &mut buses, 2, &mut hw);
+        // kick の寄与（2.0 × equal-power pan √0.5）が drum の 0.5×gain を経て hw に現れる。
+        assert!(hw
+            .iter()
+            .all(|&sample| (sample - 2.0_f32.sqrt() * 0.5).abs() < 1e-6));
+    }
+
+    #[test]
+    fn send_copies_post_insert_signal_with_gain() {
+        // stage0 "a"（0.5×insert processor・Master・send{target:1, gain:0.5}）
+        // stage1 "aux"（processor None・Master）
+        struct Half;
+        impl PostProcessor for Half {
+            fn process(&mut self, data: &mut [f32]) {
+                for sample in data {
+                    *sample *= 0.5;
+                }
+            }
+        }
+        let engine = Engine::new(48_000, 2);
+        let tagged = orbit_audio_core::Sample::new(vec![2.0; 4], 48_000, 2);
+        engine
+            .schedule_with_play_id(
+                0.0,
+                1.0,
+                0.0,
+                0,
+                0,
+                1.0,
+                Some("a".into()),
+                "tagged".into(),
+                tagged,
+            )
+            .expect("schedule");
+        let mut buses = vec![
+            InsertBusStage::new("a", Some(Box::new(Half)), 4).with_sends(vec![BusSend {
+                target: 1,
+                gain: 0.5,
+            }]),
+            InsertBusStage::unattached("aux"),
+        ];
+        buses[1].ensure_buffer_len(4);
+        let mut hw = vec![0.0; 4];
+        let mut link = None;
+        render_engine_with_insert_buses(&engine, &mut link, &mut buses, 2, &mut hw);
+        // raw = 2.0 × equal-power pan √0.5（post-pan・pre-insert）。
+        // dry = raw × 0.5（insert 後）が Master へ、wet = dry × 0.5（send gain・post-fader）が
+        // aux 経由で Master へ。hw = dry + wet = raw × 0.75。
+        let raw = 2.0_f32 * 0.5_f32.sqrt();
+        assert!(hw.iter().all(|&sample| (sample - raw * 0.75).abs() < 1e-6));
+    }
+
+    #[test]
+    fn invalid_forward_reference_rejected() {
+        // target/send が自分以下の index を指す構成は構築 API で拒否する（sum のネスト・循環を
+        // 構造的に排除する MX.4 の不変条件）。
+        let self_ref =
+            vec![InsertBusStage::new("a", None, 4).with_output_target(BusTarget::Bus(0))];
+        assert!(validate_bus_topology(&self_ref).is_err());
+
+        let backward_ref = vec![
+            InsertBusStage::new("a", None, 4).with_output_target(BusTarget::Bus(0)),
+            InsertBusStage::new("b", None, 4),
+        ];
+        assert!(validate_bus_topology(&backward_ref).is_err());
+
+        let bad_send = vec![InsertBusStage::new("a", None, 4).with_sends(vec![BusSend {
+            target: 0,
+            gain: 0.5,
+        }])];
+        assert!(validate_bus_topology(&bad_send).is_err());
+
+        let ok = vec![
+            InsertBusStage::new("a", None, 4).with_output_target(BusTarget::Bus(1)),
+            InsertBusStage::new("b", None, 4),
+        ];
+        assert!(validate_bus_topology(&ok).is_ok());
+    }
+
+    #[test]
+    fn inactive_sum_target_still_receives_member_output() {
+        // stage0 "kick"（active・processor None・output_target=Bus(1)）
+        // stage1 "drum"（inactive = 未 declare・processor None・output_target 既定 Master）でも、
+        // active な member から参照される is_render_target として buffer が生き、
+        // hw まで合成が届くこと。
+        let engine = Engine::new(48_000, 2);
+        let tagged = orbit_audio_core::Sample::new(vec![1.0; 4], 48_000, 2);
+        engine
+            .schedule_with_play_id(
+                0.0,
+                1.0,
+                0.0,
+                0,
+                0,
+                1.0,
+                Some("kick".into()),
+                "tagged".into(),
+                tagged,
+            )
+            .expect("schedule");
+        let mut buses = vec![
+            InsertBusStage::new("kick", None, 4).with_output_target(BusTarget::Bus(1)),
+            InsertBusStage::with_activation("drum", None, 4, Arc::new(AtomicBool::new(false))),
+        ];
+        let mut hw = vec![0.0; 4];
+        let mut link = None;
+        render_engine_with_insert_buses(&engine, &mut link, &mut buses, 2, &mut hw);
+        assert!(hw
+            .iter()
+            .all(|&sample| (sample - 0.5_f32.sqrt()).abs() < 1e-6));
     }
 
     #[test]

--- a/rust/crates/orbit-audio-native/src/output.rs
+++ b/rust/crates/orbit-audio-native/src/output.rs
@@ -1,7 +1,7 @@
 //! cpal を使った既定出力デバイスへのストリーム設定。
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -169,9 +169,25 @@ pub struct InsertBusStage {
     /// 構造的に成立）。
     active: Arc<AtomicBool>,
     /// この stage の insert 適用後 buffer を最終的にどこへ足すか（既定 `Master` = 従来経路）。
+    /// **静的**構成（テスト・PH.2b の固定 topology）用。M2 の実行時切替は `routing_override` を
+    /// 優先する（後述）。
     output_target: BusTarget,
     /// post-insert の buffer を copy 加算する先（既定空 = 従来経路）。MX.3 の send/aux。
+    /// `output_target` と同様、静的構成専用。M2 の実行時切替は `send_gain_overrides` を使う。
     sends: Vec<BusSend>,
+    /// M2（#459/#453）: `SetBusRouting` daemon コマンド（非 RT・session.rs）が書き込む実行時
+    /// ルーティング。RT callback は atomic load のみ行う（Relaxed で可・ルーティング変更は
+    /// 音楽的タイミング精度不要）。エンコード: `0` = override 無し（静的 `output_target` を使う）・
+    /// `1` = `Master`・`n >= 2` = `Bus(n - 2)`。呼び出し側（`build_effect_bus_stages` 系）が
+    /// 構築時に `Arc::new(AtomicUsize::new(0))` を渡し、control 側にも同じ Arc の clone を保持させる
+    /// ことで、命名解決済みの routing 変更を RT 側に不可視な形で反映する。
+    routing_override: Arc<AtomicUsize>,
+    /// M2: 実行時 send gain override。index `k` は「この stage より `k + 1` 個後ろ」の stage への
+    /// send gain（f32 bits・`0.0` = 無効 = send 無し）。構築時に「この stage より後ろの全 stage」分の
+    /// スロットを確保しておく（v1 の設計判断: SetBusRouting は既存スロットへの書き込みのみで、
+    /// 実行時に Vec を伸長しない）。send 先は aux kind のみ許可（control 側 `SetBusRouting` ハンドラが
+    /// 検証・spec MX.4）。
+    send_gain_overrides: Vec<Arc<AtomicU32>>,
 }
 
 impl InsertBusStage {
@@ -202,6 +218,8 @@ impl InsertBusStage {
             active,
             output_target: BusTarget::default(),
             sends: Vec::new(),
+            routing_override: Arc::new(AtomicUsize::new(0)),
+            send_gain_overrides: Vec::new(),
         }
     }
 
@@ -223,10 +241,36 @@ impl InsertBusStage {
         self
     }
 
+    /// M2（#459/#453）: 実行時ルーティング用の atomic ハンドルを装着する。`routing_override` は
+    /// この stage の output target 切替用（呼び出し側が control 側にも同じ Arc の clone を保持し
+    /// `SetBusRouting` で書き込む）。`send_gain_overrides` は「この stage より後ろの全 stage」分の
+    /// gain スロットを、絶対 index の昇順（この stage の直後から順）で渡す（呼び出し側が
+    /// stage 配列の組み立て時にサイズを決める）。
+    pub fn with_routing_overrides(
+        mut self,
+        routing_override: Arc<AtomicUsize>,
+        send_gain_overrides: Vec<Arc<AtomicU32>>,
+    ) -> Self {
+        self.routing_override = routing_override;
+        self.send_gain_overrides = send_gain_overrides;
+        self
+    }
+
     fn ensure_buffer_len(&mut self, len: usize) {
         if self.buffer.len() < len {
             self.buffer.resize(len, 0.0);
         }
+    }
+}
+
+/// stage の実行時 output target を解決する（M2）。`routing_override` が `0`（override 無し）なら
+/// 静的 `output_target` をそのまま使う。RT callback から呼ぶため atomic load 以外の副作用は無い。
+#[inline]
+fn effective_output_target(stage: &InsertBusStage) -> BusTarget {
+    match stage.routing_override.load(Ordering::Relaxed) {
+        0 => stage.output_target,
+        1 => BusTarget::Master,
+        n => BusTarget::Bus(n - 2),
     }
 }
 
@@ -375,11 +419,18 @@ fn render_engine_with_insert_buses(
         if !active_flags[i] {
             continue;
         }
-        if let BusTarget::Bus(j) = bus.output_target {
+        if let BusTarget::Bus(j) = effective_output_target(bus) {
             render_targets[j] = true;
         }
         for send in &bus.sends {
             render_targets[send.target] = true;
+        }
+        // M2: 実行時 send override も render target 判定に加える（override が非ゼロ gain の間、
+        // 合流先 stage を post-loop の zero-fill/processor 対象に含める必要がある）。
+        for (k, gain) in bus.send_gain_overrides.iter().enumerate() {
+            if f32::from_bits(gain.load(Ordering::Relaxed)) != 0.0 {
+                render_targets[i + 1 + k] = true;
+            }
         }
     }
 
@@ -441,7 +492,7 @@ fn render_engine_with_insert_buses(
         let (left, right) = buses.split_at_mut(i + 1);
         let src_stage = &left[i];
 
-        match src_stage.output_target {
+        match effective_output_target(src_stage) {
             BusTarget::Master => {
                 for (dst, s) in hw.iter_mut().zip(&src_stage.buffer[..bs]) {
                     *dst += *s;
@@ -458,6 +509,17 @@ fn render_engine_with_insert_buses(
             let dst_buf = &mut right[send.target - i - 1].buffer[..bs];
             for (d, s) in dst_buf.iter_mut().zip(&src_stage.buffer[..bs]) {
                 *d += *s * send.gain;
+            }
+        }
+        // M2: 実行時 send override（`SetBusRouting`）。gain=0.0 は無効（分岐で skip・RT はロードのみ）。
+        for (k, gain_atomic) in src_stage.send_gain_overrides.iter().enumerate() {
+            let gain = f32::from_bits(gain_atomic.load(Ordering::Relaxed));
+            if gain == 0.0 {
+                continue;
+            }
+            let dst_buf = &mut right[k].buffer[..bs];
+            for (d, s) in dst_buf.iter_mut().zip(&src_stage.buffer[..bs]) {
+                *d += *s * gain;
             }
         }
     }
@@ -1177,6 +1239,134 @@ mod tests {
         // aux 経由で Master へ。hw = dry + wet = raw × 0.75。
         let raw = 2.0_f32 * 0.5_f32.sqrt();
         assert!(hw.iter().all(|&sample| (sample - raw * 0.75).abs() < 1e-6));
+    }
+
+    // #459/#453 M2: 実行時ルーティング（`routing_override`/`send_gain_overrides`）が次の
+    // callback から反映されることを固定する（`SetBusRouting` は control 側で atomic を書き換える
+    // だけで render 側には触れない、という設計の生命線）。
+
+    #[test]
+    fn routing_override_retargets_output_from_master_to_bus_on_next_callback() {
+        // stage0 "a"（static output_target=Master）に override で Bus(1) を書き込むと、次の
+        // callback から「a → drum(0.5×gain) → Master」経路に切り替わる。
+        struct Half;
+        impl PostProcessor for Half {
+            fn process(&mut self, data: &mut [f32]) {
+                for sample in data {
+                    *sample *= 0.5;
+                }
+            }
+        }
+        let engine = Engine::new(48_000, 2);
+        let tagged = orbit_audio_core::Sample::new(vec![2.0; 4], 48_000, 2);
+        engine
+            .schedule_with_play_id(
+                0.0,
+                1.0,
+                0.0,
+                0,
+                0,
+                1.0,
+                Some("a".into()),
+                "tagged".into(),
+                tagged,
+            )
+            .expect("schedule");
+
+        let routing_override = Arc::new(AtomicUsize::new(0));
+        let mut buses = vec![
+            InsertBusStage::new("a", None, 4).with_routing_overrides(
+                routing_override.clone(),
+                vec![Arc::new(AtomicU32::new(0))],
+            ),
+            InsertBusStage::new("drum", Some(Box::new(Half)), 4),
+        ];
+        let mut hw = vec![0.0; 4];
+        let mut link = None;
+
+        // override 前: 既定 static Master へ直接加算される（drum の 0.5×gain を経ない）。
+        render_engine_with_insert_buses(&engine, &mut link, &mut buses, 2, &mut hw);
+        let raw = 2.0_f32 * 0.5_f32.sqrt();
+        assert!(hw.iter().all(|&sample| (sample - raw).abs() < 1e-6));
+
+        // override 書き込み（= `SetBusRouting` が control 側から行う操作の模擬）。
+        // encoding: n = target_index(1) + 2 = 3.
+        routing_override.store(3, Ordering::Relaxed);
+
+        // 次の block を再スケジュールして再度 render（同じ音を再現）。
+        engine
+            .schedule_with_play_id(
+                0.0,
+                1.0,
+                0.0,
+                0,
+                0,
+                1.0,
+                Some("a".into()),
+                "tagged2".into(),
+                orbit_audio_core::Sample::new(vec![2.0; 4], 48_000, 2),
+            )
+            .expect("schedule");
+        let mut hw2 = vec![0.0; 4];
+        render_engine_with_insert_buses(&engine, &mut link, &mut buses, 2, &mut hw2);
+        assert!(hw2.iter().all(|&sample| (sample - raw * 0.5).abs() < 1e-6));
+    }
+
+    #[test]
+    fn send_gain_override_applies_from_the_correct_slot_on_next_callback() {
+        // stage0 "a"（processor None）に override で aux(index 1) への send gain を書き込むと、
+        // 次の callback から Master(dry) + aux(wet) の合成に切り替わる。
+        let engine = Engine::new(48_000, 2);
+        let tagged = orbit_audio_core::Sample::new(vec![2.0; 4], 48_000, 2);
+        engine
+            .schedule_with_play_id(
+                0.0,
+                1.0,
+                0.0,
+                0,
+                0,
+                1.0,
+                Some("a".into()),
+                "tagged".into(),
+                tagged,
+            )
+            .expect("schedule");
+
+        let send_slot = Arc::new(AtomicU32::new(0));
+        let mut buses = vec![
+            InsertBusStage::new("a", None, 4)
+                .with_routing_overrides(Arc::new(AtomicUsize::new(0)), vec![send_slot.clone()]),
+            InsertBusStage::unattached("aux"),
+        ];
+        buses[1].ensure_buffer_len(4);
+        let mut hw = vec![0.0; 4];
+        let mut link = None;
+
+        // override 前: dry のみ Master へ。
+        render_engine_with_insert_buses(&engine, &mut link, &mut buses, 2, &mut hw);
+        let raw = 2.0_f32 * 0.5_f32.sqrt();
+        assert!(hw.iter().all(|&sample| (sample - raw).abs() < 1e-6));
+
+        // send gain override 書き込み（`SetBusRouting` の模擬）。
+        send_slot.store(0.5_f32.to_bits(), Ordering::Relaxed);
+
+        engine
+            .schedule_with_play_id(
+                0.0,
+                1.0,
+                0.0,
+                0,
+                0,
+                1.0,
+                Some("a".into()),
+                "tagged2".into(),
+                orbit_audio_core::Sample::new(vec![2.0; 4], 48_000, 2),
+            )
+            .expect("schedule");
+        let mut hw2 = vec![0.0; 4];
+        render_engine_with_insert_buses(&engine, &mut link, &mut buses, 2, &mut hw2);
+        // dry(raw) + wet(raw × 0.5 send gain) = raw × 1.5.
+        assert!(hw2.iter().all(|&sample| (sample - raw * 1.5).abs() < 1e-6));
     }
 
     #[test]

--- a/tests/audio-parser/mixer-handle-syntax.spec.ts
+++ b/tests/audio-parser/mixer-handle-syntax.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Bare `sum("name")` / `aux("name")` reference syntax (MX.2/MX.3, #459/#453 M3):
+ * `sum("drum").effect("GlueComp.clap")`. Distinct from `global.sum(name)` /
+ * `global.aux(name)` (the declaration form — a plain GlobalStatement, unaffected by
+ * this grammar addition and covered by the existing GlobalStatement parsing tests).
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+
+describe('Bare sum()/aux() reference parsing', () => {
+  it('parses a chained sum("name").effect(path) as a mixer_handle statement', () => {
+    const ir = parseAudioDSL('sum("drum").effect("GlueComp.clap")')
+    expect(ir.statements[0]).toMatchObject({
+      type: 'mixer_handle',
+      kind: 'sum',
+      name: 'drum',
+      chain: [{ method: 'effect', args: ['GlueComp.clap'] }],
+    })
+  })
+
+  it('parses a chained aux("name").effect(path) as a mixer_handle statement', () => {
+    const ir = parseAudioDSL('aux("rev").effect("Reverb.clap")')
+    expect(ir.statements[0]).toMatchObject({
+      type: 'mixer_handle',
+      kind: 'aux',
+      name: 'rev',
+      chain: [{ method: 'effect', args: ['Reverb.clap'] }],
+    })
+  })
+
+  it('parses a bare reference with no chain', () => {
+    const ir = parseAudioDSL('sum("drum")')
+    expect(ir.statements[0]).toMatchObject({
+      type: 'mixer_handle',
+      kind: 'sum',
+      name: 'drum',
+    })
+    expect((ir.statements[0] as any).chain).toBeUndefined()
+  })
+
+  it('parses global.sum(name) as an ordinary GlobalStatement (declaration form, unaffected)', () => {
+    // Parser cannot distinguish global vs. sequence targets at parse time (arbitrary variable
+    // names) — it emits `type: 'sequence'` and the interpreter re-labels it at execution via
+    // `state.globals`/`state.sequences` (see process-statement.ts). Same as `global.tempo()`.
+    const ir = parseAudioDSL('global.sum("drum")')
+    expect(ir.statements[0]).toMatchObject({
+      type: 'sequence',
+      target: 'global',
+      method: 'sum',
+      args: ['drum'],
+    })
+  })
+
+  it('parses global.aux(name).effect(path) as a GlobalStatement with a chain', () => {
+    const ir = parseAudioDSL('global.aux("rev").effect("Reverb.clap")')
+    expect(ir.statements[0]).toMatchObject({
+      type: 'sequence',
+      target: 'global',
+      method: 'aux',
+      args: ['rev'],
+      chain: [{ method: 'effect', args: ['Reverb.clap'] }],
+    })
+  })
+
+  it('supports multiple statements mixing declaration and bare-reference forms', () => {
+    const ir = parseAudioDSL(
+      'global.sum("drum")\nkick.output("drum")\nsum("drum").effect("GlueComp.clap")',
+    )
+    expect(ir.statements).toHaveLength(3)
+    expect(ir.statements[2]).toMatchObject({ type: 'mixer_handle', kind: 'sum', name: 'drum' })
+  })
+})

--- a/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
+++ b/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
@@ -12,6 +12,7 @@ interface FakeDaemon {
   loadPlugin: ReturnType<typeof vi.fn>
   pluginNoteOn: ReturnType<typeof vi.fn>
   pluginNoteOff: ReturnType<typeof vi.fn>
+  setBusRouting: ReturnType<typeof vi.fn>
   quit: ReturnType<typeof vi.fn>
 }
 
@@ -32,6 +33,7 @@ function createHarness() {
     loadPlugin: vi.fn().mockResolvedValue(ECHO_LOAD_RESULT),
     pluginNoteOn: vi.fn().mockResolvedValue(undefined),
     pluginNoteOff: vi.fn().mockResolvedValue(undefined),
+    setBusRouting: vi.fn().mockResolvedValue(undefined),
     quit: vi.fn().mockResolvedValue(undefined),
   }
   Object.defineProperty(player, 'daemon', { value: daemon })
@@ -186,6 +188,90 @@ describe('RustEnginePlayer plugin recovery after daemon respawn', () => {
       'seq-bus-0',
     )
     expect(player.isPluginActive()).toBe(false)
+  })
+})
+
+describe('RustEnginePlayer bus routing recovery after daemon respawn (MX.4 M3)', () => {
+  const players: RustEnginePlayer[] = []
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await Promise.all(players.splice(0).map((player) => player.quit()))
+  })
+
+  it('replays the last intended SetBusRouting per seq bus after respawn', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    await player.setBusRouting('seq-bus-0', 'sum-bus-0', [{ bus: 'aux-bus-0', gain: 0.3 }])
+    await player.setBusRouting('seq-bus-1', undefined, [{ bus: 'aux-bus-0', gain: 0.5 }])
+    daemon.setBusRouting.mockClear()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await (player as any).respawnLoop()
+
+    expect(daemon.setBusRouting).toHaveBeenCalledTimes(2)
+    expect(daemon.setBusRouting).toHaveBeenCalledWith('seq-bus-0', 'sum-bus-0', [
+      { bus: 'aux-bus-0', gain: 0.3 },
+    ])
+    expect(daemon.setBusRouting).toHaveBeenCalledWith('seq-bus-1', undefined, [
+      { bus: 'aux-bus-0', gain: 0.5 },
+    ])
+  })
+
+  it('keeps the intended routing on a transport failure so the respawn replay restores it', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    daemon.setBusRouting.mockRejectedValueOnce(new Error('socket closed'))
+    await expect(player.setBusRouting('seq-bus-0', 'sum-bus-0', [])).rejects.toThrow(
+      'socket closed',
+    )
+    daemon.setBusRouting.mockClear()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await (player as any).respawnLoop()
+
+    expect(daemon.setBusRouting).toHaveBeenCalledWith('seq-bus-0', 'sum-bus-0', [])
+  })
+
+  it('reverts the cache on a definitive daemon-side rejection (no bad replay after respawn)', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    await player.setBusRouting('seq-bus-0', 'sum-bus-0', [])
+    daemon.setBusRouting.mockRejectedValueOnce(
+      new DaemonProtocolError('MALFORMED_REQUEST', 'output must target a sum bus'),
+    )
+    await expect(player.setBusRouting('seq-bus-0', 'aux-bus-0', [])).rejects.toThrow(
+      'output must target a sum bus',
+    )
+    daemon.setBusRouting.mockClear()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await (player as any).respawnLoop()
+
+    // The rejected request is NOT replayed; the last accepted routing is.
+    expect(daemon.setBusRouting).toHaveBeenCalledTimes(1)
+    expect(daemon.setBusRouting).toHaveBeenCalledWith('seq-bus-0', 'sum-bus-0', [])
+  })
+
+  it('one routing replay failure logs an error and does not skip the others or fail the respawn', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    await player.setBusRouting('seq-bus-0', 'sum-bus-0', [])
+    await player.setBusRouting('seq-bus-1', 'sum-bus-0', [])
+    daemon.setBusRouting.mockClear()
+    daemon.setBusRouting
+      .mockRejectedValueOnce(new Error('replay failed'))
+      .mockResolvedValueOnce(undefined)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await (player as any).respawnLoop()
+
+    expect(daemon.setBusRouting).toHaveBeenCalledTimes(2)
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('failed to restore bus routing'),
+      expect.any(Error),
+    )
   })
 })
 

--- a/tests/core/global-mixer-sum-aux.spec.ts
+++ b/tests/core/global-mixer-sum-aux.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * global.sum() / global.aux() — mixer group/return bus declarations (MX.2/MX.3, #459/#453 M3).
+ */
+
+import path from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { Global } from '../../packages/engine/src/core/global'
+import { MIXER_BUS_POOL_SIZE } from '../../packages/engine/src/core/global/mixer-manager'
+
+function makeGlobal(loadPlugin = vi.fn().mockResolvedValue({})) {
+  const engine = {
+    loadPlugin,
+    boot: vi.fn(),
+    quit: vi.fn(),
+    isRunning: true,
+  } as any
+  const global = new Global(engine)
+  global.setDocumentDirectory('/songs/session')
+  return { global, loadPlugin }
+}
+
+describe('Global.sum() / Global.aux()', () => {
+  it('allocates the first pool bus per kind, in declaration order', () => {
+    const { global } = makeGlobal()
+    expect(global.sum('drum').bus).toBe('sum-bus-0')
+    expect(global.sum('lead').bus).toBe('sum-bus-1')
+    expect(global.aux('rev').bus).toBe('aux-bus-0')
+    expect(global.aux('delay').bus).toBe('aux-bus-1')
+  })
+
+  it('is idempotent: re-declaring the same name returns the same bus', () => {
+    const { global } = makeGlobal()
+    expect(global.sum('drum').bus).toBe('sum-bus-0')
+    expect(global.sum('drum').bus).toBe('sum-bus-0')
+    expect(global.resolveSumBus('drum')).toBe('sum-bus-0')
+  })
+
+  it('resolveSumBus()/resolveAuxBus() return undefined for an undeclared name', () => {
+    const { global } = makeGlobal()
+    expect(global.resolveSumBus('nope')).toBeUndefined()
+    expect(global.resolveAuxBus('nope')).toBeUndefined()
+  })
+
+  it('exhausts the sum pool after the v1 cap (4) with an explicit message', () => {
+    const { global } = makeGlobal()
+    for (let i = 0; i < MIXER_BUS_POOL_SIZE; i++) global.sum(`s${i}`)
+    expect(() => global.sum('overflow')).toThrow('pool exhausted')
+  })
+
+  it('exhausts the aux pool after the v1 cap (4) with an explicit message', () => {
+    const { global } = makeGlobal()
+    for (let i = 0; i < MIXER_BUS_POOL_SIZE; i++) global.aux(`a${i}`)
+    expect(() => global.aux('overflow')).toThrow('pool exhausted')
+  })
+
+  it('rejects sum()/aux() while LinkAudio is enabled', () => {
+    const { global } = makeGlobal()
+    global.linkAudio()
+    expect(() => global.sum('drum')).toThrow('LinkAudio')
+    expect(() => global.aux('rev')).toThrow('LinkAudio')
+  })
+
+  it('blocks a later global.linkAudio() once a sum/aux bus has been declared', () => {
+    const { global } = makeGlobal()
+    global.sum('drum')
+    expect(() => global.linkAudio()).toThrow('plugin hosting')
+  })
+
+  it('handle.effect() loads via LoadPlugin(role=effect, bus=<sum/aux bus>)', async () => {
+    const { global, loadPlugin } = makeGlobal()
+    const handle = global.sum('drum')
+    await handle.effect('./GlueComp.clap')
+    expect(loadPlugin).toHaveBeenCalledWith(
+      path.resolve('/songs/session', 'GlueComp.clap'),
+      undefined,
+      'effect',
+      'sum-bus-0',
+    )
+  })
+
+  it('handle.effect() is idempotent on the same path + pluginId', async () => {
+    const { global, loadPlugin } = makeGlobal()
+    await global.sum('drum').effect('./GlueComp.clap', 'glue-id')
+    await global.sum('drum').effect('GlueComp.clap', 'glue-id')
+    expect(loadPlugin).toHaveBeenCalledTimes(1)
+  })
+
+  it('handle.effect() rejects re-declaration with a different path', async () => {
+    const { global } = makeGlobal()
+    await global.sum('drum').effect('./GlueComp.clap')
+    await expect(global.sum('drum').effect('./OtherComp.clap')).rejects.toThrow(
+      'one insert per bus',
+    )
+  })
+
+  it('handle.effect() rejects non-.clap specs', async () => {
+    const { global } = makeGlobal()
+    await expect(global.sum('drum').effect('Reverb.vst3')).rejects.toThrow('not yet supported')
+  })
+
+  it('sum("drum") and aux("rev") are independent namespaces/pools', () => {
+    const { global } = makeGlobal()
+    global.sum('shared-name')
+    expect(global.aux('shared-name').bus).toBe('aux-bus-0')
+    expect(global.resolveSumBus('shared-name')).toBe('sum-bus-0')
+    expect(global.resolveAuxBus('shared-name')).toBe('aux-bus-0')
+  })
+})

--- a/tests/core/sequence-output-send-mixer.spec.ts
+++ b/tests/core/sequence-output-send-mixer.spec.ts
@@ -4,6 +4,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { DaemonProtocolError } from '../../packages/engine/src/audio/rust-engine/errors'
 import { Global } from '../../packages/engine/src/core/global'
 import { Sequence } from '../../packages/engine/src/core/sequence'
 import { MidiManager } from '../../packages/engine/src/core/global/midi-manager'
@@ -102,13 +103,45 @@ describe('Sequence.output() → sum bus routing (MX.2/MX.4)', () => {
     expect(() => seq.output('drum')).toThrow('only supported on audio sequences')
   })
 
-  it('logs a warning but does not throw when SetBusRouting rejects', async () => {
-    const setBusRouting = vi.fn().mockRejectedValue(new Error('kind mismatch'))
+  it('logs a transient warning (not error) and does not throw when SetBusRouting fails at transport', async () => {
+    const setBusRouting = vi.fn().mockRejectedValue(new Error('socket closed'))
     const { global, seq } = harness(setBusRouting)
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     global.sum('drum')
     expect(() => seq.output('drum')).not.toThrow()
     await vi.waitFor(() => expect(warnSpy).toHaveBeenCalled())
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('will re-sync'))
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('logs an actionable console.error when the daemon definitively rejects SetBusRouting', async () => {
+    const setBusRouting = vi
+      .fn()
+      .mockRejectedValue(new DaemonProtocolError('MALFORMED_REQUEST', 'kind mismatch'))
+    const { global, seq } = harness(setBusRouting)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    global.sum('drum')
+    expect(() => seq.output('drum')).not.toThrow()
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalled())
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('routing was NOT applied'))
+  })
+
+  it('self-heals a failed routing push on the next routing call (full-state re-send)', async () => {
+    const setBusRouting = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('socket closed'))
+      .mockResolvedValue(undefined)
+    const { global, seq } = harness(setBusRouting)
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    global.sum('drum')
+    global.aux('rev')
+    seq.output('drum') // fails (transient)
+    seq.send('rev', 0.3) // full-state re-send carries the sum output too
+    await vi.waitFor(() => expect(setBusRouting).toHaveBeenCalledTimes(2))
+    expect(setBusRouting).toHaveBeenLastCalledWith('seq-bus-0', 'sum-bus-0', [
+      { bus: 'aux-bus-0', gain: 0.3 },
+    ])
   })
 })
 

--- a/tests/core/sequence-output-send-mixer.spec.ts
+++ b/tests/core/sequence-output-send-mixer.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * seq.output(sumName) / seq.send(auxName, amount) — mixer routing (MX.2/MX.3/MX.4, #459/#453 M3).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Global } from '../../packages/engine/src/core/global'
+import { Sequence } from '../../packages/engine/src/core/sequence'
+import { MidiManager } from '../../packages/engine/src/core/global/midi-manager'
+import type { MidiOutput } from '../../packages/engine/src/midi/midi-output'
+
+const T0 = 1_000_000
+
+// Mirrors tests/core/sequence-effect.spec.ts's harness: seq.midi() must not hit the real
+// RtMidi binding (crashes the sandbox / CI worker with no OS MIDI client available).
+function mockMidiOutput(): MidiOutput {
+  return {
+    ensurePort: vi.fn(() => 'IAC'),
+    noteOn: vi.fn(),
+    noteOff: vi.fn(),
+    pitchBend: vi.fn(),
+    releaseOwner: vi.fn(),
+    panic: vi.fn(),
+    getActiveNotes: vi.fn(() => []),
+    listPorts: vi.fn(() => ['IAC']),
+    closeAll: vi.fn(),
+  } as unknown as MidiOutput
+}
+
+function harness(setBusRouting = vi.fn().mockResolvedValue(undefined)) {
+  const audio = {
+    isRunning: true,
+    startTime: T0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(),
+    clearSequenceEvents: vi.fn(),
+    reinitializeSequenceTracking: vi.fn(),
+    scheduleEvent: vi.fn(),
+    scheduleSliceEvent: vi.fn(),
+    getAudioDuration: vi.fn(() => 1),
+    getMasterGainDb: () => 0,
+    loadPlugin: vi.fn().mockResolvedValue({}),
+    setBusRouting,
+  } as any
+  const midiOutput = mockMidiOutput()
+  const global = new Global(audio, new MidiManager(() => midiOutput))
+  global.setDocumentDirectory('/songs')
+  const seq = new Sequence(global, audio)
+  seq.setName('kick')
+  return { audio, global, seq, setBusRouting }
+}
+
+describe('Sequence.output() → sum bus routing (MX.2/MX.4)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(T0)
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('auto-allocates a per-seq insert bus and issues SetBusRouting(output=<sum bus>) when no seq.effect() was declared', async () => {
+    const { global, seq, setBusRouting } = harness()
+    global.sum('drum')
+    seq.output('drum')
+    await vi.waitFor(() => expect(setBusRouting).toHaveBeenCalled())
+    expect(seq.getInsertBus()).toBe('seq-bus-0')
+    expect(setBusRouting).toHaveBeenCalledWith('seq-bus-0', 'sum-bus-0', [])
+  })
+
+  it('reuses the existing insert bus when seq.effect() was already declared', async () => {
+    const { global, seq, setBusRouting } = harness()
+    global.sum('drum')
+    await seq.effect('./reverb.clap')
+    expect(seq.getInsertBus()).toBe('seq-bus-0')
+    seq.output('drum')
+    await vi.waitFor(() => expect(setBusRouting).toHaveBeenCalled())
+    expect(setBusRouting).toHaveBeenCalledWith('seq-bus-0', 'sum-bus-0', [])
+  })
+
+  it('falls back to the LinkAudio/warn behavior for a name that is not a declared sum bus', () => {
+    const { seq, setBusRouting } = harness()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    seq.output('not-a-sum')
+    expect(seq.getOutputChannel()).toBe('not-a-sum')
+    expect(setBusRouting).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('is method-chainable (returns this)', () => {
+    const { global, seq } = harness()
+    global.sum('drum')
+    expect(seq.output('drum')).toBe(seq)
+  })
+
+  it('rejects sum routing on a note (midi) sequence', () => {
+    const { global, seq } = harness()
+    global.sum('drum')
+    seq.midi('iac', 1)
+    expect(() => seq.output('drum')).toThrow('only supported on audio sequences')
+  })
+
+  it('logs a warning but does not throw when SetBusRouting rejects', async () => {
+    const setBusRouting = vi.fn().mockRejectedValue(new Error('kind mismatch'))
+    const { global, seq } = harness(setBusRouting)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    global.sum('drum')
+    expect(() => seq.output('drum')).not.toThrow()
+    await vi.waitFor(() => expect(warnSpy).toHaveBeenCalled())
+  })
+})
+
+describe('Sequence.send() → aux bus routing (MX.3/MX.4)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(T0)
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('auto-allocates a per-seq insert bus and issues SetBusRouting(sends=[{bus, gain}])', async () => {
+    const { global, seq, setBusRouting } = harness()
+    global.aux('rev')
+    seq.send('rev', 0.3)
+    await vi.waitFor(() => expect(setBusRouting).toHaveBeenCalled())
+    expect(seq.getInsertBus()).toBe('seq-bus-0')
+    expect(setBusRouting).toHaveBeenCalledWith('seq-bus-0', undefined, [
+      { bus: 'aux-bus-0', gain: 0.3 },
+    ])
+  })
+
+  it('accumulates multiple sends (fan-out) and re-sends the full set each time', async () => {
+    const { global, seq, setBusRouting } = harness()
+    global.aux('rev')
+    global.aux('delay')
+    seq.send('rev', 0.3)
+    seq.send('delay', 0.5)
+    await vi.waitFor(() => expect(setBusRouting).toHaveBeenCalledTimes(2))
+    expect(setBusRouting).toHaveBeenLastCalledWith('seq-bus-0', undefined, [
+      { bus: 'aux-bus-0', gain: 0.3 },
+      { bus: 'aux-bus-1', gain: 0.5 },
+    ])
+  })
+
+  it('combines an existing sum output with sends in the re-issued SetBusRouting', async () => {
+    const { global, seq, setBusRouting } = harness()
+    global.sum('drum')
+    global.aux('rev')
+    seq.output('drum')
+    seq.send('rev', 0.3)
+    await vi.waitFor(() => expect(setBusRouting).toHaveBeenCalledTimes(2))
+    expect(setBusRouting).toHaveBeenLastCalledWith('seq-bus-0', 'sum-bus-0', [
+      { bus: 'aux-bus-0', gain: 0.3 },
+    ])
+  })
+
+  it('rejects send() to an undeclared aux bus', () => {
+    const { seq } = harness()
+    expect(() => seq.send('nope', 0.5)).toThrow('undeclared aux bus')
+  })
+
+  it('rejects non-finite gain', () => {
+    const { global, seq } = harness()
+    global.aux('rev')
+    expect(() => seq.send('rev', NaN)).toThrow('must be finite')
+  })
+
+  it('rejects send() on a note (midi) sequence', () => {
+    const { global, seq } = harness()
+    global.aux('rev')
+    seq.midi('iac', 1)
+    expect(() => seq.send('rev', 0.5)).toThrow('only supported on audio sequences')
+  })
+
+  it('is method-chainable (returns this)', () => {
+    const { global, seq } = harness()
+    global.aux('rev')
+    expect(seq.send('rev', 0.5)).toBe(seq)
+  })
+})


### PR DESCRIPTION
Closes #459
Closes #453

## 概要

#434 の insert bus 基盤の上に、DAW ミキサー構造を DSL まで完走。**spec 先行**（MX.1-MX.5・PR #466 マージ済み）+ 3ステージ。

```js
global.sum("drum")
sum("drum").effect("GlueComp.clap")
kick.output("drum")

global.aux("rev")
aux("rev").effect("Reverb.clap")
kick.send("rev", 0.3)
```

## ステージ

| Stage | コミット | 内容 |
|---|---|---|
| M1 | `3029545` | core: BusTarget/BusSend・トポロジカル post-loop（前方参照のみ = ネスト/循環が構造的に不可）・is_render_target 分離 |
| M2 | `95d3fc9` | daemon: kind 別プール（insert/sum/aux）・実行時 routing の atomic overlay・SetBusRouting protocol |
| M3 | `7b70b1b` | DSL: MixerManager・seq.output()/send()・pass-through 自動確保・activation・parser 拡張 |

## 実機検証（客観値）

- **gated: insert→sum→aux カスケード全段厳密半減** 0.70711 → 0.35355 → 0.17678 → 0.08839
- **DSL sum oracle: peak 0.35355 厳密一致**
- **DSL aux oracle: 窓解析で send 実効を実証**（第1窓 dry 0.7071 → 定常 0.4965 = dry+位相シフト wet。素朴期待値との差は **MX.5 の既知制約（PDC なし）の実観測** = spec と実挙動の一致）
- 退行なし: bus/both gated 実機・npm test 1397・rust 3構成

## 設計の核

fan-out は event 複製ではなく **bus 処理段の copy 加算**（`render_multi` 無変更）。決定記録 = issue #459 コメント（2026-07-17）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu