### PR TITLE
refactor(engine): unify effect-slot pool + self-heal across managers (#468)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,26 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.267 refactor(engine): unify effect-slot pool + self-heal across 3 managers #468 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 実装（既存テスト全 green = 挙動ピン留めの下で統合）
+
+**内容**: `PluginEffectManager` / `SequenceEffectManager` / `MixerManager` に ~15 行ずつ
+複製されていたパターンを `effect-slot.ts` に一本化:
+- `resolveEffectSpec()` — validate → LinkAudio gate → resolve（順序 load-bearing）
+- `EffectSlotMap<K>` — 冪等再宣言 + respawn 後 self-heal（isPluginActive=false → 再ロード）+
+  install/rollback（自分の宣言のみ削除）。master insert は 3 引数呼びを維持（既存契約）
+- `BusPool` — prefix 連番 + free-list（失敗が pool を恒久消費しない #461 根拠を共通化）
+
+SequenceEffectManager は buses（passthrough 含む routing 用割当）と slots（実 insert）を
+分離し、「昇格/self-heal 失敗時は bus を返却しない・新規割当失敗のみ free-list へ返す」
+固有ロールバックを catch 側に残した。MixerManager は sum/aux を同型 KindState 2 面に。
+
+**検証**: 既存の manager 系テスト（global-plugin-effect / sequence-effect /
+global-mixer-sum-aux 等）を変更せず全 green・全体 1425 passed。
+
+Refs #468 #467
 ### 6.266 feat: import I3 — REPL メタ行で基準ディレクトリを帯域外先渡し #456 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/packages/engine/src/core/global/effect-slot.ts
+++ b/packages/engine/src/core/global/effect-slot.ts
@@ -54,10 +54,6 @@ export class EffectSlotMap<K> {
     return this.slots.has(key)
   }
 
-  get size(): number {
-    return this.slots.size
-  }
-
   /**
    * 宣言する（または冪等に再宣言する）。同一 spec の再宣言は既存 load を待ち、
    * respawn 後の stale cache（`isPluginActive?.('effect', bus) === false`）なら

--- a/packages/engine/src/core/global/effect-slot.ts
+++ b/packages/engine/src/core/global/effect-slot.ts
@@ -1,0 +1,151 @@
+/**
+ * Shared building blocks for the three effect-declaring managers (#468):
+ * `PluginEffectManager`（master insert）/ `SequenceEffectManager`（per-seq insert）/
+ * `MixerManager`（sum・aux insert）。各 manager に ~15 行ずつ複製されていた
+ * 「validate → LinkAudio gate → resolve」「冪等再宣言 + respawn 後 self-heal +
+ * install/rollback」「prefix 連番 + free-list の bus pool」をここに一本化する。
+ */
+
+import type { AudioEngine } from '../../audio/types'
+
+import { AudioManager } from './audio-manager'
+import { LinkAudioManager } from './link-audio-manager'
+import { resolvePluginPath, validatePluginExtension } from './plugin-resolver'
+
+/**
+ * effect spec の共通前処理。順序は load-bearing（PluginEffectManager 由来）:
+ * spec 検証 → LinkAudio gate → パス解決。未保存ファイル等で resolve が
+ * 「cannot resolve」を投げる前に、より本質的な LinkAudio 競合エラーを出すため。
+ */
+export function resolveEffectSpec(
+  spec: string,
+  deps: { audioManager: AudioManager; linkAudioManager: LinkAudioManager },
+  linkAudioErrorMessage: string,
+): string {
+  validatePluginExtension(spec, 'effect')
+  if (deps.linkAudioManager.isEnabled()) {
+    throw new Error(linkAudioErrorMessage)
+  }
+  return resolvePluginPath(
+    spec,
+    deps.audioManager.getAudioPaths(),
+    deps.audioManager.getDocumentDirectory(),
+    'effect',
+  )
+}
+
+interface EffectSlotEntry {
+  resolvedPath: string
+  pluginId?: string
+  load: Promise<void>
+}
+
+/**
+ * key ごとに 1 つの effect 宣言（v1: チェーン不可）を持つ slot 集合。
+ * `declare()` が冪等再宣言・respawn 後 self-heal（`isPluginActive === false` で再ロード）・
+ * 失敗時の宣言ロールバック（自分が入れた宣言のみ削除）を一手に実装する。
+ */
+export class EffectSlotMap<K> {
+  private readonly slots = new Map<K, EffectSlotEntry>()
+
+  constructor(private readonly audioEngine: AudioEngine) {}
+
+  has(key: K): boolean {
+    return this.slots.has(key)
+  }
+
+  get size(): number {
+    return this.slots.size
+  }
+
+  /**
+   * 宣言する（または冪等に再宣言する）。同一 spec の再宣言は既存 load を待ち、
+   * respawn 後の stale cache（`isPluginActive?.('effect', bus) === false`）なら
+   * 再ロードで self-heal する。異なる spec は `duplicateError` を throw（v1: 1 slot）。
+   * 新規宣言の load 失敗は宣言を取り除いて rethrow（呼び出し側は catch で bus の
+   * 返却等の後始末を行える）。
+   */
+  async declare(
+    key: K,
+    bus: string | undefined,
+    resolvedPath: string,
+    pluginId: string | undefined,
+    duplicateError: () => Error,
+  ): Promise<void> {
+    const existing = this.slots.get(key)
+    if (existing) {
+      if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
+        await existing.load
+        // Self-heal: respawn 後の復元失敗で engine 側だけ宣言が消えている場合、
+        // 冪等パスで false success を返さず再ロードする（PluginEffectManager 由来の
+        // silent-failure guard）。isPluginActive を持たない engine（SC/素の mock）は
+        // 従来の no-op 冪等のまま。
+        if (this.audioEngine.isPluginActive?.('effect', bus) === false) {
+          await this.issueLoad(key, bus, resolvedPath, pluginId)
+        }
+        return
+      }
+      throw duplicateError()
+    }
+    await this.issueLoad(key, bus, resolvedPath, pluginId)
+  }
+
+  private async issueLoad(
+    key: K,
+    bus: string | undefined,
+    resolvedPath: string,
+    pluginId: string | undefined,
+  ): Promise<void> {
+    if (!this.audioEngine.loadPlugin) {
+      throw new Error('Plugin hosting requires the Rust engine backend.')
+    }
+    // bus 無し（master insert）は 3 引数のまま呼ぶ（既存の呼び出し契約を変えない —
+    // explicit undefined でも実 engine は等価だが、契約をピンするテスト/モックがある）。
+    const load = (
+      bus === undefined
+        ? this.audioEngine.loadPlugin(resolvedPath, pluginId, 'effect')
+        : this.audioEngine.loadPlugin(resolvedPath, pluginId, 'effect', bus)
+    ).then(() => undefined)
+    const entry: EffectSlotEntry = { resolvedPath, pluginId, load }
+    this.slots.set(key, entry)
+    try {
+      await load
+    } catch (err) {
+      if (this.slots.get(key) === entry) this.slots.delete(key)
+      throw err
+    }
+  }
+}
+
+/**
+ * `<prefix><n>` 連番 + free-list の bus pool（SequenceEffectManager / MixerManager 由来）。
+ * 失敗した宣言が pool を恒久消費しないよう、返却された名前を優先再利用する
+ * （#461 review Important の free-list 根拠）。
+ */
+export class BusPool {
+  private nextIndex = 0
+  private readonly freed: string[] = []
+
+  constructor(
+    private readonly prefix: string,
+    private readonly size: number,
+    private readonly exhaustedMessage: (name: string) => string,
+  ) {}
+
+  /** free-list 優先で bus 名を確保する。枯渇時は exhaustedMessage で throw。 */
+  acquire(name: string): string {
+    const freed = this.freed.pop()
+    if (freed !== undefined) return freed
+    if (this.nextIndex >= this.size) {
+      throw new Error(this.exhaustedMessage(name))
+    }
+    const bus = `${this.prefix}${this.nextIndex}`
+    this.nextIndex += 1
+    return bus
+  }
+
+  /** 失敗した宣言の bus を pool へ返す。 */
+  release(bus: string): void {
+    this.freed.push(bus)
+  }
+}

--- a/packages/engine/src/core/global/mixer-manager.ts
+++ b/packages/engine/src/core/global/mixer-manager.ts
@@ -2,7 +2,7 @@ import type { AudioEngine } from '../../audio/types'
 
 import { AudioManager } from './audio-manager'
 import { LinkAudioManager } from './link-audio-manager'
-import { resolvePluginPath, validatePluginExtension } from './plugin-resolver'
+import { BusPool, EffectSlotMap, resolveEffectSpec } from './effect-slot'
 
 /**
  * `sum-bus-<n>` / `aux-bus-<n>` default pool prefixes. Must match
@@ -21,16 +21,6 @@ export const MIXER_BUS_POOL_SIZE = 4
 
 type MixerKind = 'sum' | 'aux'
 
-interface MixerBusDeclaration {
-  bus: string
-}
-
-interface MixerInsertDeclaration {
-  resolvedPath: string
-  pluginId?: string
-  load: Promise<void>
-}
-
 /** Returned by `global.sum(name)` / `global.aux(name)` and the bare `sum(name)` / `aux(name)` reference. */
 export interface MixerBusHandle {
   readonly bus: string
@@ -38,12 +28,18 @@ export interface MixerBusHandle {
   effect(path: string, pluginId?: string): Promise<MixerBusHandle>
 }
 
+/** kind ごと（sum / aux）の宣言テーブル一式。 */
+interface KindState {
+  readonly buses: Map<string, string> // declared name → bus
+  readonly inserts: EffectSlotMap<string> // keyed by bus name
+  readonly pool: BusPool
+}
+
 /**
  * Owns `global.sum(name)` / `global.aux(name)` declarations (MX.2/MX.3, #459/#453 M3): one
  * bus per declared name, allocated from the daemon's default sum/aux bus pools
- * (`sum-bus-0..3` / `aux-bus-0..3`). Mirrors `SequenceEffectManager`'s eager-load +
- * idempotent-redeclare pattern, but keyed by declared name in two independent namespaces
- * (sum vs. aux) instead of by sequence name.
+ * (`sum-bus-0..3` / `aux-bus-0..3`). 実装は #468 の共通基盤（`BusPool` + `EffectSlotMap`）
+ * に委譲し、sum / aux は同型の `KindState` 2 面として持つ。
  *
  * The bus's own insert (`sum("drum").effect(...)`) reuses the SAME `LoadPlugin` endpoint
  * as `seq.effect()` (`role: 'effect', bus: <name>`) — the daemon does not distinguish insert
@@ -51,26 +47,30 @@ export interface MixerBusHandle {
  * so no new engine-side wiring is needed for this half of M3.
  */
 export class MixerManager {
-  private readonly sumBuses = new Map<string, MixerBusDeclaration>()
-  private readonly auxBuses = new Map<string, MixerBusDeclaration>()
-  private readonly sumInserts = new Map<string, MixerInsertDeclaration>() // keyed by bus name
-  private readonly auxInserts = new Map<string, MixerInsertDeclaration>() // keyed by bus name
-  private nextSumIndex = 0
-  private nextAuxIndex = 0
-  // Mirrors SequenceEffectManager's free-list rationale (#461 review Important): a failed
-  // declaration must not permanently consume a pool slot.
-  private freedSumBuses: string[] = []
-  private freedAuxBuses: string[] = []
+  private readonly kinds: Record<MixerKind, KindState>
 
   constructor(
-    private readonly audioEngine: AudioEngine,
+    audioEngine: AudioEngine,
     private readonly audioManager: AudioManager,
     private readonly linkAudioManager: LinkAudioManager,
-  ) {}
+  ) {
+    const makeKind = (kind: MixerKind, prefix: string): KindState => ({
+      buses: new Map(),
+      inserts: new EffectSlotMap(audioEngine),
+      pool: new BusPool(
+        prefix,
+        MIXER_BUS_POOL_SIZE,
+        (name) =>
+          `global.${kind}("${name}"): ${kind} bus pool exhausted — v1 supports at most ` +
+          `${MIXER_BUS_POOL_SIZE} concurrent ${kind} buses.`,
+      ),
+    })
+    this.kinds = { sum: makeKind('sum', SUM_BUS_PREFIX), aux: makeKind('aux', AUX_BUS_PREFIX) }
+  }
 
   /** Whether any sum or aux bus has been declared (used by `Global.linkAudio()`'s v1 exclusion gate). */
   hasAnyDeclaration(): boolean {
-    return this.sumBuses.size > 0 || this.auxBuses.size > 0
+    return this.kinds.sum.buses.size > 0 || this.kinds.aux.buses.size > 0
   }
 
   /** Declares (or idempotently re-declares) a sum/group bus. MX.2: sum nesting is not supported in v1. */
@@ -85,12 +85,12 @@ export class MixerManager {
 
   /** Resolves a declared sum bus name to its allocated bus, or undefined if undeclared. */
   resolveSum(name: string): string | undefined {
-    return this.sumBuses.get(name)?.bus
+    return this.kinds.sum.buses.get(name)
   }
 
   /** Resolves a declared aux bus name to its allocated bus, or undefined if undeclared. */
   resolveAux(name: string): string | undefined {
-    return this.auxBuses.get(name)?.bus
+    return this.kinds.aux.buses.get(name)
   }
 
   private declareBus(kind: MixerKind, name: string): MixerBusHandle {
@@ -101,31 +101,13 @@ export class MixerManager {
       throw new Error(`global.${kind}() cannot be used while LinkAudio is enabled in v1.`)
     }
 
-    const buses = kind === 'sum' ? this.sumBuses : this.auxBuses
-    let declaration = buses.get(name)
-    if (!declaration) {
-      const freed = kind === 'sum' ? this.freedSumBuses : this.freedAuxBuses
-      const bus = freed.pop() ?? this.allocateFreshBus(kind, name)
-      declaration = { bus }
-      buses.set(name, declaration)
+    const state = this.kinds[kind]
+    let bus = state.buses.get(name)
+    if (bus === undefined) {
+      bus = state.pool.acquire(name)
+      state.buses.set(name, bus)
     }
-    return this.makeHandle(kind, name, declaration.bus)
-  }
-
-  private allocateFreshBus(kind: MixerKind, name: string): string {
-    const index = kind === 'sum' ? this.nextSumIndex : this.nextAuxIndex
-    if (index >= MIXER_BUS_POOL_SIZE) {
-      throw new Error(
-        `global.${kind}("${name}"): ${kind} bus pool exhausted — v1 supports at most ` +
-          `${MIXER_BUS_POOL_SIZE} concurrent ${kind} buses.`,
-      )
-    }
-    if (kind === 'sum') {
-      this.nextSumIndex += 1
-      return `${SUM_BUS_PREFIX}${index}`
-    }
-    this.nextAuxIndex += 1
-    return `${AUX_BUS_PREFIX}${index}`
+    return this.makeHandle(kind, name, bus)
   }
 
   private makeHandle(kind: MixerKind, name: string, bus: string): MixerBusHandle {
@@ -142,65 +124,24 @@ export class MixerManager {
     spec: string,
     pluginId: string | undefined,
   ): Promise<MixerBusHandle> {
-    // Order mirrors PluginEffectManager.effect() / SequenceEffectManager.effect(): validate
-    // the spec, gate on LinkAudio (declaration order can't produce this in practice since
-    // declareBus() already gated, but a respawn/reload path could re-run effect() alone),
-    // then resolve the path.
-    validatePluginExtension(spec, 'effect')
-
-    if (this.linkAudioManager.isEnabled()) {
-      throw new Error(
-        `${kind}("${name}").effect() cannot be used while LinkAudio is enabled in v1.`,
-      )
-    }
-
-    const resolvedPath = resolvePluginPath(
+    // LinkAudio gate は declareBus() 済みでも維持する（respawn/reload 経路で effect() 単独が
+    // 再実行され得るため — resolveEffectSpec が spec 検証 → gate → 解決の順序を保証する）。
+    const resolvedPath = resolveEffectSpec(
       spec,
-      this.audioManager.getAudioPaths(),
-      this.audioManager.getDocumentDirectory(),
-      'effect',
+      { audioManager: this.audioManager, linkAudioManager: this.linkAudioManager },
+      `${kind}("${name}").effect() cannot be used while LinkAudio is enabled in v1.`,
     )
-
-    const inserts = kind === 'sum' ? this.sumInserts : this.auxInserts
-    const existing = inserts.get(bus)
-    if (existing) {
-      if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
-        await existing.load
-        if (this.audioEngine.isPluginActive?.('effect', bus) === false) {
-          await this.issueLoad(kind, bus, resolvedPath, pluginId)
-        }
-        return this.makeHandle(kind, name, bus)
-      }
-      throw new Error(
-        `${kind}("${name}").effect() supports one insert per bus in v1; chains (multiple ` +
-          `inserts) are reserved for future support.`,
-      )
-    }
-
-    await this.issueLoad(kind, bus, resolvedPath, pluginId)
+    await this.kinds[kind].inserts.declare(
+      bus,
+      bus,
+      resolvedPath,
+      pluginId,
+      () =>
+        new Error(
+          `${kind}("${name}").effect() supports one insert per bus in v1; chains (multiple ` +
+            `inserts) are reserved for future support.`,
+        ),
+    )
     return this.makeHandle(kind, name, bus)
-  }
-
-  private async issueLoad(
-    kind: MixerKind,
-    bus: string,
-    resolvedPath: string,
-    pluginId: string | undefined,
-  ): Promise<void> {
-    if (!this.audioEngine.loadPlugin) {
-      throw new Error('Plugin hosting requires the Rust engine backend.')
-    }
-    const inserts = kind === 'sum' ? this.sumInserts : this.auxInserts
-    const load = this.audioEngine
-      .loadPlugin(resolvedPath, pluginId, 'effect', bus)
-      .then(() => undefined)
-    const declaration: MixerInsertDeclaration = { resolvedPath, pluginId, load }
-    inserts.set(bus, declaration)
-    try {
-      await load
-    } catch (err) {
-      if (inserts.get(bus) === declaration) inserts.delete(bus)
-      throw err
-    }
   }
 }

--- a/packages/engine/src/core/global/plugin-effect-manager.ts
+++ b/packages/engine/src/core/global/plugin-effect-manager.ts
@@ -2,84 +2,40 @@ import type { AudioEngine } from '../../audio/types'
 
 import { AudioManager } from './audio-manager'
 import { LinkAudioManager } from './link-audio-manager'
-import { resolvePluginPath, validatePluginExtension } from './plugin-resolver'
-
-interface EffectDeclaration {
-  resolvedPath: string
-  pluginId?: string
-  load: Promise<void>
-}
+import { EffectSlotMap, resolveEffectSpec } from './effect-slot'
 
 /** Owns the single v1 master-insert plugin declaration and eager load. */
 export class PluginEffectManager {
-  private declaration?: EffectDeclaration
+  /** 単一 slot（v1 master insert）を固定 key で EffectSlotMap に載せる（#468 共通化）。 */
+  private readonly slots: EffectSlotMap<'master'>
 
   constructor(
-    private readonly audioEngine: AudioEngine,
+    audioEngine: AudioEngine,
     private readonly audioManager: AudioManager,
     private readonly linkAudioManager: LinkAudioManager,
-  ) {}
+  ) {
+    this.slots = new EffectSlotMap(audioEngine)
+  }
 
   hasDeclaration(): boolean {
-    return this.declaration !== undefined
+    return this.slots.has('master')
   }
 
   async effect(spec: string, pluginId?: string): Promise<void> {
-    // Order is load-bearing: validate the spec, then gate on LinkAudio, and
-    // only then resolve the path. A relative spec with no document context
-    // yet (unsaved file) makes `resolvePluginPath` throw a "cannot resolve"
-    // error; if that ran before the LinkAudio gate, it would mask the more
-    // relevant LinkAudio-conflict error with a confusing resolve failure.
-    validatePluginExtension(spec, 'effect')
-
-    if (this.linkAudioManager.isEnabled()) {
-      throw new Error('global.effect() cannot be used while LinkAudio is enabled in v1.')
-    }
-
-    const resolvedPath = resolvePluginPath(
+    const resolvedPath = resolveEffectSpec(
       spec,
-      this.audioManager.getAudioPaths(),
-      this.audioManager.getDocumentDirectory(),
-      'effect',
+      { audioManager: this.audioManager, linkAudioManager: this.linkAudioManager },
+      'global.effect() cannot be used while LinkAudio is enabled in v1.',
     )
-
-    const existing = this.declaration
-    if (existing) {
-      if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
-        await existing.load
-        // Self-heal: `isPluginActive() === false` means a prior daemon respawn
-        // failed to restore this plugin in the engine even though our cache
-        // still thinks it succeeded (silent-failure guard). Re-issue the load
-        // instead of returning a false "success". Engines without
-        // `isPluginActive` (SC backend / plain mocks) keep the old no-op
-        // idempotent behavior.
-        if (this.audioEngine.isPluginActive?.('effect') === false) {
-          await this.issueLoad(resolvedPath, pluginId)
-        }
-        return
-      }
-      throw new Error(
-        'global.effect() supports one master insert in v1; effect chains are reserved for future support.',
-      )
-    }
-
-    await this.issueLoad(resolvedPath, pluginId)
-  }
-
-  /** Issues (or re-issues) the load, installing the declaration and clearing it on failure. */
-  private async issueLoad(resolvedPath: string, pluginId: string | undefined): Promise<void> {
-    if (!this.audioEngine.loadPlugin) {
-      throw new Error('Plugin hosting requires the Rust engine backend.')
-    }
-
-    const load = this.audioEngine.loadPlugin(resolvedPath, pluginId, 'effect').then(() => undefined)
-    const declaration: EffectDeclaration = { resolvedPath, pluginId, load }
-    this.declaration = declaration
-    try {
-      await load
-    } catch (err) {
-      if (this.declaration === declaration) this.declaration = undefined
-      throw err
-    }
+    await this.slots.declare(
+      'master',
+      undefined,
+      resolvedPath,
+      pluginId,
+      () =>
+        new Error(
+          'global.effect() supports one master insert in v1; effect chains are reserved for future support.',
+        ),
+    )
   }
 }

--- a/packages/engine/src/core/global/sequence-effect-manager.ts
+++ b/packages/engine/src/core/global/sequence-effect-manager.ts
@@ -108,6 +108,10 @@ export class SequenceEffectManager {
       }
       // 既存 bus（passthrough 昇格 / self-heal 再ロード）の失敗は bus を返却しない —
       // seq.output()/seq.send() の routing がその bus を参照し続けているため。
+      // 【意図的な旧実装との差分】旧実装は self-heal 再ロード失敗で宣言ごと bus を消して
+      // いた（hasDeclaration/hasAnyDeclaration が false に反転 = LinkAudio 排他ゲートが
+      // 緩む + routing が参照中の bus 名が pool 外へ漏失）。本実装は bus を温存する —
+      // MixerManager の従来挙動とも一致（#472 レビューで確認・回帰テストでピン留め済み）。
       throw err
     }
     return bus

--- a/packages/engine/src/core/global/sequence-effect-manager.ts
+++ b/packages/engine/src/core/global/sequence-effect-manager.ts
@@ -2,7 +2,7 @@ import type { AudioEngine } from '../../audio/types'
 
 import { AudioManager } from './audio-manager'
 import { LinkAudioManager } from './link-audio-manager'
-import { resolvePluginPath, validatePluginExtension } from './plugin-resolver'
+import { BusPool, EffectSlotMap, resolveEffectSpec } from './effect-slot'
 
 /**
  * Bus name prefix for the daemon's default per-sequence insert bus pool. Must
@@ -19,49 +19,46 @@ export const SEQUENCE_EFFECT_BUS_PREFIX = 'seq-bus-'
  */
 export const SEQUENCE_EFFECT_BUS_POOL_SIZE = 8
 
-interface SeqEffectDeclaration {
-  bus: string
-  // undefined = passthrough-only (bus allocated via `ensureBus()`, no plugin loaded yet —
-  // MX.4/#459/#453 M3: `seq.output()`/`seq.send()` on a sequence without `seq.effect()`).
-  resolvedPath?: string
-  pluginId?: string
-  load: Promise<void>
-}
-
 /**
  * Owns the per-sequence insert (`seq.effect()` — PH.2b / #434 S3) declarations:
  * one bus per sequence, allocated from the daemon's default bus pool
- * (`seq-bus-0`.."seq-bus-7"). Mirrors `PluginEffectManager` /
- * `PluginInstrumentManager`'s eager-load + idempotent-redeclare pattern, keyed
- * by sequence name instead of a single master slot.
+ * (`seq-bus-0`.."seq-bus-7"). 実装は #468 の共通基盤（`BusPool` + `EffectSlotMap`）に
+ * 委譲し、この manager 固有なのは「passthrough bus（`ensureBus()` — plugin 未ロードの
+ * routing 用割当・MX.4）と insert の分離、および昇格失敗時に bus を返却しない
+ * ロールバック」だけ。
  */
 export class SequenceEffectManager {
-  private readonly declarations = new Map<string, SeqEffectDeclaration>()
-  private nextBusIndex = 0
-  /**
-   * 失敗した宣言から返却された bus 名の free-list。ライブコーディングでは
-   * 「typo → 失敗 → 直して再宣言」が普通に起きるため、失敗が pool を恒久消費すると
-   * 数回のリトライで枯渇する（#461 review Important）。返却された名前を優先的に再利用する。
-   */
-  private freedBuses: string[] = []
+  /** sequenceName → 割当 bus（passthrough 含む）。routing（output/send）が参照する。 */
+  private readonly buses = new Map<string, string>()
+  /** sequenceName → 実 insert 宣言（passthrough は含まない）。 */
+  private readonly slots: EffectSlotMap<string>
+  private readonly pool = new BusPool(
+    SEQUENCE_EFFECT_BUS_PREFIX,
+    SEQUENCE_EFFECT_BUS_POOL_SIZE,
+    (name) =>
+      `Sequence '${name}': seq.effect() insert bus pool exhausted — v1 supports at ` +
+      `most ${SEQUENCE_EFFECT_BUS_POOL_SIZE} sequences with a concurrent insert.`,
+  )
 
   constructor(
-    private readonly audioEngine: AudioEngine,
+    audioEngine: AudioEngine,
     private readonly audioManager: AudioManager,
     private readonly linkAudioManager: LinkAudioManager,
-  ) {}
+  ) {
+    this.slots = new EffectSlotMap(audioEngine)
+  }
 
   hasDeclaration(sequenceName: string): boolean {
-    return this.declarations.has(sequenceName)
+    return this.buses.has(sequenceName)
   }
 
   /** Whether any sequence has declared an insert (used by `Global.linkAudio()`'s v1 exclusion gate). */
   hasAnyDeclaration(): boolean {
-    return this.declarations.size > 0
+    return this.buses.size > 0
   }
 
   getBus(sequenceName: string): string | undefined {
-    return this.declarations.get(sequenceName)?.bus
+    return this.buses.get(sequenceName)
   }
 
   /**
@@ -74,105 +71,45 @@ export class SequenceEffectManager {
    * bus in place instead of allocating a second one (see `effect()` below).
    */
   ensureBus(sequenceName: string): string {
-    const existing = this.declarations.get(sequenceName)
-    if (existing) return existing.bus
-    const bus = this.freedBuses.pop() ?? this.allocateFreshBus(sequenceName)
-    this.declarations.set(sequenceName, { bus, load: Promise.resolve() })
+    const existing = this.buses.get(sequenceName)
+    if (existing) return existing
+    const bus = this.pool.acquire(sequenceName)
+    this.buses.set(sequenceName, bus)
     return bus
   }
 
   /** Declares (or idempotently re-declares) the insert for `sequenceName`. Returns the allocated bus name. */
   async effect(sequenceName: string, spec: string, pluginId?: string): Promise<string> {
-    // Order mirrors PluginEffectManager.effect(): validate the spec, gate on
-    // LinkAudio, then resolve the path (see that file's doc comment for why).
-    validatePluginExtension(spec, 'effect')
-
-    if (this.linkAudioManager.isEnabled()) {
-      throw new Error(
-        `Sequence '${sequenceName}': seq.effect() cannot be used while LinkAudio is enabled in v1.`,
-      )
-    }
-
-    const resolvedPath = resolvePluginPath(
+    const resolvedPath = resolveEffectSpec(
       spec,
-      this.audioManager.getAudioPaths(),
-      this.audioManager.getDocumentDirectory(),
-      'effect',
+      { audioManager: this.audioManager, linkAudioManager: this.linkAudioManager },
+      `Sequence '${sequenceName}': seq.effect() cannot be used while LinkAudio is enabled in v1.`,
     )
 
-    const existing = this.declarations.get(sequenceName)
-    // A passthrough-only declaration (from ensureBus(), no resolvedPath yet) is not a real
-    // insert — upgrade it in place instead of treating it as an existing insert declaration.
-    if (existing && existing.resolvedPath !== undefined) {
-      if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
-        await existing.load
-        // Self-heal on stale cache after a daemon respawn (see PluginEffectManager
-        // for the full rationale). Engines without isPluginActive keep the old
-        // no-op idempotent behavior.
-        if (this.audioEngine.isPluginActive?.('effect', existing.bus) === false) {
-          await this.issueLoad(sequenceName, existing.bus, resolvedPath, pluginId)
-        }
-        return existing.bus
-      }
-      throw new Error(
+    const duplicateError = () =>
+      new Error(
         `Sequence '${sequenceName}': seq.effect() supports one insert per sequence in v1; ` +
           `chains (multiple inserts) are reserved for future support.`,
       )
-    }
 
-    const wasPassthrough = existing !== undefined
-    const bus = existing?.bus ?? this.freedBuses.pop() ?? this.allocateFreshBus(sequenceName)
+    // passthrough（ensureBus 由来・insert 未ロード）は「既存 insert」ではない — 同じ bus を
+    // その場で昇格する。実 insert が既にあれば slots.declare が冪等/self-heal/重複エラーを担う。
+    const hadBus = this.buses.has(sequenceName)
+    const bus = this.buses.get(sequenceName) ?? this.pool.acquire(sequenceName)
+    this.buses.set(sequenceName, bus)
     try {
-      await this.issueLoad(sequenceName, bus, resolvedPath, pluginId)
+      await this.slots.declare(sequenceName, bus, resolvedPath, pluginId, duplicateError)
     } catch (err) {
-      if (wasPassthrough) {
-        // ロールバック: passthrough から昇格しようとして失敗した場合は bus を pool に
-        // 戻さず、passthrough 状態に戻す（seq.output()/seq.send() の routing がまだその
-        // bus を参照しているため — bus 自体は生き続ける必要がある）。
-        this.declarations.set(sequenceName, { bus, load: Promise.resolve() })
-      } else {
-        // 新規割当が失敗した場合は free-list に返す（daemon 側も activation を巻き戻す
-        // ため、両側の状態が対称に戻る）。
-        this.freedBuses.push(bus)
+      if (!hadBus) {
+        // この呼び出しで新規に確保した bus の load 失敗: free-list へ返す（daemon 側も
+        // activation を巻き戻すため、両側の状態が対称に戻る）。
+        this.buses.delete(sequenceName)
+        this.pool.release(bus)
       }
+      // 既存 bus（passthrough 昇格 / self-heal 再ロード）の失敗は bus を返却しない —
+      // seq.output()/seq.send() の routing がその bus を参照し続けているため。
       throw err
     }
     return bus
-  }
-
-  private allocateFreshBus(sequenceName: string): string {
-    if (this.nextBusIndex >= SEQUENCE_EFFECT_BUS_POOL_SIZE) {
-      throw new Error(
-        `Sequence '${sequenceName}': seq.effect() insert bus pool exhausted — v1 supports at ` +
-          `most ${SEQUENCE_EFFECT_BUS_POOL_SIZE} sequences with a concurrent insert.`,
-      )
-    }
-    const bus = `${SEQUENCE_EFFECT_BUS_PREFIX}${this.nextBusIndex}`
-    this.nextBusIndex += 1
-    return bus
-  }
-
-  private async issueLoad(
-    sequenceName: string,
-    bus: string,
-    resolvedPath: string,
-    pluginId: string | undefined,
-  ): Promise<void> {
-    if (!this.audioEngine.loadPlugin) {
-      throw new Error('Plugin hosting requires the Rust engine backend.')
-    }
-    const load = this.audioEngine
-      .loadPlugin(resolvedPath, pluginId, 'effect', bus)
-      .then(() => undefined)
-    const declaration: SeqEffectDeclaration = { bus, resolvedPath, pluginId, load }
-    this.declarations.set(sequenceName, declaration)
-    try {
-      await load
-    } catch (err) {
-      if (this.declarations.get(sequenceName) === declaration) {
-        this.declarations.delete(sequenceName)
-      }
-      throw err
-    }
   }
 }

--- a/tests/core/sequence-effect-self-heal-failure.spec.ts
+++ b/tests/core/sequence-effect-self-heal-failure.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * #468/#472: self-heal 再ロード失敗時の bus 温存をピン留めする回帰テスト。
+ *
+ * 旧実装（3 manager 複製時代）は self-heal 失敗で宣言ごと bus を消していたが、
+ * routing（seq.output()/send()）が参照中の bus 名が失われる + LinkAudio 排他ゲート
+ * （hasAnyDeclaration）が緩む問題があった。統合後は bus を温存する（MixerManager の
+ * 従来挙動と一致）。この意味論が黙って戻らないようにする。
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+
+import { SequenceEffectManager } from '../../packages/engine/src/core/global/sequence-effect-manager'
+import { AudioManager } from '../../packages/engine/src/core/global/audio-manager'
+import { LinkAudioManager } from '../../packages/engine/src/core/global/link-audio-manager'
+
+function harness() {
+  const loadPlugin = vi.fn().mockResolvedValue({})
+  const isPluginActive = vi.fn().mockReturnValue(true)
+  const audioEngine = { loadPlugin, isPluginActive } as any
+  const audioManager = new AudioManager()
+  audioManager.setDocumentDirectory('/songs')
+  const manager = new SequenceEffectManager(
+    audioEngine,
+    audioManager,
+    new LinkAudioManager(audioEngine),
+  )
+  return { manager, loadPlugin, isPluginActive }
+}
+
+describe('SequenceEffectManager — self-heal reload failure keeps the bus (#472)', () => {
+  it('keeps hasDeclaration()/getBus() and does not recycle the bus into the pool', async () => {
+    const { manager, loadPlugin, isPluginActive } = harness()
+    const bus = await manager.effect('kick', './echo.clap')
+    expect(bus).toBe('seq-bus-0')
+
+    // respawn 後の stale cache を再現: 冪等再宣言が self-heal 再ロードに入り、それが失敗する
+    isPluginActive.mockReturnValue(false)
+    loadPlugin.mockRejectedValueOnce(new Error('reload failed'))
+    await expect(manager.effect('kick', './echo.clap')).rejects.toThrow('reload failed')
+
+    // bus は温存される（routing が参照中・LinkAudio 排他ゲートも維持）
+    expect(manager.hasDeclaration('kick')).toBe(true)
+    expect(manager.hasAnyDeclaration()).toBe(true)
+    expect(manager.getBus('kick')).toBe('seq-bus-0')
+
+    // 別シーケンスの新規宣言が kick の bus を再利用しない（pool へ返却されていない）
+    isPluginActive.mockReturnValue(true)
+    const other = await manager.effect('snare', './comp.clap')
+    expect(other).toBe('seq-bus-1')
+  })
+
+  it('a retry after the failed self-heal reuses the SAME bus and succeeds', async () => {
+    const { manager, loadPlugin, isPluginActive } = harness()
+    await manager.effect('kick', './echo.clap')
+    isPluginActive.mockReturnValue(false)
+    loadPlugin.mockRejectedValueOnce(new Error('reload failed'))
+    await expect(manager.effect('kick', './echo.clap')).rejects.toThrow('reload failed')
+
+    loadPlugin.mockResolvedValue({})
+    const bus = await manager.effect('kick', './echo.clap')
+    expect(bus).toBe('seq-bus-0')
+  })
+})


### PR DESCRIPTION
## 概要

PR #467 レビューで指摘・#468 で計画した DRY 統合。`PluginEffectManager` / `SequenceEffectManager` / `MixerManager` に ~15 行ずつ複製されていた「冪等再宣言 + respawn 後 self-heal + install/rollback + bus pool free-list」を `effect-slot.ts` に一本化する。

Closes #468

## 変更内容

- **effect-slot.ts 新設**: `resolveEffectSpec()`(validate → LinkAudio gate → resolve・順序 load-bearing)/ `EffectSlotMap<K>`(冪等再宣言・`isPluginActive === false` self-heal・自宣言のみ削除する rollback)/ `BusPool`(prefix 連番 + free-list)
- **PluginEffectManager**: 単一 slot を固定 key で載せ替え(master insert の 3 引数 `loadPlugin` 契約は維持)
- **SequenceEffectManager**: `buses`(passthrough 含む routing 用割当)と `slots`(実 insert)を分離。固有ロールバック(昇格/self-heal 失敗時は bus を返却しない・新規割当失敗のみ free-list へ)は catch 側に残置
- **MixerManager**: sum/aux を同型 `KindState` 2 面に統合

## 検証

- **既存の manager 系テストを一切変更せず全 green**(挙動のピン留めの下での統合)
- 全体 1425 passed・tsc/eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu