### PR TITLE
feat(orbitstudio): Engine view device list + selection (#484 D3)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,26 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.280 feat(orbitstudio): Engine ビューにデバイス表示/選択 #484 D3 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 実装（D2 走行中切替は次段 — 選択は「次回起動時に適用」と正直に明示）
+
+**内容**:
+- daemon `--list-audio-devices` 軽量モード（cpal 列挙のみ・stream 非開 = hotfix の教訓で
+  ハングリスク回避・JSON 1 行出力で即 exit）
+- Engine ビューを TreeDataProvider 化（#483 の基礎）: 停止中は welcome ボタン・起動中は
+  Engine 状態（クリックで toggle）+ Output Device 一覧（展開時 lazy 取得・ポーリングなし）
+- デバイス選択 → `orbitscore.audioDevice` 設定（新設・machine-overridable）書き込み。
+  起動中なら再起動を提案。設定の正 = VS Code 設定（.orbitscore.json は後方互換 fallback —
+  palette/MCP の旧 write 経路の統合は follow-up）
+
+**検証**: Rust 7 tests・TS 13 tests・tsc/lint/build green。実機: `--list-audio-devices` が
+2 デバイス（MacBook Proのスピーカー default / Pro Tools Aggregate I/O）を返し即 exit。
+
+Refs #484 #483
+
+
 ### 6.279 feat(orbitstudio): plugin catalog 補完 + rescan 3面 + MCP #463 C1b/C3 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -93,6 +93,11 @@
         "category": "OrbitScore"
       },
       {
+        "command": "orbitscore.engineViewSelectDevice",
+        "title": "OrbitScore: Select Audio Device (Engine View)",
+        "category": "OrbitScore"
+      },
+      {
         "command": "orbitscore.openDocs",
         "title": "OrbitScore: Open Learning Site",
         "icon": "$(book)"
@@ -153,7 +158,7 @@
       },
       {
         "view": "orbitscore.engineView",
-        "contents": "Control the OrbitScore audio engine.\n[Start Engine](command:orbitscore.toggleEngine)\n[Start Engine (Debug)](command:orbitscore.startEngineDebug)\n[Stop Engine](command:orbitscore.stopEngine)\n\nNote: process state, CPU metrics and audio-device selection (Rust engine) will appear here — see issue #484."
+        "contents": "Control the OrbitScore audio engine.\n[Start Engine](command:orbitscore.toggleEngine)\n[Start Engine (Debug)](command:orbitscore.startEngineDebug)\n[Stop Engine](command:orbitscore.stopEngine)\n\nOnce the engine is running, this view shows engine status and lets you pick the output device (applies on the next start). CPU metrics are a follow-up — see issue #484."
       }
     ],
     "menus": {
@@ -188,6 +193,10 @@
         },
         {
           "command": "orbitscore.stopEngine",
+          "when": "false"
+        },
+        {
+          "command": "orbitscore.engineViewSelectDevice",
           "when": "false"
         }
       ],
@@ -339,6 +348,12 @@
           ],
           "default": "rust",
           "description": "Audio backend to use. \"rust\" (default) is the native audio daemon (orbit-audio-daemon). \"sc\" opts into SuperCollider (requires bundled scsynth or orbitscore.scsynthPath).",
