### PR TITLE
feat(orbitstudio): plugin catalog completion + rescan surfaces + MCP tools (#463 C1b/C3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
         run: |
           cargo build --release -p orbit-audio-daemon --features outproc-effect,outproc-instrument --manifest-path rust/Cargo.toml
           cargo build --release -p orbit-clap-effect-child -p orbit-clap-instrument-child -p orbit-vst3-instrument-child --manifest-path rust/Cargo.toml
+          cargo build --release -p orbit-plugin-scan --manifest-path rust/Cargo.toml
 
       - name: Build engine + extension TypeScript
         working-directory: packages/vscode-extension
@@ -149,6 +150,19 @@ jobs:
             fi
             echo "$CHILD_BIN present and executable in packaged .vsix"
           done
+
+          # Plugin catalog scanner (#463 C1b): rescan (palette/context-menu/MCP)
+          # spawns this binary directly, independent of the daemon.
+          SCAN_BIN="$VSIX_CHECK/extension/engine/bin/darwin-arm64/orbit-plugin-scan"
+          if [ ! -f "$SCAN_BIN" ]; then
+            echo "::error::orbit-plugin-scan missing from packaged .vsix at engine/bin/darwin-arm64/ — plugin catalog rescan would fail to start" >&2
+            exit 1
+          fi
+          if [ ! -x "$SCAN_BIN" ]; then
+            echo "::error::orbit-plugin-scan in packaged .vsix is not executable (lost +x bit?)" >&2
+            exit 1
+          fi
+          echo "orbit-plugin-scan present and executable in packaged .vsix"
 
       # ─────────────────────────────────────────────────────────────────────
       # Steps below this point only run for tag pushes (not pull_request).

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,29 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.279 feat(orbitstudio): plugin catalog 補完 + rescan 3面 + MCP #463 C1b/C3 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 実装（#463 完結・バケット A 1本目完了）
+
+**内容**:
+- **補完（PC.3）**: `.effect("` / `.instrument("` の引数位置でカタログ候補（name・vendor/format
+  detail）。**タイプ中も絞り込み**（owner 要件 — 部分入力マッチ + range 明示で VS Code の
+  prefix/fuzzy フィルタが効く）。effect は PH.3 どおり CLAP のみ・instrument は roles 適合
+- **rescan 3面（C1b）**: palette コマンド + `.orbs` 右クリックメニュー + MCP `rescan_plugins`。
+  設計変更 = daemon 経由でなく拡張が `orbit-plugin-scan` を直接 spawn（crash 隔離バイナリの
+  ため daemon を経由する必然なし）。バイナリは copy-daemon-bin.sh + release gate に追加
+- **MCP（PC.4）**: `list_plugins` / `rescan_plugins`（handler seam 必須メンバー）
+
+**検証**: 拡張 tests 160（+11: 部分入力 `effect("Sca` → Scaler 絞り込み含む）・全体 1495
+passed・tsc/lint clean。実機: スキャナ spawn → count 79・bundle 5 バイナリ確認。
+
+**既知**: 実カタログに CLAP effect が 0 のため effect 補完の実データ経路は unit のみ
+（CLAPTestEffect は標準外ディレクトリ — ORBIT_PLUGIN_PATH で追加可能）。
+
+Refs #463
+
+
 ### 6.278 feat(dsl): plugin catalog 名前指し #463 C2 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -87,6 +87,12 @@
         "category": "OrbitScore"
       },
       {
+        "command": "orbitscore.rescanPlugins",
+        "title": "OrbitScore: Rescan Plugin Catalog",
+        "icon": "$(refresh)",
+        "category": "OrbitScore"
+      },
+      {
         "command": "orbitscore.openDocs",
         "title": "OrbitScore: Open Learning Site",
         "icon": "$(book)"
@@ -183,6 +189,13 @@
         {
           "command": "orbitscore.stopEngine",
           "when": "false"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "orbitscore.rescanPlugins",
+          "when": "resourceExtname == .orbs",
+          "group": "orbitscore"
         }
       ]
     },

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -29,10 +29,14 @@ import {
   type FileDiagnostics,
   type FlashConfigInput,
   type FlashConfigResult,
+  type ListPluginsResult,
   type McpServerHandle,
   type RegisterMcpServerInput,
+  type RescanPluginsResult,
   type SelectionInput,
 } from './mcp-server'
+import { detectPluginArgContext, filterCatalogEntries } from './plugin-catalog-completion'
+import { loadPluginCatalog, runPluginScan } from './plugin-catalog-reader'
 import {
   colorForSeq,
   findPlayArgRangeForPath,
@@ -54,6 +58,10 @@ let isLiveCodingMode: boolean = false
 let globalInitialized: boolean = false
 // Optional MCP control server (Agent Bridge). Non-null only while running.
 let mcpServerHandle: McpServerHandle | null = null
+// #463 C3: show the "no plugin catalog yet, run rescan" hint at most once per
+// activation (loadPluginCatalog() is cheap but the info popup shouldn't nag on
+// every keystroke while typing an effect()/instrument() argument).
+let pluginCatalogHintShown = false
 
 // let isDebugMode: boolean = false // Debug mode flag
 
@@ -295,6 +303,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('orbitscore.selectAudioDevice', selectAudioDevice),
     vscode.commands.registerCommand('orbitscore.configureFlash', configureFlash),
     vscode.commands.registerCommand('orbitscore.registerMcpServer', registerMcpServer),
+    vscode.commands.registerCommand('orbitscore.rescanPlugins', rescanPlugins),
     // viewsWelcome コンテンツは view に provider が登録されて初めて描画される
     // （空 TreeView で十分 — 章ツリーの本実装は #451 確定後の follow-up）。
     vscode.window.registerTreeDataProvider('orbitscore.learningView', {
@@ -388,6 +397,8 @@ export async function activate(context: vscode.ExtensionContext) {
           getDiagnostics: (filePath) => getDiagnosticsForAgent(filePath),
           getLog: (lines) => getLogForAgent(lines),
           analyzeAudio: (wavPath, windowMs) => analyzeAudioForAgent(wavPath, windowMs),
+          listPlugins: () => listPluginsForAgent(),
+          rescanPlugins: () => rescanPluginsForAgent(),
           registerMcpServer: (args) => registerMcpServerForAgent(args),
         },
         log: (message) => outputChannel?.appendLine(`🔌 ${message}`),
@@ -1392,6 +1403,30 @@ function forceKillScsynth() {
   })
 }
 
+/**
+ * "OrbitScore: Rescan Plugin Catalog" command (#463 C1b) — palette + editor
+ * right-click menu. Spawns `orbit-plugin-scan` directly (not via the daemon:
+ * the scanner is an independent crash-isolated binary — see
+ * docs/core/INSTRUCTION_ORBITSCORE_DSL.md §PC.1) and invalidates the
+ * in-memory catalog cache on success so completion picks up the fresh scan.
+ */
+async function rescanPlugins(): Promise<void> {
+  outputChannel?.appendLine('🔎 Rescanning plugin catalog...')
+  const result = await runPluginScan()
+  if (result.ok) {
+    pluginCatalogHintShown = false
+    outputChannel?.appendLine(
+      `✅ Plugin catalog rescanned: ${result.count} plugins (${result.skipped.length} skipped)`,
+    )
+    vscode.window.showInformationMessage(
+      `OrbitScore: rescanned ${result.count} plugins (${result.skipped.length} skipped)`,
+    )
+  } else {
+    outputChannel?.appendLine(`❌ Plugin catalog rescan failed: ${result.error}`)
+    vscode.window.showErrorMessage(`OrbitScore: plugin catalog rescan failed: ${result.error}`)
+  }
+}
+
 /** One SuperCollider-reported audio device (shared shape for the palette QuickPick and the MCP tools). */
 interface DetectedAudioDevice {
   label: string
@@ -2005,6 +2040,31 @@ function forceKillScsynthForAgent(): CommandResult {
   return { ok: true, message: 'kill signal sent' }
 }
 
+/** Read the plugin catalog for the MCP `list_plugins` tool (#463 PC.4). */
+function listPluginsForAgent(): ListPluginsResult {
+  const catalog = loadPluginCatalog()
+  if (!catalog) {
+    return {
+      ok: false,
+      error: 'plugin catalog not found — run "OrbitScore: Rescan Plugin Catalog" first',
+    }
+  }
+  return {
+    ok: true,
+    plugins: catalog.plugins.map((entry) => ({ ...entry, roles: [...entry.roles] })),
+  }
+}
+
+/** Run the scanner for the MCP `rescan_plugins` tool (#463 PC.4/C1b). Shares `runPluginScan` with the command variant above. */
+async function rescanPluginsForAgent(): Promise<RescanPluginsResult> {
+  const result = await runPluginScan()
+  if (!result.ok) {
+    return { ok: false, error: result.error }
+  }
+  pluginCatalogHintShown = false
+  return { ok: true, count: result.count, skipped: [...result.skipped] }
+}
+
 /** List audio devices for the MCP `list_audio_devices` tool. Mirrors `selectAudioDevice`'s guard/resolve steps but returns the list instead of prompting. */
 async function listAudioDevicesForAgent(): Promise<AudioDevicesResult> {
   if (getConfiguredEngineKind() === 'rust') {
@@ -2434,6 +2494,55 @@ function registerCompletionProviders(context: vscode.ExtensionContext) {
   )
 
   context.subscriptions.push(completionProvider)
+
+  // Plugin catalog name completion (#463 C3, spec §PC.3). Triggers on `"` but
+  // — per owner requirement 2026-07-17 — must also keep narrowing while the
+  // user types further characters inside the string; VS Code does this
+  // client-side via each item's `range`, so no re-trigger characters are
+  // needed for the common case (registered `"` covers the initial open-quote
+  // fire; detectPluginArgContext itself matches a partial, unclosed string,
+  // so a real re-invocation — e.g. Ctrl+Space — still resolves correctly too).
+  const pluginCompletionProvider = vscode.languages.registerCompletionItemProvider(
+    'orbitscore',
+    {
+      provideCompletionItems(document, position) {
+        const lineText = document.lineAt(position).text
+        const pluginContext = detectPluginArgContext(lineText, position.character)
+        if (!pluginContext) return undefined
+
+        const catalog = loadPluginCatalog()
+        if (!catalog) {
+          if (!pluginCatalogHintShown) {
+            pluginCatalogHintShown = true
+            vscode.window.showInformationMessage(
+              'OrbitScore: no plugin catalog found. Run "OrbitScore: Rescan Plugin Catalog" to enable name completion.',
+            )
+          }
+          return undefined
+        }
+
+        const matches = filterCatalogEntries(
+          catalog.plugins,
+          pluginContext.verb,
+          pluginContext.typed,
+        )
+        const range = new vscode.Range(
+          new vscode.Position(position.line, pluginContext.quoteStartChar),
+          new vscode.Position(position.line, position.character),
+        )
+        return matches.map((entry) => {
+          const item = new vscode.CompletionItem(entry.name, vscode.CompletionItemKind.Value)
+          item.detail = `${entry.vendor} · ${entry.format.toUpperCase()}`
+          item.insertText = entry.name
+          item.range = range
+          item.filterText = entry.name
+          return item
+        })
+      },
+    },
+    '"',
+  )
+  context.subscriptions.push(pluginCompletionProvider)
 }
 
 /**

--- a/packages/vscode-extension/src/mcp-server.ts
+++ b/packages/vscode-extension/src/mcp-server.ts
@@ -158,6 +158,25 @@ export interface FileDiagnostics {
 /** Result of analyze_audio (wav-analysis.ts is the vscode-free WAV parser). */
 export type AnalyzeAudioResult = { ok: true; analysis: WavAnalysis } | { ok: false; error: string }
 
+/** One entry of the plugin catalog (#463 PC.1), as reported by list_plugins. */
+export interface PluginCatalogEntryInfo {
+  name: string
+  vendor: string
+  format: string
+  path: string
+  pluginId: string
+  roles: string[]
+}
+/** Result of list_plugins: the plugin catalog, or an error when it hasn't been scanned yet. */
+export type ListPluginsResult =
+  | { ok: true; plugins: PluginCatalogEntryInfo[] }
+  | { ok: false; error: string }
+
+/** Result of rescan_plugins: the scan summary, or an error. */
+export type RescanPluginsResult =
+  | { ok: true; count: number; skipped: string[] }
+  | { ok: false; error: string }
+
 /**
  * Arguments for register_mcp_server. `scope` is a raw string here (rather than
  * the 'project' | 'user' union) so validation lives in one place — the
@@ -196,6 +215,10 @@ export interface OrbitScoreToolHandlers {
   getDiagnostics(path?: string): FileDiagnostics[]
   getLog(lines?: number): string[]
   analyzeAudio(wavPath: string, windowMs?: number): Promise<AnalyzeAudioResult> | AnalyzeAudioResult
+  /** list_plugins (#463 PC.4): return the plugin catalog as-is. */
+  listPlugins(): Promise<ListPluginsResult> | ListPluginsResult
+  /** rescan_plugins (#463 PC.4/C1b): run the scanner and return its summary. */
+  rescanPlugins(): Promise<RescanPluginsResult> | RescanPluginsResult
   /**
    * Optional (unlike the members above): only hosts that can register
    * themselves into Claude Code expose the register_mcp_server tool — the
@@ -772,6 +795,47 @@ function buildServer(
         return errorResult(result.error)
       }
       return { content: [{ type: 'text', text: JSON.stringify(result.analysis) }] }
+    },
+  )
+
+  server.registerTool(
+    'list_plugins',
+    {
+      title: 'List Plugins',
+      description:
+        'List the installed CLAP/VST3 plugin catalog (#463 PC.1) — name, vendor, format, ' +
+        'and roles (effect/instrument) for each entry — so an agent can pick real ' +
+        'plugin names when composing effect()/instrument() calls. Returns an error ' +
+        '(with a rescan hint) if the catalog has not been scanned yet.',
+    },
+    async () => {
+      const result = await handlers.listPlugins()
+      if (!result.ok) {
+        return errorResult(result.error)
+      }
+      return { content: [{ type: 'text', text: JSON.stringify(result.plugins) }] }
+    },
+  )
+
+  server.registerTool(
+    'rescan_plugins',
+    {
+      title: 'Rescan Plugins',
+      description:
+        'Scan the OS plugin directories (and ORBIT_PLUGIN_PATH) and rewrite the plugin ' +
+        'catalog. Equivalent to the "Rescan Plugin Catalog" command. Returns the count ' +
+        'of plugins found and any skipped (metadata-less) entries.',
+    },
+    async () => {
+      const result = await handlers.rescanPlugins()
+      if (!result.ok) {
+        return errorResult(result.error)
+      }
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify({ count: result.count, skipped: result.skipped }) },
+        ],
+      }
     },
   )
 

--- a/packages/vscode-extension/src/plugin-catalog-completion.ts
+++ b/packages/vscode-extension/src/plugin-catalog-completion.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure completion-context helpers for plugin catalog name completion
+ * (#463 C3, spec `docs/core/INSTRUCTION_ORBITSCORE_DSL.md` §PC.3).
+ *
+ * Deliberately vscode-free (unlike completion-context.ts, which constructs
+ * `vscode.CompletionItem`) so the extension's provider can build the actual
+ * `vscode.CompletionItem[]` (with `range` etc.) itself while this module stays
+ * unit-testable without a vscode mock.
+ *
+ * Owner requirement (2026-07-17): candidates must filter as the user keeps
+ * typing inside the string, not only at the `"` trigger — so `detectPluginArgContext`
+ * matches a PARTIAL string (no closing quote required) and returns the typed
+ * prefix so far, and `filterCatalogEntries` narrows by that prefix.
+ */
+
+import type { PluginCatalogEntry } from './plugin-catalog-reader'
+
+export type PluginVerb = 'effect' | 'instrument'
+
+export interface PluginArgContext {
+  readonly verb: PluginVerb
+  /** Text typed so far between the opening quote and the cursor (no closing quote required). */
+  readonly typed: string
+  /** 0-based character offset of the opening quote's content start (i.e. right after `"`). */
+  readonly quoteStartChar: number
+}
+
+// Matches `.effect("` / `.instrument("` immediately followed by an in-progress
+// string (no closing quote yet) ending at the cursor. `[^"\n]*$` anchors to the
+// end of the prefix, so this matches `effect("Sca` (partial) just as well as
+// the freshly-triggered `effect("`.
+const PLUGIN_ARG_RE = /\.(effect|instrument)\(\s*"([^"\n]*)$/
+
+/**
+ * Detects whether `position` (0-based character offset into `lineText`) sits
+ * inside the first string argument of `effect(` / `instrument(`. Returns the
+ * verb, the partial typed text, and where that text starts — regardless of
+ * whether the string's closing quote is present later on the line.
+ */
+export function detectPluginArgContext(
+  lineText: string,
+  position: number,
+): PluginArgContext | null {
+  const prefix = lineText.slice(0, position)
+  const match = PLUGIN_ARG_RE.exec(prefix)
+  if (!match) return null
+  const verb = match[1] as PluginVerb
+  const typed = match[2] ?? ''
+  return { verb, typed, quoteStartChar: position - typed.length }
+}
+
+/**
+ * Filters catalog entries for a completion request:
+ * - role match (PC.3: `instrument(` → roles includes `instrument`; `effect(` → roles includes `effect`)
+ * - format restriction for effects (PH.3: only CLAP effects are accepted today; instruments have no such restriction)
+ * - typed-prefix narrowing (case-insensitive substring match against `name` or `vendor/name`)
+ */
+export function filterCatalogEntries(
+  entries: readonly PluginCatalogEntry[],
+  verb: PluginVerb,
+  typed: string,
+): PluginCatalogEntry[] {
+  const needle = typed.trim().toLowerCase()
+  return entries.filter((entry) => {
+    if (!entry.roles.includes(verb)) return false
+    if (verb === 'effect' && entry.format.toLowerCase() !== 'clap') return false
+    if (needle === '') return true
+    const qualified = `${entry.vendor}/${entry.name}`.toLowerCase()
+    return entry.name.toLowerCase().includes(needle) || qualified.includes(needle)
+  })
+}

--- a/packages/vscode-extension/src/plugin-catalog-reader.ts
+++ b/packages/vscode-extension/src/plugin-catalog-reader.ts
@@ -1,0 +1,174 @@
+/**
+ * Plugin catalog reader for the VS Code extension (#463 C1b/C3).
+ *
+ * Deliberately independent from `packages/engine/src/core/global/plugin-catalog.ts`
+ * (same JSON shape, same mtime-cache idea) rather than a cross-package import:
+ * the extension and engine are separate build targets (engine ships as compiled
+ * JS copied into `engine/dist/`, see `scripts/copy-daemon-bin.sh` / build:engine),
+ * so this module reads the on-disk cache file directly instead of reaching into
+ * engine source.
+ *
+ * Catalog file: `~/.orbitscore/plugin-catalog.json`, written by the
+ * `orbit-plugin-scan` binary (rust/crates/orbit-plugin-scan). Consumers here
+ * only read it — the extension's job is completion (C3) + MCP tools (PC.4) +
+ * spawning a rescan (C1b), never writing the catalog itself.
+ */
+
+import * as child_process from 'child_process'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+export interface PluginCatalogEntry {
+  readonly name: string
+  readonly vendor: string
+  /** Raw scanner format tag: lowercase `clap` / `vst3` / `component`. */
+  readonly format: string
+  readonly path: string
+  readonly pluginId: string
+  readonly roles: readonly string[]
+}
+
+export interface PluginCatalogFile {
+  readonly version: number
+  readonly scannedAt: string
+  readonly plugins: readonly PluginCatalogEntry[]
+}
+
+function defaultCatalogPath(): string {
+  return path.join(os.homedir(), '.orbitscore', 'plugin-catalog.json')
+}
+
+/** Resolves the catalog file path: explicit override > `ORBIT_PLUGIN_CATALOG` env > default. */
+export function resolveCatalogPath(override?: string): string {
+  return override ?? process.env.ORBIT_PLUGIN_CATALOG ?? defaultCatalogPath()
+}
+
+interface CacheEntry {
+  readonly mtimeMs: number
+  readonly catalog: PluginCatalogFile
+}
+
+const cache = new Map<string, CacheEntry>()
+
+/**
+ * Loads and parses the plugin catalog, or returns `undefined` if it doesn't
+ * exist yet (not-yet-scanned — callers turn this into an actionable "run
+ * rescan" message/error). Malformed JSON is allowed to throw.
+ */
+export function loadPluginCatalog(catalogPathOverride?: string): PluginCatalogFile | undefined {
+  const catalogPath = resolveCatalogPath(catalogPathOverride)
+
+  let mtimeMs: number
+  try {
+    mtimeMs = fs.statSync(catalogPath).mtimeMs
+  } catch {
+    cache.delete(catalogPath)
+    return undefined
+  }
+
+  const cached = cache.get(catalogPath)
+  if (cached && cached.mtimeMs === mtimeMs) return cached.catalog
+
+  const raw = fs.readFileSync(catalogPath, 'utf8')
+  const catalog = JSON.parse(raw) as PluginCatalogFile
+  cache.set(catalogPath, { mtimeMs, catalog })
+  return catalog
+}
+
+/** Forces the next `loadPluginCatalog()` call to re-read from disk (used after a rescan, and by tests). */
+export function clearPluginCatalogCache(): void {
+  cache.clear()
+}
+
+function isExecutableFile(candidatePath: string): boolean {
+  try {
+    const stat = fs.statSync(candidatePath)
+    if (!stat.isFile()) return false
+    return (stat.mode & 0o111) !== 0
+  } catch {
+    return false
+  }
+}
+
+export class PluginScanBinaryNotFoundError extends Error {
+  constructor(readonly searched: readonly string[]) {
+    super(`orbit-plugin-scan binary not found. Searched: ${searched.join(', ')}`)
+    this.name = 'PluginScanBinaryNotFoundError'
+  }
+}
+
+/**
+ * Resolve the `orbit-plugin-scan` binary path. Candidate order mirrors
+ * `resolveDaemonBinaryPath` in `packages/engine/src/audio/rust-engine/daemon-client.ts`:
+ * explicit override → `ORBIT_PLUGIN_SCAN_PATH` env → monorepo release build
+ * (dev workflow) → .vsix-bundled binary (scripts/copy-daemon-bin.sh).
+ */
+export function resolvePluginScanBinaryPath(explicitPath?: string): string {
+  const searched: string[] = []
+  const candidates: string[] = []
+  if (explicitPath) candidates.push(explicitPath)
+  const envPath = process.env.ORBIT_PLUGIN_SCAN_PATH
+  if (envPath) candidates.push(envPath)
+
+  // This compiled file sits at `<extension>/dist/plugin-catalog-reader.js` once
+  // built (mirrors extension.ts's __dirname convention); monorepo root is 3
+  // levels up: dist -> vscode-extension -> packages -> root.
+  const monorepoRoot = path.resolve(__dirname, '../../../')
+  candidates.push(path.join(monorepoRoot, 'rust/target/release/orbit-plugin-scan'))
+  candidates.push(path.join(monorepoRoot, 'rust/target/debug/orbit-plugin-scan'))
+
+  const platform = `${process.platform}-${process.arch}`
+  candidates.push(path.join(__dirname, '../engine/bin', platform, 'orbit-plugin-scan'))
+
+  for (const candidate of candidates) {
+    searched.push(candidate)
+    if (isExecutableFile(candidate)) return candidate
+  }
+  throw new PluginScanBinaryNotFoundError(searched)
+}
+
+export interface PluginScanOutcome {
+  readonly count: number
+  readonly cachePath: string
+  readonly skipped: readonly string[]
+}
+
+export type RunPluginScanResult = ({ ok: true } & PluginScanOutcome) | { ok: false; error: string }
+
+/**
+ * Spawns `orbit-plugin-scan`, parses its single-line JSON stdout summary, and
+ * invalidates the in-memory catalog cache on success so the next
+ * `loadPluginCatalog()` call picks up the fresh scan without a process restart.
+ */
+export function runPluginScan(explicitBinaryPath?: string): Promise<RunPluginScanResult> {
+  return new Promise((resolve) => {
+    let binaryPath: string
+    try {
+      binaryPath = resolvePluginScanBinaryPath(explicitBinaryPath)
+    } catch (error) {
+      resolve({ ok: false, error: error instanceof Error ? error.message : String(error) })
+      return
+    }
+
+    child_process.execFile(binaryPath, [], (error, stdout, stderr) => {
+      if (error) {
+        resolve({ ok: false, error: stderr?.trim() || error.message })
+        return
+      }
+      try {
+        const parsed = JSON.parse(stdout) as PluginScanOutcome
+        clearPluginCatalogCache()
+        resolve({
+          ok: true,
+          count: parsed.count,
+          cachePath: parsed.cachePath,
+          skipped: parsed.skipped,
+        })
+      } catch (parseError) {
+        const reason = parseError instanceof Error ? parseError.message : String(parseError)
+        resolve({ ok: false, error: `failed to parse orbit-plugin-scan output: ${reason}` })
+      }
+    })
+  })
+}

--- a/packages/vscode-extension/src/plugin-catalog-reader.ts
+++ b/packages/vscode-extension/src/plugin-catalog-reader.ts
@@ -15,6 +15,9 @@
  */
 
 import * as child_process from 'child_process'
+
+/** スキャナ実行の上限（実測は数秒・moduleinfo 読取のみでも余裕を見て 2 分）。 */
+const SCAN_TIMEOUT_MS = 120_000
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
@@ -151,24 +154,38 @@ export function runPluginScan(explicitBinaryPath?: string): Promise<RunPluginSca
       return
     }
 
-    child_process.execFile(binaryPath, [], (error, stdout, stderr) => {
-      if (error) {
-        resolve({ ok: false, error: stderr?.trim() || error.message })
-        return
-      }
-      try {
-        const parsed = JSON.parse(stdout) as PluginScanOutcome
-        clearPluginCatalogCache()
-        resolve({
-          ok: true,
-          count: parsed.count,
-          cachePath: parsed.cachePath,
-          skipped: parsed.skipped,
-        })
-      } catch (parseError) {
-        const reason = parseError instanceof Error ? parseError.message : String(parseError)
-        resolve({ ok: false, error: `failed to parse orbit-plugin-scan output: ${reason}` })
-      }
-    })
+    // タイムアウト必須（レビュー Important）: スキャナの存在意義 = 行儀の悪いプラグインの
+    // 隔離だが、crash でなく「ハング」だと execFile は既定で永久に待つ — palette/MCP の
+    // 呼び出しが無言で固まる。timeout 超過は SIGKILL + 明示エラーで返す。
+    child_process.execFile(
+      binaryPath,
+      [],
+      { timeout: SCAN_TIMEOUT_MS, killSignal: 'SIGKILL' },
+      (error, stdout, stderr) => {
+        if (error) {
+          const timedOut = error.killed || /SIGKILL/.test(String(error.signal ?? ''))
+          resolve({
+            ok: false,
+            error: timedOut
+              ? `plugin scan timed out after ${SCAN_TIMEOUT_MS / 1000}s (a plugin may be hanging during metadata read) — binary: ${binaryPath}`
+              : stderr?.trim() || error.message,
+          })
+          return
+        }
+        try {
+          const parsed = JSON.parse(stdout) as PluginScanOutcome
+          clearPluginCatalogCache()
+          resolve({
+            ok: true,
+            count: parsed.count,
+            cachePath: parsed.cachePath,
+            skipped: parsed.skipped,
+          })
+        } catch (parseError) {
+          const reason = parseError instanceof Error ? parseError.message : String(parseError)
+          resolve({ ok: false, error: `failed to parse orbit-plugin-scan output: ${reason}` })
+        }
+      },
+    )
   })
 }

--- a/packages/vscode-extension/tsconfig.tsbuildinfo
+++ b/packages/vscode-extension/tsconfig.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./src/completion-context.ts","./src/diagnostics-analysis.ts","./src/extension.ts","./src/mcp-registration.ts","./src/mcp-server.ts","./src/playhead.ts","./src/wav-analysis.ts"],"version":"5.9.3"}
+{"root":["./src/completion-context.ts","./src/diagnostics-analysis.ts","./src/extension.ts","./src/mcp-registration.ts","./src/mcp-server.ts","./src/playhead.ts","./src/plugin-catalog-completion.ts","./src/plugin-catalog-reader.ts","./src/wav-analysis.ts"],"version":"5.9.3"}

--- a/scripts/copy-daemon-bin.sh
+++ b/scripts/copy-daemon-bin.sh
@@ -77,7 +77,8 @@ if command -v cargo >/dev/null 2>&1; then
   # （TS 専業 contributor 等）でも npm run build を落とさず、既存バイナリへ縮退する。
   if ! (cd "$PROJECT_ROOT/rust" \
     && cargo build --release -p orbit-audio-daemon --features outproc-effect,outproc-instrument \
-    && cargo build --release -p orbit-clap-effect-child -p orbit-clap-instrument-child -p orbit-vst3-instrument-child); then
+    && cargo build --release -p orbit-clap-effect-child -p orbit-clap-instrument-child -p orbit-vst3-instrument-child \
+    && cargo build --release -p orbit-plugin-scan); then
     echo "⚠️  release rebuild failed — bundling whatever exists in rust/target/release (may be stale)." >&2
   fi
 else
@@ -88,3 +89,4 @@ copy_binary "orbit-audio-daemon"
 copy_binary "orbit-clap-effect-child"
 copy_binary "orbit-clap-instrument-child"
 copy_binary "orbit-vst3-instrument-child"
+copy_binary "orbit-plugin-scan"

--- a/tests/vscode-extension/mcp-server-docs-http.spec.ts
+++ b/tests/vscode-extension/mcp-server-docs-http.spec.ts
@@ -115,6 +115,8 @@ function createStubHandlers(): OrbitScoreToolHandlers {
       }
       return result
     },
+    listPlugins: () => ({ ok: true, plugins: [] }),
+    rescanPlugins: () => ({ ok: true, count: 0, skipped: [] }),
   }
 }
 

--- a/tests/vscode-extension/mcp-server.spec.ts
+++ b/tests/vscode-extension/mcp-server.spec.ts
@@ -13,6 +13,8 @@ import {
   type EditorState,
   type DocumentText,
   type AnalyzeAudioResult,
+  type ListPluginsResult,
+  type RescanPluginsResult,
 } from '../../packages/vscode-extension/src/mcp-server'
 
 /**
@@ -146,6 +148,16 @@ function createStubHandlers(overrides: Partial<OrbitScoreToolHandlers> = {}): {
           soundDetected: false,
         },
       }
+      return result
+    },
+    listPlugins: () => {
+      record('listPlugins', [])
+      const result: ListPluginsResult = { ok: true, plugins: [] }
+      return result
+    },
+    rescanPlugins: () => {
+      record('rescanPlugins', [])
+      const result: RescanPluginsResult = { ok: true, count: 0, skipped: [] }
       return result
     },
   }
@@ -333,7 +345,7 @@ describe('OrbitScore MCP server (real HTTP, stub handlers)', () => {
     expect((res.headers['mcp-session-id'] as string).length).toBeGreaterThan(0)
   })
 
-  it('tools/list contains all 18 tools; evaluate_orbitscore requires code:string', async () => {
+  it('tools/list contains all 20 tools; evaluate_orbitscore requires code:string', async () => {
     const { handlers } = createStubHandlers()
     handle = await startTestServer(handlers)
     const client = new McpTestClient(handle.port)
@@ -365,6 +377,8 @@ describe('OrbitScore MCP server (real HTTP, stub handlers)', () => {
       'get_diagnostics',
       'get_log',
       'analyze_audio',
+      'list_plugins',
+      'rescan_plugins',
     ]
     for (const name of expectedNames) {
       expect(names, `missing tool: ${name}`).toContain(name)
@@ -418,6 +432,72 @@ describe('OrbitScore MCP server (real HTTP, stub handlers)', () => {
     expect(body.result.isError).toBeFalsy()
     expect(JSON.parse(body.result.content[0]!.text)).toEqual(docText)
     expect(getDocumentTextCalled).toBe(true)
+  })
+
+  it('tools/call list_plugins round-trips the catalog entries', async () => {
+    const plugins: ListPluginsResult = {
+      ok: true,
+      plugins: [
+        {
+          name: 'Surge XT',
+          vendor: 'Surge Synth Team',
+          format: 'clap',
+          path: '/clap/SurgeXT.clap',
+          pluginId: 'surge-xt',
+          roles: ['instrument'],
+        },
+      ],
+    }
+    const { handlers } = createStubHandlers({ listPlugins: () => plugins })
+    handle = await startTestServer(handlers)
+    const client = new McpTestClient(handle.port)
+    await client.connect()
+
+    const res = await client.toolsCall('list_plugins')
+
+    expect(res.status).toBe(200)
+    const body = res.json as JsonRpcOk<ToolCallResult>
+    expect(body.result.isError).toBeFalsy()
+    expect(JSON.parse(body.result.content[0]!.text)).toEqual(plugins.plugins)
+  })
+
+  it('tools/call list_plugins surfaces isError:true when the catalog is missing', async () => {
+    const { handlers } = createStubHandlers({
+      listPlugins: () => ({ ok: false, error: 'plugin catalog not found' }),
+    })
+    handle = await startTestServer(handlers)
+    const client = new McpTestClient(handle.port)
+    await client.connect()
+
+    const res = await client.toolsCall('list_plugins')
+
+    const body = res.json as JsonRpcOk<ToolCallResult>
+    expect(body.result.isError).toBe(true)
+    expect(body.result.content[0]?.text).toMatch(/^error:/)
+  })
+
+  it('tools/call rescan_plugins round-trips the scan summary', async () => {
+    let rescanPluginsCalled = false
+    const { handlers } = createStubHandlers({
+      rescanPlugins: () => {
+        rescanPluginsCalled = true
+        return { ok: true, count: 12, skipped: ['/vst3/NoMetadata.vst3'] }
+      },
+    })
+    handle = await startTestServer(handlers)
+    const client = new McpTestClient(handle.port)
+    await client.connect()
+
+    const res = await client.toolsCall('rescan_plugins')
+
+    expect(res.status).toBe(200)
+    const body = res.json as JsonRpcOk<ToolCallResult>
+    expect(body.result.isError).toBeFalsy()
+    expect(JSON.parse(body.result.content[0]!.text)).toEqual({
+      count: 12,
+      skipped: ['/vst3/NoMetadata.vst3'],
+    })
+    expect(rescanPluginsCalled).toBe(true)
   })
 
   it('handler error surfaces as isError:true with text starting with "error:"', async () => {

--- a/tests/vscode-extension/plugin-catalog-completion.spec.ts
+++ b/tests/vscode-extension/plugin-catalog-completion.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  detectPluginArgContext,
+  filterCatalogEntries,
+} from '../../packages/vscode-extension/src/plugin-catalog-completion'
+import type { PluginCatalogEntry } from '../../packages/vscode-extension/src/plugin-catalog-reader'
+
+const ENTRIES: PluginCatalogEntry[] = [
+  {
+    name: 'Scaler 2',
+    vendor: 'Plugin Boutique',
+    format: 'vst3',
+    path: '/vst3/Scaler2.vst3',
+    pluginId: 'scaler2',
+    roles: ['instrument'],
+  },
+  {
+    name: 'TAL Reverb 4',
+    vendor: 'TAL Software',
+    format: 'clap',
+    path: '/clap/TALReverb4.clap',
+    pluginId: 'tal-reverb-4',
+    roles: ['effect'],
+  },
+  {
+    name: 'TAL Reverb 4',
+    vendor: 'TAL Software',
+    format: 'vst3',
+    path: '/vst3/TALReverb4.vst3',
+    pluginId: 'tal-reverb-4-vst3',
+    roles: ['effect'],
+  },
+  {
+    name: 'Surge XT',
+    vendor: 'Surge Synth Team',
+    format: 'clap',
+    path: '/clap/SurgeXT.clap',
+    pluginId: 'surge-xt',
+    roles: ['instrument', 'effect'],
+  },
+]
+
+describe('detectPluginArgContext', () => {
+  it('matches at the freshly-triggered open quote', () => {
+    const line = 'kick.effect("'
+    const result = detectPluginArgContext(line, line.length)
+    expect(result).toEqual({ verb: 'effect', typed: '', quoteStartChar: line.length })
+  })
+
+  it('matches a PARTIAL in-progress string with no closing quote (owner requirement 2026-07-17)', () => {
+    const line = 'kick.effect("Sca'
+    const result = detectPluginArgContext(line, line.length)
+    expect(result).not.toBeNull()
+    expect(result?.verb).toBe('effect')
+    expect(result?.typed).toBe('Sca')
+    expect(result?.quoteStartChar).toBe(line.indexOf('"') + 1)
+  })
+
+  it('still matches when a closing quote exists later on the line but cursor is mid-string', () => {
+    const line = 'kick.effect("Sca")'
+    const cursor = line.indexOf('Sca') + 3 // right after "Sca", before the closing quote
+    const result = detectPluginArgContext(line, cursor)
+    expect(result?.typed).toBe('Sca')
+  })
+
+  it('recognizes instrument(', () => {
+    const line = 'lead.instrument("Sur'
+    const result = detectPluginArgContext(line, line.length)
+    expect(result?.verb).toBe('instrument')
+    expect(result?.typed).toBe('Sur')
+  })
+
+  it('returns null outside a plugin-name string position', () => {
+    expect(detectPluginArgContext('global.tempo(140)', 18)).toBeNull()
+    expect(detectPluginArgContext('kick.effect(', 12)).toBeNull() // no opening quote yet
+  })
+})
+
+describe('filterCatalogEntries', () => {
+  it('narrows to Scaler-prefixed candidates as the user types "Sca" for instrument(', () => {
+    const result = filterCatalogEntries(ENTRIES, 'instrument', 'Sca')
+    expect(result.map((e) => e.name)).toEqual(['Scaler 2'])
+  })
+
+  it('effect() only returns CLAP format entries even when a VST3 same-name entry exists', () => {
+    const result = filterCatalogEntries(ENTRIES, 'effect', 'TAL')
+    expect(result).toHaveLength(1)
+    expect(result[0].format).toBe('clap')
+  })
+
+  it('instrument() has no format restriction', () => {
+    const result = filterCatalogEntries(ENTRIES, 'instrument', 'Surge')
+    expect(result.map((e) => e.name)).toEqual(['Surge XT'])
+  })
+
+  it('empty typed prefix returns all role-matching entries', () => {
+    const result = filterCatalogEntries(ENTRIES, 'instrument', '')
+    expect(result.map((e) => e.name).sort()).toEqual(['Scaler 2', 'Surge XT'])
+  })
+
+  it('matches vendor-qualified prefix ("TAL Software/")', () => {
+    const result = filterCatalogEntries(ENTRIES, 'effect', 'TAL Software/TAL')
+    expect(result).toHaveLength(1)
+  })
+
+  it('role mismatch excludes an entry', () => {
+    const result = filterCatalogEntries(ENTRIES, 'effect', 'Scaler')
+    expect(result).toHaveLength(0)
+  })
+})

--- a/tests/vscode-extension/plugin-catalog-reader.spec.ts
+++ b/tests/vscode-extension/plugin-catalog-reader.spec.ts
@@ -1,0 +1,121 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import { describe, it, expect, afterEach } from 'vitest'
+
+import {
+  clearPluginCatalogCache,
+  loadPluginCatalog,
+  resolveCatalogPath,
+  resolvePluginScanBinaryPath,
+} from '../../packages/vscode-extension/src/plugin-catalog-reader'
+
+describe('resolveCatalogPath', () => {
+  const originalEnv = process.env.ORBIT_PLUGIN_CATALOG
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.ORBIT_PLUGIN_CATALOG
+    else process.env.ORBIT_PLUGIN_CATALOG = originalEnv
+  })
+
+  it('explicit override wins over env and default', () => {
+    process.env.ORBIT_PLUGIN_CATALOG = '/env/catalog.json'
+    expect(resolveCatalogPath('/explicit/catalog.json')).toBe('/explicit/catalog.json')
+  })
+
+  it('falls back to ORBIT_PLUGIN_CATALOG env when no override given', () => {
+    process.env.ORBIT_PLUGIN_CATALOG = '/env/catalog.json'
+    expect(resolveCatalogPath()).toBe('/env/catalog.json')
+  })
+
+  it('falls back to ~/.orbitscore/plugin-catalog.json when neither is set', () => {
+    delete process.env.ORBIT_PLUGIN_CATALOG
+    expect(resolveCatalogPath()).toBe(path.join(os.homedir(), '.orbitscore', 'plugin-catalog.json'))
+  })
+})
+
+describe('loadPluginCatalog', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-plugin-catalog-'))
+  const catalogPath = path.join(tmpDir, 'plugin-catalog.json')
+
+  afterEach(() => {
+    clearPluginCatalogCache()
+  })
+
+  it('returns undefined when the catalog file does not exist', () => {
+    expect(loadPluginCatalog(path.join(tmpDir, 'missing.json'))).toBeUndefined()
+  })
+
+  it('parses an existing catalog file', () => {
+    const catalog = {
+      version: 1,
+      scannedAt: '2026-07-17T00:00:00Z',
+      plugins: [
+        {
+          name: 'Surge XT',
+          vendor: 'Surge Synth Team',
+          format: 'clap',
+          path: '/clap/SurgeXT.clap',
+          pluginId: 'surge-xt',
+          roles: ['instrument'],
+        },
+      ],
+    }
+    fs.writeFileSync(catalogPath, JSON.stringify(catalog))
+    const loaded = loadPluginCatalog(catalogPath)
+    expect(loaded?.plugins).toHaveLength(1)
+    expect(loaded?.plugins[0].name).toBe('Surge XT')
+  })
+
+  it('re-reads after the file mtime changes (rescan invalidation)', async () => {
+    fs.writeFileSync(catalogPath, JSON.stringify({ version: 1, scannedAt: 't1', plugins: [] }))
+    const first = loadPluginCatalog(catalogPath)
+    expect(first?.plugins).toHaveLength(0)
+
+    // Ensure a distinct mtime (some filesystems have 1s resolution).
+    await new Promise((resolve) => setTimeout(resolve, 1100))
+    fs.writeFileSync(
+      catalogPath,
+      JSON.stringify({
+        version: 1,
+        scannedAt: 't2',
+        plugins: [
+          {
+            name: 'X',
+            vendor: 'Y',
+            format: 'clap',
+            path: '/x.clap',
+            pluginId: 'x',
+            roles: ['effect'],
+          },
+        ],
+      }),
+    )
+    const second = loadPluginCatalog(catalogPath)
+    expect(second?.plugins).toHaveLength(1)
+  }, 5000)
+})
+
+describe('resolvePluginScanBinaryPath', () => {
+  it('explicit path wins when it is an executable file', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-plugin-scan-bin-'))
+    const binPath = path.join(tmpDir, 'orbit-plugin-scan')
+    fs.writeFileSync(binPath, '#!/bin/sh\necho hi\n', { mode: 0o755 })
+    expect(resolvePluginScanBinaryPath(binPath)).toBe(binPath)
+  })
+
+  it('ORBIT_PLUGIN_SCAN_PATH env override wins when the explicit arg is not viable', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-plugin-scan-bin-env-'))
+    const binPath = path.join(tmpDir, 'orbit-plugin-scan')
+    fs.writeFileSync(binPath, '#!/bin/sh\necho hi\n', { mode: 0o755 })
+    const originalEnv = process.env.ORBIT_PLUGIN_SCAN_PATH
+    process.env.ORBIT_PLUGIN_SCAN_PATH = binPath
+    try {
+      expect(resolvePluginScanBinaryPath('/definitely/not/a/real/path')).toBe(binPath)
+    } finally {
+      if (originalEnv === undefined) delete process.env.ORBIT_PLUGIN_SCAN_PATH
+      else process.env.ORBIT_PLUGIN_SCAN_PATH = originalEnv
+    }
+  })
+})


### PR DESCRIPTION
## 概要

#463 の完結編: **エディタ補完(タイプ中絞り込み)+ rescan 3面 + MCP ツール**。これで「インストール済みプラグインが名前で補完され、名前で挿せる」体験が一式そろいます。

Closes #463

## 変更内容

- **補完(PC.3)**: `.effect("` / `.instrument("` の引数位置でカタログ候補(label=name・detail=vendor/format)。**部分入力(`effect("Sca`)でも文脈判定が効き、range 明示で VS Code 標準のタイプ中絞り込みが動く**(owner 要件)。effect は PH.3 どおり CLAP のみ・instrument は roles 適合
- **rescan 3面(C1b)**: palette コマンド・`.orbs` 右クリックメニュー・MCP `rescan_plugins`。設計判断 = daemon 経由をやめ、拡張が crash 隔離バイナリ `orbit-plugin-scan` を直接 spawn(spec PC.1 の「持ち主 = daemon」から変更 — スキャナが独立バイナリ化された C1 の帰結。spec 追従は本 PR で不要: PC.1 は生成物=キャッシュが正本という規範が本体)
- **MCP(PC.4)**: `list_plugins` / `rescan_plugins`(handler seam 必須メンバー)
- bundle: copy-daemon-bin.sh + release gate に `orbit-plugin-scan` を追加

## 検証

- 拡張 tests **160**(+11: `effect("Sca` → Scaler 絞り込み・reader・MCP 2 ツール)・全体 **1495 passed**・tsc/lint clean
- 実機: スキャナ spawn → count 79・bundle 5 バイナリ確認

## 既知

実カタログに CLAP effect が 0 のため effect 補完の実データ経路は unit のみ(dev 用 CLAPTestEffect は `ORBIT_PLUGIN_PATH` で追加可能)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu