### PR TITLE
test(daemon): deflake outproc loading test (setup deadline 2s to 30s)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,19 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.290 test(daemon): outproc loading テストの flake 除去 #491 (Jul 18, 2026)
+
+**Date**: 2026-07-18
+**Status**: ✅ 実装（レビュー前）
+
+**内容**:
+- `effect_load_outproc_concurrent_call_fails_fast_on_loading` が CI で2回 flake（#489 発見・PR #515 で再発。いずれも Rust 非接触の変更で fail、rerun で pass）
+- 原因: セットアップ（child spawn）完了待ちの deadline 2s が、検証対象の性質でないのに高負荷 runner で spawn 遅延に負けて panic する作り
+- fix: `outproc_load_error_test_support` に `SETUP_DEADLINE = 30s` 定数を導入し、セットアップ待ちポーリング2箇所（Loading 遷移待ち・child spawn PID 待ち）に適用。ポーリングは条件成立で即抜けるため正常時の所要時間は不変。本命の regression guard（2本目が mutex 待ちせず 1s 未満で fail-fast する assert）は無変更
+- ローカル: outproc テスト 38 passed・fmt/clippy 緑
+
+**関連**: #491（Closes）・#489 / PR #515（再発観測）
+
 ### 6.288 refactor+fix(vscode): #512 補完の /simplify + pr-review-team 収束 (Jul 18, 2026)
 
 **Date**: 2026-07-18

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -4477,6 +4477,12 @@ mod outproc_load_error_test_support {
 
     type InjectedSlot<R> = (Arc<EngineWrap>, Arc<Mutex<ChildSlot<R>>>);
 
+    /// テストのセットアップ段階（child spawn 等）の完了待ち上限。検証対象の性質ではなく
+    /// 「セットアップが終わらないなら何かが壊れている」の保険なので、CI の高負荷でも
+    /// 越えない大きな値にする（#491: 2s では遅い runner で spawn が間に合わず flake）。
+    /// 各ポーリングループは条件成立で即抜けるため、正常時の所要時間には影響しない。
+    const SETUP_DEADLINE: Duration = Duration::from_secs(30);
+
     fn child_launch<R: OutProcRole>(
         shm_path: PathBuf,
         child_exe: PathBuf,
@@ -4861,7 +4867,7 @@ mod outproc_load_error_test_support {
             let call = std::thread::spawn(move || {
                 wrap_call.load_outproc_plugin_impl::<R>(slot_call, path, None)
             });
-            let deadline = std::time::Instant::now() + Duration::from_secs(2);
+            let deadline = std::time::Instant::now() + SETUP_DEADLINE;
             // PID は reset_child_starting の後に publish されるため、この READY はそれによって消されない。
             while R::current_child_pid_atomic(&stats).load(std::sync::atomic::Ordering::Relaxed)
                 == 0
@@ -4924,9 +4930,11 @@ mod outproc_load_error_test_support {
             wrap_a.load_outproc_plugin_impl::<R>(slot_a, loading_path_owned, None)
         });
 
-        // 1本目が Empty -> Loading へ遷移して lock を解放するまで待つ（shm open + spawn は同期的な
-        // syscall なので通常数 ms で観測できる。2s は CI 負荷下でも十分な余裕）。
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        // 1本目が Empty -> Loading へ遷移して lock を解放するまで待つ。この deadline は
+        // セットアップ（child spawn）完了待ちであって検証対象の性質ではないので、CI の
+        // 高負荷でも越えない大きな値にする（#491: 2s では遅い runner で spawn が間に合わず
+        // flake した。ループは Loading 観測で即抜けるため通常は数 ms で終わる）。
+        let deadline = std::time::Instant::now() + SETUP_DEADLINE;
         loop {
             if matches!(
                 &*child_slot.lock().expect("poll child slot"),
@@ -4936,7 +4944,7 @@ mod outproc_load_error_test_support {
             }
             assert!(
                 std::time::Instant::now() < deadline,
-                "first LoadPlugin call never reached ChildSlot::Loading within 2s"
+                "first LoadPlugin call never reached ChildSlot::Loading within {SETUP_DEADLINE:?}"
             );
             std::thread::sleep(Duration::from_millis(5));
         }


### PR DESCRIPTION
Closes #491

## 概要

`effect_load_outproc_concurrent_call_fails_fast_on_loading` の CI flake を除去する。

## 背景

- #489 発見・PR #515 で再発（計2回）。いずれも **Rust 非接触の変更**で fail し rerun で pass = flake 確定
- 失敗メッセージ: `first LoadPlugin call never reached ChildSlot::Loading within 2s`

## 原因と修正

2s の deadline は**セットアップ（child spawn）完了待ち**であって検証対象の性質ではないのに、高負荷 runner で spawn 遅延に負けて panic する作りだった。

- `outproc_load_error_test_support` に `SETUP_DEADLINE = 30s` 定数を導入し、セットアップ待ちポーリング2箇所（Loading 遷移待ち・child spawn PID 待ち）に適用
- ポーリングは条件成立で即抜けるため、**正常時の所要時間は不変**（テスト時間は伸びない）
- 本命の regression guard（2本目の LoadPlugin が mutex 待ちせず 1s 未満で fail-fast する assert）は**無変更**

## 検証

- ローカル: `cargo test -p orbit-audio-daemon --lib --features outproc-effect outproc` → 38 passed
- `cargo fmt --check` / `cargo clippy --features outproc-effect` 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bh9W4578ovZaoC4LFMKKs