+          "scope": "machine-overridable"
+        },
+        "orbitscore.audioDevice": {
+          "type": "string",
+          "default": "",
+          "description": "Output audio device to use (both \"rust\" and \"sc\" engines). Leave empty to use the system default. Pick a device from the Audio Engine Settings view, or set the exact device name here. Applies on the *next* engine start — there is no live device switch yet (#484 D2). Takes precedence over the legacy `.orbitscore.json` \"audioDevice\" key when both are set.",
           "scope": "machine-overridable"
         },
         "orbitscore.mcpServer.port": {

--- a/packages/vscode-extension/src/engine-view.ts
+++ b/packages/vscode-extension/src/engine-view.ts
@@ -1,0 +1,137 @@
+/**
+ * Pure data-shaping helpers for the "Audio Engine Settings" TreeView (#484 D3).
+ *
+ * Kept vscode-free (like `playhead.ts`) so the tree-content logic can be unit
+ * tested without mocking the `vscode` module. `extension.ts` maps
+ * `EngineViewNode`s to `vscode.TreeItem` and owns all vscode-specific state
+ * (process handles, `onDidChangeTreeData`, async device fetch).
+ */
+
+/** One device entry, wire-compatible with `AudioDeviceListEntry`
+ * (`packages/engine/src/audio/rust-engine/daemon-client.ts`) and the
+ * `--list-audio-devices` CLI JSON (`rust/crates/orbit-audio-daemon/src/main.rs`). */
+export interface EngineViewDevice {
+  name: string
+  isDefault: boolean
+  maxOutputChannels: number
+  defaultSampleRate: number
+  direction: 'output' | 'input'
+}
+
+export type EngineViewNodeKind =
+  | 'engine-status'
+  | 'device-section'
+  | 'device'
+  | 'device-loading'
+  | 'device-error'
+  | 'device-empty'
+
+export interface EngineViewNode {
+  kind: EngineViewNodeKind
+  /** Stable id — used by `extension.ts` to route command args (e.g. which device was clicked). */
+  id: string
+  label: string
+  description?: string
+  /** Only meaningful for `kind: 'device'` — true if this is the currently-configured device. */
+  selected?: boolean
+  /** Whether the node should render as an expandable tree item. */
+  collapsible: boolean
+}
+
+/** Root-level nodes shown at all times once the engine view has a live TreeDataProvider. */
+export function buildRootNodes(engineRunning: boolean): EngineViewNode[] {
+  return [buildEngineStatusNode(engineRunning), buildDeviceSectionNode()]
+}
+
+export function buildEngineStatusNode(engineRunning: boolean): EngineViewNode {
+  return {
+    kind: 'engine-status',
+    id: 'engine-status',
+    label: engineRunning ? 'Engine: Running' : 'Engine: Stopped',
+    description: engineRunning ? 'Click to stop' : 'Click to start',
+    collapsible: false,
+  }
+}
+
+export function buildDeviceSectionNode(): EngineViewNode {
+  return {
+    kind: 'device-section',
+    id: 'device-section',
+    label: 'Output Device',
+    collapsible: true,
+  }
+}
+
+/** Fetch state for the device list, populated by `extension.ts` when the
+ * "Output Device" node is expanded (lazy — no polling, per #484 D3 task spec). */
+export type DeviceFetchState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'loaded'; devices: EngineViewDevice[] }
+
+/**
+ * Children of the "Output Device" node. `selectedDevice` is the resolved
+ * `orbitscore.audioDevice` setting value (empty string = system default —
+ * see `resolveAudioDeviceSetting` in extension.ts for the VS Code
+ * setting / `.orbitscore.json` precedence).
+ */
+export function deviceSectionChildren(
+  state: DeviceFetchState,
+  selectedDevice: string,
+): EngineViewNode[] {
+  if (state.status === 'loading') {
+    return [
+      {
+        kind: 'device-loading',
+        id: 'device-loading',
+        label: 'Loading devices…',
+        collapsible: false,
+      },
+    ]
+  }
+  if (state.status === 'error') {
+    return [
+      {
+        kind: 'device-error',
+        id: 'device-error',
+        label: `⚠️ ${state.message}`,
+        collapsible: false,
+      },
+    ]
+  }
+  if (state.devices.length === 0) {
+    return [
+      {
+        kind: 'device-empty',
+        id: 'device-empty',
+        label: 'No audio devices found',
+        collapsible: false,
+      },
+    ]
+  }
+  return state.devices.map((device) => buildDeviceNode(device, selectedDevice))
+}
+
+/**
+ * A device is "selected" if its name matches the configured device exactly,
+ * or — when nothing is configured (`selectedDevice === ''`, meaning "system
+ * default") — if it is the host's default output device.
+ */
+export function buildDeviceNode(device: EngineViewDevice, selectedDevice: string): EngineViewNode {
+  const selected = selectedDevice === '' ? device.isDefault : device.name === selectedDevice
+  const labelSuffix = device.isDefault ? ' (system default)' : ''
+  return {
+    kind: 'device',
+    id: `device:${device.name}`,
+    label: `${selected ? '● ' : ''}${device.name}${labelSuffix}`,
+    description: `${device.maxOutputChannels}ch · ${device.defaultSampleRate}Hz`,
+    selected,
+    collapsible: false,
+  }
+}
+
+/** Extract the device name from a `device:<name>` node id — the inverse of `buildDeviceNode`'s id. */
+export function deviceNameFromNodeId(nodeId: string): string | null {
+  if (!nodeId.startsWith('device:')) return null
+  return nodeId.slice('device:'.length)
+}

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -35,6 +35,14 @@ import {
   type RescanPluginsResult,
   type SelectionInput,
 } from './mcp-server'
+import {
+  buildRootNodes,
+  deviceNameFromNodeId,
+  deviceSectionChildren,
+  type DeviceFetchState,
+  type EngineViewDevice,
+  type EngineViewNode,
+} from './engine-view'
 import { detectPluginArgContext, filterCatalogEntries } from './plugin-catalog-completion'
 import { loadPluginCatalog, runPluginScan } from './plugin-catalog-reader'
 import {
@@ -58,6 +66,8 @@ let isLiveCodingMode: boolean = false
 let globalInitialized: boolean = false
 // Optional MCP control server (Agent Bridge). Non-null only while running.
 let mcpServerHandle: McpServerHandle | null = null
+// Audio Engine Settings TreeView (#484 D3). Non-null once activated.
+let engineViewProvider: EngineViewProvider | null = null
 // #463 C3: show the "no plugin catalog yet, run rescan" hint at most once per
 // activation (loadPluginCatalog() is cheap but the info popup shouldn't nag on
 // every keystroke while typing an effect()/instrument() argument).
@@ -310,11 +320,14 @@ export async function activate(context: vscode.ExtensionContext) {
       getChildren: () => [],
       getTreeItem: (element: vscode.TreeItem) => element,
     }),
-    // viewsWelcome は provider 登録が無いと描画されない（上と同じ理由）— Engine ビューにも空 provider。
-    vscode.window.registerTreeDataProvider('orbitscore.engineView', {
-      getChildren: () => [],
-      getTreeItem: (element: vscode.TreeItem) => element,
-    }),
+    // Engine ビュー（#484 D3）: エンジン停止中は空を返し viewsWelcome（Start/Debug/Stop ボタン）を
+    // 出す（viewsWelcome は tree が空の時だけ描画される — 上の学習ビューと同じ制約）。起動中は
+    // engine 状態 + Output Device セクションを TreeView として描画する。
+    (() => {
+      engineViewProvider = new EngineViewProvider()
+      return vscode.window.registerTreeDataProvider('orbitscore.engineView', engineViewProvider)
+    })(),
+    vscode.commands.registerCommand('orbitscore.engineViewSelectDevice', engineViewSelectDevice),
     vscode.commands.registerCommand('orbitscore.openDocs', openUserDocs),
     vscode.commands.registerCommand('orbitscore.openDevDocs', openDevDocs),
     vscode.commands.registerCommand('orbitscore.openDevDocsPanel', () => openDevDocsPanel(context)),
@@ -1205,7 +1218,192 @@ function setupExitHandler(process: child_process.ChildProcess): void {
 
     statusBarItem!.text = '🎵 OrbitScore: Stopped'
     statusBarItem!.tooltip = 'Click to start engine'
+    engineViewProvider?.refresh()
   })
+}
+
+function isEngineRunning(): boolean {
+  return engineProcess !== null && !engineProcess.killed
+}
+
+/**
+ * Resolve the effective output device (#484 D3). The `orbitscore.audioDevice`
+ * VS Code setting is the primary source going forward (works without a
+ * workspace file, discoverable via the Engine view); the legacy
+ * `.orbitscore.json` `audioDevice` key (written by `selectAudioDevice` /
+ * the MCP `select_audio_device` tool, #388) is kept as a fallback for
+ * back-compat with existing workspaces. Empty string means "system default".
+ */
+function resolveAudioDeviceSetting(workspaceRoot: string): string {
+  const configured = vscode.workspace.getConfiguration('orbitscore').get<string>('audioDevice', '')
+  if (configured) return configured
+  return loadAudioDeviceConfig(workspaceRoot) ?? ''
+}
+
+/**
+ * List output devices via the daemon's `--list-audio-devices` lightweight
+ * mode (#484 D3) — spawns the binary, reads its single JSON line, and exits.
+ * No stream is opened (see `orbit-audio-native::list_output_devices` /
+ * `resolve_output_device`'s Aggregate-device probe-hang note), so this is
+ * safe to run even while the engine itself is not running. `timeout` guards
+ * against an unexpected hang so the TreeView never spins forever.
+ */
+function fetchAudioDevicesForView(): Promise<EngineViewDevice[]> {
+  const resolution = resolveDaemonForUI()
+  if (!resolution) {
+    return Promise.reject(
+      new Error(
+        'orbit-audio-daemon not found. Reinstall the extension, build it via `cd rust && cargo build --release`, or set ORBIT_AUDIO_DAEMON_PATH to a custom binary.',
+      ),
+    )
+  }
+  return new Promise((resolve, reject) => {
+    child_process.execFile(
+      resolution.path,
+      ['--list-audio-devices'],
+      { timeout: 5000 },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`failed to list audio devices: ${stderr.trim() || error.message}`))
+          return
+        }
+        try {
+          const line = stdout.trim().split('\n').pop() ?? ''
+          const parsed = JSON.parse(line) as { devices: EngineViewDevice[] }
+          resolve(parsed.devices)
+        } catch (parseErr) {
+          reject(
+            new Error(
+              `failed to parse device list: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
+            ),
+          )
+        }
+      },
+    )
+  })
+}
+
+/**
+ * TreeDataProvider for the "Audio Engine Settings" view (#484 D3). Wraps the
+ * vscode-free data shaping in `engine-view.ts`: `getChildren`/`getTreeItem`
+ * translate `EngineViewNode`s to real `vscode.TreeItem`s and own the only
+ * bit of state vscode needs — a per-expansion device-list cache, invalidated
+ * on `refresh()` (called from `startEngine`/`stopEngine`/exit handler and the
+ * device-select command) so a stale list never lingers across an engine
+ * restart or device change. Devices are fetched lazily when the "Output
+ * Device" node is expanded, not polled (per task spec — the daemon spawn for
+ * enumeration is cheap but not free).
+ */
+class EngineViewProvider implements vscode.TreeDataProvider<EngineViewNode> {
+  private readonly emitter = new vscode.EventEmitter<EngineViewNode | undefined>()
+  readonly onDidChangeTreeData = this.emitter.event
+  private deviceFetchState: DeviceFetchState | null = null
+
+  refresh(): void {
+    this.deviceFetchState = null
+    this.emitter.fire(undefined)
+  }
+
+  getTreeItem(node: EngineViewNode): vscode.TreeItem {
+    const item = new vscode.TreeItem(
+      node.label,
+      node.collapsible
+        ? vscode.TreeItemCollapsibleState.Expanded
+        : vscode.TreeItemCollapsibleState.None,
+    )
+    item.id = node.id
+    item.description = node.description
+    switch (node.kind) {
+      case 'engine-status':
+        item.iconPath = new vscode.ThemeIcon(isEngineRunning() ? 'debug-stop' : 'play')
+        item.command = { command: 'orbitscore.toggleEngine', title: 'Toggle Engine' }
+        break
+      case 'device-section':
+        item.iconPath = new vscode.ThemeIcon('list-selection')
+        break
+      case 'device':
+        item.iconPath = new vscode.ThemeIcon(node.selected ? 'check' : 'circle-large-outline')
+        item.command = {
+          command: 'orbitscore.engineViewSelectDevice',
+          title: 'Select Audio Device',
+          arguments: [node],
+        }
+        break
+      case 'device-error':
+        item.iconPath = new vscode.ThemeIcon('warning')
+        break
+      default:
+        break
+    }
+    return item
+  }
+
+  getChildren(node?: EngineViewNode): EngineViewNode[] | Thenable<EngineViewNode[]> {
+    if (!node) {
+      // viewsWelcome (Start/Debug/Stop buttons) covers the stopped state —
+      // only populate the tree once the engine is actually running.
+      return isEngineRunning() ? buildRootNodes(true) : []
+    }
+    if (node.kind === 'device-section') {
+      return this.getDeviceChildren()
+    }
+    return []
+  }
+
+  private async getDeviceChildren(): Promise<EngineViewNode[]> {
+    if (!this.deviceFetchState) {
+      try {
+        const devices = await fetchAudioDevicesForView()
+        this.deviceFetchState = { status: 'loaded', devices }
+      } catch (err) {
+        this.deviceFetchState = {
+          status: 'error',
+          message: err instanceof Error ? err.message : String(err),
+        }
+      }
+    }
+    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd()
+    const selectedDevice = resolveAudioDeviceSetting(workspaceRoot)
+    return deviceSectionChildren(this.deviceFetchState, selectedDevice)
+  }
+}
+
+/**
+ * "Select Audio Device" command wired to a device `TreeItem` click in the
+ * Engine view (#484 D3). Writes `orbitscore.audioDevice` (Workspace scope
+ * when a workspace is open, Global otherwise) and — honestly, since D2
+ * (live device switch) isn't implemented — tells the user this takes effect
+ * on the *next* engine start, offering an immediate restart if one is
+ * currently running.
+ */
+async function engineViewSelectDevice(node: EngineViewNode): Promise<void> {
+  const deviceName = deviceNameFromNodeId(node.id)
+  if (!deviceName) return
+
+  const target = vscode.workspace.workspaceFolders?.[0]
+    ? vscode.ConfigurationTarget.Workspace
+    : vscode.ConfigurationTarget.Global
+  await vscode.workspace.getConfiguration('orbitscore').update('audioDevice', deviceName, target)
+  outputChannel?.appendLine(`🔊 orbitscore.audioDevice set to: ${deviceName}`)
+  engineViewProvider?.refresh()
+
+  if (isEngineRunning()) {
+    const choice = await vscode.window.showInformationMessage(
+      `🔊 Audio device set to "${deviceName}". This applies on the next engine start — restart now?`,
+      'Restart Engine',
+      'Later',
+    )
+    if (choice === 'Restart Engine') {
+      stopEngine()
+      // stopEngine()'s SIGKILL fallback fires at 2s if SIGTERM hasn't landed —
+      // wait past that so the restart doesn't race a still-exiting process.
+      setTimeout(() => startEngine(), 2200)
+    }
+  } else {
+    vscode.window.showInformationMessage(
+      `🔊 Audio device set to "${deviceName}". Applies the next time you start the engine.`,
+    )
+  }
 }
 
 function startEngine(debugMode: boolean = false, agentOpts?: { captureWav?: string }) {
@@ -1267,8 +1465,8 @@ function startEngine(debugMode: boolean = false, agentOpts?: { captureWav?: stri
   // Get workspace root
   const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd()
 
-  // Load audio device config
-  const audioDevice = loadAudioDeviceConfig(workspaceRoot)
+  // Load audio device config — VS Code setting first, `.orbitscore.json` fallback (#484 D3).
+  const audioDevice = resolveAudioDeviceSetting(workspaceRoot)
 
   // Build args
   const args = ['repl']
@@ -1333,6 +1531,7 @@ function startEngine(debugMode: boolean = false, agentOpts?: { captureWav?: stri
     debugMode ? '✅ Engine started (Debug)' : '✅ Engine started',
   )
   outputChannel?.appendLine('✅ Engine started - Ready for evaluation')
+  engineViewProvider?.refresh()
 
   // Setup handlers
   setupStdoutHandler(engineProcess, debugMode)
@@ -1367,6 +1566,7 @@ function stopEngine() {
 
     statusBarItem!.text = '🎵 OrbitScore: Stopped'
     statusBarItem!.tooltip = 'Click to start engine'
+    engineViewProvider?.refresh()
     vscode.window.showInformationMessage('🛑 Engine stopped')
     outputChannel?.appendLine('🛑 Engine stopped')
   }

--- a/packages/vscode-extension/tsconfig.tsbuildinfo
+++ b/packages/vscode-extension/tsconfig.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./src/completion-context.ts","./src/diagnostics-analysis.ts","./src/extension.ts","./src/mcp-registration.ts","./src/mcp-server.ts","./src/playhead.ts","./src/plugin-catalog-completion.ts","./src/plugin-catalog-reader.ts","./src/wav-analysis.ts"],"version":"5.9.3"}
+{"root":["./src/completion-context.ts","./src/diagnostics-analysis.ts","./src/engine-view.ts","./src/extension.ts","./src/mcp-registration.ts","./src/mcp-server.ts","./src/playhead.ts","./src/plugin-catalog-completion.ts","./src/plugin-catalog-reader.ts","./src/wav-analysis.ts"],"version":"5.9.3"}

--- a/rust/crates/orbit-audio-daemon/src/main.rs
+++ b/rust/crates/orbit-audio-daemon/src/main.rs
@@ -70,6 +70,14 @@ fn install_fatal_panic_hook() {
 }
 
 async fn run() -> Result<(), i32> {
+    // -1. `--list-audio-devices`（#484 D3）: cpal 列挙のみ行い stdout に JSON 一覧を出して即 exit
+    // する軽量モード。stream は開かない（ハングリスクを避ける・上の `resolve_output_device` の
+    // Aggregate デバイス probe 回避コメント参照）。通常起動（WebSocket listener bind・accept loop）
+    // には進まない。
+    if has_list_audio_devices_flag(std::env::args().skip(1)) {
+        return run_list_audio_devices();
+    }
+
     // 0. `--audio-device <name>` を解析し、`ORBIT_AUDIO_DEVICE` env へ反映する（#484 D1）。
     // 実際の device 解決（列挙・一致判定・不一致時の縮退警告）は `orbit-audio-native`
     // 側（`resolve_output_device`）が cpal I/O を伴って行う。ここでは env に橋渡しするだけ
@@ -141,6 +149,47 @@ fn apply_audio_device_arg<I: IntoIterator<Item = String>>(args: I) {
     }
 }
 
+/// argv に `--list-audio-devices` フラグが含まれるかを判定する純関数（#484 D3）。
+fn has_list_audio_devices_flag<I: IntoIterator<Item = String>>(args: I) -> bool {
+    args.into_iter().any(|arg| arg == "--list-audio-devices")
+}
+
+/// `--list-audio-devices` モードの実処理（#484 D3）。`orbit_audio_native::list_output_devices()`
+/// で cpal 列挙のみ行い、1 行 JSON で stdout に出力して終了する。TS 側（VS Code extension の
+/// Engine ビュー・D3）はこのプロセスを spawn → 1 行読んで即 exit を待つ想定。列挙失敗時は
+/// stderr に理由を出し非ゼロ exit（通常起動の `report_startup_failure` と同じ schema は使わない
+/// — こちらは WebSocket プロトコルの外側の一過性 CLI 呼び出しのため）。
+fn run_list_audio_devices() -> Result<(), i32> {
+    match orbit_audio_native::list_output_devices() {
+        Ok(devices) => {
+            // wire 形は session.rs `ListAudioDevices` ハンドラと同じフィールド名に揃える
+            // （`AudioDeviceInfo` は Serialize を derive していないため手動でマップする）。
+            let devices: Vec<serde_json::Value> = devices
+                .into_iter()
+                .map(|d| {
+                    json!({
+                        "name": d.name,
+                        "isDefault": d.is_default,
+                        "maxOutputChannels": d.max_output_channels,
+                        "defaultSampleRate": d.default_sample_rate,
+                        "direction": d.direction,
+                    })
+                })
+                .collect();
+            let line = serde_json::to_string(&json!({ "devices": devices }))
+                .unwrap_or_else(|_| r#"{"devices":[]}"#.to_string());
+            println!("{line}");
+            use std::io::Write;
+            let _ = std::io::stdout().flush();
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!(r#"{{"error":"{e}"}}"#);
+            Err(1)
+        }
+    }
+}
+
 fn report_startup_failure(error: ProtocolError) {
     let payload = StartupError {
         ready: false,
@@ -186,5 +235,27 @@ mod tests {
             "Second".to_string(),
         ];
         assert_eq!(parse_audio_device_arg(args), Some("Second".to_string()));
+    }
+
+    #[test]
+    fn list_audio_devices_flag_absent() {
+        let args = ["--audio-device".to_string(), "USB Audio".to_string()];
+        assert!(!has_list_audio_devices_flag(args));
+    }
+
+    #[test]
+    fn list_audio_devices_flag_present() {
+        let args = ["--list-audio-devices".to_string()];
+        assert!(has_list_audio_devices_flag(args));
+    }
+
+    #[test]
+    fn list_audio_devices_flag_present_among_others() {
+        let args = [
+            "--audio-device".to_string(),
+            "USB Audio".to_string(),
+            "--list-audio-devices".to_string(),
+        ];
+        assert!(has_list_audio_devices_flag(args));
     }
 }

--- a/rust/crates/orbit-audio-native/src/output.rs
+++ b/rust/crates/orbit-audio-native/src/output.rs
@@ -113,8 +113,14 @@ pub fn list_output_devices() -> Result<Vec<AudioDeviceInfo>, OutputError> {
     let host = cpal::default_host();
     let default_name = host.default_output_device().and_then(|d| d.name().ok());
 
+    // 【#493 と同根のハング回避（レビュー Critical）】`host.output_devices()` は使わない —
+    // その supports_output フィルタは per-device に AudioUnit + CreateIOProcID を生成し、
+    // Aggregate デバイス等で CoreAudio 内ブロックする（resolve 経路でスタック実証済み）。
+    // 代わりに probe なしの `devices()` で列挙し、出力可否と config は軽量な
+    // default_output_config のみで判定（失敗 = 入力専用等として skip）。残余リスクは
+    // 呼び出し側のプロセス timeout（拡張 5s / RPC は spawn_blocking）が受け止める。
     let devices = host
-        .output_devices()
+        .devices()
         .map_err(|e| OutputError::NoConfig(e.to_string()))?;
 
     let mut result = Vec::new();

--- a/tests/vscode-extension/engine-view.spec.ts
+++ b/tests/vscode-extension/engine-view.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  buildDeviceNode,
+  buildDeviceSectionNode,
+  buildEngineStatusNode,
+  buildRootNodes,
+  deviceNameFromNodeId,
+  deviceSectionChildren,
+  type EngineViewDevice,
+} from '../../packages/vscode-extension/src/engine-view'
+
+// #484 D3 — pure TreeDataProvider data-shaping helpers (no vscode dependency).
+
+const speaker: EngineViewDevice = {
+  name: 'MacBook Proのスピーカー',
+  isDefault: true,
+  maxOutputChannels: 2,
+  defaultSampleRate: 48000,
+  direction: 'output',
+}
+const aggregate: EngineViewDevice = {
+  name: 'Pro Tools Aggregate I/O',
+  isDefault: false,
+  maxOutputChannels: 2,
+  defaultSampleRate: 48000,
+  direction: 'output',
+}
+
+describe('buildEngineStatusNode', () => {
+  it('shows running state with a stop hint', () => {
+    expect(buildEngineStatusNode(true)).toEqual({
+      kind: 'engine-status',
+      id: 'engine-status',
+      label: 'Engine: Running',
+      description: 'Click to stop',
+      collapsible: false,
+    })
+  })
+
+  it('shows stopped state with a start hint', () => {
+    expect(buildEngineStatusNode(false)).toEqual({
+      kind: 'engine-status',
+      id: 'engine-status',
+      label: 'Engine: Stopped',
+      description: 'Click to start',
+      collapsible: false,
+    })
+  })
+})
+
+describe('buildDeviceSectionNode', () => {
+  it('is collapsible', () => {
+    expect(buildDeviceSectionNode().collapsible).toBe(true)
+  })
+})
+
+describe('buildRootNodes', () => {
+  it('returns engine-status then device-section', () => {
+    const nodes = buildRootNodes(true)
+    expect(nodes.map((n) => n.kind)).toEqual(['engine-status', 'device-section'])
+  })
+})
+
+describe('deviceSectionChildren', () => {
+  it('shows a loading placeholder', () => {
+    expect(deviceSectionChildren({ status: 'loading' }, '')).toEqual([
+      {
+        kind: 'device-loading',
+        id: 'device-loading',
+        label: 'Loading devices…',
+        collapsible: false,
+      },
+    ])
+  })
+
+  it('shows an error node', () => {
+    expect(deviceSectionChildren({ status: 'error', message: 'daemon not found' }, '')).toEqual([
+      {
+        kind: 'device-error',
+        id: 'device-error',
+        label: '⚠️ daemon not found',
+        collapsible: false,
+      },
+    ])
+  })
+
+  it('shows an empty placeholder when the device list is empty', () => {
+    expect(deviceSectionChildren({ status: 'loaded', devices: [] }, '')).toEqual([
+      {
+        kind: 'device-empty',
+        id: 'device-empty',
+        label: 'No audio devices found',
+        collapsible: false,
+      },
+    ])
+  })
+
+  it('maps each device to a node, marking the system default as selected when nothing is configured', () => {
+    const nodes = deviceSectionChildren({ status: 'loaded', devices: [speaker, aggregate] }, '')
+    expect(nodes).toEqual([buildDeviceNode(speaker, ''), buildDeviceNode(aggregate, '')])
+    expect(nodes[0].selected).toBe(true)
+    expect(nodes[1].selected).toBe(false)
+  })
+
+  it('marks the explicitly-configured device as selected instead of the host default', () => {
+    const nodes = deviceSectionChildren(
+      { status: 'loaded', devices: [speaker, aggregate] },
+      'Pro Tools Aggregate I/O',
+    )
+    expect(nodes[0].selected).toBe(false)
+    expect(nodes[1].selected).toBe(true)
+  })
+})
+
+describe('buildDeviceNode', () => {
+  it('marks the default device label and description', () => {
+    const node = buildDeviceNode(speaker, '')
+    expect(node.id).toBe('device:MacBook Proのスピーカー')
+    expect(node.label).toContain('(system default)')
+    expect(node.label.startsWith('● ')).toBe(true)
+    expect(node.description).toBe('2ch · 48000Hz')
+  })
+
+  it('does not mark a non-selected, non-default device', () => {
+    const node = buildDeviceNode(aggregate, '')
+    expect(node.selected).toBe(false)
+    expect(node.label.startsWith('● ')).toBe(false)
+    expect(node.label).not.toContain('(system default)')
+  })
+})
+
+describe('deviceNameFromNodeId', () => {
+  it('extracts the device name from a device node id', () => {
+    expect(deviceNameFromNodeId('device:Pro Tools Aggregate I/O')).toBe('Pro Tools Aggregate I/O')
+  })
+
+  it('returns null for non-device node ids', () => {
+    expect(deviceNameFromNodeId('engine-status')).toBeNull()
+    expect(deviceNameFromNodeId('device-loading')).toBeNull()
+  })
+})


### PR DESCRIPTION
## 概要

#484 D3: **Audio Engine Settings ビューでオーディオデバイスが見えて選べる**ように(#483 の TreeView 基礎を兼ねる)。

Refs #484 #483

## 変更内容

- **daemon `--list-audio-devices` 軽量モード**: cpal 列挙のみで stream を開かず JSON 1 行出力 → 即 exit(hotfix #493 の教訓 = probe/stream をこの経路に入れない)
- **Engine ビューの TreeDataProvider 化**: 停止中 = 従来の welcome ボタン(仕様上 tree が空の時のみ表示)・起動中 = Engine 状態(クリックで Start/Stop)+ Output Device 一覧(展開時 lazy 取得・5s timeout・ポーリングなし)
- **デバイス選択** → 新設定 `orbitscore.audioDevice`(正)に書き込み。エンジン起動中なら再起動を提案、それ以外は「次回起動時に適用」を明示(D2 = 走行中切替は未実装のため正直に)。`.orbitscore.json` は後方互換 fallback(palette/MCP の旧 write 経路の統合は follow-up として開示)

## 検証

- Rust 7 tests(引数 parse 含む)+ TS 13 tests(engine-view pure 関数)・tsc / lint / build green
- **実機**: `--list-audio-devices` が `MacBook Proのスピーカー`(default)/ `Pro Tools Aggregate I/O` を返し即 exit(ハングなし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu