### PR TITLE
fix(mcp): detect stale docs dist (base mismatch) and serve a rebuild hint (#480)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,17 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.272 fix(mcp): stale dist（base 不一致）検出ガード #480 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 修正
+
+**内容**: docs 配信に `isDocsDistStale()` を追加 — index.html に `base + '/assets/'` 参照が
+無い dist（base 変更前の古いビルド）は、未ビルト時と同じ 503 + rebuild 手順の actionable
+メッセージに落とす（従来は壊れた素 HTML を黙って配信）。mtime キャッシュでリクエスト毎の
+同期 read を回避。unit 4 件（正常/不一致/不在/mtime 再検査）+ 既存 docs-http 36 件 green。
+
+Refs #480
 ### 6.271 fix(engine): REPL 行処理の FIFO 直列化 #476 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/packages/vscode-extension/src/mcp-server.ts
+++ b/packages/vscode-extension/src/mcp-server.ts
@@ -384,6 +384,31 @@ export function matchDocsRequest(pathname: string, sites: DocsSite[]): DocsSite 
 }
 
 /**
+ * dist が「存在するが base 不一致の stale ビルド」でないか検査する（#480）。
+ * VitePress は SITE_BASE をアセット URL に焼き込むため、base 変更前の古い dist を
+ * 配信すると全アセットが 404 になり素 HTML が出る（実害 2026-07-17）。index.html に
+ * `base + '/assets/'` への参照が含まれることを鮮度の代理指標とし、不一致なら
+ * 未ビルト時と同じ actionable メッセージ（rebuild 手順）に落とす。結果は
+ * index.html の mtime でキャッシュ（リクエスト毎の同期 read を避ける）。
+ */
+export function isDocsDistStale(root: string, base: string): boolean {
+  const indexPath = path.join(root, 'index.html')
+  try {
+    const mtime = fs.statSync(indexPath).mtimeMs
+    const cached = staleCheckCache.get(indexPath)
+    if (cached && cached.mtime === mtime) return cached.stale
+    const html = fs.readFileSync(indexPath, 'utf8')
+    const stale = !html.includes(`${base}/assets/`)
+    staleCheckCache.set(indexPath, { mtime, stale })
+    return stale
+  } catch {
+    // index.html が読めない = 未ビルト相当。呼び出し側の existsSync ガードに任せる。
+    return false
+  }
+}
+const staleCheckCache = new Map<string, { mtime: number; stale: boolean }>()
+
+/**
  * Build a per-session McpServer with the OrbitScore tool surface registered.
  * One instance per MCP session (see `startOrbitScoreMcpServer` for routing).
  */
@@ -940,6 +965,12 @@ export async function startOrbitScoreMcpServer(opts: {
           log(`docs not built — root missing: ${docsMatch.root}`)
           res.writeHead(503, { 'content-type': 'text/plain; charset=utf-8' })
           res.end(docsMatch.buildHint)
+          return
+        }
+        if (isDocsDistStale(docsMatch.root, docsMatch.base)) {
+          log(`docs dist is stale (base mismatch) — ${docsMatch.root}`)
+          res.writeHead(503, { 'content-type': 'text/plain; charset=utf-8' })
+          res.end(`Docs build is stale (built with a different base path). ${docsMatch.buildHint}`)
           return
         }
         const filePath = resolveDocsFilePath(docsMatch.root, pathname.slice(docsMatch.base.length))

--- a/tests/vscode-extension/mcp-server-stale-dist.spec.ts
+++ b/tests/vscode-extension/mcp-server-stale-dist.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * #480: stale dist（base 不一致ビルド）の検出。base 変更前の古い dist を配信すると
+ * 全アセット 404 の素 HTML になる実害の再発防止。
+ */
+
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+import { isDocsDistStale } from '../../packages/vscode-extension/src/mcp-server'
+
+describe('isDocsDistStale (#480)', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbs-dist-'))
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('returns false for a dist built with the expected base', () => {
+    fs.writeFileSync(
+      path.join(dir, 'index.html'),
+      '<link rel="stylesheet" href="/orbitscore/dev/assets/style.css">',
+    )
+    expect(isDocsDistStale(dir, '/orbitscore/dev')).toBe(false)
+  })
+
+  it('returns true for a dist built with a different base (root-absolute assets)', () => {
+    fs.writeFileSync(
+      path.join(dir, 'index.html'),
+      '<link rel="stylesheet" href="/assets/style.css">',
+    )
+    expect(isDocsDistStale(dir, '/orbitscore/dev')).toBe(true)
+  })
+
+  it('returns false (defers to the not-built guard) when index.html is missing', () => {
+    expect(isDocsDistStale(dir, '/orbitscore/dev')).toBe(false)
+  })
+
+  it('re-checks after index.html is rebuilt (mtime cache invalidation)', async () => {
+    const idx = path.join(dir, 'index.html')
+    fs.writeFileSync(idx, 'href="/assets/style.css"')
+    expect(isDocsDistStale(dir, '/orbitscore/dev')).toBe(true)
+    // mtime を確実に変える
+    await new Promise((r) => setTimeout(r, 10))
+    fs.writeFileSync(idx, 'href="/orbitscore/dev/assets/style.css"')
+    fs.utimesSync(idx, new Date(), new Date(Date.now() + 1000))
+    expect(isDocsDistStale(dir, '/orbitscore/dev')).toBe(false)
+  })
+})


### PR DESCRIPTION
## 概要

#480(品質チェック E2E の発見): base 変更前の古い dist を黙って配信し、全アセット 404 の素 HTML が出る問題の再発防止。

Closes #480

## 変更内容

- `isDocsDistStale()`: dist の index.html に `base + '/assets/'` 参照が含まれるかを鮮度の代理指標とし、不一致なら **503 + rebuild 手順**(未ビルト時と同じ actionable 形式)を返す
- 検査結果は index.html の mtime でキャッシュ(リクエスト毎の同期 read 回避・再ビルドで自動再検査)

## 検証

- 新規 unit 4 件(base 一致/不一致/index 不在/mtime 再検査)+ 既存 docs-http 36 件 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu