### PR TITLE
feat(rust): plugin catalog scanner C1 — orbit-plugin-scan (#463)

### DIFF
--- a/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
+++ b/docs/core/INSTRUCTION_ORBITSCORE_DSL.md
@@ -1280,9 +1280,12 @@ drums.effect("~/plugins/TAL-Reverb-4.clap")   // この seq だけに掛かる i
 - スキャン対象 = OS 標準ディレクトリ（macOS: `~/Library/Audio/Plug-Ins/CLAP`・
   `/Library/Audio/Plug-Ins/CLAP`・同 `VST3`）+ 環境変数 `ORBIT_PLUGIN_PATH`
   （`:` 区切り・追加検索パス・**各ディレクトリ直下のみ = 非再帰**）
-- metadata の取得: CLAP = factory metadata（軽量・load 不要）、VST3 = bundle 内
-  `moduleinfo.json` があれば load 不要、無ければ probe（`probe_plugin` 資産 #397）。
-  probe は逐次で時間がかかるため**バックグラウンド + キャッシュ必須**
+- **スキャンは UI を出さない・ブロックしない**（規範）: プラグインの実ロード（probe）は
+  コンテンツ依存プラグインがネイティブダイアログを出し得るため（実害確認 2026-07-17）、
+  **v1 では行わない**。metadata の取得: CLAP = factory metadata（dlopen のみ）、
+  VST3 = bundle 内 `Contents/Resources/moduleinfo.json` **のみ**（無ければ skip し、
+  スキャン結果 summary の `skipped` 配列で開示）。UI 抑止付き probe による skip 解消は
+  将来拡張（C1b 以降）
 - キャッシュ = `~/.orbitscore/plugin-catalog.json`（正本はこのファイル。エンジン・
   拡張・MCP はこれを読むだけ）。生成/更新 = 初回スキャン + 明示 rescan（自動 watch は
   v1 スコープ外）。スキャンの持ち主 = **daemon**（probe 資産が Rust 側にあるため。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,30 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.269 feat(rust): plugin catalog scanner C1 — orbit-plugin-scan #463 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 実装（実機スモーク済み・daemon 配線 C1b / DSL 解決 C2 / 補完 C3 は別 PR）
+
+**内容**: カタログスキャナを**独立バイナリ** `orbit-plugin-scan` として新設（crash 隔離・
+#397 の isolation 原則）。標準ディレクトリ + ORBIT_PLUGIN_PATH（非再帰）を走査し
+`~/.orbitscore/plugin-catalog.json`（atomic write）を生成。
+
+**設計変更（owner 実害報告に基づく・spec へ反映済み）**: VST3 の probe fallback（実ロード）
+はコンテンツ依存プラグインがネイティブダイアログを出す実害が出たため**撤去**。v1 は
+moduleinfo.json のみ（Steinberg の trailing-comma 方言は string-aware ストリッパで対応・
+Audio Module Class のみエントリ化・Sub Categories で role 推定）。CLAP は既存 discovery に
+vendor/features を追加して利用。
+
+**検証**: 新規 20 unit + orbit-clap-host 21 green・clippy/fmt clean。実機スモーク:
+ダイアログなしで完走・VST3 335 バンドル中 79 エントリ化 / 256 skip（moduleinfo 無し・
+summary で開示）。CLAP は実機に 0 個のため fixture のみ（既知の残テスト）。
+
+**残**: skip 256 の解消 = UI 抑止付き probe（C1b 検討）・daemon ScanPlugins 配線・C2/C3。
+
+Refs #463
+
+
 ### 6.268 docs(spec): plugin catalog spec 起草（PC.1-PC.5）#463 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -389,10 +389,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -664,6 +680,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -1021,6 +1043,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "orbit-plugin-scan"
+version = "0.0.1"
+dependencies = [
+ "orbit-clap-host",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
 name = "orbit-sandbox-spike"
 version = "0.0.1"
 dependencies = [
@@ -1257,6 +1290,19 @@ dependencies = [
  "primal-check",
  "strength_reduce",
  "transpose",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1558,6 +1604,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "crates/orbit-vst3-host",
   "crates/orbit-vst3-gain-oracle",
   "crates/orbit-vst3-synth-oracle",
+  "crates/orbit-plugin-scan",
 ]
 # 🔴 orbit-link-audio(GPL 隔離 crate)は **member にしない**。
 # member にすると default の `cargo build` / cargo-deny がこの GPL crate を root として

--- a/rust/crates/orbit-clap-host/src/discovery.rs
+++ b/rust/crates/orbit-clap-host/src/discovery.rs
@@ -29,6 +29,11 @@ pub struct PluginDescriptor {
     pub id: String,
     pub name: Option<String>,
     pub version: Option<String>,
+    /// プラグインベンダー名（#463 plugin catalog 用に追加）。
+    pub vendor: Option<String>,
+    /// CLAP feature タグ一覧（例: "instrument", "audio-effect"）。#463 plugin catalog の
+    /// role 判定（instrument/effect）に使う。非 UTF-8 なタグは黙って skip する。
+    pub features: Vec<String>,
 }
 
 impl PluginDescriptor {
@@ -48,10 +53,16 @@ impl PluginDescriptor {
                 return None;
             }
         };
+        let features = p
+            .features()
+            .filter_map(|f| f.to_str().ok().map(str::to_owned))
+            .collect();
         Some(Self {
             id,
             name: p.name().map(|v| v.to_string_lossy().to_string()),
             version: p.version().map(|v| v.to_string_lossy().to_string()),
+            vendor: p.vendor().map(|v| v.to_string_lossy().to_string()),
+            features,
         })
     }
 }

--- a/rust/crates/orbit-clap-host/src/lib.rs
+++ b/rust/crates/orbit-clap-host/src/lib.rs
@@ -24,7 +24,9 @@ mod processor;
 
 pub use clack_host::events::io::EventBuffer;
 pub use controller::{ClapHost, ClapHostError, LoadedPluginInfo};
-pub use discovery::DiscoveryError;
+// #463 plugin catalog スキャナ（orbit-plugin-scan）が discovery API を外部から使うために追加
+// re-export（DiscoveryError は元から公開済み）。ロジック変更なし。
+pub use discovery::{list_plugins_in_file, DiscoveryError, FoundPlugin, PluginDescriptor};
 pub use effect::ClapEffectProcessor;
 pub use events::{
     make_event_ring, push_neutral_event, PluginEvent, PluginEventConsumer, PluginEventProducer,

--- a/rust/crates/orbit-plugin-scan/Cargo.toml
+++ b/rust/crates/orbit-plugin-scan/Cargo.toml
@@ -1,0 +1,33 @@
+# orbit-plugin-scan — プラグインカタログスキャナ（#463 C1）。
+#
+# CLAP/VST3 バンドルをスキャンし ~/.orbitscore/plugin-catalog.json を生成する。
+# スキャン・probe はプラグインロードを伴い crash リスクがあるため、daemon 本体でなく
+# 短命な独立バイナリに隔離する（#397 の crash isolation 原則）。
+#
+# 正本: docs/core/INSTRUCTION_ORBITSCORE_DSL.md「Plugin Catalog」節 PC.1
+[package]
+name = "orbit-plugin-scan"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Plugin catalog scanner: discovers CLAP/VST3 plugins and writes ~/.orbitscore/plugin-catalog.json (Issue #463)"
+publish = false
+
+[lib]
+name = "orbit_plugin_scan"
+path = "src/lib.rs"
+
+[[bin]]
+name = "orbit-plugin-scan"
+path = "src/main.rs"
+
+[dependencies]
+orbit-clap-host = { path = "../orbit-clap-host" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/rust/crates/orbit-plugin-scan/src/lib.rs
+++ b/rust/crates/orbit-plugin-scan/src/lib.rs
@@ -1,0 +1,725 @@
+//! プラグインカタログスキャナのコアロジック（#463 C1）。
+//!
+//! CLAP/VST3 バンドルを走査して `CatalogEntry` のリストを作り、
+//! `~/.orbitscore/plugin-catalog.json` に atomic write する。
+//!
+//! 正本: docs/core/INSTRUCTION_ORBITSCORE_DSL.md「Plugin Catalog」節 PC.1
+
+use serde::Serialize;
+use std::collections::HashSet;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// スキャン対象フォーマット。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Format {
+    Clap,
+    Vst3,
+}
+
+/// カタログの role タグ（PC.1）。
+pub const ROLE_INSTRUMENT: &str = "instrument";
+pub const ROLE_EFFECT: &str = "effect";
+
+/// カタログ 1 エントリ（PC.1 JSON スキーマ）。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogEntry {
+    pub name: String,
+    pub vendor: String,
+    pub format: Format,
+    pub path: String,
+    pub plugin_id: String,
+    pub roles: Vec<String>,
+}
+
+/// トップレベルのカタログドキュメント（PC.1）。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Catalog {
+    pub version: u32,
+    pub scanned_at: String,
+    pub plugins: Vec<CatalogEntry>,
+}
+
+/// スキャン対象ディレクトリのデフォルト（PC.1）。
+/// `~` は `dirs_home` で解決する（HOME 環境変数が読めない場合はスキップ）。
+fn default_scan_dirs(home: Option<&Path>) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(home) = home {
+        dirs.push(home.join("Library/Audio/Plug-Ins/CLAP"));
+        dirs.push(home.join("Library/Audio/Plug-Ins/VST3"));
+    }
+    dirs.push(PathBuf::from("/Library/Audio/Plug-Ins/CLAP"));
+    dirs.push(PathBuf::from("/Library/Audio/Plug-Ins/VST3"));
+    dirs
+}
+
+/// `ORBIT_PLUGIN_PATH`（`:` 区切り）を追加のスキャンディレクトリとして解釈する。
+fn extra_scan_dirs_from_env(value: Option<&str>) -> Vec<PathBuf> {
+    match value {
+        None => Vec::new(),
+        Some(raw) => raw
+            .split(':')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from)
+            .collect(),
+    }
+}
+
+/// スキャンする全ディレクトリ（デフォルト + `ORBIT_PLUGIN_PATH`、重複除去）を返す。
+pub fn resolve_scan_dirs(home: Option<&Path>, orbit_plugin_path: Option<&str>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    let mut dirs = Vec::new();
+    for dir in default_scan_dirs(home)
+        .into_iter()
+        .chain(extra_scan_dirs_from_env(orbit_plugin_path))
+    {
+        if seen.insert(dir.clone()) {
+            dirs.push(dir);
+        }
+    }
+    dirs
+}
+
+/// 1 ディレクトリ直下（非再帰）を走査し、`.clap` / `.vst3` バンドル候補を列挙する。
+/// ディレクトリが存在しない・読めない場合は空 Vec を返す（stderr warn のみ）。
+pub fn list_bundle_candidates(dir: &Path) -> Vec<(PathBuf, Format)> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            // 存在しないデフォルトパスは珍しくない（プラグイン未インストール環境）ので debug 相当。
+            tracing::debug!("[orbit-plugin-scan] ディレクトリを読めません: {dir:?}: {error}");
+            return Vec::new();
+        }
+    };
+
+    let mut found = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(extension) = path.extension().and_then(|e| e.to_str()) else {
+            continue;
+        };
+        match extension.to_ascii_lowercase().as_str() {
+            "clap" => found.push((path, Format::Clap)),
+            "vst3" => found.push((path, Format::Vst3)),
+            _ => {}
+        }
+    }
+    found
+}
+
+/// 全スキャンディレクトリからバンドル候補を集める（非再帰・重複除去済みディレクトリのみ対象）。
+pub fn collect_all_bundle_candidates(dirs: &[PathBuf]) -> Vec<(PathBuf, Format)> {
+    dirs.iter()
+        .flat_map(|dir| list_bundle_candidates(dir))
+        .collect()
+}
+
+/// CLAP バンドル 1 つを走査してカタログエントリを作る。
+/// ロード失敗時は空 Vec + stderr warn（全体を止めない・PC 仕様の「probe 失敗は skip」）。
+pub fn scan_clap_bundle(path: &Path) -> Vec<CatalogEntry> {
+    let found = match orbit_clap_host::list_plugins_in_file(path) {
+        Ok(found) => found,
+        Err(error) => {
+            eprintln!("[orbit-plugin-scan] WARN: CLAP バンドルの走査に失敗: {path:?}: {error}");
+            return Vec::new();
+        }
+    };
+
+    found
+        .into_iter()
+        .map(|entry| {
+            let roles = roles_from_clap_features(&entry.plugin.features);
+            CatalogEntry {
+                name: entry.plugin.name.unwrap_or_else(|| entry.plugin.id.clone()),
+                vendor: entry.plugin.vendor.unwrap_or_default(),
+                format: Format::Clap,
+                path: path.to_string_lossy().into_owned(),
+                plugin_id: entry.plugin.id,
+                roles,
+            }
+        })
+        .collect()
+}
+
+/// CLAP feature タグから role (instrument/effect) を判定する。
+/// 両方一致・どちらも不一致の場合は両方入れる（安全側・PC.1 の role フィルタで絞り込む前提）。
+fn roles_from_clap_features(features: &[String]) -> Vec<String> {
+    let has_instrument = features.iter().any(|f| f == "instrument");
+    let has_effect = features
+        .iter()
+        .any(|f| f == "audio-effect" || f == "audio_effect");
+
+    match (has_instrument, has_effect) {
+        (true, false) => vec![ROLE_INSTRUMENT.to_owned()],
+        (false, true) => vec![ROLE_EFFECT.to_owned()],
+        _ => vec![ROLE_INSTRUMENT.to_owned(), ROLE_EFFECT.to_owned()],
+    }
+}
+
+/// VST3 バンドル 1 つを走査してカタログエントリを作る。
+///
+/// **`Contents/Resources/moduleinfo.json` がある場合のみ**エントリ化する（load 不要）。
+/// 無い場合は probe（実ロード）せずに skip する — コンテンツ依存プラグイン（例: FIN-BOOST）が
+/// ロード中にネイティブダイアログ（"Plugin content not found — navigate to .blob"）を出すことが
+/// 実機確認され、無人スキャンで UI が出る/ブロックするのは受け入れ不可と判断されたため（owner
+/// 実害報告・#463）。「UI 抑止付き probe」は C1b 以降で別途検討する。
+pub fn scan_vst3_bundle(path: &Path) -> VstScanResult {
+    let moduleinfo_path = path.join("Contents/Resources/moduleinfo.json");
+    if !moduleinfo_path.is_file() {
+        eprintln!("[orbit-plugin-scan] WARN: moduleinfo.json が無いため probe せず skip: {path:?}");
+        return VstScanResult::Skipped;
+    }
+
+    match fs::read_to_string(&moduleinfo_path) {
+        Ok(text) => match parse_moduleinfo(&text, path) {
+            Ok(entries) if !entries.is_empty() => VstScanResult::Entries(entries),
+            Ok(_) => {
+                eprintln!(
+                    "[orbit-plugin-scan] WARN: moduleinfo.json に Audio Module Class が無い、skip: {moduleinfo_path:?}"
+                );
+                VstScanResult::Skipped
+            }
+            Err(error) => {
+                eprintln!(
+                    "[orbit-plugin-scan] WARN: moduleinfo.json の parse に失敗、skip: {moduleinfo_path:?}: {error}"
+                );
+                VstScanResult::Skipped
+            }
+        },
+        Err(error) => {
+            eprintln!(
+                "[orbit-plugin-scan] WARN: moduleinfo.json を読めません、skip: {moduleinfo_path:?}: {error}"
+            );
+            VstScanResult::Skipped
+        }
+    }
+}
+
+/// [`scan_vst3_bundle`] の結果。moduleinfo.json 不在/不正は probe にフォールバックせず
+/// `Skipped` として明示的に扱う（呼び出し側が `skipped` リストへ集約できるように）。
+pub enum VstScanResult {
+    Entries(Vec<CatalogEntry>),
+    Skipped,
+}
+
+/// Steinberg moduleinfo.json（trailing comma を含む非-strict JSON）を parse する。
+/// `Category == "Audio Module Class"` のクラスのみカタログエントリ化する（Controller /
+/// Compatibility クラスはロード可能な実体を持たないため除外）。
+fn parse_moduleinfo(text: &str, bundle_path: &Path) -> Result<Vec<CatalogEntry>, String> {
+    let sanitized = strip_trailing_commas(text);
+    let doc: ModuleInfoDoc = serde_json::from_str(&sanitized).map_err(|error| error.to_string())?;
+
+    let top_vendor = doc
+        .factory_info
+        .as_ref()
+        .and_then(|f| f.vendor.clone())
+        .unwrap_or_default();
+
+    let entries = doc
+        .classes
+        .into_iter()
+        .filter(|class| class.category.as_deref() == Some("Audio Module Class"))
+        .filter_map(|class| {
+            let cid = class.cid?;
+            let name = class.name.unwrap_or_else(|| doc.name.clone());
+            let vendor = class.vendor.unwrap_or_else(|| top_vendor.clone());
+            let roles = roles_from_vst3_subcategories(&class.sub_categories);
+            Some(CatalogEntry {
+                name,
+                vendor,
+                format: Format::Vst3,
+                path: bundle_path.to_string_lossy().into_owned(),
+                plugin_id: cid,
+                roles,
+            })
+        })
+        .collect();
+    Ok(entries)
+}
+
+/// VST3 moduleinfo.json の `Sub Categories` から role を判定する。
+/// Instrument/Synth/Generator を instrument、それ以外（Fx 等）を effect とみなす。
+/// どちらのヒントも無ければ安全側で両方入れる。
+fn roles_from_vst3_subcategories(sub_categories: &[String]) -> Vec<String> {
+    const INSTRUMENT_HINTS: [&str; 3] = ["Instrument", "Synth", "Generator"];
+    let has_instrument = sub_categories
+        .iter()
+        .any(|s| INSTRUMENT_HINTS.contains(&s.as_str()));
+    let has_other = sub_categories
+        .iter()
+        .any(|s| !INSTRUMENT_HINTS.contains(&s.as_str()));
+
+    match (has_instrument, has_other) {
+        (true, false) => vec![ROLE_INSTRUMENT.to_owned()],
+        (false, true) => vec![ROLE_EFFECT.to_owned()],
+        (true, true) => vec![ROLE_INSTRUMENT.to_owned(), ROLE_EFFECT.to_owned()],
+        (false, false) => vec![ROLE_INSTRUMENT.to_owned(), ROLE_EFFECT.to_owned()],
+    }
+}
+
+/// JSON 文字列中の trailing comma（`,` の直後に `}` または `]` が続くもの、空白/改行を挟んでもよい）
+/// を取り除く。Steinberg の moduleinfo.json は仕様上 strict JSON ではなくこれを含むため必要。
+/// 文字列リテラル内のカンマは変更しない。
+fn strip_trailing_commas(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while let Some(ch) = chars.next() {
+        if in_string {
+            output.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+            output.push(ch);
+            continue;
+        }
+
+        if ch == ',' {
+            // 後続の空白/改行を先読みし、その次が `}` か `]` なら、このカンマを落とす。
+            let mut lookahead = String::new();
+            let mut temp_chars = chars.clone();
+            let mut is_trailing = false;
+            for next in temp_chars.by_ref() {
+                if next.is_whitespace() {
+                    lookahead.push(next);
+                    continue;
+                }
+                is_trailing = next == '}' || next == ']';
+                break;
+            }
+            if is_trailing {
+                // カンマを出力せず、空白はそのまま消費して進める。
+                for _ in 0..lookahead.chars().count() {
+                    chars.next();
+                }
+                continue;
+            }
+        }
+
+        output.push(ch);
+    }
+
+    output
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ModuleInfoDoc {
+    #[serde(rename = "Name", default)]
+    name: String,
+    #[serde(rename = "Factory Info", default)]
+    factory_info: Option<FactoryInfo>,
+    #[serde(rename = "Classes", default)]
+    classes: Vec<ModuleClass>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct FactoryInfo {
+    #[serde(rename = "Vendor", default)]
+    vendor: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ModuleClass {
+    #[serde(rename = "CID", default)]
+    cid: Option<String>,
+    #[serde(rename = "Category", default)]
+    category: Option<String>,
+    #[serde(rename = "Name", default)]
+    name: Option<String>,
+    #[serde(rename = "Vendor", default)]
+    vendor: Option<String>,
+    #[serde(rename = "Sub Categories", default)]
+    sub_categories: Vec<String>,
+}
+
+/// dedup キー: (format, path, pluginId)。多バージョン/同名は「スキャン順で後勝ち」（PC.5）。
+fn dedup_key(entry: &CatalogEntry) -> (u8, String, String) {
+    let format_tag = match entry.format {
+        Format::Clap => 0,
+        Format::Vst3 => 1,
+    };
+    (format_tag, entry.path.clone(), entry.plugin_id.clone())
+}
+
+/// エントリ列を dedup する（後勝ち: 同キーの後続要素が前の要素を置き換える）。
+pub fn dedup_entries(entries: Vec<CatalogEntry>) -> Vec<CatalogEntry> {
+    let mut order: Vec<(u8, String, String)> = Vec::new();
+    let mut map: std::collections::HashMap<(u8, String, String), CatalogEntry> =
+        std::collections::HashMap::new();
+
+    for entry in entries {
+        let key = dedup_key(&entry);
+        if !map.contains_key(&key) {
+            order.push(key.clone());
+        }
+        map.insert(key, entry);
+    }
+
+    order
+        .into_iter()
+        .map(|key| map.remove(&key).expect("key was just inserted"))
+        .collect()
+}
+
+/// 全ディレクトリを走査した結果: dedup 済みカタログエントリと、probe せず skip した VST3
+/// バンドルのパス一覧（moduleinfo.json 不在/不正）。
+pub struct ScanOutcome {
+    pub entries: Vec<CatalogEntry>,
+    pub skipped: Vec<String>,
+}
+
+/// 全ディレクトリを走査し、dedup 済みカタログエントリと skip リストを返す。
+pub fn scan_all(dirs: &[PathBuf]) -> ScanOutcome {
+    let candidates = collect_all_bundle_candidates(dirs);
+    let mut entries = Vec::new();
+    let mut skipped = Vec::new();
+    for (path, format) in candidates {
+        match format {
+            Format::Clap => entries.append(&mut scan_clap_bundle(&path)),
+            Format::Vst3 => match scan_vst3_bundle(&path) {
+                VstScanResult::Entries(mut found) => entries.append(&mut found),
+                VstScanResult::Skipped => skipped.push(path.to_string_lossy().into_owned()),
+            },
+        }
+    }
+    ScanOutcome {
+        entries: dedup_entries(entries),
+        skipped,
+    }
+}
+
+/// `~/.orbitscore/plugin-catalog.json` のパスを返す。
+pub fn cache_path(home: &Path) -> PathBuf {
+    home.join(".orbitscore").join("plugin-catalog.json")
+}
+
+/// カタログを JSON にシリアライズして `path` へ atomic write（tmp + rename）する。
+pub fn write_catalog(catalog: &Catalog, path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(catalog)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+
+    let tmp_path = path.with_extension("json.tmp");
+    fs::write(&tmp_path, json)?;
+    fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+/// 現在時刻を ISO8601 (UTC, `YYYY-MM-DDTHH:MM:SSZ`) にフォーマットする。
+/// chrono 等の外部 crate を workspace に追加しないため自前実装（うるう秒は考慮しない）。
+pub fn now_iso8601() -> String {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    format_unix_timestamp(duration.as_secs())
+}
+
+fn format_unix_timestamp(total_seconds: u64) -> String {
+    let days = total_seconds / 86_400;
+    let rem = total_seconds % 86_400;
+    let hour = rem / 3600;
+    let minute = (rem % 3600) / 60;
+    let second = rem % 60;
+
+    let (year, month, day) = civil_from_days(days as i64);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+/// Howard Hinnant の `civil_from_days` アルゴリズム（proleptic Gregorian, days since epoch 1970-01-01）。
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32; // [1, 12]
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extra_scan_dirs_from_env_splits_on_colon() {
+        let dirs = extra_scan_dirs_from_env(Some("/a/b:/c/d: :"));
+        assert_eq!(dirs, vec![PathBuf::from("/a/b"), PathBuf::from("/c/d")]);
+    }
+
+    #[test]
+    fn extra_scan_dirs_from_env_none_is_empty() {
+        assert!(extra_scan_dirs_from_env(None).is_empty());
+    }
+
+    #[test]
+    fn resolve_scan_dirs_dedupes_and_includes_defaults() {
+        let home = PathBuf::from("/Users/tester");
+        let dirs = resolve_scan_dirs(
+            Some(&home),
+            Some("/Library/Audio/Plug-Ins/VST3:/extra/path"),
+        );
+        assert!(dirs.contains(&home.join("Library/Audio/Plug-Ins/CLAP")));
+        assert!(dirs.contains(&home.join("Library/Audio/Plug-Ins/VST3")));
+        assert!(dirs.contains(&PathBuf::from("/Library/Audio/Plug-Ins/CLAP")));
+        assert!(dirs.contains(&PathBuf::from("/extra/path")));
+        // 重複除去: /Library/Audio/Plug-Ins/VST3 はデフォルトにも env にも入っているが 1 回のみ。
+        let vst3_count = dirs
+            .iter()
+            .filter(|d| *d == &PathBuf::from("/Library/Audio/Plug-Ins/VST3"))
+            .count();
+        assert_eq!(vst3_count, 1);
+    }
+
+    #[test]
+    fn list_bundle_candidates_is_non_recursive_and_filters_extensions() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+
+        fs::create_dir(root.join("Foo.clap")).unwrap();
+        fs::create_dir(root.join("Bar.vst3")).unwrap();
+        fs::write(root.join("ignore.txt"), "").unwrap();
+        // 非再帰: サブディレクトリ内の .clap は見つからない。
+        let nested = root.join("Foo.clap").join("Nested.clap");
+        fs::create_dir(&nested).unwrap();
+
+        let mut found = list_bundle_candidates(root);
+        found.sort_by(|a, b| a.0.cmp(&b.0));
+
+        assert_eq!(found.len(), 2);
+        assert_eq!(found[0].1, Format::Vst3);
+        assert_eq!(found[1].1, Format::Clap);
+    }
+
+    #[test]
+    fn list_bundle_candidates_on_missing_dir_is_empty() {
+        let found = list_bundle_candidates(Path::new("/does/not/exist/orbit-plugin-scan-test"));
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn catalog_entry_serializes_expected_json_shape() {
+        let entry = CatalogEntry {
+            name: "Test Synth".to_owned(),
+            vendor: "Acme".to_owned(),
+            format: Format::Clap,
+            path: "/path/to/Test.clap".to_owned(),
+            plugin_id: "com.acme.testsynth".to_owned(),
+            roles: vec![ROLE_INSTRUMENT.to_owned()],
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["name"], "Test Synth");
+        assert_eq!(json["vendor"], "Acme");
+        assert_eq!(json["format"], "clap");
+        assert_eq!(json["path"], "/path/to/Test.clap");
+        assert_eq!(json["pluginId"], "com.acme.testsynth");
+        assert_eq!(json["roles"][0], "instrument");
+    }
+
+    #[test]
+    fn catalog_serializes_top_level_shape() {
+        let catalog = Catalog {
+            version: 1,
+            scanned_at: "2026-07-17T00:00:00Z".to_owned(),
+            plugins: vec![],
+        };
+        let json = serde_json::to_value(&catalog).unwrap();
+        assert_eq!(json["version"], 1);
+        assert_eq!(json["scannedAt"], "2026-07-17T00:00:00Z");
+        assert!(json["plugins"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn dedup_entries_keeps_last_write_wins() {
+        let make = |vendor: &str| CatalogEntry {
+            name: "Same".to_owned(),
+            vendor: vendor.to_owned(),
+            format: Format::Vst3,
+            path: "/p/Same.vst3".to_owned(),
+            plugin_id: "CID123".to_owned(),
+            roles: vec![ROLE_EFFECT.to_owned()],
+        };
+        let entries = vec![make("Old"), make("New")];
+        let deduped = dedup_entries(entries);
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].vendor, "New");
+    }
+
+    #[test]
+    fn dedup_entries_preserves_distinct_keys() {
+        let a = CatalogEntry {
+            name: "A".to_owned(),
+            vendor: String::new(),
+            format: Format::Clap,
+            path: "/p/A.clap".to_owned(),
+            plugin_id: "id.a".to_owned(),
+            roles: vec![],
+        };
+        let b = CatalogEntry {
+            path: "/p/B.clap".to_owned(),
+            plugin_id: "id.b".to_owned(),
+            name: "B".to_owned(),
+            ..a.clone()
+        };
+        let deduped = dedup_entries(vec![a, b]);
+        assert_eq!(deduped.len(), 2);
+    }
+
+    #[test]
+    fn roles_from_clap_features_instrument_only() {
+        let features = vec!["instrument".to_owned(), "stereo".to_owned()];
+        assert_eq!(roles_from_clap_features(&features), vec![ROLE_INSTRUMENT]);
+    }
+
+    #[test]
+    fn roles_from_clap_features_effect_only() {
+        let features = vec!["audio-effect".to_owned()];
+        assert_eq!(roles_from_clap_features(&features), vec![ROLE_EFFECT]);
+    }
+
+    #[test]
+    fn roles_from_clap_features_unknown_gets_both() {
+        let features = vec!["stereo".to_owned()];
+        let roles = roles_from_clap_features(&features);
+        assert_eq!(roles, vec![ROLE_INSTRUMENT, ROLE_EFFECT]);
+    }
+
+    #[test]
+    fn strip_trailing_commas_removes_before_close_brace_and_bracket() {
+        let input = "{\"a\":1,\"b\":[1,2,],}";
+        let stripped = strip_trailing_commas(input);
+        let value: serde_json::Value = serde_json::from_str(&stripped).unwrap();
+        assert_eq!(value["a"], 1);
+        assert_eq!(value["b"][1], 2);
+    }
+
+    #[test]
+    fn strip_trailing_commas_preserves_commas_inside_strings() {
+        let input = r#"{"a":"has, a comma,"}"#;
+        let stripped = strip_trailing_commas(input);
+        let value: serde_json::Value = serde_json::from_str(&stripped).unwrap();
+        assert_eq!(value["a"], "has, a comma,");
+    }
+
+    #[test]
+    fn parse_moduleinfo_extracts_audio_module_class_only() {
+        let text = r#"{
+  "Name": "Scaler 3",
+  "Factory Info": { "Vendor": "Scaler Music" },
+  "Classes": [
+    {
+      "CID": "ABCDEF019182FAEB53634D7353636C33",
+      "Category": "Audio Module Class",
+      "Name": "Scaler 3",
+      "Vendor": "Scaler Music",
+      "Sub Categories": ["Instrument"],
+    },
+    {
+      "CID": "ABCDEF011234ABCD53634D7353636C33",
+      "Category": "Component Controller Class",
+      "Name": "Scaler 3",
+      "Vendor": "Scaler Music",
+      "Sub Categories": ["Instrument"],
+    },
+  ],
+}"#;
+        let entries = parse_moduleinfo(text, Path::new("/p/Scaler.vst3")).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].plugin_id, "ABCDEF019182FAEB53634D7353636C33");
+        assert_eq!(entries[0].vendor, "Scaler Music");
+        assert_eq!(entries[0].roles, vec![ROLE_INSTRUMENT.to_owned()]);
+    }
+
+    #[test]
+    fn parse_moduleinfo_fx_subcategory_maps_to_effect() {
+        let text = r#"{
+  "Name": "Some Fx",
+  "Classes": [
+    { "CID": "AAAA", "Category": "Audio Module Class", "Sub Categories": ["Fx", "Reverb"] },
+  ],
+}"#;
+        let entries = parse_moduleinfo(text, Path::new("/p/Fx.vst3")).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].roles, vec![ROLE_EFFECT.to_owned()]);
+    }
+
+    #[test]
+    fn scan_vst3_bundle_without_moduleinfo_is_skipped_not_probed() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bundle = temp.path().join("NoModuleInfo.vst3");
+        fs::create_dir_all(bundle.join("Contents/Resources")).unwrap();
+        // moduleinfo.json を意図的に置かない。
+
+        match scan_vst3_bundle(&bundle) {
+            VstScanResult::Skipped => {}
+            VstScanResult::Entries(entries) => {
+                panic!("expected Skipped, got Entries({entries:?})")
+            }
+        }
+    }
+
+    #[test]
+    fn scan_vst3_bundle_with_moduleinfo_returns_entries() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bundle = temp.path().join("HasModuleInfo.vst3");
+        let resources = bundle.join("Contents/Resources");
+        fs::create_dir_all(&resources).unwrap();
+        fs::write(
+            resources.join("moduleinfo.json"),
+            r#"{
+  "Name": "Test",
+  "Classes": [
+    { "CID": "AAAA", "Category": "Audio Module Class", "Sub Categories": ["Fx"] },
+  ],
+}"#,
+        )
+        .unwrap();
+
+        match scan_vst3_bundle(&bundle) {
+            VstScanResult::Entries(entries) => {
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].plugin_id, "AAAA");
+            }
+            VstScanResult::Skipped => panic!("expected Entries, got Skipped"),
+        }
+    }
+
+    #[test]
+    fn now_iso8601_matches_expected_format() {
+        let ts = now_iso8601();
+        assert_eq!(ts.len(), 20);
+        assert!(ts.ends_with('Z'));
+        assert_eq!(ts.as_bytes()[4], b'-');
+        assert_eq!(ts.as_bytes()[10], b'T');
+    }
+
+    #[test]
+    fn format_unix_timestamp_known_epoch() {
+        // 2024-01-01T00:00:00Z = 1704067200
+        assert_eq!(format_unix_timestamp(1_704_067_200), "2024-01-01T00:00:00Z");
+        // Unix epoch itself.
+        assert_eq!(format_unix_timestamp(0), "1970-01-01T00:00:00Z");
+    }
+}

--- a/rust/crates/orbit-plugin-scan/src/main.rs
+++ b/rust/crates/orbit-plugin-scan/src/main.rs
@@ -1,0 +1,53 @@
+//! orbit-plugin-scan バイナリエントリポイント（#463 C1）。
+//!
+//! CLAP/VST3 プラグインをスキャンし `~/.orbitscore/plugin-catalog.json` を生成する。
+//! daemon への `ScanPlugins` コマンド配線は C1b（別 PR）— このバイナリは単体で完結する。
+
+use orbit_plugin_scan::{
+    cache_path, now_iso8601, resolve_scan_dirs, scan_all, write_catalog, Catalog,
+};
+use std::env;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let home = env::var_os("HOME").map(PathBuf::from);
+    let orbit_plugin_path = env::var("ORBIT_PLUGIN_PATH").ok();
+
+    let Some(home) = home else {
+        eprintln!("[orbit-plugin-scan] ERROR: HOME 環境変数が読めません");
+        return ExitCode::FAILURE;
+    };
+
+    let dirs = resolve_scan_dirs(Some(&home), orbit_plugin_path.as_deref());
+    let outcome = scan_all(&dirs);
+    let catalog = Catalog {
+        version: 1,
+        scanned_at: now_iso8601(),
+        plugins: outcome.entries,
+    };
+
+    let path = cache_path(&home);
+    if let Err(error) = write_catalog(&catalog, &path) {
+        eprintln!("[orbit-plugin-scan] ERROR: カタログの書き込みに失敗: {path:?}: {error}");
+        return ExitCode::FAILURE;
+    }
+
+    let count = catalog.plugins.len();
+    let cache_path_json = json_escape(&path.to_string_lossy());
+    let skipped_json = outcome
+        .skipped
+        .iter()
+        .map(|path| format!("\"{}\"", json_escape(path)))
+        .collect::<Vec<_>>()
+        .join(",");
+    println!(
+        "{{\"count\":{count},\"cachePath\":\"{cache_path_json}\",\"skipped\":[{skipped_json}]}}"
+    );
+
+    ExitCode::SUCCESS
+}
+
+fn json_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}


### PR DESCRIPTION
## 概要

plugin カタログ(#463)の C1: スキャナを**独立バイナリ** `orbit-plugin-scan` として新設し、`~/.orbitscore/plugin-catalog.json` を生成する。spec 正本 = PC.1(本 PR で「スキャンは UI を出さない」を規範化)。

Refs #463

## 変更内容

- **rust/crates/orbit-plugin-scan 新設**(bin+lib): 標準ディレクトリ + `ORBIT_PLUGIN_PATH`(非再帰)走査 → atomic write でキャッシュ生成。dedup = (format,path,pluginId) 後勝ち
- **VST3 = moduleinfo.json のみ**: Steinberg の trailing-comma 方言を string-aware ストリッパで許容・`Audio Module Class` のみエントリ化・Sub Categories で role 推定。**probe fallback は撤去** — 実機でコンテンツ依存プラグイン(FIN-BOOST)がネイティブダイアログを出す実害が確認されたため(owner 報告)。moduleinfo 無しは skip し summary の `skipped` 配列で開示
- **CLAP**: 既存 `orbit-clap-host` discovery に vendor/features を追加(+public re-export 1行)し、feature タグで role 推定
- spec PC.1 更新: 「スキャンは UI を出さない・ブロックしない(規範)」「VST3 は moduleinfo.json のみ・UI 抑止付き probe は C1b 以降」

## 検証

- 新規 20 unit tests + orbit-clap-host 21 green(既存無変更)・clippy -D warnings / fmt clean
- **実機スモーク**: SSD 未接続環境でダイアログなしに完走(= UI 非発出の実証)。VST3 335 バンドル中 79 エントリ化・256 skip(開示済み)。例: `{"name":"Scaler 3","vendor":"Scaler Music","format":"vst3","roles":["instrument"]}`

## 残(別 PR)

C1b(daemon ScanPlugins 配線・UI 抑止付き probe 検討)/ C2(DSL 名前解決)/ C3(補完+MCP+右クリック rescan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu