### PR TITLE
fix(engine): serialize REPL line handling with a FIFO queue (#476)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,28 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.271 fix(engine): REPL 行処理の FIFO 直列化 #476 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 修正・実機再現シナリオ PASS
+
+**内容**: readline の同 tick 連続 'line' イベントを FIFO promise チェーンで直列化
+（`createReplSession` として分離・単体テスト可能に）。旧実装は async ハンドラが互いを
+待たず、共有 buffer が「実行中 execute 完了前に伸びる → 累積 buffer の重複実行・
+完了時 clear との競合」を起こす構造だった（unit テストは旧実装で fail する形で
+ピン留め: 全行 1 回ずつ順序実行・失敗行が後続を失わない・不完全入力の buffering 維持）。
+
+**根因の訂正（issue に反映）**: 当初の「effect 入りファイル一括実行で無音」の実機再現は、
+E2E ドライバの set_selection 境界の取り違え（end_char 省略 = end_line の行頭 → 最終行
+RUN が選択外）が混入していた。競合自体は構造的に実在（汚れセッションでの誤エラーも同根）。
+
+**検証**: 新規 3 tests・全体 1436 passed。ヘッドレス REPL で全行実行確認。実機
+（OrbitStudio + MCP・正しい選択）で effect 入り 9 行ファイル一括実行 → capture peak
+0.35355（オラクル一致）。
+
+Refs #476
+
+
 ### 6.270 chore(qa): docs-driven 実機 E2E + 学習サイト最新化 #481 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/packages/engine/src/cli/repl-mode.ts
+++ b/packages/engine/src/cli/repl-mode.ts
@@ -148,7 +148,13 @@ export function createReplSession(interpreter: InterpreterV2): {
     pushLine(line: string): void {
       // handleLine は内部で全エラーを捕捉するが、防御としてチェーン自体も reject を握る
       // （1 行の異常で以後の入力が全停止しないように）。
-      lineQueue = lineQueue.then(() => handleLine(line)).catch(() => {})
+      lineQueue = lineQueue
+        .then(() => handleLine(line))
+        .catch((e) => {
+          // handleLine は既知エラーを内部で捕捉する。ここに来るのは想定外のみ —
+          // 黙って握ると REPL が silent に劣化するため、必ず痕跡を残して続行する。
+          console.error(`[ERROR] unexpected REPL queue failure: ${e?.message ?? e}`)
+        })
     },
     idle(): Promise<void> {
       return lineQueue

--- a/packages/engine/src/cli/repl-mode.ts
+++ b/packages/engine/src/cli/repl-mode.ts
@@ -74,6 +74,88 @@ export function extractDocumentDirectoryMeta(code: string): string | undefined {
   return dir
 }
 
+/**
+ * REPL の行処理セッション（#476 で分離・単体テスト可能に）。
+ *
+ * 【直列化の根拠 — #476】readline は 1 チャンクの複数行を同 tick で 'line' 連発する。
+ * async ハンドラは互いを待たないため、素朴な実装では共有 buffer が「実行中の execute が
+ * 終わる前に後続行で伸びる → 累積 buffer の重複実行・完了時 clear との競合で行が失われる」
+ * （遅い await = plugin ロードで顕在化し、エディタの複数行実行が silent に壊れる）。
+ * `pushLine` は FIFO promise チェーンに積むだけで、1 行の処理（execute 完了と buffer
+ * 更新まで）が終わってから次の行に進む。`idle()` はキュー drain を待つ（テスト用）。
+ */
+export function createReplSession(interpreter: InterpreterV2): {
+  pushLine: (line: string) => void
+  idle: () => Promise<void>
+} {
+  let buffer = ''
+  let emptyLineCount = 0
+  // メタ行で受けた基準ディレクトリ（セッション内で最後の値が持続 — エディタ側は eval ごとに
+  // 現在ファイルの dir を送るので、ファイル切替にも追従する）。
+  let sessionDocumentDirectory: string | undefined
+  let lineQueue: Promise<void> = Promise.resolve()
+
+  async function executeCurrentBuffer(clearOnIncomplete: boolean): Promise<void> {
+    const code = buffer.trim()
+    if (!code) {
+      buffer = ''
+      emptyLineCount = 0
+      return
+    }
+    try {
+      const ir = parseAudioDSL(code)
+      const metaDir = extractDocumentDirectoryMeta(code)
+      if (metaDir) sessionDocumentDirectory = metaDir
+      await interpreter.execute(ir, {
+        source: code,
+        evalSource: 'human',
+        documentDirectory: sessionDocumentDirectory,
+      }) // §L1
+      console.log('✓') // Success indicator
+      buffer = ''
+    } catch (error: any) {
+      // 不完全入力（複数行の途中）は buffering を続ける（強制実行時は除く）
+      if (
+        !clearOnIncomplete &&
+        (error.message.includes('EOF') ||
+          error.message.includes('Expected RPAREN') ||
+          error.message.includes('Expected comma or closing parenthesis'))
+      ) {
+        return
+      }
+      console.error(`[ERROR] ${error.message}`)
+      buffer = ''
+    }
+  }
+
+  async function handleLine(line: string): Promise<void> {
+    if (line.trim() === '') {
+      emptyLineCount++
+      buffer += '\n'
+      // 2+ 連続空行 = バッファ確定・強制実行
+      if (emptyLineCount >= 2 && buffer.trim()) {
+        await executeCurrentBuffer(true)
+        emptyLineCount = 0
+      }
+      return
+    }
+    emptyLineCount = 0
+    buffer += line + '\n'
+    await executeCurrentBuffer(false)
+  }
+
+  return {
+    pushLine(line: string): void {
+      // handleLine は内部で全エラーを捕捉するが、防御としてチェーン自体も reject を握る
+      // （1 行の異常で以後の入力が全停止しないように）。
+      lineQueue = lineQueue.then(() => handleLine(line)).catch(() => {})
+    },
+    idle(): Promise<void> {
+      return lineQueue
+    },
+  }
+}
+
 export async function startREPL(interpreter: InterpreterV2): Promise<void> {
   const rl = readline.createInterface({
     input: process.stdin,
@@ -81,113 +163,8 @@ export async function startREPL(interpreter: InterpreterV2): Promise<void> {
     terminal: false,
   })
 
-  let buffer = ''
-  let emptyLineCount = 0
-  // メタ行で受けた基準ディレクトリ（セッション内で最後の値が持続 — エディタ側は eval ごとに
-  // 現在ファイルの dir を送るので、ファイル切替にも追従する）。
-  let sessionDocumentDirectory: string | undefined
-
-  rl.on('line', async (line) => {
-    if (process.env.ORBITSCORE_DEBUG) {
-      console.log(`[DEBUG] Received line (length=${line.length}): ${JSON.stringify(line)}`)
-      console.log(`[DEBUG] Buffer length before: ${buffer.length}`)
-    }
-
-    // If we receive an empty line, increment counter
-    if (line.trim() === '') {
-      emptyLineCount++
-      buffer += '\n'
-
-      if (process.env.ORBITSCORE_DEBUG) {
-        console.log(`[DEBUG] Empty line detected, count=${emptyLineCount}`)
-      }
-
-      // If we get 2+ consecutive empty lines, treat buffer as complete and execute
-      if (emptyLineCount >= 2 && buffer.trim()) {
-        if (process.env.ORBITSCORE_DEBUG) {
-          console.log(`[DEBUG] Forcing execution due to 2+ empty lines`)
-        }
-        await executeBuffer()
-      }
-      return
-    }
-
-    // Reset empty line counter and add line to buffer
-    emptyLineCount = 0
-    buffer += line + '\n'
-
-    if (process.env.ORBITSCORE_DEBUG) {
-      console.log(`[DEBUG] Buffer length after: ${buffer.length}`)
-      console.log(`[DEBUG] Attempting to parse buffer...`)
-    }
-
-    // Try to parse and execute the buffer
-    // If parsing fails due to incomplete input, keep buffering
-    try {
-      const code = buffer.trim()
-      const ir = parseAudioDSL(code)
-      const metaDir = extractDocumentDirectoryMeta(code)
-      if (metaDir) sessionDocumentDirectory = metaDir
-      await interpreter.execute(ir, {
-        source: code,
-        evalSource: 'human',
-        documentDirectory: sessionDocumentDirectory,
-      }) // §L1
-      console.log('✓') // Success indicator
-      buffer = '' // Reset buffer on success
-      if (process.env.ORBITSCORE_DEBUG) {
-        console.log(`[DEBUG] Parse success, buffer cleared`)
-      }
-    } catch (error: any) {
-      if (process.env.ORBITSCORE_DEBUG) {
-        console.log(`[DEBUG] Parse error: ${error.message}`)
-      }
-      // If error is about EOF or incomplete input, keep buffering
-      if (
-        error.message.includes('EOF') ||
-        error.message.includes('Expected RPAREN') ||
-        error.message.includes('Expected comma or closing parenthesis')
-      ) {
-        if (process.env.ORBITSCORE_DEBUG) {
-          console.log(`[DEBUG] Incomplete input, continuing to buffer`)
-        }
-        // Continue buffering
-        return
-      }
-      // For other errors, report and reset buffer
-      console.error(`[ERROR] ${error.message}`)
-      buffer = ''
-      if (process.env.ORBITSCORE_DEBUG) {
-        console.log(`[DEBUG] Fatal parse error, buffer cleared`)
-      }
-    }
-  })
-
-  async function executeBuffer() {
-    const code = buffer.trim()
-    if (!code) {
-      buffer = ''
-      emptyLineCount = 0
-      return
-    }
-
-    try {
-      const ir = parseAudioDSL(code)
-      const metaDir = extractDocumentDirectoryMeta(code)
-      if (metaDir) sessionDocumentDirectory = metaDir
-      await interpreter.execute(ir, {
-        source: code,
-        evalSource: 'human',
-        documentDirectory: sessionDocumentDirectory,
-      }) // §L1
-      console.log('✓') // Success indicator
-    } catch (error: any) {
-      console.error(`[ERROR] ${error.message}`)
-    }
-
-    buffer = ''
-    emptyLineCount = 0
-  }
+  const session = createReplSession(interpreter)
+  rl.on('line', (line) => session.pushLine(line))
 
   // Keep process alive indefinitely for interactive REPL
   // This is intentional: REPL mode is designed to run continuously,

--- a/tests/cli/repl-line-serialization.spec.ts
+++ b/tests/cli/repl-line-serialization.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * #476: REPL 行処理の FIFO 直列化。
+ *
+ * 旧実装は readline の同 tick 連続 'line' イベントを直列化せず、遅い execute
+ * （plugin ロード等）中に共有 buffer が伸びて「累積 buffer の重複実行・行の消失」を
+ * 起こした（実機 E2E で発見）。本テストは「遅い execute を挟んでも全行が 1 回ずつ・
+ * 順序どおり実行される」ことをピン留めする。
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { createReplSession } from '../../packages/engine/src/cli/repl-mode'
+
+function mockInterpreter(delayMsFor: (code: string) => number) {
+  const executed: string[] = []
+  return {
+    executed,
+    interpreter: {
+      execute: async (_ir: unknown, options: { source?: string }) => {
+        const code = options.source ?? ''
+        const delay = delayMsFor(code)
+        if (delay > 0) await new Promise((r) => setTimeout(r, delay))
+        executed.push(code)
+      },
+    } as any,
+  }
+}
+
+describe('createReplSession — line serialization (#476)', () => {
+  it('executes every line exactly once, in order, even with a slow statement in the middle', async () => {
+    // 3 行目（sum の effect 相当）だけ遅い — 旧実装ではこの間に後続行が buffer に積まれ
+    // 重複実行・消失が起きた
+    const { interpreter, executed } = mockInterpreter((code) =>
+      code.includes('global.start') ? 80 : 0,
+    )
+    const session = createReplSession(interpreter)
+    const lines = [
+      'var global = init GLOBAL',
+      'global.tempo(120)',
+      'global.start()',
+      'var kick = init global.seq',
+      'RUN(kick)',
+    ]
+    // readline の同 tick 連発を再現: 同期的に全行 push
+    for (const l of lines) session.pushLine(l)
+    await session.idle()
+
+    expect(executed).toEqual(lines)
+  })
+
+  it('an execute failure on one line does not lose the following lines', async () => {
+    const { interpreter, executed } = mockInterpreter(() => 0)
+    const failing = interpreter as any
+    const orig = failing.execute
+    failing.execute = async (ir: unknown, options: { source?: string }) => {
+      if ((options.source ?? '').includes('BOOM')) throw new Error('boom')
+      return orig(ir, options)
+    }
+    const session = createReplSession(interpreter)
+    session.pushLine('var global = init GLOBAL')
+    session.pushLine('RUN(BOOM)')
+    session.pushLine('global.tempo(120)')
+    await session.idle()
+    expect(executed).toEqual(['var global = init GLOBAL', 'global.tempo(120)'])
+  })
+
+  it('keeps buffering an incomplete multi-line statement and executes it once complete', async () => {
+    const { interpreter, executed } = mockInterpreter(() => 0)
+    const session = createReplSession(interpreter)
+    // 括弧が閉じるまで parse は incomplete → buffering、閉じた時点で全体を 1 回実行
+    session.pushLine('RUN(kick,')
+    session.pushLine('snare)')
+    await session.idle()
+    expect(executed).toEqual(['RUN(kick,\nsnare)'])
+  })
+})


### PR DESCRIPTION
## 概要

REPL の行処理を FIFO 直列化し、同 tick 連続 line イベント × 共有 buffer の競合(#476)を解消。

Closes #476

## 変更内容

- `createReplSession` を分離(buffer・直列 queue・メタ行抽出を内包・単体テスト可能)。startREPL はこれを使うだけに
- `pushLine` は FIFO promise チェーンに積み、1 行の処理(execute 完了と buffer 更新)後に次へ。失敗行が後続入力を止めない防御 catch 付き

## 根因の訂正(issue にも記録)

当初の実機無音再現には E2E ドライバの selection 境界取り違えが混入(end_char 省略 = end_line 行頭)。競合自体は構造的に実在 — **unit テストは旧実装で fail する形**(累積 buffer の重複実行で順序・回数が壊れる)。

## 検証

- 新規 3 tests(全行 1 回ずつ順序実行・失敗行の非伝播・不完全入力 buffering 維持)・全体 1436 passed
- ヘッドレス REPL で全行実行確認
- **実機**(OrbitStudio + MCP・正しい選択): effect 入り 9 行ファイル一括実行 → capture **peak 0.35355** オラクル一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu