### PR TITLE
feat(engine): runtime audio device switching (#484 D2)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,31 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.281 feat(engine): 走行中のオーディオデバイス切替 #484 D2 (Jul 17, 2026)
+
+**Date**: 2026-07-17
+**Status**: ✅ 実装（Codex + Sonnet 協働・実機切替 11〜99ms）
+
+**内容**:
+- native: `RenderState`（link/insert_buses/post）を Arc<Mutex> で callback と制御スレッドが
+  共有（callback は try_lock・競合時は zero-fill + render_contentions カウンタ）。
+  `rebuild_output_stream()` が同じ Engine/RenderState で新デバイスの stream を再構築
+- daemon: **audio owner thread** 設計 — `cpal::Stream` は !Send のため、stream 所有を
+  専用 OS スレッドに固定し、EngineWrap は Send+Sync な mpsc Sender だけ持つ。
+  `SelectAudioDevice` RPC（空文字 = 既定へ）。全 6 feature 変種に一様適用
+- capture 有効時は AUDIO_DEVICE_SWITCH_UNAVAILABLE で明示拒否（正直エラー）
+- TS: daemon-client / rust-engine-player に selectAudioDevice 公開
+
+**実機**: sine ループ再生中にスピーカー ⇔ Pro Tools Aggregate ⇔ 既定を切替 —
+99ms/34ms/11ms・uptime 連続・loaded_samples/active_plays 保持・daemon 無再起動。
+
+**残（D2.5）**: Engine ビュー/MCP からの即時切替接続 — 拡張 → 走行中 daemon への制御
+チャネルが未存在（engine とは DSL-eval stdin のみ）。`//#selectAudioDevice` メタ行
+（#456 の前例踏襲）で橋渡しする設計を提案として記録。
+
+Refs #484
+
+
 ### 6.280 feat(orbitstudio): Engine ビューにデバイス表示/選択 #484 D3 (Jul 17, 2026)
 
 **Date**: 2026-07-17

--- a/packages/engine/src/audio/rust-engine/daemon-client.ts
+++ b/packages/engine/src/audio/rust-engine/daemon-client.ts
@@ -431,13 +431,28 @@ export class DaemonClient extends EventEmitter {
   }
 
   /**
-   * cpal output device 一覧を daemon から取得する（#484 D1）。ランタイム切替（`SelectAudioDevice`）
-   * は D2 scope・未実装。ここは列挙のみで、実際の選択は daemon 起動引数（`--audio-device`）で行う。
+   * cpal output device 一覧を daemon から取得する（#484 D1）。ランタイム切替は
+   * {@link DaemonClient.selectAudioDevice}（#484 D2）で行う。
    */
   async listAudioDevices(): Promise<AudioDeviceListEntry[]> {
     const result = await this.request('ListAudioDevices', {})
     const devices = result.devices
     return Array.isArray(devices) ? (devices as AudioDeviceListEntry[]) : []
+  }
+
+  /**
+   * daemon プロセスを再起動せずに出力デバイスを切り替える（#484 D2）。`device` は
+   * `listAudioDevices()` が返す `name`、または空文字列（システム既定へ縮退）。切替中の短い
+   * 無音ギャップは許容される仕様（daemon 側で render state ごと新 stream へ引き継ぐ）。
+   *
+   * `ORBIT_CAPTURE_WAV` で daemon が録音中の場合は daemon 側が明示的に拒否する
+   * （`AUDIO_DEVICE_SWITCH_UNAVAILABLE`）— 継続不可のため、この場合は daemon 再起動が必要。
+   *
+   * @returns 実際に適用されたデバイス名（`"system default"` を含みうる）。
+   */
+  async selectAudioDevice(device: string): Promise<string> {
+    const result = await this.request('SelectAudioDevice', { device })
+    return typeof result.device === 'string' ? result.device : device
   }
 
   /**

--- a/packages/engine/src/audio/rust-engine/protocol-types.ts
+++ b/packages/engine/src/audio/rust-engine/protocol-types.ts
@@ -42,8 +42,12 @@ export type CommandMethod =
   // ORBIT_DAEMON_ALLOW_FAULT_INJECTION=1 のときだけ受理し、それ以外は MALFORMED_REQUEST。
   | 'InjectFault'
   // cpal output device 列挙（#484 D1）。起動時 device 選択（`--audio-device`）とは別経路 —
-  // 一覧を返すのみで、選択は起動引数（将来のランタイム切替は D2 で `SelectAudioDevice` を追加）。
+  // 一覧を返すのみで、選択は起動引数（ランタイム切替は D2 の `SelectAudioDevice`）。
   | 'ListAudioDevices'
+  // ランタイムのオーディオデバイス切替（#484 D2）。daemon プロセスを再起動せず cpal
+  // Device/Stream だけを差し替える。`{ device: string }`（空文字列 = システム既定）。
+  // ORBIT_CAPTURE_WAV 有効時は AUDIO_DEVICE_SWITCH_UNAVAILABLE を返す（未対応・#484 D2 ブリーフ選択(a)）。
+  | 'SelectAudioDevice'
 
 export interface CommandFrame {
   id: string

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -44,6 +44,7 @@ import type { AudioDevice } from '../supercollider/types'
 import type { PluginLoadResult } from '../types'
 
 import { DaemonClient } from './daemon-client'
+import type { AudioDeviceListEntry } from './daemon-client'
 import { DaemonConnectionError, DaemonProtocolError, DaemonQuitError } from './errors'
 
 /**
@@ -581,6 +582,26 @@ export class RustEnginePlayer implements AudioEngineBackend {
 
   setAvailableDevices(_devices: AudioDevice[]): void {
     // S2 では daemon 側のデバイス列挙 API が無いため no-op。
+  }
+
+  /**
+   * cpal output device 一覧を daemon から取得する（#484 D1）。`AudioEngineBackend` の同期
+   * `getAvailableDevices()`/`setAvailableDevices()` は SC 経路向けの既存 shape で rust 経路には
+   * まだ配線されていない（S2 の既知ギャップ）— このメソッドはそれとは別に、daemon の非同期
+   * `ListAudioDevices` RPC への直接の passthrough を提供する。
+   */
+  async listAudioDevices(): Promise<AudioDeviceListEntry[]> {
+    return this.daemon.listAudioDevices()
+  }
+
+  /**
+   * daemon プロセスを再起動せずに出力デバイスを切り替える（#484 D2）。`daemon.selectAudioDevice`
+   * への薄い passthrough。切替中の短い無音ギャップは仕様として許容される。
+   *
+   * @returns 実際に適用されたデバイス名。
+   */
+  async selectAudioDevice(device: string): Promise<string> {
+    return this.daemon.selectAudioDevice(device)
   }
 
   /**

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -88,6 +88,11 @@ pub enum WrapError {
     /// OOP slot が永久に closed（起動インフラの失敗）。
     #[error("out-of-process slot closed: {0}")]
     OutProcSlotClosed(String),
+    /// ランタイムのオーディオデバイス切替（`SelectAudioDevice`・#484 D2）が実行できない状態。
+    /// capture（`ORBIT_CAPTURE_WAV`）有効時の明示拒否、または `StreamGuard` 未生存（test backend 等）
+    /// の場合に返す。cpal 側の実失敗（device open 失敗等）は `Output`（`OutputError` 経由）に別れる。
+    #[error("audio device switch unavailable: {0}")]
+    AudioDeviceSwitchUnavailable(String),
 }
 
 /// 共有可能なエンジン wrapper。
@@ -169,6 +174,21 @@ pub struct EngineWrap {
     /// producer 側を別スレッドへ outsource せず常に `&self` 経由で `EngineWrap` 自身が直接書くため、
     /// `Arc` clone による cross-thread 共有が不要で、プレーンな `AtomicU64` で足りる。
     plugin_event_ring_overflow_count: AtomicU64,
+    /// device switch（#484 D2）: `StreamGuard`（延いては `cpal::Stream`）を排他所有する専用 OS thread
+    /// （"audio owner thread"・`main.rs` が spawn）への要求チャンネル。`cpal::Stream` は `!Send` なので
+    /// `EngineWrap`（`Arc` 共有で `Send + Sync` 必須）にはハンドルを一切持たせられない — 代わりに
+    /// `Send + Sync` な `mpsc::Sender` だけを持ち、実際の device 差し替え（[`OutputStream`] の入れ替え）
+    /// は要求を受けた owner thread 自身が [`EngineWrap::apply_device_switch`] で行う。`start_with`
+    /// （test backend）経路では未設定（`None`）のまま — `select_audio_device` は
+    /// `AudioDeviceSwitchUnavailable` を返す。
+    device_switch_tx: Mutex<Option<std::sync::mpsc::Sender<DeviceSwitchRequest>>>,
+    /// device switch（#484 D2）: 起動時に解決した `buffer_frames`（gated stale-rate harness 用の
+    /// 明示指定 or `None`=device 既定）。`rebuild_output_stream` に同じ値を渡し、switch 前後で
+    /// バッファサイズ設定がドリフトしないようにする。
+    output_buffer_frames: Mutex<Option<u32>>,
+    /// device switch（#484 D2）: 起動時に得た callback-duration 統計 Arc（`post` 有りの variant のみ
+    /// `Some`）。switch 後の新 stream にも同じ Arc を渡し、計測を継続させる（カウンタリセットしない）。
+    output_cb_stats: Mutex<Option<Arc<orbit_audio_native::CallbackTimeStats>>>,
     /// LinkAudio egress の control-side ハンドル（feature `link-audio` 専用・A4-2b-2）。
     /// reg-ring push / mpsc send が内部可変性（`&mut LinkAudioControl`）を要する一方、`EngineWrap`
     /// は `Arc` 共有で `&self` しか持てない。`Mutex` で内包することで `register_link_audio_channel`
@@ -1330,7 +1350,13 @@ pub struct StreamGuard {
     /// stream 停止後の child guard 2つと同じ独立性）。
     #[cfg(feature = "outproc-instrument")]
     _outproc_instrument_teardown: crate::outproc_instrument::OutProcInstrumentTeardownGuard,
-    _stream: OutputStream,
+    /// device switch（#484 D2）: `cpal::Stream`（`OutputStream` 内部）は `!Send` のため、`EngineWrap`
+    /// （`Arc` 共有・tokio task を跨ぐため `Send + Sync` 必須）には一切保持させない。`StreamGuard` は
+    /// 従来どおり単一の "audio owner thread"（`main.rs` が spawn する専用 OS thread）だけがローカル
+    /// 変数として所有し続け、switch は `mpsc` 経由でその thread 上に処理を委譲する
+    /// （[`EngineWrap::apply_device_switch`]）。**field 順は変わらず load-bearing**（従来の `_stream`
+    /// と同じ位置）。
+    stream: OutputStream,
     #[cfg(feature = "link-audio")]
     _link: Option<crate::link_audio::LinkAudioGuard>,
     /// clap-host: stream 停止 **後** に drop され、専用スレッドを停止 → `ClapHost::shutdown()` で
@@ -1355,10 +1381,18 @@ pub struct StreamGuard {
 impl StreamGuard {
     /// capture seam（#307 realtime）: capture 有効時のみ producer-side drop 累積を返す（無効は `None`）。
     /// `Some(0)` は録音健全・`> 0` は録音破損（検証 invalid）。gated 検証ハーネスが teardown 前に
-    /// assert する（`_stream: OutputStream` へ委譲）。全 feature variant が `_stream` を持つので共通。
+    /// assert する（`stream: OutputStream` へ委譲）。全 feature variant が `stream` を持つので共通。
     pub fn capture_drops(&self) -> Option<u64> {
-        self._stream.capture_drops()
+        self.stream.capture_drops()
     }
+}
+
+/// device switch（#484 D2）: `EngineWrap::select_audio_device`（任意スレッド・`Send`）から
+/// audio owner thread（`StreamGuard` を所有する専用 OS thread）へ送る要求。`reply` は
+/// `std::sync::mpsc::Sender` なので、要求元は対応する `Receiver::recv()` で同期的に結果を待てる。
+pub struct DeviceSwitchRequest {
+    pub device: Option<String>,
+    pub reply: std::sync::mpsc::Sender<Result<String, WrapError>>,
 }
 
 /// 生の env 値（`Some(raw)`）を capture 出力先 [`PathBuf`] へ解決する純関数（`capture_path_from_env`
@@ -1426,7 +1460,9 @@ impl EngineWrap {
             device_name_from_env(),
         )?;
         let wrap = Self::build(engine, stream.sample_rate, stream.channels, stream_stats);
-        Ok((wrap, StreamGuard { _stream: stream }))
+        let guard = StreamGuard { stream };
+        wrap.record_stream_config(None, None);
+        Ok((wrap, guard))
     }
 
     /// feature `link-audio` 版: cpal 出力を LinkAudio egress 経路付きで起動し、GPL consumer thread を
@@ -1456,13 +1492,12 @@ impl EngineWrap {
             .link
             .lock()
             .map_err(|_| WrapError::LinkAudio("link mutex poisoned".into()))? = Some(control);
-        Ok((
-            wrap,
-            StreamGuard {
-                _stream: stream,
-                _link: Some(link_guard),
-            },
-        ))
+        let guard = StreamGuard {
+            stream,
+            _link: Some(link_guard),
+        };
+        wrap.record_stream_config(None, None);
+        Ok((wrap, guard))
     }
 
     /// feature `clap-host` 版（Issue #340）: cpal 出力を CLAP master-bus post-processor 経路付きで
@@ -1502,19 +1537,18 @@ impl EngineWrap {
             loaded_role: None,
             event_tx: parts.event_producer,
             stats: parts.stats,
-            cb_stats,
+            cb_stats: cb_stats.clone(),
         });
-        Ok((
-            wrap,
-            StreamGuard {
-                _clap_teardown: crate::clap_host::ClapTeardownGuard::new(
-                    parts.teardown_requested,
-                    parts.teardown_done,
-                ),
-                _stream: stream,
-                _clap_thread: thread_guard,
-            },
-        ))
+        let guard = StreamGuard {
+            _clap_teardown: crate::clap_host::ClapTeardownGuard::new(
+                parts.teardown_requested,
+                parts.teardown_done,
+            ),
+            stream,
+            _clap_thread: thread_guard,
+        };
+        wrap.record_stream_config(None, Some(cb_stats));
+        Ok((wrap, guard))
     }
 
     /// feature `outproc-effect` 版（γ M1 PR-C・Issue #359）: cpal 出力を OOP effect master-bus
@@ -1617,7 +1651,7 @@ impl EngineWrap {
             .map_err(|_| WrapError::OutProcEffect("outproc mutex poisoned".into()))? =
             Some(OutProcControl {
                 stats,
-                cb_stats,
+                cb_stats: cb_stats.clone(),
                 child_slot: Arc::downgrade(&child_slot),
                 bus_slots: HashMap::new(),
                 bus_stats: HashMap::new(),
@@ -1655,16 +1689,15 @@ impl EngineWrap {
         }
 
         // 7. StreamGuard（field 順 = teardown 順）。
-        Ok((
-            wrap,
-            StreamGuard {
-                _outproc_teardown: OutProcTeardownGuard::new(teardown_requested, teardown_done),
-                _outproc_bus_teardowns: bus_teardowns,
-                _stream: stream,
-                _child_guard: child_slot,
-                _bus_child_guards: bus_child_guards,
-            },
-        ))
+        let guard = StreamGuard {
+            _outproc_teardown: OutProcTeardownGuard::new(teardown_requested, teardown_done),
+            _outproc_bus_teardowns: bus_teardowns,
+            stream,
+            _child_guard: child_slot,
+            _bus_child_guards: bus_child_guards,
+        };
+        wrap.record_stream_config(cfg.buffer_frames, Some(cb_stats));
+        Ok((wrap, guard))
     }
 
     /// feature `outproc-instrument` production entry point. Configuration is fixed at daemon
@@ -1736,10 +1769,11 @@ impl EngineWrap {
             stats.clone(),
         ));
 
-        let (engine, stream, stream_stats, _cb_stats) =
+        let buffer_frames = cfg.buffer_frames;
+        let (engine, stream, stream_stats, cb_stats) =
             orbit_audio_native::start_default_output_with_clap(
                 processor,
-                cfg.buffer_frames,
+                buffer_frames,
                 capture_path_from_env(),
                 device_name_from_env(),
             )
@@ -1766,17 +1800,16 @@ impl EngineWrap {
             child_slot: Arc::downgrade(&child_slot),
         });
 
-        Ok((
-            wrap,
-            StreamGuard {
-                _outproc_instrument_teardown: OutProcInstrumentTeardownGuard::new(
-                    teardown_requested,
-                    teardown_done,
-                ),
-                _stream: stream,
-                _child_guard: child_slot,
-            },
-        ))
+        let guard = StreamGuard {
+            _outproc_instrument_teardown: OutProcInstrumentTeardownGuard::new(
+                teardown_requested,
+                teardown_done,
+            ),
+            stream,
+            _child_guard: child_slot,
+        };
+        wrap.record_stream_config(buffer_frames, Some(cb_stats));
+        Ok((wrap, guard))
     }
 
     /// both build の buffer size を解決する。両方指定され値が異なる場合は、RT 設定の暗黙優先を
@@ -1895,7 +1928,7 @@ impl EngineWrap {
             .map_err(|_| WrapError::OutProcEffect("outproc mutex poisoned".into()))? =
             Some(OutProcControl {
                 stats: effect_stats,
-                cb_stats: effect_cb_stats,
+                cb_stats: effect_cb_stats.clone(),
                 child_slot: Arc::downgrade(&effect_slot),
                 bus_slots: HashMap::new(),
                 bus_stats: HashMap::new(),
@@ -1939,21 +1972,20 @@ impl EngineWrap {
             control.bus_sends = bus_sends;
         }
 
-        Ok((
-            wrap,
-            StreamGuard {
-                _outproc_teardown: OutProcTeardownGuard::new(effect_stop, effect_done),
-                _outproc_bus_teardowns: bus_teardowns,
-                _outproc_instrument_teardown: OutProcInstrumentTeardownGuard::new(
-                    instrument_stop,
-                    instrument_done,
-                ),
-                _stream: stream,
-                _child_guard: effect_slot,
-                _bus_child_guards: bus_child_guards,
-                _instrument_child_guard: instrument_slot,
-            },
-        ))
+        let guard = StreamGuard {
+            _outproc_teardown: OutProcTeardownGuard::new(effect_stop, effect_done),
+            _outproc_bus_teardowns: bus_teardowns,
+            _outproc_instrument_teardown: OutProcInstrumentTeardownGuard::new(
+                instrument_stop,
+                instrument_done,
+            ),
+            stream,
+            _child_guard: effect_slot,
+            _bus_child_guards: bus_child_guards,
+            _instrument_child_guard: instrument_slot,
+        };
+        wrap.record_stream_config(buffer_frames, Some(effect_cb_stats));
+        Ok((wrap, guard))
     }
 
     #[cfg(all(
@@ -2013,6 +2045,9 @@ impl EngineWrap {
             outproc_instrument_respawns: Arc::new(AtomicU64::new(0)),
             outproc_instrument_measurement_invalid: Arc::new(AtomicBool::new(false)),
             plugin_event_ring_overflow_count: AtomicU64::new(0),
+            device_switch_tx: Mutex::new(None),
+            output_buffer_frames: Mutex::new(None),
+            output_cb_stats: Mutex::new(None),
             // 本番 `start()`（feature 時）が spawn 後に Some を注入する。test backend 経路は None。
             #[cfg(feature = "link-audio")]
             link: Mutex::new(None),
@@ -2026,6 +2061,111 @@ impl EngineWrap {
             #[cfg(feature = "outproc-instrument")]
             outproc_instrument: Mutex::new(None),
         })
+    }
+
+    /// device switch（#484 D2）: 各 `start*()` variant 共通の後処理。`buffer_frames`/`cb_stats` を
+    /// `self` に保存する（`apply_device_switch` が switch 時に同じ値を再利用し、バッファサイズ設定・
+    /// callback-duration 計測の連続性を保つ）。`StreamGuard` 自体の所有権はこれまでどおり呼び出し側
+    /// （`main.rs` の audio owner thread ローカル変数）が持つ — ここでは触らない。
+    fn record_stream_config(
+        self: &Arc<Self>,
+        buffer_frames: Option<u32>,
+        cb_stats: Option<Arc<orbit_audio_native::CallbackTimeStats>>,
+    ) {
+        if let Ok(mut slot) = self.output_buffer_frames.lock() {
+            *slot = buffer_frames;
+        }
+        if let Ok(mut slot) = self.output_cb_stats.lock() {
+            *slot = cb_stats;
+        }
+    }
+
+    /// device switch（#484 D2）: `main.rs` の audio owner thread が `EngineWrap::start()` 直後に
+    /// 一度だけ呼ぶ。以後、[`Self::select_audio_device`] からの要求はこのチャンネル経由で
+    /// owner thread（`tx` の受け手側 `rx` を loop で回すコード）に届く。
+    pub fn install_device_switch_channel(&self, tx: std::sync::mpsc::Sender<DeviceSwitchRequest>) {
+        if let Ok(mut slot) = self.device_switch_tx.lock() {
+            *slot = Some(tx);
+        }
+    }
+
+    /// device switch（#484 D2）: 制御スレッド（RPC handler・`spawn_blocking` 経由）から呼ぶ公開 API。
+    /// 実際の cpal I/O は行わず、audio owner thread へ要求を送って応答を待つだけ（`cpal::Stream` は
+    /// `!Send` のため `EngineWrap` 自身は一切触れない）。
+    ///
+    /// - `device`: `None`/空文字列 = システム既定へ縮退（`resolve_output_device` と同じ規約）。
+    /// - capture（`ORBIT_CAPTURE_WAV`）が有効な場合は明示的に拒否する（継続不可・#484 D2 ブリーフの
+    ///   選択(a)）: capture writer は switch 前の stream 専用に生成されており、新 stream に持ち越すと
+    ///   ring producer が古い stream の drop と一緒に失われるため、無音で録音が壊れるより先に fail する。
+    /// - **ブロッキング呼び出し**: 呼び出し側は `spawn_blocking`（session.rs の他の cpal I/O ハンドラと
+    ///   同じ隔離）から呼ぶこと。RT callback 内からは絶対に呼ばない。
+    pub fn select_audio_device(&self, device: Option<String>) -> Result<String, WrapError> {
+        if capture_path_from_env().is_some() {
+            return Err(WrapError::AudioDeviceSwitchUnavailable(
+                "ORBIT_CAPTURE_WAV is active; runtime device switch is unsupported while \
+                 capture is recording (restart the daemon to change device with capture on)"
+                    .into(),
+            ));
+        }
+        let tx = self
+            .device_switch_tx
+            .lock()
+            .map_err(|_| {
+                WrapError::AudioDeviceSwitchUnavailable("device switch channel poisoned".into())
+            })?
+            .clone()
+            .ok_or_else(|| {
+                WrapError::AudioDeviceSwitchUnavailable(
+                    "no audio owner thread registered (test backend or daemon shutting down)"
+                        .into(),
+                )
+            })?;
+        let (reply_tx, reply_rx) = std::sync::mpsc::channel();
+        tx.send(DeviceSwitchRequest {
+            device,
+            reply: reply_tx,
+        })
+        .map_err(|_| {
+            WrapError::AudioDeviceSwitchUnavailable("audio owner thread has exited".into())
+        })?;
+        reply_rx.recv().map_err(|_| {
+            WrapError::AudioDeviceSwitchUnavailable(
+                "audio owner thread dropped the reply channel".into(),
+            )
+        })?
+    }
+
+    /// device switch（#484 D2）: 実際の cpal I/O。**audio owner thread 上でのみ呼ぶこと**
+    /// （`cpal::Stream` の `!Send` 制約を型システムではなく運用で守る seam — `&mut StreamGuard` を
+    /// 要求することで、呼び出し側が `StreamGuard` を所有するその thread からしか呼べないよう
+    /// 誘導する）。`Engine`（scheduler 状態）・OOP effect/instrument child・plugin routing は
+    /// 一切触らない（`orbit_audio_native::RenderState` を新 stream に丸ごと引き継ぐ）。
+    pub fn apply_device_switch(
+        &self,
+        guard: &mut StreamGuard,
+        device: Option<String>,
+    ) -> Result<String, WrapError> {
+        let device_label = match &device {
+            Some(name) if !name.trim().is_empty() => name.clone(),
+            _ => "system default".to_string(),
+        };
+        let render_state = guard.stream.render_state();
+        let buffer_frames = self.output_buffer_frames.lock().ok().and_then(|g| *g);
+        let cb_stats = self.output_cb_stats.lock().ok().and_then(|g| g.clone());
+
+        let new_stream = orbit_audio_native::rebuild_output_stream(
+            render_state,
+            self.engine.clone(),
+            self.stream_stats.clone(),
+            cb_stats,
+            buffer_frames,
+            device,
+        )?;
+        // 新 stream が再生開始した後にだけ古い stream を差し替える（`rebuild_output_stream` は
+        // 内部で `stream.play()` 済みを返す）。切替が失敗した場合はこの代入に到達せず、古い stream が
+        // そのまま生き続ける＝無音のまま失敗しない。
+        guard.stream = new_stream;
+        Ok(device_label)
     }
 
     /// 名前付き LinkAudio channel を登録する（A4-2b-2・feature `link-audio` 専用）。
@@ -4278,6 +4418,51 @@ mod capture_path_tests {
         assert_eq!(
             resolve_capture_path(Some("  /tmp/out.wav  ".to_string())),
             Some(PathBuf::from("/tmp/out.wav"))
+        );
+    }
+}
+
+/// device switch（#484 D2）: `select_audio_device` の非 cpal 分岐（capture 拒否・
+/// owner thread 未生存）を `StubBackend`（実 cpal I/O を伴わない test backend）で検証する。
+/// 実際の cpal `Device`/`Stream` 差し替えそのもの（`apply_device_switch`）は実機 gated harness の
+/// 領域（unit test では検証不能）。
+#[cfg(test)]
+mod select_audio_device_tests {
+    use super::EngineWrap;
+    use crate::backend::StubBackend;
+
+    /// capture-active（`ORBIT_CAPTURE_WAV`）拒否と、audio owner thread 未登録（`start_with` /
+    /// test backend 経路）拒否の両方を **1 テスト関数内**で順に検証する。`ORBIT_CAPTURE_WAV` は
+    /// プロセス全体で共有される可変状態なので、別テスト関数に分けて cargo test のデフォルト並列
+    /// 実行に晒すと set/remove がレースする（`named_bus_pool_tests` の既存 env 慣習と同じ落とし穴）。
+    #[test]
+    fn select_audio_device_rejects_capture_active_then_missing_owner_thread() {
+        // SAFETY: テスト専用の単一テスト関数内 env 操作（このテストの実行区間でのみ意味を持つ値）。
+        unsafe {
+            std::env::set_var("ORBIT_CAPTURE_WAV", "/tmp/does-not-matter.wav");
+        }
+        let (wrap, _guard) =
+            EngineWrap::start_with(StubBackend::default()).expect("stub backend start");
+        let capture_error = wrap
+            .select_audio_device(Some("Any Device".to_string()))
+            .expect_err("capture-active must reject the switch");
+        assert!(
+            format!("{capture_error}").contains("ORBIT_CAPTURE_WAV is active"),
+            "{capture_error}"
+        );
+
+        // capture を無効化すると、`start_with`（test backend）が `install_device_switch_channel`
+        // を一度も呼んでいないため「audio owner thread 未登録」として明示的に reject する
+        // （無音で成功したふりをしない）。
+        unsafe {
+            std::env::remove_var("ORBIT_CAPTURE_WAV");
+        }
+        let no_owner_error = wrap
+            .select_audio_device(None)
+            .expect_err("no owner thread must reject the switch");
+        assert!(
+            format!("{no_owner_error}").contains("no audio owner thread"),
+            "{no_owner_error}"
         );
     }
 }

--- a/rust/crates/orbit-audio-daemon/src/main.rs
+++ b/rust/crates/orbit-audio-daemon/src/main.rs
@@ -8,13 +8,14 @@
 //!
 //! 起動失敗時は stderr に 1 行 JSON を出して非ゼロ exit code で終了する。
 
-use orbit_audio_daemon::engine_wrap::EngineWrap;
+use orbit_audio_daemon::engine_wrap::{DeviceSwitchRequest, EngineWrap, WrapError};
 use orbit_audio_daemon::protocol::{
     Event, ProtocolError, StartupError, StartupReady, ERROR_CODE_FATAL_PANIC, ERROR_SEVERITY_FATAL,
     EVENT_DAEMON_ERROR, PROTOCOL_VERSION,
 };
 use orbit_audio_daemon::server;
 use serde_json::json;
+use std::sync::Arc;
 
 // 既知事項（#448）: この daemon には SIGTERM/SIGINT ハンドラが無く、`install_fatal_panic_hook`
 // の panic hook も `process::exit(1)` を hook 内から直接呼ぶ（unwind が supervisor 保持フレーム
@@ -84,8 +85,11 @@ async fn run() -> Result<(), i32> {
     // （`engine_wrap::device_name_from_env` が capture_path_from_env と同じ層分けで読む）。
     apply_audio_device_arg(std::env::args().skip(1));
 
-    // 1. Engine を起動（audio device 取得）
-    let (engine, _stream_guard) = match EngineWrap::start() {
+    // 1. Engine を起動（audio device 取得）。ランタイム device switch（#484 D2）に備え、実際の
+    // `EngineWrap::start()` 呼び出しと `StreamGuard` の生存管理を専用 OS thread（"audio owner
+    // thread"）へ委譲する — `cpal::Stream` は `!Send` なので、以降 tokio worker 間を自由に飛び回る
+    // 通常の async task にはハンドルを一切持ち込めない。
+    let engine = match start_engine_with_device_switch() {
         Ok(e) => e,
         Err(e) => {
             report_startup_failure(ProtocolError::new("DEVICE_CONFIG_ERROR", e.to_string()));
@@ -121,6 +125,55 @@ async fn run() -> Result<(), i32> {
     // 4. accept loop
     server::serve(bound.listener, engine).await;
     Ok(())
+}
+
+/// ランタイム device switch（#484 D2）: `EngineWrap::start()`（cpal I/O・`cpal::Stream` は `!Send`）を
+/// 専用 OS thread（"audio owner thread"）上で実行し、その thread に `StreamGuard` を生涯所有させる。
+/// 呼び出し元（`run()`・tokio 上の async fn）は `Arc<EngineWrap>`（`Send + Sync`）だけを受け取る。
+///
+/// 以後の `SelectAudioDevice` RPC は `EngineWrap::select_audio_device` → `mpsc` 経由でこの thread に
+/// 委譲され、この thread が [`EngineWrap::apply_device_switch`] で実際の cpal `Device`/`Stream` 差し替え
+/// を行う。thread は `switch_rx` が close する（= `engine.device_switch_tx` を保持する最後の `Arc`
+/// が drop される）まで無期限に生存し、`_guard`（`StreamGuard`）を握り続ける — 既存の「`main()` の
+/// ローカル変数が daemon プロセス終了まで guard を握る」という寿命モデルと同一。
+fn start_engine_with_device_switch() -> Result<Arc<EngineWrap>, WrapError> {
+    let (switch_tx, switch_rx) = std::sync::mpsc::channel::<DeviceSwitchRequest>();
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<Arc<EngineWrap>, WrapError>>();
+
+    std::thread::Builder::new()
+        .name("orbit-audio-owner".into())
+        .spawn(move || {
+            let (engine, mut guard) = match EngineWrap::start() {
+                Ok(pair) => pair,
+                Err(e) => {
+                    // ready_rx 側が既に drop されていても（呼び出し元が別経路で失敗した等）
+                    // send 失敗は無視してよい — 報告先が無いだけで、この thread はそのまま終了する。
+                    let _ = ready_tx.send(Err(e));
+                    return;
+                }
+            };
+            engine.install_device_switch_channel(switch_tx);
+            if ready_tx.send(Ok(engine.clone())).is_err() {
+                // 呼び出し元が既に諦めている（recv 側 drop）。stream 起動には成功しているので、
+                // 静かに guard を保持したまま待ち受けを続ける意味はない — 即座に終了して stream を
+                // 閉じる（プロセス自体は起動失敗として既に exit 済みのはず）。
+                return;
+            }
+            // switch_rx: 要求が来る限り処理し続ける。`engine`（延いては `device_switch_tx` の
+            // Sender clone）が全て drop されるとこの for ループは自然終了するが、`Arc<EngineWrap>`
+            // は `server::serve` の accept loop タスクが保持し続けるため、実運用ではプロセスが
+            // 生きている間ずっとブロックしたままになる（既存の「グレースフルシャットダウン機構が
+            // 無い」という #448 既知事項と同じ前提）。
+            for req in switch_rx {
+                let result = engine.apply_device_switch(&mut guard, req.device);
+                let _ = req.reply.send(result);
+            }
+        })
+        .expect("spawn audio owner thread");
+
+    ready_rx
+        .recv()
+        .expect("audio owner thread exited before reporting readiness")
 }
 
 /// `--audio-device <name>` を argv から抽出する純関数（#484 D1）。値が欠けている（末尾で

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -763,6 +763,28 @@ async fn handle_command(
                 ),
             }
         }
+        // ランタイムのオーディオデバイス切替（#484 D2）。`device` 省略 / 空文字列 = システム既定へ
+        // 縮退（`ListAudioDevices` と同じ wire 規約）。cpal I/O を伴うため `ListAudioDevices` と同様
+        // spawn_blocking で隔離する（実処理は audio owner thread へさらに委譲される・
+        // `EngineWrap::select_audio_device` 参照）。
+        "SelectAudioDevice" => {
+            let device = params
+                .get("device")
+                .and_then(|d| d.as_str())
+                .map(|s| s.to_string())
+                .filter(|s| !s.trim().is_empty());
+            let engine = engine.clone();
+            let switched =
+                tokio::task::spawn_blocking(move || engine.select_audio_device(device)).await;
+            match switched {
+                Ok(Ok(device)) => ok(&id, json!({ "ok": true, "device": device })),
+                Ok(Err(e)) => err(&id, wrap_err_to_protocol(&e)),
+                Err(join_err) => err(
+                    &id,
+                    ProtocolError::new("INTERNAL_ERROR", join_err.to_string()),
+                ),
+            }
+        }
         "GetStatus" => {
             let status = json!({
                 "daemon_version": env!("CARGO_PKG_VERSION"),
@@ -1380,6 +1402,11 @@ fn wrap_err_to_protocol(e: &WrapError) -> ProtocolError {
             ProtocolError::new("OUTPROC_ATTACH_FAILED", msg.clone())
         }
         WrapError::OutProcSlotClosed(msg) => ProtocolError::new("OUTPROC_SLOT_CLOSED", msg.clone()),
+        // ランタイム device switch（`SelectAudioDevice`・#484 D2）が実行できない状態
+        // （capture 有効中の明示拒否・audio owner thread 未生存 = test backend 等）。
+        WrapError::AudioDeviceSwitchUnavailable(msg) => {
+            ProtocolError::new("AUDIO_DEVICE_SWITCH_UNAVAILABLE", msg.clone())
+        }
     }
 }
 

--- a/rust/crates/orbit-audio-daemon/src/session.rs
+++ b/rust/crates/orbit-audio-daemon/src/session.rs
@@ -607,6 +607,9 @@ pub async fn run(
                         "cpu_load": 0.0,
                         "xruns": snapshot.xruns,
                         "buffer_underruns": snapshot.buffer_underruns,
+                        // D2: RenderState try_lock 競合（デバイス切替中の zero-fill）の観測面。
+                        // 定常時は 0 のはず — 増え続けるなら切替以外の contention を疑う。
+                        "render_contentions": snapshot.render_contentions,
                         "now_sec": now_sec,
                     }),
                 );
@@ -794,6 +797,7 @@ async fn handle_command(
                 "loaded_samples": engine.loaded_sample_count(),
                 "active_plays": engine.active_play_count(),
                 "uptime_sec": engine.uptime_sec(),
+                "render_contentions": engine.stream_stats_snapshot().render_contentions,
             });
             ok(&id, status)
         }

--- a/rust/crates/orbit-audio-native/src/lib.rs
+++ b/rust/crates/orbit-audio-native/src/lib.rs
@@ -16,11 +16,11 @@ mod resampler;
 pub use link_audio_ring::{PostMixSink, RingTapSink};
 pub use loader::{load_sample_from_file, load_sample_resampled, LoaderError};
 pub use output::{
-    list_output_devices, resolve_requested_device_name, start_default_output,
-    start_default_output_with_clap, start_default_output_with_device,
+    list_output_devices, rebuild_output_stream, resolve_requested_device_name,
+    start_default_output, start_default_output_with_clap, start_default_output_with_device,
     start_default_output_with_insert_buses, start_default_output_with_insert_buses_and_post,
     start_default_output_with_link_egress, AudioDeviceInfo, BusSend, BusTarget, InsertBusStage,
-    LinkChannelActivate, OutputError, OutputStream, StreamStats, StreamStatsSnapshot,
+    LinkChannelActivate, OutputError, OutputStream, RenderState, StreamStats, StreamStatsSnapshot,
     MAX_INSERT_BUS_STAGES, MAX_LINK_CHANNELS,
 };
 pub use post_processor::{CallbackTimeSnapshot, CallbackTimeStats, PostProcessor};

--- a/rust/crates/orbit-audio-native/src/output.rs
+++ b/rust/crates/orbit-audio-native/src/output.rs
@@ -29,6 +29,7 @@ pub struct StreamStats {
     xruns: AtomicU64,
     buffer_underruns: AtomicU64,
     device_lost: AtomicBool,
+    render_contentions: AtomicU64,
 }
 
 impl StreamStats {
@@ -37,6 +38,7 @@ impl StreamStats {
             xruns: self.xruns.load(Ordering::Relaxed),
             buffer_underruns: self.buffer_underruns.load(Ordering::Relaxed),
             device_lost: self.device_lost.load(Ordering::Relaxed),
+            render_contentions: self.render_contentions.load(Ordering::Relaxed),
         }
     }
 
@@ -70,6 +72,10 @@ impl StreamStats {
             cpal::StreamError::BackendSpecific { .. } => self.record_xrun(),
         }
     }
+
+    fn record_render_contention(&self) {
+        self.render_contentions.fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -77,6 +83,7 @@ pub struct StreamStatsSnapshot {
     pub xruns: u64,
     pub buffer_underruns: u64,
     pub device_lost: bool,
+    pub render_contentions: u64,
 }
 
 #[derive(Error, Debug)]
@@ -221,17 +228,33 @@ pub struct OutputStream {
     /// 宣言する**ことで drop 順を「stream 停止（callback 停止＝以後 commit なし）→ writer が ring の
     /// 残りを drain して WAV を finalize」に固定する（Rust は struct field を宣言順に drop する）。
     _capture: Option<crate::capture::CaptureWriter>,
+    render_state: Arc<std::sync::Mutex<RenderState>>,
     pub sample_rate: u32,
     pub channels: u16,
 }
 
 impl OutputStream {
+    /// Callback-owned state shared with a replacement stream. This deliberately
+    /// excludes capture: capture switches are rejected by the daemon.
+    pub fn render_state(&self) -> Arc<std::sync::Mutex<RenderState>> {
+        self.render_state.clone()
+    }
     /// capture 有効時のみ、producer 側で drop した interleaved サンプル累積を返す。capture 無効は
     /// `None`。**`> 0` は「off-thread writer が追いつかず録音が破損した = 検証 invalid」を意味する**
     /// （検証ハーネス/オペレータが assert・監視する silent-failure ガード）。
     pub fn capture_drops(&self) -> Option<u64> {
         self._capture.as_ref().map(|w| w.dropped_samples())
     }
+}
+
+/// Mutable callback state which must survive a cpal stream rebuild (notably
+/// out-of-process processor adapters). The callback uses one `try_lock`; a
+/// concurrent control-plane rebuild produces a silent block instead of ever
+/// blocking an audio thread.
+pub struct RenderState {
+    link: Option<LinkEgress>,
+    insert_buses: Vec<InsertBusStage>,
+    post: Option<Box<dyn PostProcessor>>,
 }
 
 /// callback が同時に egress できる LinkAudio channel の上限（A4-2b-2b）。RT callback の per-block
@@ -451,6 +474,41 @@ fn channel_egress_active(ready: bool, scratch_len: usize, block: usize) -> bool 
 }
 
 /// 1 callback 分の処理（計測 + engine render + master-bus post-processor）。
+#[inline]
+fn render_shared_block(
+    engine: &Engine,
+    state: &Arc<std::sync::Mutex<RenderState>>,
+    capture: &mut Option<RingTapSink>,
+    cb_stats: &Option<Arc<CallbackTimeStats>>,
+    output_channels: usize,
+    hw: &mut [f32],
+    stats: &StreamStats,
+) {
+    match state.try_lock() {
+        Ok(mut state) => {
+            let RenderState {
+                link,
+                insert_buses,
+                post,
+            } = &mut *state;
+            render_block(
+                engine,
+                link,
+                insert_buses,
+                post,
+                capture,
+                cb_stats,
+                output_channels,
+                hw,
+            )
+        }
+        Err(_) => {
+            hw.fill(0.0);
+            stats.record_render_contention();
+        }
+    }
+}
+
 ///
 /// 手順: (1) callback 開始時刻を取る（`cb_stats` 有り時のみ）→ (2) [`render_engine`] で engine
 /// （+ LinkAudio egress）を render → (3) `post` 有りなら hardware sum を in-place 変換（CLAP
@@ -967,15 +1025,18 @@ fn start_output_inner(
     // 従来通り無計測（None → render_block は計測分岐を踏まずビット同一）。
     let cb_stats = post.as_ref().map(|_| CallbackTimeStats::new());
     let engine = Engine::new(sample_rate, channels);
+    let render_state = Arc::new(std::sync::Mutex::new(RenderState {
+        link,
+        insert_buses,
+        post,
+    }));
     let stream = build_stream(
         &device,
         &config,
         sample_format,
         engine.clone(),
         stats.clone(),
-        link,
-        insert_buses,
-        post,
+        render_state.clone(),
         capture_sink,
         cb_stats.clone(),
     )?;
@@ -988,12 +1049,55 @@ fn start_output_inner(
         OutputStream {
             _stream: stream,
             _capture: capture_writer,
+            render_state,
             sample_rate,
             channels,
         },
         stats,
         cb_stats,
     ))
+}
+
+/// Rebuild only the cpal device/stream while preserving the engine, callback
+/// state, and stream statistics. Capture is intentionally not attached here.
+pub fn rebuild_output_stream(
+    render_state: Arc<std::sync::Mutex<RenderState>>,
+    engine: Engine,
+    stats: Arc<StreamStats>,
+    cb_stats: Option<Arc<CallbackTimeStats>>,
+    buffer_frames: Option<u32>,
+    device_name: Option<String>,
+) -> Result<OutputStream, OutputError> {
+    let host = cpal::default_host();
+    let device = resolve_output_device(&host, device_name.as_deref())?;
+    let supported = device
+        .default_output_config()
+        .map_err(|e| OutputError::NoConfig(e.to_string()))?;
+    let sample_format = supported.sample_format();
+    let mut config = supported.config();
+    if let Some(frames) = buffer_frames {
+        config.buffer_size = cpal::BufferSize::Fixed(frames);
+    }
+    let stream = build_stream(
+        &device,
+        &config,
+        sample_format,
+        engine,
+        stats,
+        render_state.clone(),
+        None,
+        cb_stats,
+    )?;
+    stream
+        .play()
+        .map_err(|e| OutputError::PlayStream(e.to_string()))?;
+    Ok(OutputStream {
+        _stream: stream,
+        _capture: None,
+        render_state,
+        sample_rate: config.sample_rate.0,
+        channels: config.channels,
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1003,15 +1107,12 @@ fn build_stream(
     sample_format: SampleFormat,
     engine: Engine,
     stats: Arc<StreamStats>,
-    mut link: Option<LinkEgress>,
-    mut insert_buses: Vec<InsertBusStage>,
-    mut post: Option<Box<dyn PostProcessor>>,
+    render_state: Arc<std::sync::Mutex<RenderState>>,
     mut capture: Option<RingTapSink>,
     cb_stats: Option<Arc<CallbackTimeStats>>,
 ) -> Result<Stream, OutputError> {
-    let make_err_fn = || {
+    let make_err_fn = |stats: Arc<StreamStats>| {
         // 上位 (daemon session) が StreamStats / DaemonError 経由で可視化する責務を持つ。
-        let stats = stats.clone();
         move |err: cpal::StreamError| stats.record_error(&err)
     };
 
@@ -1023,24 +1124,24 @@ fn build_stream(
     }
 
     let out_ch = config.channels as usize;
+    let callback_stats = stats.clone();
 
     let stream = match sample_format {
         SampleFormat::F32 => device
             .build_output_stream(
                 config,
                 move |data: &mut [f32], _| {
-                    render_block(
+                    render_shared_block(
                         &engine,
-                        &mut link,
-                        &mut insert_buses,
-                        &mut post,
+                        &render_state,
                         &mut capture,
                         &cb_stats,
                         out_ch,
                         data,
+                        &callback_stats,
                     )
                 },
-                make_err_fn(),
+                make_err_fn(stats.clone()),
                 None,
             )
             .map_err(|e| OutputError::BuildStream(e.to_string()))?,
@@ -1055,21 +1156,20 @@ fn build_stream(
                             scratch.resize(data.len(), 0.0);
                         }
                         let buf = &mut scratch[..data.len()];
-                        render_block(
+                        render_shared_block(
                             &engine,
-                            &mut link,
-                            &mut insert_buses,
-                            &mut post,
+                            &render_state,
                             &mut capture,
                             &cb_stats,
                             out_ch,
                             buf,
+                            &callback_stats,
                         );
                         for (i, s) in buf.iter().enumerate() {
                             data[i] = (s.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
                         }
                     },
-                    make_err_fn(),
+                    make_err_fn(stats.clone()),
                     None,
                 )
                 .map_err(|e| OutputError::BuildStream(e.to_string()))?
@@ -1085,21 +1185,20 @@ fn build_stream(
                             scratch.resize(data.len(), 0.0);
                         }
                         let buf = &mut scratch[..data.len()];
-                        render_block(
+                        render_shared_block(
                             &engine,
-                            &mut link,
-                            &mut insert_buses,
-                            &mut post,
+                            &render_state,
                             &mut capture,
                             &cb_stats,
                             out_ch,
                             buf,
+                            &callback_stats,
                         );
                         for (i, s) in buf.iter().enumerate() {
                             data[i] = (s.clamp(-1.0, 1.0) * i32::MAX as f32) as i32;
                         }
                     },
-                    make_err_fn(),
+                    make_err_fn(stats.clone()),
                     None,
                 )
                 .map_err(|e| OutputError::BuildStream(e.to_string()))?
@@ -1114,22 +1213,21 @@ fn build_stream(
                             scratch.resize(data.len(), 0.0);
                         }
                         let buf = &mut scratch[..data.len()];
-                        render_block(
+                        render_shared_block(
                             &engine,
-                            &mut link,
-                            &mut insert_buses,
-                            &mut post,
+                            &render_state,
                             &mut capture,
                             &cb_stats,
                             out_ch,
                             buf,
+                            &callback_stats,
                         );
                         for (i, s) in buf.iter().enumerate() {
                             let v = (s.clamp(-1.0, 1.0) * 0.5 + 0.5) * u16::MAX as f32;
                             data[i] = v as u16;
                         }
                     },
-                    make_err_fn(),
+                    make_err_fn(stats.clone()),
                     None,
                 )
                 .map_err(|e| OutputError::BuildStream(e.to_string()))?


### PR DESCRIPTION
## 概要

#484 D2: **エンジンを止めずに出力デバイスを切り替える**。エンジングラフ(サンプル・plugin・routing・transport)は保持し、stream だけ再構築。

Refs #484

## 設計

- **native**: `RenderState`(link/insert_buses/post)を `Arc<Mutex>` で callback と制御側が共有(callback は `try_lock`・競合時 zero-fill + `render_contentions` 計測)。`rebuild_output_stream()` が同一 Engine で新デバイスの stream を開く
- **daemon**: `cpal::Stream` は `!Send` のため **audio owner thread** — stream 所有を専用 OS スレッドに固定し、`EngineWrap` は `Send+Sync` な mpsc Sender だけ持つ。`SelectAudioDevice` RPC(空文字 = システム既定)。全 6 feature 変種に一様適用
- capture(ORBIT_CAPTURE_WAV)有効時は `AUDIO_DEVICE_SWITCH_UNAVAILABLE` で明示拒否

## 実機検証

sine ループ再生中に: スピーカー → Pro Tools Aggregate(**99ms**)→ スピーカー(**34ms**)→ 既定(**11ms**)。全切替で daemon 無再起動(uptime 連続)・loaded_samples/active_plays 保持。

## 検証

Rust **160 tests**・6 feature 変種 build/clippy/fmt clean・TS **2332 passed**

## 残(D2.5・別 PR)

Engine ビュー/MCP からの即時切替接続 — 拡張 → 走行中 daemon の制御チャネルが未存在のため、`//#selectAudioDevice` メタ行(#456 の前例踏襲)での橋渡しを次段で実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNBpN5mYkmT2oYJFuTAySu