### PR TITLE
feat: import I3 — REPL meta line for out-of-band base directory (#456)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,29 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.266 feat: import I3 — REPL メタ行で基準ディレクトリを帯域外先渡し #456 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 実装（unit 検証済み・OrbitStudio 実機 MCP E2E は別途 = owner「あとでもいい」）
+
+**問題**: VS Code 拡張は基準ディレクトリを `global.setDocumentDirectory(...)` の **DSL 注入**
+（statements として実行）で渡すが、import 文（IM.2）はどの statement よりも先に評価される
+ため、拡張 REPL 経由の import は IM.6 ガード（基準未解決エラー）に落ちる。
+
+**解決**: REPL プロトコルにメタ行 `//#documentDirectory <path>` を追加（帯域外チャネル）。
+- engine (repl-mode.ts): `extractDocumentDirectoryMeta()` で抽出し `execute()` の
+  `documentDirectory` option に渡す（セッション内で最後の値が持続 = ファイル切替追従）。
+  `//` コメントなので DSL として無害（tokenizer が読み飛ばす）
+- extension (extension.ts writeCodeToEngine): メタ行を常に先頭へ prepend。既存の DSL 注入
+  は残す（audio() 既存経路の実績を変えない・同値の冪等再設定）
+
+**検証**: 新規 6 tests（抽出・重複時 last-wins・空白/スペースパス・DSL 無害性・メタ経由
+import 解決）。全体 1431 passed。拡張 tsc --noEmit clean。
+
+**残**: OrbitStudio 実機 MCP E2E（task 化済み・Agent Bridge の SOUND CONFIRMED ループ再利用）
+
+Refs #456
+
 ### 6.265 feat(engine): file import declaration — parser + interpreter (I1+I2) #456 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/packages/engine/src/cli/repl-mode.ts
+++ b/packages/engine/src/cli/repl-mode.ts
@@ -57,6 +57,23 @@ export async function startREPLMode(options: REPLOptions = {}): Promise<void> {
  * @param interpreter - Existing interpreter instance
  * @returns Never resolves (keeps process alive)
  */
+/**
+ * REPL メタ行 `//#documentDirectory <path>`（I3, #456）: エディタ統合（VS Code 拡張）が
+ * 「開いているファイルのディレクトリ」を eval 単位で伝えるための帯域外チャネル。DSL 注入
+ * （`global.setDocumentDirectory(...)`）は statements として import より後に評価されるため、
+ * import の基準ディレクトリ（IM.6）はこのメタ行でしか先渡しできない。`//` コメントなので
+ * DSL としても無害（tokenizer が読み飛ばす）— 戻り値では code から取り除かず、値だけ抽出する。
+ * 複数あれば最後の値が勝つ。
+ */
+export function extractDocumentDirectoryMeta(code: string): string | undefined {
+  let dir: string | undefined
+  for (const line of code.split('\n')) {
+    const m = line.match(/^\s*\/\/#documentDirectory\s+(.+?)\s*$/)
+    if (m) dir = m[1]
+  }
+  return dir
+}
+
 export async function startREPL(interpreter: InterpreterV2): Promise<void> {
   const rl = readline.createInterface({
     input: process.stdin,
@@ -66,6 +83,9 @@ export async function startREPL(interpreter: InterpreterV2): Promise<void> {
 
   let buffer = ''
   let emptyLineCount = 0
+  // メタ行で受けた基準ディレクトリ（セッション内で最後の値が持続 — エディタ側は eval ごとに
+  // 現在ファイルの dir を送るので、ファイル切替にも追従する）。
+  let sessionDocumentDirectory: string | undefined
 
   rl.on('line', async (line) => {
     if (process.env.ORBITSCORE_DEBUG) {
@@ -106,7 +126,13 @@ export async function startREPL(interpreter: InterpreterV2): Promise<void> {
     try {
       const code = buffer.trim()
       const ir = parseAudioDSL(code)
-      await interpreter.execute(ir, { source: code, evalSource: 'human' }) // §L1
+      const metaDir = extractDocumentDirectoryMeta(code)
+      if (metaDir) sessionDocumentDirectory = metaDir
+      await interpreter.execute(ir, {
+        source: code,
+        evalSource: 'human',
+        documentDirectory: sessionDocumentDirectory,
+      }) // §L1
       console.log('✓') // Success indicator
       buffer = '' // Reset buffer on success
       if (process.env.ORBITSCORE_DEBUG) {
@@ -147,7 +173,13 @@ export async function startREPL(interpreter: InterpreterV2): Promise<void> {
 
     try {
       const ir = parseAudioDSL(code)
-      await interpreter.execute(ir, { source: code, evalSource: 'human' }) // §L1
+      const metaDir = extractDocumentDirectoryMeta(code)
+      if (metaDir) sessionDocumentDirectory = metaDir
+      await interpreter.execute(ir, {
+        source: code,
+        evalSource: 'human',
+        documentDirectory: sessionDocumentDirectory,
+      }) // §L1
       console.log('✓') // Success indicator
     } catch (error: any) {
       console.error(`[ERROR] ${error.message}`)

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1903,6 +1903,11 @@ function writeCodeToEngine(rawCode: string, documentDir: string | undefined): bo
   }
   let codeToSend = rawCode
   if (documentDir) {
+    // I3 (#456): REPL メタ行で基準ディレクトリを帯域外で先渡しする。import 文（IM.2）は
+    // どの statement よりも先に評価されるため、下の DSL 注入（statements として実行）では
+    // 間に合わない — メタ行だけが import の基準（IM.6）を初回 eval から確定できる。
+    // DSL 注入も残す（audio() 等の既存経路の実績を変えない・同値の冪等再設定）。
+    codeToSend = `//#documentDirectory ${documentDir}\n` + codeToSend
     const setDirCommand = `global.setDocumentDirectory("${documentDir.replace(/\\/g, '\\\\')}")`
     const globalInitMatch = codeToSend.match(/(var\s+global\s*=\s*init\s+GLOBAL[^\n]*)/)
     if (globalInitMatch) {

--- a/tests/cli/repl-document-directory-meta.spec.ts
+++ b/tests/cli/repl-document-directory-meta.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * REPL メタ行 `//#documentDirectory <path>`（I3, #456 / IM.6）。
+ * エディタ統合が import の基準ディレクトリを帯域外で先渡しするチャネル。
+ */
+
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import { describe, it, expect, vi } from 'vitest'
+
+import { extractDocumentDirectoryMeta } from '../../packages/engine/src/cli/repl-mode'
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+import { InterpreterV2 } from '../../packages/engine/src/interpreter/interpreter-v2'
+
+describe('extractDocumentDirectoryMeta', () => {
+  it('extracts the path from a meta line', () => {
+    expect(extractDocumentDirectoryMeta('//#documentDirectory /songs/live\nvar x = 1')).toBe(
+      '/songs/live',
+    )
+  })
+
+  it('returns undefined when absent', () => {
+    expect(extractDocumentDirectoryMeta('var global = init GLOBAL')).toBeUndefined()
+  })
+
+  it('takes the last value when repeated', () => {
+    expect(extractDocumentDirectoryMeta('//#documentDirectory /a\n//#documentDirectory /b\n')).toBe(
+      '/b',
+    )
+  })
+
+  it('tolerates leading whitespace and preserves spaces inside the path', () => {
+    expect(extractDocumentDirectoryMeta('  //#documentDirectory /My Songs/set 1\n')).toBe(
+      '/My Songs/set 1',
+    )
+  })
+
+  it('is inert for the DSL parser (plain // comment)', () => {
+    const ir = parseAudioDSL('//#documentDirectory /songs\nvar global = init GLOBAL\n')
+    expect(ir.globalInit?.variableName).toBe('global')
+  })
+})
+
+describe('meta-provided documentDirectory feeds import resolution (IM.6)', () => {
+  it('resolves an import against the meta directory when there is no sourceFile', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbs-repl-meta-'))
+    try {
+      fs.writeFileSync(
+        path.join(dir, 'drums.orbs'),
+        'var global = init GLOBAL\nvar kick = init global.seq\n',
+      )
+      const interpreter = new InterpreterV2()
+      const audioEngine = (interpreter as any).state.audioEngine
+      audioEngine.boot = vi.fn().mockResolvedValue(undefined)
+      await interpreter.boot()
+
+      // REPL 経路の等価形: sourceFile なし・メタ行から得た documentDirectory を渡す
+      const code = `//#documentDirectory ${dir}\nimport { kick } from "./drums.orbs"\n`
+      const ir = parseAudioDSL(code)
+      await interpreter.execute(ir, {
+        source: code,
+        documentDirectory: extractDocumentDirectoryMeta(code),
+      })
+      expect(interpreter.getState().sequences).toHaveProperty('kick')
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## 概要

import I3(最終ステージ): VS Code 拡張(OrbitStudio)の REPL 経由で import(IM.1-IM.6)を成立させる。

Closes #456

## 問題

拡張は基準ディレクトリを `global.setDocumentDirectory(...)` の **DSL 注入**(statements として実行)で渡すが、import 文は IM.2 の規範でどの statement よりも先に評価されるため、拡張 REPL 経由の import は IM.6 ガード(基準未解決エラー)に落ちる。

## 解決 — REPL メタ行(帯域外チャネル)

- **engine** (repl-mode.ts): メタ行 `//#documentDirectory <path>` を `extractDocumentDirectoryMeta()` で抽出し、`execute()` の `documentDirectory` option に渡す。セッション内で最後の値が持続 = エディタのファイル切替に追従。`//` コメントなので DSL としても無害
- **extension** (writeCodeToEngine): メタ行を常に先頭へ prepend。既存の DSL 注入は残す(audio() 既存経路の実績を変えない・同値の冪等再設定)

## 検証

- 新規 6 tests(抽出・last-wins・スペース入りパス・DSL 無害性・メタ経由 import 解決)
- 全体 1431 passed・拡張 `tsc --noEmit` clean
- OrbitStudio 実機 MCP E2E は別途実施(owner 了承・task 化済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu