### PR TITLE
feat(engine): file import declaration — parser + interpreter (#456 I1+I2)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,32 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.265 feat(engine): file import declaration — parser + interpreter (I1+I2) #456 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 実装・実機 E2E 済み（spec = IM.1-IM.6・PR #469 マージ済みの正本に準拠）
+
+**内容**:
+- **parser (I1)**: `import { names } from "./file.orbs"` を既存 `import chords` と同一キーワードで
+  分岐パース（次トークン `{` = file import）。パス検査（`./`|`../` 開始・`.orbs` 必須）・
+  先頭領域検査（非 import 文の後の import はエラー）。IR は `fileImports` 別バケット
+  （評価順序の規範を担保）
+- **interpreter (I2)**: `process-file-import.ts` 新設。realpath ベースの module cache
+  （ダイヤモンド 1 回評価）・循環検出（entry 含む stack）・契約検査（IR 静的宣言列挙 vs
+  names）・transport 禁止（IM.3）・module 評価中は documentDirectory を module dir に
+  差し替え（IM.4: audio() は呼び出し時即時解決のためこれで成立）・entry の宣言は常に最後
+  （IM.2 評価順序）
+- REPL/部分 eval: sourceFile 無しは documentDirectory 基準・どちらも無ければエラー（IM.6）
+
+**検証**: 新規 spec 17 tests（parser 7 + interpreter 10: merge/契約/循環/自己 import/
+ダイヤモンド/transport 拒否/transitive パス/REPL 基準/基準なしエラー）。全体 1420 passed。
+実機 E2E: module（`./sine_880.wav` = module 相対）を entry が import → RUN → capture
+peak 0.70711（オラクル一致・IM.4 実機確認）。
+
+**残（I3・別 PR）**: VS Code 拡張の import 行対応（診断抑制・保存時再評価の動線）。
+
+Refs #456
+
 ### 6.264 docs(spec): import 宣言の spec 起草（IM.1-IM.6）#456 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/packages/engine/src/interpreter/interpreter-v2.ts
+++ b/packages/engine/src/interpreter/interpreter-v2.ts
@@ -179,7 +179,15 @@ export class InterpreterV2 {
         )
       }
       const ctx = createImportContext(options?.sourceFile)
-      await processFileImports(ir.fileImports, baseDir, this.state, ctx)
+      try {
+        await processFileImports(ir.fileImports, baseDir, this.state, ctx)
+      } finally {
+        // 成功・失敗を問わず基準ディレクトリを entry 側（documentDirectory または
+        // sourceFile のディレクトリ = baseDir）へ復元する。復元しないと entry 自身の
+        // audio() が最後に評価した module のディレクトリ基準で解決される（IM.4 違反）し、
+        // 失敗時は長寿命 interpreter（REPL/live）で次の評価まで基準が腐る。
+        this.state.currentGlobal?.setDocumentDirectory(options?.documentDirectory ?? baseDir)
+      }
     }
 
     // Process global initialization

--- a/packages/engine/src/interpreter/interpreter-v2.ts
+++ b/packages/engine/src/interpreter/interpreter-v2.ts
@@ -6,6 +6,8 @@
  * For new code, consider using the modules directly from './interpreter/'.
  */
 
+import * as path from 'path'
+
 import { AudioIR } from '../parser/audio-parser'
 import { createAudioEngine } from '../audio/create-audio-engine'
 import { AudioEngineBackend } from '../audio/engine-backend'
@@ -20,6 +22,7 @@ import { ENGINE_VERSION, DSL_VERSION } from '../version'
 import { InterpreterState } from './types'
 import { processGlobalInit, processSequenceInit } from './process-initialization'
 import { processStatement } from './process-statement'
+import { createImportContext, processFileImports } from './process-file-import'
 
 /**
  * Interpreter V2 - Object-oriented approach
@@ -163,6 +166,21 @@ export class InterpreterV2 {
 
     // Ensure SuperCollider is booted
     await this.ensureBooted()
+
+    // File imports (IM.2, #456): evaluated BEFORE the entry's own declarations, in
+    // source order, depth-first. The cache/cycle context lives for this eval only.
+    if (ir.fileImports?.length) {
+      const baseDir = options?.sourceFile
+        ? path.dirname(path.resolve(options.sourceFile))
+        : options?.documentDirectory
+      if (!baseDir) {
+        throw new Error(
+          'import: cannot resolve the base directory — no source file or document directory (IM.6).',
+        )
+      }
+      const ctx = createImportContext(options?.sourceFile)
+      await processFileImports(ir.fileImports, baseDir, this.state, ctx)
+    }
 
     // Process global initialization
     if (ir.globalInit) {

--- a/packages/engine/src/interpreter/process-file-import.ts
+++ b/packages/engine/src/interpreter/process-file-import.ts
@@ -31,8 +31,16 @@ export function createImportContext(entryFile?: string | null): ImportContext {
   if (entryFile) {
     try {
       stack.push(fs.realpathSync(path.resolve(entryFile)))
-    } catch {
-      // entry が未保存バッファ等で実在しない場合は自己 import 検出だけ諦める（REPL・IM.6）。
+    } catch (err) {
+      // ENOENT（entry が未保存バッファ等で実在しない）だけは自己 import 検出を諦めて続行
+      // してよい（REPL・IM.6）。それ以外（EACCES/ELOOP 等）は黙って検出を落とすと IM.2 の
+      // 保証が silent に劣化するため明示エラーにする。
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+        throw new Error(
+          `import: cannot resolve entry file ${entryFile} ` +
+            `(${(err as NodeJS.ErrnoException)?.code ?? 'unknown'}): ${(err as Error)?.message} (IM.6).`,
+        )
+      }
     }
   }
   return { cache: new Map(), stack }
@@ -82,8 +90,17 @@ async function processOneImport(
   try {
     // IM.2: ダイヤモンド同一性の基準は symlink 解決後の realpath。
     realPath = fs.realpathSync(resolvedRaw)
-  } catch {
-    throw new Error(`import "${imp.path}": file not found at ${resolvedRaw} (IM.4).`)
+  } catch (err) {
+    // ENOENT 以外（EACCES/ELOOP/ENOTDIR 等）を「file not found」に丸めると、権限や
+    // symlink 循環の問題をパス typo と誤診させる — errno を出し分ける。
+    const code = (err as NodeJS.ErrnoException)?.code
+    if (code === 'ENOENT') {
+      throw new Error(`import "${imp.path}": file not found at ${resolvedRaw} (IM.4).`)
+    }
+    throw new Error(
+      `import "${imp.path}": could not resolve ${resolvedRaw} (${code ?? 'unknown'}): ` +
+        `${(err as Error)?.message} (IM.4).`,
+    )
   }
   if (ctx.stack.includes(realPath)) {
     throw new Error(
@@ -93,8 +110,27 @@ async function processOneImport(
 
   let names = ctx.cache.get(realPath)
   if (!names) {
-    const sourceText = fs.readFileSync(realPath, 'utf8')
-    const ir = parseAudioDSL(sourceText)
+    let sourceText: string
+    try {
+      sourceText = fs.readFileSync(realPath, 'utf8')
+    } catch (err) {
+      // realpath 成功後の read 失敗（EACCES・TOCTOU 削除等）。生の Node エラーを漏らさず
+      // どの import 文が原因かを付ける（本ファイルのエラー規約に合わせる）。
+      throw new Error(
+        `import "${imp.path}": could not read ${realPath} ` +
+          `(${(err as NodeJS.ErrnoException)?.code ?? 'unknown'}): ${(err as Error)?.message} (IM.4).`,
+      )
+    }
+    let ir: AudioIR
+    try {
+      ir = parseAudioDSL(sourceText)
+    } catch (err) {
+      // import 先の構文エラーは「どのファイルか」を必ず付ける（深い import 連鎖で
+      // ユーザーが手動二分探索する羽目にならないように）。
+      throw new Error(
+        `import "${imp.path}": parse error in ${realPath}: ${(err as Error)?.message ?? err} (IM.1).`,
+      )
+    }
     names = declaredNames(ir)
     ctx.stack.push(realPath)
     try {

--- a/packages/engine/src/interpreter/process-file-import.ts
+++ b/packages/engine/src/interpreter/process-file-import.ts
@@ -1,0 +1,152 @@
+/**
+ * File import processing (IM.1-IM.6, #456).
+ *
+ * import = 名前一致のグラフ合成（IM.2）: import 先の宣言群を共有名前空間へ評価するだけで、
+ * 隔離スコープは作らない。identity は既存の名前キー reconciliation（process-initialization）
+ * に乗る。評価順序（規範）: import はソース記載順・深さ優先（依存が先）・import 元自身の
+ * 宣言が常に最後。
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+import { AudioIR, FileImportStatement } from '../parser/types'
+import { parseAudioDSL } from '../parser/audio-parser'
+
+import { InterpreterState } from './types'
+import { processGlobalInit, processSequenceInit } from './process-initialization'
+import { processStatement } from './process-statement'
+
+/** 1 回の top-level 評価内でだけ生きる import コンテキスト（IM.2: 評価ごとの module cache）。 */
+export interface ImportContext {
+  /** 解決済み絶対パス（realpath）→ そのファイルの top-level 宣言名（契約検査用）。 */
+  cache: Map<string, Set<string>>
+  /** 評価中ファイルの realpath チェーン（循環 import 検出・IM.2）。 */
+  stack: string[]
+}
+
+/** entry ファイル（あれば）を循環検出チェーンに積んだ新規コンテキストを作る。 */
+export function createImportContext(entryFile?: string | null): ImportContext {
+  const stack: string[] = []
+  if (entryFile) {
+    try {
+      stack.push(fs.realpathSync(path.resolve(entryFile)))
+    } catch {
+      // entry が未保存バッファ等で実在しない場合は自己 import 検出だけ諦める（REPL・IM.6）。
+    }
+  }
+  return { cache: new Map(), stack }
+}
+
+/**
+ * module ファイルの top-level 宣言名を IR から静的に列挙する（IM.1 契約検査の根拠）。
+ * 評価前後の状態差分ではなく IR を見るので、「別ファイル由来で既に存在する同名」を
+ * 誤って宣言済み扱いしない。
+ */
+export function declaredNames(ir: AudioIR): Set<string> {
+  const names = new Set<string>()
+  if (ir.globalInit) names.add(ir.globalInit.variableName)
+  for (const init of ir.sequenceInits) names.add(init.variableName)
+  for (const st of ir.statements) {
+    if (
+      st.type === 'pattern_binding' ||
+      st.type === 'chord_binding' ||
+      st.type === 'mode_binding'
+    ) {
+      names.add(st.variableName)
+    }
+  }
+  return names
+}
+
+/** import 群をソース記載順に処理する（IM.2 評価順序）。`baseDir` = import 元のディレクトリ。 */
+export async function processFileImports(
+  imports: FileImportStatement[],
+  baseDir: string,
+  state: InterpreterState,
+  ctx: ImportContext,
+): Promise<void> {
+  for (const imp of imports) {
+    await processOneImport(imp, baseDir, state, ctx)
+  }
+}
+
+async function processOneImport(
+  imp: FileImportStatement,
+  baseDir: string,
+  state: InterpreterState,
+  ctx: ImportContext,
+): Promise<void> {
+  const resolvedRaw = path.resolve(baseDir, imp.path)
+  let realPath: string
+  try {
+    // IM.2: ダイヤモンド同一性の基準は symlink 解決後の realpath。
+    realPath = fs.realpathSync(resolvedRaw)
+  } catch {
+    throw new Error(`import "${imp.path}": file not found at ${resolvedRaw} (IM.4).`)
+  }
+  if (ctx.stack.includes(realPath)) {
+    throw new Error(
+      `import "${imp.path}": circular import detected (${[...ctx.stack, realPath].join(' → ')}) (IM.2).`,
+    )
+  }
+
+  let names = ctx.cache.get(realPath)
+  if (!names) {
+    const sourceText = fs.readFileSync(realPath, 'utf8')
+    const ir = parseAudioDSL(sourceText)
+    names = declaredNames(ir)
+    ctx.stack.push(realPath)
+    try {
+      await executeModuleIR(ir, realPath, state, ctx)
+    } finally {
+      ctx.stack.pop()
+    }
+    ctx.cache.set(realPath, names)
+  }
+
+  // IM.1: 名前列挙は契約検査（隔離ではない）。import 先に宣言が無ければエラー。
+  for (const n of imp.names) {
+    if (!names.has(n)) {
+      throw new Error(
+        `import { ${n} } from "${imp.path}": "${n}" is not declared in that file (IM.1).`,
+      )
+    }
+  }
+}
+
+/**
+ * module の IR を import コンテキストで評価する。entry の execute() と同じ
+ * globalInit → sequenceInits → statements 順だが、(a) 自身の import を先に処理し
+ * （深さ優先）、(b) transport はエラー（IM.3: import 先は宣言専用）、(c) 評価中の
+ * documentDirectory は module 自身のディレクトリ（IM.4: audio() 等はファイル基準）。
+ */
+async function executeModuleIR(
+  ir: AudioIR,
+  modulePath: string,
+  state: InterpreterState,
+  ctx: ImportContext,
+): Promise<void> {
+  const moduleDir = path.dirname(modulePath)
+  if (ir.fileImports?.length) {
+    await processFileImports(ir.fileImports, moduleDir, state, ctx)
+  }
+  if (ir.globalInit) {
+    await processGlobalInit(ir.globalInit, state)
+  }
+  // audio() は呼び出し時に resolveAudioSpec で即時解決するため、module 評価中だけ
+  // 基準ディレクトリを差し替えれば IM.4 が成立する（entry の documentDirectory は
+  // execute() が import 処理の後に設定し直す）。
+  state.currentGlobal?.setDocumentDirectory(moduleDir)
+  for (const seqInit of ir.sequenceInits) {
+    await processSequenceInit(seqInit, state)
+  }
+  for (const st of ir.statements) {
+    if (st.type === 'transport') {
+      throw new Error(
+        `${st.command.toUpperCase()} is not allowed in an imported file (IM.3): ${modulePath}`,
+      )
+    }
+    await processStatement(st, state)
+  }
+}

--- a/packages/engine/src/parser/audio-parser.ts
+++ b/packages/engine/src/parser/audio-parser.ts
@@ -85,10 +85,8 @@ export class AudioParser {
         // Handle different statement types
         if (stmtResult.statement.type === 'global_init') {
           result.globalInit = stmtResult.statement as GlobalInit
-          seenNonImport = true
         } else if (stmtResult.statement.type === 'seq_init') {
           result.sequenceInits.push(stmtResult.statement as SequenceInit)
-          seenNonImport = true
         } else if (stmtResult.statement.type === 'file_import') {
           if (seenNonImport) {
             throw new Error(
@@ -98,10 +96,11 @@ export class AudioParser {
           }
           result.fileImports!.push(stmtResult.statement as FileImportStatement)
         } else {
-          if (stmtResult.statement.type !== 'import') {
-            seenNonImport = true
-          }
           result.statements.push(stmtResult.statement as Statement)
+        }
+        // import 文（stdlib / file の両方）だけが先頭領域を延長する — 不変条件はこの1行。
+        if (stmtResult.statement.type !== 'import' && stmtResult.statement.type !== 'file_import') {
+          seenNonImport = true
         }
       }
 

--- a/packages/engine/src/parser/audio-parser.ts
+++ b/packages/engine/src/parser/audio-parser.ts
@@ -8,7 +8,14 @@
  * For new code, consider using the modules directly from './'.
  */
 
-import { AudioToken, AudioIR, GlobalInit, SequenceInit, Statement } from './types'
+import {
+  AudioToken,
+  AudioIR,
+  FileImportStatement,
+  GlobalInit,
+  SequenceInit,
+  Statement,
+} from './types'
 import { AudioTokenizer } from './tokenizer'
 import { ParserUtils } from './parser-utils'
 import { StatementParser } from './parse-statement'
@@ -58,7 +65,11 @@ export class AudioParser {
     const result: AudioIR = {
       sequenceInits: [],
       statements: [],
+      fileImports: [],
     }
+    // IM.1: file import はファイル先頭領域（最初の非 import 文より前）のみ。
+    // import 文（stdlib 含む）以外を見たら以降の file import はエラー。
+    let seenNonImport = false
 
     this.pos = ParserUtils.skipNewlines(this.tokens, this.pos)
 
@@ -74,9 +85,22 @@ export class AudioParser {
         // Handle different statement types
         if (stmtResult.statement.type === 'global_init') {
           result.globalInit = stmtResult.statement as GlobalInit
+          seenNonImport = true
         } else if (stmtResult.statement.type === 'seq_init') {
           result.sequenceInits.push(stmtResult.statement as SequenceInit)
+          seenNonImport = true
+        } else if (stmtResult.statement.type === 'file_import') {
+          if (seenNonImport) {
+            throw new Error(
+              `import "${(stmtResult.statement as FileImportStatement).path}": ` +
+                `import statements must appear before any other statement (IM.1).`,
+            )
+          }
+          result.fileImports!.push(stmtResult.statement as FileImportStatement)
         } else {
+          if (stmtResult.statement.type !== 'import') {
+            seenNonImport = true
+          }
           result.statements.push(stmtResult.statement as Statement)
         }
       }

--- a/packages/engine/src/parser/parse-statement.ts
+++ b/packages/engine/src/parser/parse-statement.ts
@@ -15,6 +15,7 @@ import {
   PatternBinding,
   ModeBinding,
   ImportStatement,
+  FileImportStatement,
   PlayStack,
   PlayElement,
 } from './types'
@@ -213,11 +214,16 @@ export class StatementParser {
   }
 
   /**
-   * Parse `import chords` (§6). Only the `chords` stdlib is accepted in v1.1.
+   * Parse `import ...`. Two forms share the keyword and are disambiguated by the next
+   * token (IM.1, #456): `{` → file import (`import { a, b } from "./file.orbs"`),
+   * identifier → stdlib import (`import chords`, §6 — the only stdlib module in v1.1).
    */
-  private parseImport(): { statement: ImportStatement; newPos: number } {
+  private parseImport(): { statement: ImportStatement | FileImportStatement; newPos: number } {
     const importKw = ParserUtils.expect(this.tokens, this.pos, 'IMPORT')
     this.pos = importKw.newPos
+    if (this.tokens[this.pos]?.type === 'LBRACE') {
+      return this.parseFileImport()
+    }
     const moduleResult = ParserUtils.expect(this.tokens, this.pos, 'IDENTIFIER')
     this.pos = moduleResult.newPos
     const module = moduleResult.token.value
@@ -225,6 +231,46 @@ export class StatementParser {
       throw new Error(`Unknown import "${module}". v1.1 supports only \`import chords\` (§6).`)
     }
     return { statement: { type: 'import', module }, newPos: this.pos }
+  }
+
+  /**
+   * Parse the file-import tail after `import` (IM.1, #456):
+   * `{ name (, name)* } from "<./|../>path.orbs"`. The name list is a contract check
+   * (IM.2 — not isolation); the path must be relative (`./` or `../`) and end in `.orbs`.
+   */
+  private parseFileImport(): { statement: FileImportStatement; newPos: number } {
+    this.pos = ParserUtils.expect(this.tokens, this.pos, 'LBRACE').newPos
+    const names: string[] = []
+    for (;;) {
+      const nameResult = ParserUtils.expect(this.tokens, this.pos, 'IDENTIFIER')
+      this.pos = nameResult.newPos
+      names.push(nameResult.token.value)
+      if (this.tokens[this.pos]?.type === 'COMMA') {
+        this.pos++
+        continue
+      }
+      break
+    }
+    this.pos = ParserUtils.expect(this.tokens, this.pos, 'RBRACE').newPos
+    const fromResult = ParserUtils.expect(this.tokens, this.pos, 'IDENTIFIER')
+    this.pos = fromResult.newPos
+    if (fromResult.token.value !== 'from') {
+      throw new Error(
+        `import: expected \`from\` after the name list, got "${fromResult.token.value}" (IM.1).`,
+      )
+    }
+    const pathResult = ParserUtils.expect(this.tokens, this.pos, 'STRING')
+    this.pos = pathResult.newPos
+    const path = pathResult.token.value
+    if (!path.startsWith('./') && !path.startsWith('../')) {
+      throw new Error(
+        `import "${path}": path must be relative to the importing file (start with ./ or ../) (IM.1).`,
+      )
+    }
+    if (!path.endsWith('.orbs')) {
+      throw new Error(`import "${path}": the .orbs extension is required (IM.1).`)
+    }
+    return { statement: { type: 'file_import', names, path }, newPos: this.pos }
   }
 
   /**

--- a/packages/engine/src/parser/parse-statement.ts
+++ b/packages/engine/src/parser/parse-statement.ts
@@ -244,6 +244,9 @@ export class StatementParser {
     for (;;) {
       const nameResult = ParserUtils.expect(this.tokens, this.pos, 'IDENTIFIER')
       this.pos = nameResult.newPos
+      if (names.includes(nameResult.token.value)) {
+        throw new Error(`import: duplicate name "${nameResult.token.value}" in the list (IM.1).`)
+      }
       names.push(nameResult.token.value)
       if (this.tokens[this.pos]?.type === 'COMMA') {
         this.pos++

--- a/packages/engine/src/parser/types.ts
+++ b/packages/engine/src/parser/types.ts
@@ -49,6 +49,12 @@ export type AudioIR = {
   globalInit?: GlobalInit
   sequenceInits: SequenceInit[]
   statements: Statement[]
+  /**
+   * ファイル import（IM.1-IM.2, #456）。評価順序の規範（imports が entry 自身の宣言より
+   * 先・ソース記載順）を守るため statements とは別バケットで保持し、interpreter が
+   * globalInit より前に処理する。ファイル先頭領域のみ（AudioParser.parse が検査）。
+   */
+  fileImports?: FileImportStatement[]
 }
 
 export type GlobalInit = {
@@ -70,6 +76,7 @@ export type Statement =
   | PatternBinding
   | ModeBinding
   | ImportStatement
+  | FileImportStatement
   | MixerHandleStatement
 
 /**
@@ -103,6 +110,17 @@ export type ChordBinding = {
 export type ImportStatement = {
   type: 'import'
   module: string // 'chords' (the only module accepted in v1.1)
+}
+
+/**
+ * `import { kick, snare } from "./drums.orbs"` — file import (IM.1, #456).
+ * `names` は契約検査（import 先の top-level 宣言に存在しなければエラー・隔離ではない —
+ * IM.2）。`path` は import 元ファイル基準の相対パス（`./` | `../` 開始・`.orbs` 必須）。
+ */
+export type FileImportStatement = {
+  type: 'file_import'
+  names: string[]
+  path: string
 }
 
 /**

--- a/tests/interpreter/file-import.spec.ts
+++ b/tests/interpreter/file-import.spec.ts
@@ -49,6 +49,10 @@ describe('file import — parser (IM.1)', () => {
     const ir = parseAudioDSL(`import chords\nimport { a } from "./x.orbs"`)
     expect(ir.fileImports).toHaveLength(1)
   })
+
+  it('rejects a duplicate name in the list', () => {
+    expect(() => parseAudioDSL(`import { a, a } from "./x.orbs"`)).toThrow('duplicate name "a"')
+  })
 })
 
 describe('file import — interpreter (IM.2-IM.6)', () => {
@@ -176,5 +180,47 @@ describe('file import — interpreter (IM.2-IM.6)', () => {
   it('errors when neither sourceFile nor documentDirectory is available (IM.6)', async () => {
     const ir = parseAudioDSL(`import { kick } from "./drums.orbs"\n`)
     await expect(interpreter.execute(ir)).rejects.toThrow('cannot resolve the base directory')
+  })
+
+  it('reports a permission failure as its errno, not as "file not found"', async () => {
+    write('locked.orbs', `var global = init GLOBAL\n`)
+    fs.chmodSync(path.join(dir, 'locked.orbs'), 0o000)
+    const entry = write('main.orbs', `import { global } from "./locked.orbs"\n`)
+    try {
+      await expect(run(entry)).rejects.toThrow(/could not read .*EACCES/)
+      await expect(run(entry)).rejects.not.toThrow('file not found')
+    } finally {
+      fs.chmodSync(path.join(dir, 'locked.orbs'), 0o644)
+    }
+  })
+
+  it('attributes a syntax error in an imported file to the import statement (IM.1)', async () => {
+    write('broken.orbs', `import { x } from "not-even-a-string\n`)
+    const entry = write('main.orbs', `import { x } from "./broken.orbs"\n`)
+    await expect(run(entry)).rejects.toThrow(/parse error in .*broken\.orbs/)
+  })
+
+  it('restores the base directory from sourceFile when documentDirectory is not passed (IM.4)', async () => {
+    fs.mkdirSync(path.join(dir, 'sub'))
+    write('sub/mod.orbs', `var global = init GLOBAL\nvar pad = init global.seq\n`)
+    const entry = write('main.orbs', `import { pad } from "./sub/mod.orbs"\n`)
+    const ir = parseAudioDSL(fs.readFileSync(entry, 'utf8'))
+    await interpreter.execute(ir, { sourceFile: entry }) // documentDirectory 省略
+    const g = (interpreter as any).state.currentGlobal
+    // module dir (sub/) が漏れず、entry のディレクトリへ復元される
+    expect(g.getState().documentDirectory).toBe(dir)
+  })
+
+  it('restores the entry documentDirectory even when an import throws mid-chain', async () => {
+    write('good.orbs', `var global = init GLOBAL\nvar pad = init global.seq\n`)
+    write('bad.orbs', `var global = init GLOBAL\nvar b = init global.seq\nRUN(b)\n`)
+    const entry = write(
+      'main.orbs',
+      `import { pad } from "./good.orbs"\nimport { b } from "./bad.orbs"\n`,
+    )
+    await expect(run(entry)).rejects.toThrow('not allowed in an imported file')
+    // 失敗しても基準ディレクトリは entry の documentDirectory に復元される（module dir が残らない）
+    const g = (interpreter as any).state.currentGlobal
+    expect(g.getState().documentDirectory).toBe(dir)
   })
 })

--- a/tests/interpreter/file-import.spec.ts
+++ b/tests/interpreter/file-import.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * File import (IM.1-IM.6, #456) — parser + interpreter.
+ */
+
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+import { InterpreterV2 } from '../../packages/engine/src/interpreter/interpreter-v2'
+
+describe('file import — parser (IM.1)', () => {
+  it('parses names and path into the fileImports bucket', () => {
+    const ir = parseAudioDSL(`import { kick, snare } from "./drums.orbs"\nvar global = init GLOBAL`)
+    expect(ir.fileImports).toEqual([
+      { type: 'file_import', names: ['kick', 'snare'], path: './drums.orbs' },
+    ])
+    expect(ir.globalInit?.variableName).toBe('global')
+  })
+
+  it('keeps `import chords` (stdlib) parsing unchanged', () => {
+    const ir = parseAudioDSL(`import chords`)
+    expect(ir.fileImports).toEqual([])
+    expect(ir.statements).toEqual([{ type: 'import', module: 'chords' }])
+  })
+
+  it('rejects a non-relative path', () => {
+    expect(() => parseAudioDSL(`import { a } from "/abs/x.orbs"`)).toThrow('start with ./ or ../')
+    expect(() => parseAudioDSL(`import { a } from "bare.orbs"`)).toThrow('start with ./ or ../')
+  })
+
+  it('rejects a path without the .orbs extension', () => {
+    expect(() => parseAudioDSL(`import { a } from "./x"`)).toThrow('.orbs extension is required')
+  })
+
+  it('rejects a missing `from`', () => {
+    expect(() => parseAudioDSL(`import { a } "./x.orbs"`)).toThrow()
+  })
+
+  it('rejects a file import after a non-import statement (IM.1 head-position rule)', () => {
+    expect(() => parseAudioDSL(`var global = init GLOBAL\nimport { a } from "./x.orbs"`)).toThrow(
+      'must appear before any other statement',
+    )
+  })
+
+  it('allows file import after stdlib import (both are head-area imports)', () => {
+    const ir = parseAudioDSL(`import chords\nimport { a } from "./x.orbs"`)
+    expect(ir.fileImports).toHaveLength(1)
+  })
+})
+
+describe('file import — interpreter (IM.2-IM.6)', () => {
+  let dir: string
+  let interpreter: InterpreterV2
+
+  function write(name: string, content: string): string {
+    const p = path.join(dir, name)
+    fs.writeFileSync(p, content)
+    return p
+  }
+
+  async function run(entryFile: string) {
+    const source = fs.readFileSync(entryFile, 'utf8')
+    const ir = parseAudioDSL(source)
+    await interpreter.execute(ir, {
+      sourceFile: entryFile,
+      documentDirectory: path.dirname(entryFile),
+    })
+  }
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbs-import-'))
+    interpreter = new InterpreterV2()
+    const audioEngine = (interpreter as any).state.audioEngine
+    audioEngine.boot = vi.fn().mockResolvedValue(undefined)
+    audioEngine.getCurrentTime = vi.fn().mockReturnValue(0)
+    audioEngine.scheduleEvent = vi.fn()
+    audioEngine.scheduleSliceEvent = vi.fn()
+    audioEngine.getMasterGainDb = vi.fn().mockReturnValue(0)
+    await interpreter.boot()
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('merges imported declarations into the shared namespace (IM.2)', async () => {
+    write('drums.orbs', `var global = init GLOBAL\nvar kick = init global.seq\n`)
+    const entry = write(
+      'main.orbs',
+      `import { kick } from "./drums.orbs"\nvar global = init GLOBAL\n`,
+    )
+    await run(entry)
+    const state = interpreter.getState()
+    expect(state.sequences).toHaveProperty('kick')
+    // 名前キー reconciliation: entry の `var global` は module が作った Global と同一
+    expect(Object.keys(state.globals)).toEqual(['global'])
+  })
+
+  it('rejects an import name that the file does not declare (IM.1 contract check)', async () => {
+    write('drums.orbs', `var global = init GLOBAL\nvar kick = init global.seq\n`)
+    const entry = write('main.orbs', `import { nope } from "./drums.orbs"\n`)
+    await expect(run(entry)).rejects.toThrow('"nope" is not declared in that file')
+  })
+
+  it('rejects a missing file with the resolved path in the message (IM.4)', async () => {
+    const entry = write('main.orbs', `import { a } from "./ghost.orbs"\n`)
+    await expect(run(entry)).rejects.toThrow('file not found')
+  })
+
+  it('detects a circular import (IM.2)', async () => {
+    write(
+      'a.orbs',
+      `import { b } from "./b.orbs"\nvar global = init GLOBAL\nvar a = init global.seq\n`,
+    )
+    write(
+      'b.orbs',
+      `import { a } from "./a.orbs"\nvar global = init GLOBAL\nvar b = init global.seq\n`,
+    )
+    const entry = write('main.orbs', `import { a } from "./a.orbs"\n`)
+    await expect(run(entry)).rejects.toThrow('circular import')
+  })
+
+  it('detects a self-import via the entry file (IM.2)', async () => {
+    const entry = write('main.orbs', `import { x } from "./main.orbs"\n`)
+    await expect(run(entry)).rejects.toThrow('circular import')
+  })
+
+  it('evaluates a diamond exactly once and succeeds (IM.2)', async () => {
+    write('shared.orbs', `var global = init GLOBAL\nvar pad = init global.seq\n`)
+    write(
+      'a.orbs',
+      `import { pad } from "./shared.orbs"\nvar global = init GLOBAL\nvar a = init global.seq\n`,
+    )
+    write(
+      'b.orbs',
+      `import { pad } from "./shared.orbs"\nvar global = init GLOBAL\nvar b = init global.seq\n`,
+    )
+    const entry = write(
+      'main.orbs',
+      `import { a } from "./a.orbs"\nimport { b } from "./b.orbs"\nvar global = init GLOBAL\n`,
+    )
+    await run(entry)
+    const state = interpreter.getState()
+    expect(Object.keys(state.sequences).sort()).toEqual(['a', 'b', 'pad'])
+  })
+
+  it('rejects transport commands in an imported file (IM.3)', async () => {
+    write('perf.orbs', `var global = init GLOBAL\nvar kick = init global.seq\nRUN(kick)\n`)
+    const entry = write('main.orbs', `import { kick } from "./perf.orbs"\n`)
+    await expect(run(entry)).rejects.toThrow('not allowed in an imported file')
+  })
+
+  it('resolves transitive import paths against the importing file (IM.4)', async () => {
+    fs.mkdirSync(path.join(dir, 'sub'))
+    write('sub/inner.orbs', `var global = init GLOBAL\nvar inner = init global.seq\n`)
+    write(
+      'sub/outer.orbs',
+      `import { inner } from "./inner.orbs"\nvar global = init GLOBAL\nvar outer = init global.seq\n`,
+    )
+    const entry = write('main.orbs', `import { outer } from "./sub/outer.orbs"\n`)
+    await run(entry)
+    const state = interpreter.getState()
+    expect(Object.keys(state.sequences).sort()).toEqual(['inner', 'outer'])
+  })
+
+  it('falls back to documentDirectory when there is no sourceFile (REPL, IM.6)', async () => {
+    write('drums.orbs', `var global = init GLOBAL\nvar kick = init global.seq\n`)
+    const ir = parseAudioDSL(`import { kick } from "./drums.orbs"\n`)
+    await interpreter.execute(ir, { documentDirectory: dir })
+    expect(interpreter.getState().sequences).toHaveProperty('kick')
+  })
+
+  it('errors when neither sourceFile nor documentDirectory is available (IM.6)', async () => {
+    const ir = parseAudioDSL(`import { kick } from "./drums.orbs"\n`)
+    await expect(interpreter.execute(ir)).rejects.toThrow('cannot resolve the base directory')
+  })
+})


### PR DESCRIPTION
## 概要

`import { name } from "./file.orbs"`（複数ファイル .orbs プロジェクト構成）の I1(parser) + I2(interpreter) 実装。spec 正本 = INSTRUCTION_ORBITSCORE_DSL.md IM.1-IM.6（PR #469 でマージ済み）。

Refs #456

## 変更内容

- **parser (I1)**: `import` キーワードを次トークンで分岐（`{` = file import / 識別子 = 既存 stdlib `import chords`）。パス検査（`./`|`../` 開始・`.orbs` 必須）・先頭領域検査。IR は `fileImports` 別バケットで評価順序の規範（imports が entry 宣言より先）を担保
- **interpreter (I2)**: `process-file-import.ts` 新設
  - realpath ベースの module cache（ダイヤモンド 1 回評価）・循環検出（entry 含む stack）
  - 契約検査 = module IR の静的宣言列挙 vs 名前リスト（状態差分でなく IR を見るので他ファイル由来の同名を誤認しない）
  - transport 禁止（IM.3: import 先は宣言専用）
  - module 評価中は documentDirectory を module dir に差し替え（IM.4: `audio()` は呼び出し時即時解決）
  - REPL: sourceFile 無し → documentDirectory 基準・両方無し → エラー（IM.6）

## 検証

- 新規 17 tests（parser 7 + interpreter 10）green・全体 1420 passed
- **実機 E2E**: module（`./sine_880.wav` = module 相対パス）を entry が import → `RUN` → capture peak **0.70711**（オラクル一致・IM.4 実機確認）

## 残（別 PR = I3）

VS Code 拡張の import 対応（ファイル横断診断の抑制・保存時再評価の動線）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu