### PR TITLE
fix(native): resolve device by name without per-device config probing (#484)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,31 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.277 fix(native): device 解決の CoreAudio ハングを解消 #484 hotfix (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 修正・確認 E2E 全 PASS（owner 指示の「バグ確認 E2E」が main の P0 を検出）
+
+**発見**: マージ直後の確認 E2E で engine 起動が ready line timeout。スタック採取で確定 —
+`resolve_output_device` の `host.output_devices()` は cpal 内部で各デバイスの
+supported_output_configs を probe（AudioUnit + CreateIOProcID 生成）し、Aggregate
+デバイス等で CoreAudio 内ブロック。boot が設定デバイス名を渡すようになったため
+**OrbitStudio の既定起動が壊れていた**（環境依存で顕在化 — D1 実装時の実機検証は通過
+していた）。
+
+**修正**: 起動クリティカルパスは probe なしの `host.devices()` 名前照合のみに。config
+検証は選択後の stream 構築（1 台のみ）に委ねる。3 ケース（実在名/不在名/指定なし）で
+即 ready を確認。
+
+**確認 E2E（アプリ経由・全修正の再検証）**: #476 = effect 入りファイル一括実行 →
+peak 0.35355 一致 / #478 = soundDetected true（onset 1）+ windows 2197・steady 0.3536 /
+#480 = stale 偽装 → 503 + rebuild hint → 復元 200 / #487 = ビルド時 rebuild 走行確認。
+
+**既知 Minor**: daemon stderr のデバイス fallback 警告が拡張ログに未転送（可視性・別途）。
+
+Refs #484
+
+
 ### 6.276 feat(daemon): audio device enumeration + startup selection #484 D1 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/rust/crates/orbit-audio-native/src/output.rs
+++ b/rust/crates/orbit-audio-native/src/output.rs
@@ -160,9 +160,15 @@ fn resolve_output_device(
         return host.default_output_device().ok_or(OutputError::NoDevice);
     };
 
+    // 【重要・確認 E2E での P0 再発防止】ここで `host.output_devices()` を使ってはいけない。
+    // cpal の output フィルタは各デバイスの supported_output_configs を probe し、その実装が
+    // macOS では AudioUnit + CreateIOProcID を生成する — Aggregate デバイス等で CoreAudio 内
+    // ブロック（実測: 起動が ready line 前に無限ハング・スタックで確定）。起動クリティカル
+    // パスでは probe なしの `devices()` 名前照合のみ行い、config 検証は選択後の通常の
+    // stream 構築（そのデバイス 1 台に対してのみ）に任せる。
     let mut matched: Option<Device> = None;
     let mut available_names = Vec::new();
-    if let Ok(devices) = host.output_devices() {
+    if let Ok(devices) = host.devices() {
         for device in devices {
             if let Ok(name) = device.name() {
                 if name == requested {

--- a/rust/crates/orbit-audio-native/src/output.rs
+++ b/rust/crates/orbit-audio-native/src/output.rs
@@ -181,7 +181,19 @@ fn resolve_output_device(
     }
 
     match matched {
-        Some(device) => Ok(device),
+        // `devices()` は入力専用デバイスも含む（probe 回避の代償）。マッチした 1 台だけ
+        // default_output_config で出力可否を確認し、出力不可なら旧挙動どおり警告 + 既定へ
+        // 縮退する（起動失敗にしない）。probe はユーザーが明示指定した 1 台に限定される。
+        Some(device) => {
+            if device.default_output_config().is_ok() {
+                Ok(device)
+            } else {
+                eprintln!(
+                    "[audio-device] requested device \"{requested}\" is not an output device — falling back to system default output"
+                );
+                host.default_output_device().ok_or(OutputError::NoDevice)
+            }
+        }
         None => {
             eprintln!(
                 "[audio-device] requested device \"{requested}\" not found (available: {available_names:?}) — falling back to system default output"


### PR DESCRIPTION
## 概要

owner 指示の**バグ確認 E2E が main の P0 を検出**: `--audio-device` 指定時(= OrbitStudio の既定 boot 経路)に daemon が ready line 前に無限ハングし、engine が起動不能。

Refs #484

## 根因(スタック採取で確定)

`resolve_output_device` の `host.output_devices()` は cpal 内部で**各デバイスの supported_output_configs を probe**(AudioUnit + `CreateIOProcID` 生成)し、Pro Tools Aggregate 等で CoreAudio 内ブロック。環境状態依存のため D1 実装時の実機検証はすり抜けた。

## 修正

起動クリティカルパスは **probe なしの `host.devices()` 名前照合のみ**。config 検証は選択後の stream 構築(選ばれた 1 台のみ)に委ねる。

## 検証

- 3 ケース(実在名 / 不在名 / 指定なし)すべて即 ready・native 45 tests / clippy / fmt green
- **アプリ経由の確認 E2E 全 PASS**: #476(0.35355 一致)・#478(soundDetected true + windows 2197)・#480(stale 偽装 → 503 → 復元 200)・#487(rebuild 走行)

## 既知 Minor(別途)

daemon stderr の fallback 警告が拡張ログに未転送(機能は正常・可視性のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu