### PR TITLE
feat(dsl): plugin catalog name resolution — effect/instrument by name (#463 C2)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,28 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.278 feat(dsl): plugin catalog 名前指し #463 C2 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 実装（バケット A 先頭・owner の「フルパスをどうにかしたい」に応答）
+
+**内容（PC.2 準拠）**: `kick.effect("TAL Reverb 4")` / `seq.instrument("Scaler 3")` —
+- 判別 = path-direct 形 or 既知拡張子 → 従来 path 解決（不変）・それ以外 → カタログ名
+  （audio 系 looksLikePath は不使用 — vendor 修飾が `/` を含むため専用判別）
+- 一致 = NFC/case-insensitive/trim・曖昧は候補列挙エラー・`"vendor/name"` 修飾
+- 解決 = (path, pluginId) の組を LoadPlugin へ・名前指し + pluginId 引数の併用はエラー
+- format 優先 = verb 受理内で CLAP > VST3・受理不能は専用エラー・未ヒットは rescan 案内
+- カタログ読取 = plugin-catalog.ts（mtime キャッシュ・`ORBIT_PLUGIN_CATALOG` で注入可）
+
+**意図的挙動変更**: 既知拡張子なしの裸名（例 `effect.wav`）は拡張子エラーでなくカタログ
+解決へルーティング（PC.2 の規範・既存テスト 2 件を `./` 付きに更新）。
+
+**検証**: 新規 25 tests・全体 1473 passed・tsc/lint clean。実カタログ（79 entries）で
+"Scaler 3" → VST3 path + CID 解決・"Mic Room"（VST3-only）を effect() で専用エラー確認。
+
+Refs #463
+
+
 ### 6.277 fix(native): device 解決の CoreAudio ハングを解消 #484 hotfix (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/packages/engine/src/core/global/effect-slot.ts
+++ b/packages/engine/src/core/global/effect-slot.ts
@@ -10,27 +10,40 @@ import type { AudioEngine } from '../../audio/types'
 
 import { AudioManager } from './audio-manager'
 import { LinkAudioManager } from './link-audio-manager'
-import { resolvePluginPath, validatePluginExtension } from './plugin-resolver'
+import {
+  isPluginPathSpec,
+  resolvePluginSpec,
+  validatePluginExtension,
+  type ResolvedPluginSpec,
+} from './plugin-resolver'
 
 /**
  * effect spec の共通前処理。順序は load-bearing（PluginEffectManager 由来）:
  * spec 検証 → LinkAudio gate → パス解決。未保存ファイル等で resolve が
  * 「cannot resolve」を投げる前に、より本質的な LinkAudio 競合エラーを出すため。
+ * 拡張子検証（`validatePluginExtension`）は path-direct spec にのみ適用する
+ * （#463 C2: カタログ名はここで弾かず、`resolvePluginSpec` のカタログ解決に委ねる）。
  */
 export function resolveEffectSpec(
   spec: string,
+  pluginId: string | undefined,
   deps: { audioManager: AudioManager; linkAudioManager: LinkAudioManager },
   linkAudioErrorMessage: string,
-): string {
-  validatePluginExtension(spec, 'effect')
+  catalogPathOverride?: string,
+): ResolvedPluginSpec {
+  if (isPluginPathSpec(spec)) {
+    validatePluginExtension(spec, 'effect')
+  }
   if (deps.linkAudioManager.isEnabled()) {
     throw new Error(linkAudioErrorMessage)
   }
-  return resolvePluginPath(
+  return resolvePluginSpec(
     spec,
+    pluginId,
     deps.audioManager.getAudioPaths(),
     deps.audioManager.getDocumentDirectory(),
     'effect',
+    catalogPathOverride,
   )
 }
 

--- a/packages/engine/src/core/global/mixer-manager.ts
+++ b/packages/engine/src/core/global/mixer-manager.ts
@@ -126,16 +126,17 @@ export class MixerManager {
   ): Promise<MixerBusHandle> {
     // LinkAudio gate は declareBus() 済みでも維持する（respawn/reload 経路で effect() 単独が
     // 再実行され得るため — resolveEffectSpec が spec 検証 → gate → 解決の順序を保証する）。
-    const resolvedPath = resolveEffectSpec(
+    const resolved = resolveEffectSpec(
       spec,
+      pluginId,
       { audioManager: this.audioManager, linkAudioManager: this.linkAudioManager },
       `${kind}("${name}").effect() cannot be used while LinkAudio is enabled in v1.`,
     )
     await this.kinds[kind].inserts.declare(
       bus,
       bus,
-      resolvedPath,
-      pluginId,
+      resolved.path,
+      resolved.pluginId,
       () =>
         new Error(
           `${kind}("${name}").effect() supports one insert per bus in v1; chains (multiple ` +

--- a/packages/engine/src/core/global/plugin-catalog.ts
+++ b/packages/engine/src/core/global/plugin-catalog.ts
@@ -1,0 +1,78 @@
+/**
+ * Plugin catalog reader (#463 C2 — spec `docs/core/INSTRUCTION_ORBITSCORE_DSL.md` §PC.1/PC.2).
+ *
+ * Reads the daemon-generated catalog (`~/.orbitscore/plugin-catalog.json`, default location;
+ * overridable via the `ORBIT_PLUGIN_CATALOG` env var so tests can point at a fixture) and
+ * caches it in memory keyed by mtime, so repeated `effect()`/`instrument()` name-lookups in a
+ * long-running daemon session don't re-parse the file on every call while still picking up a
+ * rescan without a process restart.
+ *
+ * This module is pure I/O + typing; the matching/resolution rules (PC.2) live in
+ * `plugin-resolver.ts`, which is the only intended caller.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+export interface PluginCatalogEntry {
+  readonly name: string
+  readonly vendor: string
+  /** Raw catalog format tag (C1 scanner emits lowercase `clap` / `vst3` / `component`). */
+  readonly format: string
+  readonly path: string
+  readonly pluginId: string
+  readonly roles: readonly string[]
+}
+
+export interface PluginCatalogFile {
+  readonly version: number
+  readonly scannedAt: string
+  readonly plugins: readonly PluginCatalogEntry[]
+}
+
+function defaultCatalogPath(): string {
+  return path.join(os.homedir(), '.orbitscore', 'plugin-catalog.json')
+}
+
+/** Resolves the catalog file path: explicit override > `ORBIT_PLUGIN_CATALOG` env > default. */
+export function resolveCatalogPath(override?: string): string {
+  return override ?? process.env.ORBIT_PLUGIN_CATALOG ?? defaultCatalogPath()
+}
+
+interface CacheEntry {
+  readonly mtimeMs: number
+  readonly catalog: PluginCatalogFile
+}
+
+const cache = new Map<string, CacheEntry>()
+
+/**
+ * Loads and parses the plugin catalog, or returns `undefined` if it doesn't exist yet
+ * (not-yet-scanned — caller turns this into an actionable "run orbit-plugin-scan" error).
+ * Malformed JSON is allowed to throw — that's a real corruption the caller should surface.
+ */
+export function loadPluginCatalog(catalogPathOverride?: string): PluginCatalogFile | undefined {
+  const catalogPath = resolveCatalogPath(catalogPathOverride)
+
+  let mtimeMs: number
+  try {
+    mtimeMs = fs.statSync(catalogPath).mtimeMs
+  } catch {
+    cache.delete(catalogPath)
+    return undefined
+  }
+
+  const cached = cache.get(catalogPath)
+  if (cached && cached.mtimeMs === mtimeMs) return cached.catalog
+
+  const raw = fs.readFileSync(catalogPath, 'utf8')
+  const catalog = JSON.parse(raw) as PluginCatalogFile
+  cache.set(catalogPath, { mtimeMs, catalog })
+  return catalog
+}
+
+/** Test-only: forces the next `loadPluginCatalog()` call to re-read from disk. */
+export function clearPluginCatalogCache(): void {
+  cache.clear()
+}

--- a/packages/engine/src/core/global/plugin-effect-manager.ts
+++ b/packages/engine/src/core/global/plugin-effect-manager.ts
@@ -22,16 +22,17 @@ export class PluginEffectManager {
   }
 
   async effect(spec: string, pluginId?: string): Promise<void> {
-    const resolvedPath = resolveEffectSpec(
+    const resolved = resolveEffectSpec(
       spec,
+      pluginId,
       { audioManager: this.audioManager, linkAudioManager: this.linkAudioManager },
       'global.effect() cannot be used while LinkAudio is enabled in v1.',
     )
     await this.slots.declare(
       'master',
       undefined,
-      resolvedPath,
-      pluginId,
+      resolved.path,
+      resolved.pluginId,
       () =>
         new Error(
           'global.effect() supports one master insert in v1; effect chains are reserved for future support.',

--- a/packages/engine/src/core/global/plugin-instrument-manager.ts
+++ b/packages/engine/src/core/global/plugin-instrument-manager.ts
@@ -2,7 +2,7 @@ import type { AudioEngine } from '../../audio/types'
 
 import { AudioManager } from './audio-manager'
 import { LinkAudioManager } from './link-audio-manager'
-import { resolvePluginPath, validatePluginExtension } from './plugin-resolver'
+import { isPluginPathSpec, resolvePluginSpec, validatePluginExtension } from './plugin-resolver'
 
 interface InstrumentDeclaration {
   resolvedPath: string
@@ -25,29 +25,36 @@ export class PluginInstrumentManager {
   }
 
   async instrument(spec: string, pluginId?: string): Promise<void> {
-    validatePluginExtension(spec, 'instrument')
+    // 拡張子検証は path-direct spec にのみ適用する（#463 C2: カタログ名はここで弾かず、
+    // resolvePluginSpec のカタログ解決に委ねる — effect-slot.ts の resolveEffectSpec と同型）。
+    if (isPluginPathSpec(spec)) {
+      validatePluginExtension(spec, 'instrument')
+    }
     if (this.linkAudioManager.isEnabled()) {
       throw new Error('seq.instrument() cannot be used while LinkAudio is enabled in v1.')
     }
 
-    const resolvedPath = resolvePluginPath(
+    const resolved = resolvePluginSpec(
       spec,
+      pluginId,
       this.audioManager.getAudioPaths(),
       this.audioManager.getDocumentDirectory(),
       'instrument',
     )
+    const resolvedPath = resolved.path
+    const resolvedPluginId = resolved.pluginId
     const existing = this.declaration
     if (existing) {
-      if (existing.resolvedPath === resolvedPath && existing.pluginId === pluginId) {
+      if (existing.resolvedPath === resolvedPath && existing.pluginId === resolvedPluginId) {
         await existing.load
         if (this.audioEngine.isPluginActive?.('instrument') === false) {
-          await this.issueLoad(resolvedPath, pluginId)
+          await this.issueLoad(resolvedPath, resolvedPluginId)
         }
         return
       }
       throw new Error('seq.instrument() supports one instrument instance in v1.')
     }
-    await this.issueLoad(resolvedPath, pluginId)
+    await this.issueLoad(resolvedPath, resolvedPluginId)
   }
 
   private async issueLoad(resolvedPath: string, pluginId: string | undefined): Promise<void> {

--- a/packages/engine/src/core/global/plugin-resolver.ts
+++ b/packages/engine/src/core/global/plugin-resolver.ts
@@ -2,7 +2,9 @@
  * Plugin path resolver.
  *
  * Shared role-aware extension-validation + path-resolution logic for plugin
- * specs.
+ * specs, plus (#463 C2) catalog name resolution — spec
+ * `docs/core/INSTRUCTION_ORBITSCORE_DSL.md` §PC.2 is the source of truth for the
+ * discriminator and matching rules implemented here.
  *
  * `resolvePluginPath` validates the extension first, then resolves the path
  * (`resolvePathDirect`) — this single entry point always does both, in that
@@ -12,11 +14,17 @@
  * resolution — call `validatePluginExtension(spec, role)` directly first, do the
  * gating check, then call `resolvePluginPath` (which re-validates; the
  * function is pure so the repeat call is harmless).
+ *
+ * `resolvePluginSpec` is the catalog-aware entry point callers should use for
+ * `effect()`/`instrument()`: it runs the PC.2 discriminator first (path-direct
+ * specs fall through to `resolvePluginPath`, unchanged) and only reaches the
+ * catalog for bare names.
  */
 
 import path from 'node:path'
 
 import { resolvePathDirect } from './audio-resolver'
+import { loadPluginCatalog, resolveCatalogPath, type PluginCatalogEntry } from './plugin-catalog'
 
 export function resolvePluginPath(
   spec: string,
@@ -41,4 +49,139 @@ export function validatePluginExtension(spec: string, role: PluginRole): void {
   }
   const expected = role === 'instrument' ? '.clap or .vst3' : '.clap'
   throw new Error(`Unknown plugin extension "${extension || '(none)'}"; expected ${expected}.`)
+}
+
+const PATH_DIRECT_PREFIXES = ['./', '../', '~/', '/']
+const KNOWN_PLUGIN_EXTENSIONS = ['.clap', '.vst3', '.component']
+
+/**
+ * PC.2 discriminator: path-direct specs start with `./`/`../`/`~/`/`/` or end with a known
+ * plugin extension; everything else is a catalog name. Deliberately does NOT reuse audio's
+ * `looksLikePath()` ("contains `/`" = path) — a vendor-qualified catalog name like
+ * `"TAL Software/TAL Reverb 4"` contains `/` but is not a path.
+ */
+export function isPluginPathSpec(spec: string): boolean {
+  if (PATH_DIRECT_PREFIXES.some((prefix) => spec.startsWith(prefix))) return true
+  const lower = spec.toLowerCase()
+  return KNOWN_PLUGIN_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+function normalizeCatalogKey(value: string): string {
+  return value.trim().normalize('NFC').toLowerCase()
+}
+
+function acceptedFormatsForRole(role: PluginRole): readonly string[] {
+  return role === 'instrument' ? ['clap', 'vst3'] : ['clap']
+}
+
+const RESCAN_HINT = 'Run `orbit-plugin-scan` to (re)generate the plugin catalog, then retry.'
+
+interface ResolvedCatalogPlugin {
+  readonly path: string
+  readonly pluginId: string
+}
+
+/**
+ * Resolves a catalog (non-path) spec to `(path, pluginId)` per PC.2: exact name match
+ * (case-insensitive/trim/NFC), optional `"vendor/name"` qualification, role check, then
+ * format preference (CLAP > VST3) among the formats the verb accepts (PH.3).
+ */
+function resolveCatalogSpec(
+  spec: string,
+  role: PluginRole,
+  catalogPathOverride: string | undefined,
+): ResolvedCatalogPlugin {
+  const catalogPath = resolveCatalogPath(catalogPathOverride)
+  const catalog = loadPluginCatalog(catalogPathOverride)
+  if (!catalog) {
+    throw new Error(`Plugin catalog not found at ${catalogPath}. ${RESCAN_HINT}`)
+  }
+
+  const slashIndex = spec.indexOf('/')
+  const hasVendor = slashIndex !== -1
+  const vendorKey = hasVendor ? normalizeCatalogKey(spec.slice(0, slashIndex)) : undefined
+  const nameKey = normalizeCatalogKey(hasVendor ? spec.slice(slashIndex + 1) : spec)
+
+  let candidates = catalog.plugins.filter((entry) => normalizeCatalogKey(entry.name) === nameKey)
+  if (vendorKey !== undefined) {
+    candidates = candidates.filter((entry) => normalizeCatalogKey(entry.vendor) === vendorKey)
+  }
+
+  if (candidates.length === 0) {
+    throw new Error(
+      `No plugin named "${spec}" found in the plugin catalog (${catalogPath}). ${RESCAN_HINT}`,
+    )
+  }
+
+  if (vendorKey === undefined) {
+    const distinctVendors = new Set(candidates.map((entry) => normalizeCatalogKey(entry.vendor)))
+    if (distinctVendors.size > 1) {
+      const listed = candidates.map((entry) => `"${entry.vendor}/${entry.name}" (${entry.format})`)
+      throw new Error(
+        `Plugin name "${spec}" is ambiguous across multiple vendors: ${listed.join(', ')}. ` +
+          'Qualify it as "vendor/name" to disambiguate.',
+      )
+    }
+  }
+
+  const roleCandidates = candidates.filter((entry) => entry.roles.includes(role))
+  if (roleCandidates.length === 0) {
+    const foundRoles = [...new Set(candidates.flatMap((entry) => entry.roles))].join(', ') || 'none'
+    throw new Error(
+      `Plugin "${spec}" does not support the "${role}" role (catalog roles: ${foundRoles}).`,
+    )
+  }
+
+  const accepted = acceptedFormatsForRole(role)
+  const formatCandidates = roleCandidates.filter((entry) =>
+    accepted.includes(entry.format.toLowerCase()),
+  )
+  if (formatCandidates.length === 0) {
+    const foundFormats = [...new Set(roleCandidates.map((entry) => entry.format))].join(', ')
+    throw new Error(
+      `Plugin "${spec}" was found in the catalog only as [${foundFormats}], which ${role}() ` +
+        `cannot host in v1 (accepts: ${accepted.join(', ')}).`,
+    )
+  }
+
+  const chosen: PluginCatalogEntry =
+    formatCandidates.find((entry) => entry.format.toLowerCase() === 'clap') ?? formatCandidates[0]
+
+  return { path: chosen.path, pluginId: chosen.pluginId }
+}
+
+export interface ResolvedPluginSpec {
+  readonly path: string
+  readonly pluginId: string | undefined
+}
+
+/**
+ * Catalog-aware entry point for `effect()`/`instrument()` spec resolution (#463 C2). Path-direct
+ * specs (PC.2 discriminator) resolve exactly as before via `resolvePluginPath`, and the caller's
+ * `pluginIdArg` passes through untouched. Catalog names resolve `(path, pluginId)` together —
+ * pairing a catalog name with an explicit `pluginIdArg` is an error, since the name already
+ * pins a single pluginId (PC.2: "カタログ名指しと第2引数 pluginId の併用はエラー").
+ */
+export function resolvePluginSpec(
+  spec: string,
+  pluginIdArg: string | undefined,
+  audioPaths: readonly string[],
+  documentDirectory: string,
+  role: PluginRole,
+  catalogPathOverride?: string,
+): ResolvedPluginSpec {
+  if (isPluginPathSpec(spec)) {
+    return {
+      path: resolvePluginPath(spec, audioPaths, documentDirectory, role),
+      pluginId: pluginIdArg,
+    }
+  }
+  if (pluginIdArg !== undefined) {
+    throw new Error(
+      `A catalog plugin name ("${spec}") resolves its pluginId automatically; do not pass a ` +
+        'second pluginId argument together with it (explicit pluginId is only for path specs).',
+    )
+  }
+  const resolved = resolveCatalogSpec(spec, role, catalogPathOverride)
+  return { path: resolved.path, pluginId: resolved.pluginId }
 }

--- a/packages/engine/src/core/global/sequence-effect-manager.ts
+++ b/packages/engine/src/core/global/sequence-effect-manager.ts
@@ -80,8 +80,9 @@ export class SequenceEffectManager {
 
   /** Declares (or idempotently re-declares) the insert for `sequenceName`. Returns the allocated bus name. */
   async effect(sequenceName: string, spec: string, pluginId?: string): Promise<string> {
-    const resolvedPath = resolveEffectSpec(
+    const resolved = resolveEffectSpec(
       spec,
+      pluginId,
       { audioManager: this.audioManager, linkAudioManager: this.linkAudioManager },
       `Sequence '${sequenceName}': seq.effect() cannot be used while LinkAudio is enabled in v1.`,
     )
@@ -98,7 +99,7 @@ export class SequenceEffectManager {
     const bus = this.buses.get(sequenceName) ?? this.pool.acquire(sequenceName)
     this.buses.set(sequenceName, bus)
     try {
-      await this.slots.declare(sequenceName, bus, resolvedPath, pluginId, duplicateError)
+      await this.slots.declare(sequenceName, bus, resolved.path, resolved.pluginId, duplicateError)
     } catch (err) {
       if (!hadBus) {
         // この呼び出しで新規に確保した bus の load 失敗: free-list へ返す（daemon 側も

--- a/tests/core/global-plugin-effect.spec.ts
+++ b/tests/core/global-plugin-effect.spec.ts
@@ -22,7 +22,10 @@ describe('Global.effect()', () => {
     await expect(global.effect(spec)).rejects.toThrow('not yet supported')
   })
 
-  it.each(['effect.wav', 'effect'])('rejects unknown extension %s', async (spec) => {
+  // Bare names (no `./`-style prefix, no known plugin extension) are now catalog names
+  // per #463 C2's PC.2 discriminator — use a path-direct prefix to keep exercising the
+  // path-side "unknown extension" validation.
+  it.each(['./effect.wav', './effect'])('rejects unknown extension %s', async (spec) => {
     const { global } = makeGlobal()
     await expect(global.effect(spec)).rejects.toThrow('Unknown plugin extension')
   })

--- a/tests/core/plugin-catalog-resolution.spec.ts
+++ b/tests/core/plugin-catalog-resolution.spec.ts
@@ -1,0 +1,263 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Global } from '../../packages/engine/src/core/global'
+import {
+  clearPluginCatalogCache,
+  type PluginCatalogFile,
+} from '../../packages/engine/src/core/global/plugin-catalog'
+import {
+  isPluginPathSpec,
+  resolvePluginSpec,
+} from '../../packages/engine/src/core/global/plugin-resolver'
+
+function writeCatalog(dir: string, catalog: PluginCatalogFile): string {
+  const file = path.join(dir, 'plugin-catalog.json')
+  fs.writeFileSync(file, JSON.stringify(catalog))
+  return file
+}
+
+const FIXTURE_CATALOG: PluginCatalogFile = {
+  version: 1,
+  scannedAt: '2026-07-17T00:00:00Z',
+  plugins: [
+    {
+      name: 'TAL Reverb 4',
+      vendor: 'TAL Software',
+      format: 'clap',
+      path: '/plugins/tal-reverb.clap',
+      pluginId: 'tal-reverb-id',
+      roles: ['effect'],
+    },
+    // Same bare name, two different vendors — ambiguous without vendor qualifier.
+    {
+      name: 'Reverb',
+      vendor: 'Vendor A',
+      format: 'clap',
+      path: '/plugins/vendor-a-reverb.clap',
+      pluginId: 'vendor-a-reverb-id',
+      roles: ['effect'],
+    },
+    {
+      name: 'Reverb',
+      vendor: 'Vendor B',
+      format: 'clap',
+      path: '/plugins/vendor-b-reverb.clap',
+      pluginId: 'vendor-b-reverb-id',
+      roles: ['effect'],
+    },
+    // Same vendor+name, two formats — CLAP must win the preference.
+    {
+      name: 'Scaler 3',
+      vendor: 'Scaler Music',
+      format: 'vst3',
+      path: '/plugins/scaler3.vst3',
+      pluginId: 'scaler3-vst3-id',
+      roles: ['instrument'],
+    },
+    {
+      name: 'Scaler 3',
+      vendor: 'Scaler Music',
+      format: 'clap',
+      path: '/plugins/scaler3.clap',
+      pluginId: 'scaler3-clap-id',
+      roles: ['instrument'],
+    },
+    // VST3-only plugin — effect() (CLAP-only in v1) must get a dedicated error.
+    {
+      name: 'VstOnlyFX',
+      vendor: 'Some Vendor',
+      format: 'vst3',
+      path: '/plugins/vstonlyfx.vst3',
+      pluginId: 'vstonlyfx-id',
+      roles: ['effect'],
+    },
+    // Instrument-only role — querying it as effect() must trigger a role error.
+    {
+      name: 'InstrumentOnly',
+      vendor: 'Some Vendor',
+      format: 'clap',
+      path: '/plugins/instronly.clap',
+      pluginId: 'instronly-id',
+      roles: ['instrument'],
+    },
+  ],
+}
+
+describe('PC.2 discriminator (isPluginPathSpec)', () => {
+  it.each([['./rel.clap'], ['../rel.clap'], ['~/home.clap'], ['/abs.clap']])(
+    'treats %s as path-direct (prefix)',
+    (spec) => {
+      expect(isPluginPathSpec(spec)).toBe(true)
+    },
+  )
+
+  it.each([['bundle.clap'], ['bundle.vst3'], ['bundle.component'], ['Bundle.CLAP']])(
+    'treats %s as path-direct (known extension)',
+    (spec) => {
+      expect(isPluginPathSpec(spec)).toBe(true)
+    },
+  )
+
+  it.each([['TAL Reverb 4'], ['TAL Software/TAL Reverb 4'], ['Scaler 3']])(
+    'treats %s as a catalog name',
+    (spec) => {
+      expect(isPluginPathSpec(spec)).toBe(false)
+    },
+  )
+})
+
+describe('resolvePluginSpec catalog resolution', () => {
+  let dir: string
+  let catalogPath: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-plugin-catalog-'))
+    catalogPath = writeCatalog(dir, FIXTURE_CATALOG)
+    clearPluginCatalogCache()
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+    clearPluginCatalogCache()
+  })
+
+  it('resolves an exact name match case-insensitively, trimmed, and NFC-normalized', () => {
+    const resolved = resolvePluginSpec(
+      '  tal reverb 4  '.toUpperCase(),
+      undefined,
+      [],
+      '/doc',
+      'effect',
+      catalogPath,
+    )
+    expect(resolved).toEqual({ path: '/plugins/tal-reverb.clap', pluginId: 'tal-reverb-id' })
+  })
+
+  it('NFD-composed spec matches an NFC catalog name', () => {
+    // "TAL Reverb 4" has no combining marks, so build one via a diacritic case to
+    // exercise NFC normalization end to end without needing a non-ASCII fixture name.
+    const nfd = 'TAL Reverb 4'.normalize('NFD')
+    const resolved = resolvePluginSpec(nfd, undefined, [], '/doc', 'effect', catalogPath)
+    expect(resolved.pluginId).toBe('tal-reverb-id')
+  })
+
+  it('disambiguates via vendor qualification', () => {
+    const a = resolvePluginSpec('Vendor A/Reverb', undefined, [], '/doc', 'effect', catalogPath)
+    const b = resolvePluginSpec('Vendor B/Reverb', undefined, [], '/doc', 'effect', catalogPath)
+    expect(a.pluginId).toBe('vendor-a-reverb-id')
+    expect(b.pluginId).toBe('vendor-b-reverb-id')
+  })
+
+  it('throws an enumerated ambiguity error without a vendor qualifier', () => {
+    expect(() => resolvePluginSpec('Reverb', undefined, [], '/doc', 'effect', catalogPath)).toThrow(
+      /ambiguous.*Vendor A\/Reverb.*Vendor B\/Reverb/s,
+    )
+  })
+
+  it('prefers CLAP over VST3 when both formats exist for the same vendor/name', () => {
+    const resolved = resolvePluginSpec('Scaler 3', undefined, [], '/doc', 'instrument', catalogPath)
+    expect(resolved).toEqual({ path: '/plugins/scaler3.clap', pluginId: 'scaler3-clap-id' })
+  })
+
+  it('rejects pairing a catalog name with an explicit pluginId argument', () => {
+    expect(() =>
+      resolvePluginSpec('TAL Reverb 4', 'explicit-id', [], '/doc', 'effect', catalogPath),
+    ).toThrow(/pluginId/)
+  })
+
+  it('rejects a VST3-only catalog entry for effect() with a dedicated message (not the path "not yet supported" wording)', () => {
+    expect(() =>
+      resolvePluginSpec('VstOnlyFX', undefined, [], '/doc', 'effect', catalogPath),
+    ).toThrow(/VstOnlyFX.*vst3.*effect\(\)/s)
+  })
+
+  it('rejects a role mismatch (instrument-only entry requested as effect)', () => {
+    expect(() =>
+      resolvePluginSpec('InstrumentOnly', undefined, [], '/doc', 'effect', catalogPath),
+    ).toThrow(/does not support the "effect" role/)
+  })
+
+  it('gives an actionable rescan error when the name is not found', () => {
+    expect(() =>
+      resolvePluginSpec('NoSuchPlugin', undefined, [], '/doc', 'effect', catalogPath),
+    ).toThrow(/orbit-plugin-scan/)
+  })
+
+  it('gives an actionable rescan error when the catalog file does not exist', () => {
+    const missing = path.join(dir, 'does-not-exist.json')
+    expect(() =>
+      resolvePluginSpec('TAL Reverb 4', undefined, [], '/doc', 'effect', missing),
+    ).toThrow(/orbit-plugin-scan/)
+  })
+
+  it('honors the ORBIT_PLUGIN_CATALOG env var when no explicit override is passed', () => {
+    const previous = process.env.ORBIT_PLUGIN_CATALOG
+    process.env.ORBIT_PLUGIN_CATALOG = catalogPath
+    try {
+      const resolved = resolvePluginSpec('TAL Reverb 4', undefined, [], '/doc', 'effect', undefined)
+      expect(resolved.pluginId).toBe('tal-reverb-id')
+    } finally {
+      if (previous === undefined) delete process.env.ORBIT_PLUGIN_CATALOG
+      else process.env.ORBIT_PLUGIN_CATALOG = previous
+      clearPluginCatalogCache()
+    }
+  })
+})
+
+describe('Global.effect()/instrument() catalog name integration', () => {
+  let dir: string
+  let catalogPath: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-plugin-catalog-int-'))
+    catalogPath = writeCatalog(dir, FIXTURE_CATALOG)
+    process.env.ORBIT_PLUGIN_CATALOG = catalogPath
+    clearPluginCatalogCache()
+  })
+
+  afterEach(() => {
+    delete process.env.ORBIT_PLUGIN_CATALOG
+    clearPluginCatalogCache()
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('resolves a catalog instrument name to (path, pluginId) end to end', async () => {
+    const loadPlugin = vi.fn().mockResolvedValue({})
+    const engine = { loadPlugin, boot: vi.fn(), quit: vi.fn(), isRunning: true } as any
+    const global = new Global(engine)
+    global.setDocumentDirectory('/songs/session')
+
+    await expect(global.instrument('Scaler 3')).resolves.toBe(global)
+    expect(loadPlugin).toHaveBeenCalledWith(
+      '/plugins/scaler3.clap',
+      'scaler3-clap-id',
+      'instrument',
+    )
+  })
+
+  it('resolves a catalog effect name to (path, pluginId) end to end', async () => {
+    const loadPlugin = vi.fn().mockResolvedValue({})
+    const engine = { loadPlugin, boot: vi.fn(), quit: vi.fn(), isRunning: true } as any
+    const global = new Global(engine)
+    global.setDocumentDirectory('/songs/session')
+
+    await expect(global.effect('TAL Software/TAL Reverb 4')).resolves.toBe(global)
+    expect(loadPlugin).toHaveBeenCalledWith('/plugins/tal-reverb.clap', 'tal-reverb-id', 'effect')
+  })
+
+  it('rejects passing an explicit pluginId together with a catalog effect name', async () => {
+    const engine = {
+      loadPlugin: vi.fn().mockResolvedValue({}),
+      boot: vi.fn(),
+      quit: vi.fn(),
+      isRunning: true,
+    } as any
+    const global = new Global(engine)
+    global.setDocumentDirectory('/songs/session')
+    await expect(global.effect('TAL Reverb 4', 'explicit-id')).rejects.toThrow(/pluginId/)
+  })
+})


### PR DESCRIPTION
## 概要

#463 C2: **プラグインを名前で指せる**ように(PC.2 準拠)。owner の「フルパスをどうにかしたい・名前だけで呼びたい」への応答で、バケット A の先頭。

```js
kick.effect("TAL Reverb 4")          // カタログ名
pad.instrument("Scaler 3")           // vendor 修飾も可: "Scaler Music/Scaler 3"
kick.effect("./plugins/My.clap")     // path 指定は従来どおり不変
```

Refs #463

## 変更内容

- **plugin-catalog.ts 新設**: `~/.orbitscore/plugin-catalog.json`(C1 生成)読取・mtime キャッシュ・`ORBIT_PLUGIN_CATALOG` でテスト注入可
- **plugin-resolver**: PC.2 判別(`isPluginPathSpec` — audio 系 looksLikePath は不使用)・名前解決(NFC/case-insensitive/trim・曖昧は候補列挙・vendor 修飾)・format 優先(verb 受理内で CLAP > VST3・受理不能は専用エラー)・role 検査・rescan 案内付きエラー
- **解決出力 = (path, pluginId) の組**を LoadPlugin へ。名前指しと pluginId 引数の併用はエラー(1:1 写像)
- effect(3 manager 経由)+ instrument の両経路に配線

## 意図的な挙動変更(spec 準拠)

既知拡張子なしの裸名(例 `effect.wav`)は「未知拡張子エラー」ではなく**カタログ解決へルーティング**(→ 未ヒットなら rescan 案内)。既存テスト 2 件を `./` 付きに更新。

## 検証

- 新規 25 tests・全体 **1473 passed**・tsc/lint clean
- **実カタログ(79 entries)**: `"Scaler 3"` → `/Library/.../Scaler 3.vst3` + CID 解決 / `"Mic Room"`(VST3-only)を `effect()` で専用 format エラー確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu