### PR TITLE
feat(engine): execute Signal Chain mixer declarations (#517 S1)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,55 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.291 feat(engine): Signal Chain ミキサー宣言の実行 #517 S1 (Jul 26, 2026)
+
+**Date**: 2026-07-26
+**Status**: ✅ レビュー収束（PR #518・owner マージ指示待ち）
+
+**#517 のスコープ改訂（owner 決定・重要）**:
+当初は「Phase C = TS 側の写像のみ / Rust 側拡張は Phase D」の分割だったが、事前調査で **SC.0 の例は TS 側の写像だけでは原理的に実行できない**ことが判明（下記）。owner 判断により **Rust 拡張を取り込み、SC.0 完全実行までを #517 の到達点**とし、S1〜S5 に分割した。本項はその S1。
+
+**調査で確定した制約**（Codex 起案 + Fable 独立検証・いずれも一次ソース確認）:
+- 1レシーバ=1insert がハードコード（`effect-slot.ts:84-98` / `sequence-effect-manager.ts:92` / `mixer-manager.ts:142`）。daemon の `LoadPlugin` はチェーン位置を持たない（`daemon-client.ts:378`）
+- プラグインのパラメータ設定経路が存在しない（`audio/types.ts:70-75` / `daemon-client.ts:384-391` / `session.rs:884-999`。`protocol-types.ts` の `CommandMethod` union に param set/enumeration/preset/bypass なし）
+- send のプリ/ポスト位置を表現できない（routing state にタップ点の概念なし）
+- `syncBusRouting()` は fire-and-forget（`sequence.ts:412-429`）→ SC.2 規範5 の「評価時に明示エラー」には await 可能経路が要る
+
+**S1 の内容**:
+- `InterpreterState` に mixer registry を追加。新規 `signal-chain/runtime.ts` に集約
+- `MixerInit` → 同一 Global の卓への冪等な handle 取得（SC.2 規範1）
+- `MixerNodeDecl` → `mix.sum`/`mix.aux` を既存 `Global.sum()`/`Global.aux()` へ、`mix.output(ch, ch)` を endpoint メタデータへ写像
+- mixer node をレシーバとする文の dispatch（SC.2 規範4）
+- `declaredNames()` に mixer 宣言を追加
+- 未解決レシーバ・output エンドポイントへのメソッド呼び出しを明示エラー化（SC.3.3）
+- LinkAudio 排他ゲートを、バスを確保しない宣言にも適用（両方向）
+- 名前空間の衝突検出（global / sequence / mixer handle / mixer node の全交差）
+- 仕様の誤記修正: SC.0 の `kick.audioPath(...)` → `audio(...)`（`Sequence.audio()` が正・`audioPath` は Global の検索パス設定）
+
+**暗黙 master(1,2) の扱い（SC.2 規範6・決定 #75）**:
+名前解決時の**遅延解決**とし registry には登録しない。`execute()` は REPL の評価単位ごとに呼ばれ `InterpreterState` は評価をまたいで持続するため、評価単位ごとの先読みにすると宣言ブロックとトラック行を別評価した際に誤登録する。spec は静的な「ファイル」単位で書かれておりライブ増分評価との橋渡しに明文がないため、**spec 追記は follow-up**。
+
+**レビュー経緯（PR #518・`/simplify` + pr-review-team 4ラウンド）**:
+本レビューで **4つの実バグ**が出た。いずれも「不完全な経路を黙って飲み込む」同一の病で、**同じ穴が3回、別々の入口から再発**した:
+1. 既定チャンネルの output だけが黙る非対称（`/simplify`）
+2. バスが `effect()` 以外を飲み込む・宣言形（ラウンド1）
+3. 同じ穴が裸の文字列形 `sum("drums").gain(0.5)` から（ラウンド2）
+4. 同じ穴がターゲット接頭辞形 `global.sum("drums").gain(0.5)` から（ラウンド3）
+
+3回目で2名のレビュアーが独立に「強制が値ではなく呼び出し箇所に付いているのが根本原因」と診断。箇所ごとのパッチをやめ、**構造的修正**へエスカレーションした（`9d2e412`）:
+- `MixerBusHandle` に module-private Symbol の brand を付与（`Sequence` も `effect()` を持つため duck typing では誤検知し得る）。TypeScript が全 `MixerBusHandle` に brand を要求し、Symbol は未 export のため外部から偽造不能
+- チェーンの唯一の実行点 `applyMethodChain` が `callMethod` の直前に毎回 `guardBusChain` を実行。ハンドラ側の「検証を呼ぶ義務」を撤去
+- 閉包の根拠: `chain?:` を持つ statement 型は3つのみ、そのハンドラ4つはすべて `applyMethodChain` を通る、外部の `callMethod` は transport の4箇所（コマンド名固定・チェーンなし・非バス受け手）のみ
+- fail-fast は分岐2（受け手が Global で次が `sum`/`aux`）が担い、分岐1（受け手が既にバス）が強制を担う。分岐2 を失っても劣化は原子性のみ
+
+**テストの検出力はミューテーションで検証**（暗黙 master の遅延解決・output レシーバの明示エラー・10個の衝突ガード・共有ヘルパの2呼び出し元・原子性の分岐・衝突メッセージのアサーション）。レビュアー側も独立に17回のミューテーションを再実行して確認。
+
+**検証**: 全 suite 1594 passed / 29 skipped・lint エラー0・build 通過・CI 4/4 pass
+
+**follow-up**: `callMethod` の素通り自体（全レシーバに波及するため別 issue）/ `requireGlobal` と `processSequenceInit` の既存素通り / brand のシリアライズ境界（現状バスハンドルはプロセス内のみ）/ 増分評価下の暗黙 master 規則の spec 追記
+
+**関連**: #517（S1）・#514 / PR #515（Phase B）・#511（P0）・#484 D4・#408 / #409
+
 ### 6.290 test(daemon): outproc loading テストの flake 除去 #491 (Jul 18, 2026)
 
 **Date**: 2026-07-18

--- a/docs/specs-v2/SIGNAL_CHAIN_DSL_SPEC_v1.md
+++ b/docs/specs-v2/SIGNAL_CHAIN_DSL_SPEC_v1.md
@@ -22,14 +22,14 @@ Status: 正本（specs-v2）/ 2026-07-18 制定 / 受け皿 issue: \#506 / 決�
     verb.HogeReverb(size: 0.8).master
 
     // ── トラック
-    kick.audioPath("kick.wav").chop(16).play(1, 5, 9, 13)
+    kick.audio("kick.wav").chop(16).play(1, 5, 9, 13)
         .CLAPTestEffect(mix: 0.5)
         .HogeComp(threshold: -18, sidechain: duck)
         .verb(0.3)                        // aux 名 → send（位置 = プリ/ポスト）
         .FugaEQ(low: 2)
         .drums                            // sum 名 → 本流の出力先（宣言層・括弧なし）
 
-    bass.audioPath("bass.wav").play(1, 9).duck(1.0).drums
+    bass.audio("bass.wav").play(1, 9).duck(1.0).drums
     drums.GlueComp(ratio: 2).master
     lead.Serum(preset: "Pluck 01").TALReverb4(size: 0.6).subout
 
@@ -37,7 +37,7 @@ Status: 正本（specs-v2）/ 2026-07-18 制定 / 受け皿 issue: \#506 / 決�
 
 | 層 | 属するもの | 順序の意味 |
 |----|----|----|
-| **宣言層** | audioPath / chop / play / gain / pan / 出力先ノード名（括弧なし）/ instrument 役のプラグイン呼び出し / ミキサー宣言 | **可換**。どこに書いても同じ。同一項目の再宣言は後勝ち。 |
+| **宣言層** | audio / chop / play / gain / pan / 出力先ノード名（括弧なし）/ instrument 役のプラグイン呼び出し / ミキサー宣言 | **可換**。どこに書いても同じ。同一項目の再宣言は後勝ち。 |
 | **信号層** | effect 役のプラグイン呼び出し / send（aux 名メソッドを含む） | **この層内の相対順序だけ**が接続順になる。宣言層の文がどこに挟まっても影響しない。 |
 
 <div class="norm">

--- a/packages/engine/src/cli/midi-run.ts
+++ b/packages/engine/src/cli/midi-run.ts
@@ -24,6 +24,7 @@ import { parseAudioDSL } from '../parser/audio-parser'
 import { processGlobalInit, processSequenceInit } from '../interpreter/process-initialization'
 import { processStatement } from '../interpreter/process-statement'
 import { InterpreterState } from '../interpreter/types'
+import { createMixerRuntimeRegistry } from '../signal-chain/runtime'
 
 /**
  * No-op audio engine. MIDI runs on the TransportClock (no SuperCollider), so
@@ -74,6 +75,7 @@ async function main(): Promise<void> {
   const state: InterpreterState = {
     globals: new Map(),
     sequences: new Map(),
+    mixers: createMixerRuntimeRegistry(),
     currentGlobal: undefined,
     audioEngine: noopEngine as unknown as InterpreterState['audioEngine'],
     isBooted: true,

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -275,6 +275,11 @@ export class Global {
     return this.linkAudioManager.isEnabled()
   }
 
+  /** @internal Marks use of the Signal Chain hardware mixer namespace. */
+  declareMixerRuntime(): void {
+    this.mixerManager.declareRuntime()
+  }
+
   /** Eagerly load the v1 single master-insert plugin. */
   async effect(path: string, pluginId?: string): Promise<this> {
     await this.pluginEffectManager.effect(path, pluginId)

--- a/packages/engine/src/core/global/mixer-manager.ts
+++ b/packages/engine/src/core/global/mixer-manager.ts
@@ -19,13 +19,39 @@ export const AUX_BUS_PREFIX = 'aux-bus-'
  */
 export const MIXER_BUS_POOL_SIZE = 4
 
-type MixerKind = 'sum' | 'aux'
+/**
+ * The `Global` methods that hand back a {@link MixerBusHandle}. Single source for
+ * both the sum/aux dispatch below and the interpreter's fail-fast bus gate, which
+ * needs to know a bus is coming *before* it calls (and thereby allocates) it.
+ */
+export const MIXER_BUS_KINDS = ['sum', 'aux'] as const
+
+type MixerKind = (typeof MIXER_BUS_KINDS)[number]
+
+/**
+ * Brand marking a value as a mixer bus handle. Carried by the handle itself
+ * rather than inferred from its shape, so {@link isMixerBusHandle} identifies
+ * buses exactly — a `Sequence` also has an `effect()` method, and any future
+ * receiver might too.
+ */
+const MIXER_BUS_HANDLE = Symbol('orbitscore.MixerBusHandle')
 
 /** Returned by `global.sum(name)` / `global.aux(name)` and the bare `sum(name)` / `aux(name)` reference. */
 export interface MixerBusHandle {
+  readonly [MIXER_BUS_HANDLE]: true
   readonly bus: string
   /** Declares (or idempotently re-declares) the bus's own insert (MX.2/MX.3: v1 one insert). */
   effect(path: string, pluginId?: string): Promise<MixerBusHandle>
+}
+
+/**
+ * Whether `value` is a mixer bus handle, wherever it came from — a declared
+ * `mix.sum` node, a string-form `sum("x")` call, or the handle another
+ * `effect()` returns mid-chain. TypeScript requires the brand on every
+ * `MixerBusHandle`, so no bus can reach a caller without answering this.
+ */
+export function isMixerBusHandle(value: unknown): value is MixerBusHandle {
+  return typeof value === 'object' && value !== null && MIXER_BUS_HANDLE in value
 }
 
 /** kind ごと（sum / aux）の宣言テーブル一式。 */
@@ -128,6 +154,7 @@ export class MixerManager {
 
   private makeHandle(kind: MixerKind, name: string, bus: string): MixerBusHandle {
     return {
+      [MIXER_BUS_HANDLE]: true,
       bus,
       effect: (path: string, pluginId?: string) => this.effectFor(kind, name, bus, path, pluginId),
     }

--- a/packages/engine/src/core/global/mixer-manager.ts
+++ b/packages/engine/src/core/global/mixer-manager.ts
@@ -48,6 +48,7 @@ interface KindState {
  */
 export class MixerManager {
   private readonly kinds: Record<MixerKind, KindState>
+  private hasRuntimeDeclaration = false
 
   constructor(
     audioEngine: AudioEngine,
@@ -70,7 +71,17 @@ export class MixerManager {
 
   /** Whether any sum or aux bus has been declared (used by `Global.linkAudio()`'s v1 exclusion gate). */
   hasAnyDeclaration(): boolean {
-    return this.kinds.sum.buses.size > 0 || this.kinds.aux.buses.size > 0
+    return (
+      this.hasRuntimeDeclaration || this.kinds.sum.buses.size > 0 || this.kinds.aux.buses.size > 0
+    )
+  }
+
+  /** Records a Signal Chain mixer handle/output without allocating a daemon bus. */
+  declareRuntime(): void {
+    if (this.linkAudioManager.isEnabled()) {
+      throw new Error('global.mixer cannot be used while LinkAudio is enabled in v1.')
+    }
+    this.hasRuntimeDeclaration = true
   }
 
   /** Declares (or idempotently re-declares) a sum/group bus. MX.2: sum nesting is not supported in v1. */

--- a/packages/engine/src/core/global/mixer-manager.ts
+++ b/packages/engine/src/core/global/mixer-manager.ts
@@ -69,7 +69,12 @@ export class MixerManager {
     this.kinds = { sum: makeKind('sum', SUM_BUS_PREFIX), aux: makeKind('aux', AUX_BUS_PREFIX) }
   }
 
-  /** Whether any sum or aux bus has been declared (used by `Global.linkAudio()`'s v1 exclusion gate). */
+  /**
+   * Whether this console has been claimed at all — by a declared sum/aux bus, or
+   * by a Signal Chain mixer declaration that allocates no bus (`init global.mixer`
+   * / `mix.output(...)`, recorded via {@link declareRuntime}). Used by
+   * `Global.linkAudio()`'s v1 exclusion gate, which must fire for both.
+   */
   hasAnyDeclaration(): boolean {
     return (
       this.hasRuntimeDeclaration || this.kinds.sum.buses.size > 0 || this.kinds.aux.buses.size > 0

--- a/packages/engine/src/interpreter/evaluate-method.ts
+++ b/packages/engine/src/interpreter/evaluate-method.ts
@@ -22,9 +22,9 @@
  */
 export async function callMethod(obj: any, methodName: string, args: any[]): Promise<any> {
   // Process arguments BEFORE the method-existence check: plugin/bus chain names
-  // (SC.3) are NOT real methods until Phase C, so a named arg on them would
+  // (SC.3) are NOT real methods until their #517 implementation stage, so a named arg would
   // otherwise be swallowed by the not-found branch below instead of reaching
-  // the explicit Phase C guard in processArguments (SC.3.3 forbids that).
+  // the explicit staged-execution guard in processArguments (SC.3.3 forbids that).
   const processedArgs = await processArguments(methodName, args)
 
   const method = obj[methodName]
@@ -66,11 +66,16 @@ export async function processArguments(methodName: string, args: any[]): Promise
 
   for (const arg of args) {
     if (arg && typeof arg === 'object' && arg.type === 'named_arg') {
-      // Signal Chain named arguments (SC.3) parse since #514 (Phase B) but
-      // execute only from Phase C. Explicit — SC.3.3 forbids silent ignoring.
+      // Selector arguments belong to plugin resolution in S2. Parameter values
+      // require S4's Rust param-set/enumeration protocol. Keep this explicit:
+      // SC.3.3 forbids silently ignoring either shape.
+      const stage =
+        arg.name === 'format' || arg.name === 'vendor'
+          ? 'selectors (format:/vendor:) arrive with plugin resolution in S2'
+          : 'parameter values require the Rust param-set/enumeration protocol in S4'
       throw new Error(
         `named argument "${arg.name}:" in ${methodName}() is not executable yet: ` +
-          `parsing landed in #514 (Phase B); execution lands in Phase C.`,
+          `${stage} (#517).`,
       )
     }
     if (methodName === 'beat' && arg.numerator !== undefined) {

--- a/packages/engine/src/interpreter/evaluate-method.ts
+++ b/packages/engine/src/interpreter/evaluate-method.ts
@@ -69,10 +69,21 @@ export async function processArguments(methodName: string, args: any[]): Promise
       // Selector arguments belong to plugin resolution in S2. Parameter values
       // require S4's Rust param-set/enumeration protocol. Keep this explicit:
       // SC.3.3 forbids silently ignoring either shape.
-      const stage =
-        arg.name === 'format' || arg.name === 'vendor'
-          ? 'selectors (format:/vendor:) arrive with plugin resolution in S2'
-          : 'parameter values require the Rust param-set/enumeration protocol in S4'
+      let stage: string
+      switch (arg.name) {
+        case 'format':
+        case 'vendor':
+          stage = 'selectors (format:/vendor:) arrive with plugin resolution in S2'
+          break
+        case 'sidechain':
+          stage = 'sidechain routing arrives in #409'
+          break
+        case 'outs':
+          stage = 'multi-output routing arrives in #408'
+          break
+        default:
+          stage = 'parameter values require the Rust param-set/enumeration protocol in S4'
+      }
       throw new Error(
         `named argument "${arg.name}:" in ${methodName}() is not executable yet: ` +
           `${stage} (#517).`,

--- a/packages/engine/src/interpreter/interpreter-v2.ts
+++ b/packages/engine/src/interpreter/interpreter-v2.ts
@@ -18,6 +18,7 @@ import {
   formatLogStamp,
 } from '../core/session-log/session-log-writer'
 import { ENGINE_VERSION, DSL_VERSION } from '../version'
+import { createMixerRuntimeRegistry } from '../signal-chain/runtime'
 
 import { InterpreterState } from './types'
 import { processGlobalInit, processSequenceInit } from './process-initialization'
@@ -47,6 +48,7 @@ export class InterpreterV2 {
       audioEngine: opts?.audioEngine ?? createAudioEngine(),
       globals: new Map(),
       sequences: new Map(),
+      mixers: createMixerRuntimeRegistry(),
       currentGlobal: undefined,
       isBooted: false,
       // Initialize unidirectional toggle groups

--- a/packages/engine/src/interpreter/process-file-import.ts
+++ b/packages/engine/src/interpreter/process-file-import.ts
@@ -59,7 +59,9 @@ export function declaredNames(ir: AudioIR): Set<string> {
     if (
       st.type === 'pattern_binding' ||
       st.type === 'chord_binding' ||
-      st.type === 'mode_binding'
+      st.type === 'mode_binding' ||
+      st.type === 'mixer_init' ||
+      st.type === 'mixer_node_decl'
     ) {
       names.add(st.variableName)
     }

--- a/packages/engine/src/interpreter/process-initialization.ts
+++ b/packages/engine/src/interpreter/process-initialization.ts
@@ -25,6 +25,12 @@ import { InterpreterState } from './types'
  * ```
  */
 export async function processGlobalInit(init: GlobalInit, state: InterpreterState): Promise<void> {
+  if (state.mixers.handles.has(init.variableName) || state.mixers.nodes.has(init.variableName)) {
+    throw new Error(
+      `Global name "${init.variableName}" conflicts with the existing mixer namespace.`,
+    )
+  }
+
   // Reuse existing global if it exists (for REPL persistence)
   let globalInstance = state.globals.get(init.variableName)
 
@@ -57,6 +63,12 @@ export async function processSequenceInit(
   init: SequenceInit,
   state: InterpreterState,
 ): Promise<void> {
+  if (state.mixers.handles.has(init.variableName) || state.mixers.nodes.has(init.variableName)) {
+    throw new Error(
+      `Sequence name "${init.variableName}" conflicts with the existing mixer namespace.`,
+    )
+  }
+
   let global: Global | undefined
 
   // If globalVariable is specified (new syntax: init global.seq)

--- a/packages/engine/src/interpreter/process-statement.ts
+++ b/packages/engine/src/interpreter/process-statement.ts
@@ -19,6 +19,7 @@ import {
   registerMixerHandle,
   registerMixerNode,
   resolveMixerNode,
+  validateBusChainMethods,
   type MixerRuntimeNode,
 } from '../signal-chain/runtime'
 
@@ -194,6 +195,7 @@ async function processMixerHandleStatement(
   const global = requireGlobal(state, `${statement.kind}("${statement.name}")`)
   if (!global) return
 
+  validateBusChainMethods((statement.chain ?? []).map((call) => call.method))
   await applyMethodChain(global, statement.kind, [statement.name], statement.chain)
 }
 

--- a/packages/engine/src/interpreter/process-statement.ts
+++ b/packages/engine/src/interpreter/process-statement.ts
@@ -97,17 +97,30 @@ export async function processStatement(
   }
 }
 
+/**
+ * Apply a statement's main call and then its chained calls to `receiver`,
+ * threading each call's return value into the next (methods return `this` to
+ * chain). Every receiver kind — global, sequence, mixer handle, mixer node —
+ * shares this loop so chain semantics stay defined in exactly one place.
+ */
+async function applyMethodChain(
+  receiver: unknown,
+  method: string,
+  args: any[],
+  chain?: ReadonlyArray<{ method: string; args: any[] }>,
+): Promise<any> {
+  let result: any = await callMethod(receiver, method, args)
+  for (const chainedCall of chain ?? []) {
+    result = await callMethod(result, chainedCall.method, chainedCall.args)
+  }
+  return result
+}
+
 async function processMixerNodeStatement(
   statement: SequenceStatement,
   node: MixerRuntimeNode,
 ): Promise<void> {
-  let result: any = mixerNodeReceiver(node)
-  result = await callMethod(result, statement.method, statement.args)
-  if (statement.chain) {
-    for (const chainedCall of statement.chain) {
-      result = await callMethod(result, chainedCall.method, chainedCall.args)
-    }
-  }
+  await applyMethodChain(mixerNodeReceiver(node), statement.method, statement.args, statement.chain)
 }
 
 /**
@@ -175,13 +188,7 @@ async function processMixerHandleStatement(
   const global = requireGlobal(state, `${statement.kind}("${statement.name}")`)
   if (!global) return
 
-  let result: any = await callMethod(global, statement.kind, [statement.name])
-
-  if (statement.chain) {
-    for (const chainedCall of statement.chain) {
-      result = await callMethod(result, chainedCall.method, chainedCall.args)
-    }
-  }
+  await applyMethodChain(global, statement.kind, [statement.name], statement.chain)
 }
 
 /**
@@ -210,18 +217,7 @@ export async function processGlobalStatement(
     return
   }
 
-  // Start with the global object
-  let result: any = global
-
-  // Process the main method
-  result = await callMethod(result, statement.method, statement.args)
-
-  // Process any chained methods
-  if (statement.chain) {
-    for (const chainedCall of statement.chain) {
-      result = await callMethod(result, chainedCall.method, chainedCall.args)
-    }
-  }
+  await applyMethodChain(global, statement.method, statement.args, statement.chain)
 }
 
 /**
@@ -250,18 +246,7 @@ export async function processSequenceStatement(
     return
   }
 
-  // Start with the sequence object
-  let result: any = sequence
-
-  // Process the main method
-  result = await callMethod(result, statement.method, statement.args)
-
-  // Process any chained methods
-  if (statement.chain) {
-    for (const chainedCall of statement.chain) {
-      result = await callMethod(result, chainedCall.method, chainedCall.args)
-    }
-  }
+  await applyMethodChain(sequence, statement.method, statement.args, statement.chain)
 }
 
 /**

--- a/packages/engine/src/interpreter/process-statement.ts
+++ b/packages/engine/src/interpreter/process-statement.ts
@@ -14,6 +14,13 @@ import {
   ImportStatement,
   MixerHandleStatement,
 } from '../parser/audio-parser'
+import {
+  mixerNodeReceiver,
+  registerMixerHandle,
+  registerMixerNode,
+  resolveMixerNode,
+  type MixerRuntimeNode,
+} from '../signal-chain/runtime'
 
 import { InterpreterState } from './types'
 import { callMethod } from './evaluate-method'
@@ -52,7 +59,12 @@ export async function processStatement(
         // It's a sequence statement
         await processSequenceStatement(statement, state)
       } else {
-        console.error(`Variable not found: ${statement.target}`)
+        const node = resolveMixerNode(state.mixers, statement.target, state.currentGlobal)
+        if (node) {
+          await processMixerNodeStatement(statement, node)
+        } else {
+          throw new Error(`Variable not found: ${statement.target}`)
+        }
       }
       break
     case 'transport':
@@ -74,17 +86,27 @@ export async function processStatement(
       await processMixerHandleStatement(statement, state)
       break
     case 'mixer_init':
+      registerMixerHandle(state.mixers, statement, state.globals)
+      break
     case 'mixer_node_decl':
-      // Signal Chain mixer declarations (SC.2.1) parse since #514 (Phase B,
-      // notation layer) but execute only from Phase C. Explicit — SC.3.3
-      // forbids silently ignoring what the user wrote.
-      throw new Error(
-        `Signal Chain mixer declarations (var ${statement.variableName} = ...) are not ` +
-          `executable yet: parsing landed in #514 (Phase B); execution lands in Phase C.`,
-      )
+      registerMixerNode(state.mixers, statement)
+      break
     default:
       // TypeScript should prevent this, but handle gracefully at runtime
       console.warn(`Unknown statement type: ${(statement as any).type}`)
+  }
+}
+
+async function processMixerNodeStatement(
+  statement: SequenceStatement,
+  node: MixerRuntimeNode,
+): Promise<void> {
+  let result: any = mixerNodeReceiver(node)
+  result = await callMethod(result, statement.method, statement.args)
+  if (statement.chain) {
+    for (const chainedCall of statement.chain) {
+      result = await callMethod(result, chainedCall.method, chainedCall.args)
+    }
   }
 }
 

--- a/packages/engine/src/interpreter/process-statement.ts
+++ b/packages/engine/src/interpreter/process-statement.ts
@@ -15,11 +15,11 @@ import {
   MixerHandleStatement,
 } from '../parser/audio-parser'
 import {
+  guardBusChain,
   mixerNodeReceiver,
   registerMixerHandle,
   registerMixerNode,
   resolveMixerNode,
-  validateBusChainMethods,
   type MixerRuntimeNode,
 } from '../signal-chain/runtime'
 
@@ -103,6 +103,11 @@ export async function processStatement(
  * threading each call's return value into the next (methods return `this` to
  * chain). Every receiver kind — global, sequence, bare bus reference, mixer node —
  * shares this loop so chain semantics stay defined in exactly one place.
+ *
+ * That includes which methods a receiver even accepts: {@link guardBusChain} runs
+ * against the value about to be dispatched on, before each call. Enforcement
+ * therefore travels with the value rather than with the handler that produced it,
+ * so a handler added later inherits it instead of having to remember it.
  */
 async function applyMethodChain(
   receiver: unknown,
@@ -110,8 +115,12 @@ async function applyMethodChain(
   args: any[],
   chain?: ReadonlyArray<{ method: string; args: any[] }>,
 ): Promise<any> {
+  const pending = [method, ...(chain ?? []).map((call) => call.method)]
+  guardBusChain(receiver, pending)
+
   let result: any = await callMethod(receiver, method, args)
-  for (const chainedCall of chain ?? []) {
+  for (const [index, chainedCall] of (chain ?? []).entries()) {
+    guardBusChain(result, pending.slice(index + 1))
     result = await callMethod(result, chainedCall.method, chainedCall.args)
   }
   return result
@@ -121,13 +130,7 @@ async function processMixerNodeStatement(
   statement: SequenceStatement,
   node: MixerRuntimeNode,
 ): Promise<void> {
-  const methods = [statement.method, ...(statement.chain ?? []).map((call) => call.method)]
-  await applyMethodChain(
-    mixerNodeReceiver(node, methods),
-    statement.method,
-    statement.args,
-    statement.chain,
-  )
+  await applyMethodChain(mixerNodeReceiver(node), statement.method, statement.args, statement.chain)
 }
 
 /**
@@ -195,7 +198,6 @@ async function processMixerHandleStatement(
   const global = requireGlobal(state, `${statement.kind}("${statement.name}")`)
   if (!global) return
 
-  validateBusChainMethods((statement.chain ?? []).map((call) => call.method))
   await applyMethodChain(global, statement.kind, [statement.name], statement.chain)
 }
 

--- a/packages/engine/src/interpreter/process-statement.ts
+++ b/packages/engine/src/interpreter/process-statement.ts
@@ -86,10 +86,10 @@ export async function processStatement(
       await processMixerHandleStatement(statement, state)
       break
     case 'mixer_init':
-      registerMixerHandle(state.mixers, statement, state.globals)
+      registerMixerHandle(state, statement)
       break
     case 'mixer_node_decl':
-      registerMixerNode(state.mixers, statement)
+      registerMixerNode(state, statement)
       break
     default:
       // TypeScript should prevent this, but handle gracefully at runtime
@@ -100,7 +100,7 @@ export async function processStatement(
 /**
  * Apply a statement's main call and then its chained calls to `receiver`,
  * threading each call's return value into the next (methods return `this` to
- * chain). Every receiver kind — global, sequence, mixer handle, mixer node —
+ * chain). Every receiver kind — global, sequence, bare bus reference, mixer node —
  * shares this loop so chain semantics stay defined in exactly one place.
  */
 async function applyMethodChain(
@@ -120,7 +120,13 @@ async function processMixerNodeStatement(
   statement: SequenceStatement,
   node: MixerRuntimeNode,
 ): Promise<void> {
-  await applyMethodChain(mixerNodeReceiver(node), statement.method, statement.args, statement.chain)
+  const methods = [statement.method, ...(statement.chain ?? []).map((call) => call.method)]
+  await applyMethodChain(
+    mixerNodeReceiver(node, methods),
+    statement.method,
+    statement.args,
+    statement.chain,
+  )
 }
 
 /**
@@ -213,8 +219,7 @@ export async function processGlobalStatement(
 ): Promise<void> {
   const global = state.globals.get(statement.target)
   if (!global) {
-    console.error(`Global instance not found: ${statement.target}`)
-    return
+    throw new Error(`Variable not found: ${statement.target}`)
   }
 
   await applyMethodChain(global, statement.method, statement.args, statement.chain)
@@ -242,8 +247,7 @@ export async function processSequenceStatement(
 ): Promise<void> {
   const sequence = state.sequences.get(statement.target)
   if (!sequence) {
-    console.error(`Sequence instance not found: ${statement.target}`)
-    return
+    throw new Error(`Variable not found: ${statement.target}`)
   }
 
   await applyMethodChain(sequence, statement.method, statement.args, statement.chain)

--- a/packages/engine/src/interpreter/types.ts
+++ b/packages/engine/src/interpreter/types.ts
@@ -6,6 +6,7 @@ import { Global } from '../core/global'
 import { Sequence } from '../core/sequence'
 import { AudioEngineBackend } from '../audio/engine-backend'
 import { SessionLogWriter } from '../core/session-log/session-log-writer'
+import type { MixerRuntimeRegistry } from '../signal-chain/runtime'
 
 /**
  * Interpreter state containing globals and sequences
@@ -13,6 +14,7 @@ import { SessionLogWriter } from '../core/session-log/session-log-writer'
 export interface InterpreterState {
   globals: Map<string, Global>
   sequences: Map<string, Sequence>
+  mixers: MixerRuntimeRegistry
   currentGlobal?: Global
   audioEngine: AudioEngineBackend
   isBooted: boolean

--- a/packages/engine/src/parser/types.ts
+++ b/packages/engine/src/parser/types.ts
@@ -86,7 +86,7 @@ export type Statement =
  * `var mix = init global.mixer` (SC.2.1): a named handle onto the ONE implicit mixer
  * space (the console). `globalVariable` is the identifier before `.mixer` — not
  * validated at parse time (names are arbitrary; the interpreter resolves it).
- * Execution is Phase C (#514 is notation-layer only): reaching the interpreter throws.
+ * The interpreter executes this declaration in #517 S1.
  */
 export type MixerInit = {
   type: 'mixer_init'
@@ -100,7 +100,7 @@ export type MixerInit = {
  * identifier as written (may itself be imported) — resolution is deferred to the
  * interpreter, which also rejects a non-mixer base. sum/aux take NO parentheses
  * (the declaration allocates an anonymous bus named by the variable); output takes
- * exactly one physical channel pair. Execution is Phase C: reaching the interpreter throws.
+ * exactly one physical channel pair. The interpreter executes it in #517 S1.
  */
 export type MixerNodeDecl = {
   type: 'mixer_node_decl'
@@ -114,8 +114,9 @@ export type MixerNodeDecl = {
  * A named argument `name: value` inside a call (SC.3): tagged so it can coexist in
  * the same `args` array as positional raw values without changing their shape
  * (existing consumers depend on positional args being unwrapped). `value` is a
- * number | string | boolean | {@link ArgRef}. Execution is Phase C: a named arg
- * reaching evaluate-method throws (SC.3.3 forbids silent ignoring).
+ * number | string | boolean | {@link ArgRef}. Selectors execute from #517 S2;
+ * parameter values require the Rust param-set/enumeration protocol in S4. Until
+ * then evaluate-method throws (SC.3.3 forbids silent ignoring).
  */
 export type NamedArg = {
   type: 'named_arg'

--- a/packages/engine/src/signal-chain/resolve.ts
+++ b/packages/engine/src/signal-chain/resolve.ts
@@ -1,10 +1,10 @@
 /**
- * Signal Chain shared name-resolution module (#514 Phase B).
+ * Signal Chain shared name-resolution module (#514 notation layer).
  *
  * Spec: docs/specs-v2/SIGNAL_CHAIN_DSL_SPEC_v1.md — SC.3.1 "grammar is static,
  * vocabulary is dynamic": the parser accepts any method name; what a chain method
  * MEANS is decided here, and this decision must be identical everywhere it is
- * asked — the interpreter (Phase C), diagnostics, and editor completion (#495)
+ * asked — the staged #517 interpreter mapping, diagnostics, and editor completion (#495)
  * all call these pure functions.
  *
  * Resolution order (SC.2 norm 3): known DSL method > declared mixer name >
@@ -12,12 +12,12 @@
  * the built-in vocabulary. Ties across the remaining two are reported as
  * `collisions` for the language service to warn about.
  *
- * The caller supplies the name tables. Note for Phase C: the declared-mixer-name
+ * The caller supplies the name tables. For the #517 runtime stages, the declared-mixer-name
  * table must include the implicit `master(1,2)` of a file that declares no mixer
  * (SC.2 norm 6) — that defaulting is the caller's responsibility, not this module's.
  *
- * Landed ahead of its first caller ON PURPOSE: #514 Phase B locks the
- * resolution-order contract early; the first consumers are the Phase C
+ * Landed ahead of its first caller ON PURPOSE: #514 locks the notation and
+ * resolution-order contract early; the first consumers are the #517 staged
  * interpreter mapping and the #495 language service.
  */
 

--- a/packages/engine/src/signal-chain/runtime.ts
+++ b/packages/engine/src/signal-chain/runtime.ts
@@ -1,6 +1,7 @@
 import { Global } from '../core/global'
 import type { MixerBusHandle } from '../core/global/mixer-manager'
 import type { MixerInit, MixerNodeDecl } from '../parser/types'
+import type { InterpreterState } from '../interpreter/types'
 
 export type MixerRuntimeNode =
   | {
@@ -20,16 +21,14 @@ export interface MixerRuntimeRegistry {
   readonly nodes: Map<string, MixerRuntimeNode>
 }
 
+// SC.2 norm 5's DAG validation starts in #517 S2/S3, together with the send and
+// output-routing edges that can actually form a cycle. S1 only registers nodes.
 export function createMixerRuntimeRegistry(): MixerRuntimeRegistry {
   return { handles: new Map(), nodes: new Map() }
 }
 
-export function registerMixerHandle(
-  registry: MixerRuntimeRegistry,
-  statement: MixerInit,
-  globals: Map<string, Global>,
-): Global {
-  const global = globals.get(statement.globalVariable)
+export function registerMixerHandle(state: InterpreterState, statement: MixerInit): Global {
+  const global = state.globals.get(statement.globalVariable)
   if (!global) {
     throw new Error(
       `Mixer base global not found: ${statement.globalVariable} ` +
@@ -37,7 +36,19 @@ export function registerMixerHandle(
     )
   }
 
-  const existing = registry.handles.get(statement.variableName)
+  const conflictingNamespace = state.globals.has(statement.variableName)
+    ? 'global'
+    : state.sequences.has(statement.variableName)
+      ? 'sequence'
+      : undefined
+  if (conflictingNamespace) {
+    throw new Error(
+      `Mixer name "${statement.variableName}" conflicts with the existing ` +
+        `${conflictingNamespace} namespace.`,
+    )
+  }
+
+  const existing = state.mixers.handles.get(statement.variableName)
   if (existing && existing !== global) {
     throw new Error(
       `Mixer handle "${statement.variableName}" is already bound to a different Global.`,
@@ -46,15 +57,15 @@ export function registerMixerHandle(
 
   // SC.2 norm 1: the console is one, so re-evaluation is an idempotent re-bind.
   global.declareMixerRuntime()
-  registry.handles.set(statement.variableName, global)
+  state.mixers.handles.set(statement.variableName, global)
   return global
 }
 
 export function registerMixerNode(
-  registry: MixerRuntimeRegistry,
+  state: InterpreterState,
   statement: MixerNodeDecl,
 ): MixerRuntimeNode {
-  const mixerGlobal = registry.handles.get(statement.base)
+  const mixerGlobal = state.mixers.handles.get(statement.base)
   if (!mixerGlobal) {
     throw new Error(
       `Mixer node "${statement.variableName}" has invalid base "${statement.base}": ` +
@@ -62,7 +73,19 @@ export function registerMixerNode(
     )
   }
 
-  const existing = registry.nodes.get(statement.variableName)
+  const conflictingNamespace = state.globals.has(statement.variableName)
+    ? 'global'
+    : state.sequences.has(statement.variableName)
+      ? 'sequence'
+      : undefined
+  if (conflictingNamespace) {
+    throw new Error(
+      `Mixer name "${statement.variableName}" conflicts with the existing ` +
+        `${conflictingNamespace} namespace.`,
+    )
+  }
+
+  const existing = state.mixers.nodes.get(statement.variableName)
   if (existing) {
     if (existing.global !== mixerGlobal || existing.kind !== statement.kind) {
       throw new Error(
@@ -77,7 +100,8 @@ export function registerMixerNode(
     ) {
       throw new Error(
         `Mixer output "${statement.variableName}" is already declared for channels ` +
-          `(${existing.channels.join(', ')}).`,
+          `(${existing.channels.join(', ')}); cannot redeclare for ` +
+          `(${statement.channels?.join(', ')}).`,
       )
     }
     return existing
@@ -98,7 +122,7 @@ export function registerMixerNode(
     const handle = mixerGlobal[statement.kind](statement.variableName)
     node = { kind: statement.kind, global: mixerGlobal, handle }
   }
-  registry.nodes.set(statement.variableName, node)
+  state.mixers.nodes.set(statement.variableName, node)
   return node
 }
 
@@ -126,14 +150,27 @@ export function resolveMixerNode(
  * The object a mixer node exposes as a statement receiver.
  *
  * Only sum/aux buses have one in v1: they are real daemon buses that already
- * accept inserts. Output endpoints — including the implicit `master(1, 2)` —
+ * accept inserts. Output endpoints — including implicit `master` on channels 1–2 —
  * have no receiver surface at any channel pair, because routing to a physical
  * output is what #484 D4 adds. Throwing for every output keeps the unimplemented
  * path loud (SC.3.3 forbids swallowing it) instead of handing back an inert
  * object that `callMethod` would silently no-op on.
  */
-export function mixerNodeReceiver(node: MixerRuntimeNode): MixerBusHandle {
-  if (node.kind !== 'output') return node.handle
+export function mixerNodeReceiver(
+  node: MixerRuntimeNode,
+  methods: readonly string[],
+): MixerBusHandle {
+  if (node.kind !== 'output') {
+    const unsupported = methods.find((method) => method !== 'effect')
+    if (unsupported) {
+      throw new Error(
+        `Mixer ${node.kind} bus method "${unsupported}" is not available in S1: ` +
+          `plugin-name methods arrive in S2, while routing tails and send sugar arrive ` +
+          `in S3 (#517).`,
+      )
+    }
+    return node.handle
+  }
   throw new Error(
     `Mixer output endpoints (channels ${node.channels.join(', ')}) cannot receive methods yet: ` +
       `routing to a physical output lands with #484 D4.`,

--- a/packages/engine/src/signal-chain/runtime.ts
+++ b/packages/engine/src/signal-chain/runtime.ts
@@ -21,10 +21,23 @@ export interface MixerRuntimeRegistry {
   readonly nodes: Map<string, MixerRuntimeNode>
 }
 
-// SC.2 norm 5's DAG validation starts in #517 S2/S3, together with the send and
+// SC.2 norm 5's DAG validation starts in #517 S3, together with the send and
 // output-routing edges that can actually form a cycle. S1 only registers nodes.
 export function createMixerRuntimeRegistry(): MixerRuntimeRegistry {
   return { handles: new Map(), nodes: new Map() }
+}
+
+const BUS_CHAIN_METHOD = 'effect'
+
+export function validateBusChainMethods(methods: readonly string[]): void {
+  const unsupported = methods.find((method) => method !== BUS_CHAIN_METHOD)
+  if (unsupported) {
+    throw new Error(
+      `Mixer sum/aux bus method "${unsupported}" is not available in S1: ` +
+        `plugin-name methods arrive in S2, while routing tails and send sugar arrive ` +
+        `in S3 (#517).`,
+    )
+  }
 }
 
 export function registerMixerHandle(state: InterpreterState, statement: MixerInit): Global {
@@ -45,6 +58,12 @@ export function registerMixerHandle(state: InterpreterState, statement: MixerIni
     throw new Error(
       `Mixer name "${statement.variableName}" conflicts with the existing ` +
         `${conflictingNamespace} namespace.`,
+    )
+  }
+
+  if (state.mixers.nodes.has(statement.variableName)) {
+    throw new Error(
+      `Mixer handle "${statement.variableName}" conflicts with the existing mixer node namespace.`,
     )
   }
 
@@ -82,6 +101,12 @@ export function registerMixerNode(
     throw new Error(
       `Mixer name "${statement.variableName}" conflicts with the existing ` +
         `${conflictingNamespace} namespace.`,
+    )
+  }
+
+  if (state.mixers.handles.has(statement.variableName)) {
+    throw new Error(
+      `Mixer node "${statement.variableName}" conflicts with the existing mixer handle namespace.`,
     )
   }
 
@@ -161,14 +186,7 @@ export function mixerNodeReceiver(
   methods: readonly string[],
 ): MixerBusHandle {
   if (node.kind !== 'output') {
-    const unsupported = methods.find((method) => method !== 'effect')
-    if (unsupported) {
-      throw new Error(
-        `Mixer ${node.kind} bus method "${unsupported}" is not available in S1: ` +
-          `plugin-name methods arrive in S2, while routing tails and send sugar arrive ` +
-          `in S3 (#517).`,
-      )
-    }
+    validateBusChainMethods(methods)
     return node.handle
   }
   throw new Error(

--- a/packages/engine/src/signal-chain/runtime.ts
+++ b/packages/engine/src/signal-chain/runtime.ts
@@ -2,10 +2,6 @@ import { Global } from '../core/global'
 import type { MixerBusHandle } from '../core/global/mixer-manager'
 import type { MixerInit, MixerNodeDecl } from '../parser/types'
 
-export interface MixerRuntimeHandle {
-  readonly global: Global
-}
-
 export type MixerRuntimeNode =
   | {
       readonly kind: 'output'
@@ -19,7 +15,8 @@ export type MixerRuntimeNode =
     }
 
 export interface MixerRuntimeRegistry {
-  readonly handles: Map<string, MixerRuntimeHandle>
+  /** Mixer handles (`var mix = init global.mixer`) → the console they name. */
+  readonly handles: Map<string, Global>
   readonly nodes: Map<string, MixerRuntimeNode>
 }
 
@@ -31,7 +28,7 @@ export function registerMixerHandle(
   registry: MixerRuntimeRegistry,
   statement: MixerInit,
   globals: Map<string, Global>,
-): MixerRuntimeHandle {
+): Global {
   const global = globals.get(statement.globalVariable)
   if (!global) {
     throw new Error(
@@ -41,28 +38,24 @@ export function registerMixerHandle(
   }
 
   const existing = registry.handles.get(statement.variableName)
-  if (existing) {
-    if (existing.global !== global) {
-      throw new Error(
-        `Mixer handle "${statement.variableName}" is already bound to a different Global.`,
-      )
-    }
-    global.declareMixerRuntime()
-    return existing
+  if (existing && existing !== global) {
+    throw new Error(
+      `Mixer handle "${statement.variableName}" is already bound to a different Global.`,
+    )
   }
 
+  // SC.2 norm 1: the console is one, so re-evaluation is an idempotent re-bind.
   global.declareMixerRuntime()
-  const handle = { global }
-  registry.handles.set(statement.variableName, handle)
-  return handle
+  registry.handles.set(statement.variableName, global)
+  return global
 }
 
 export function registerMixerNode(
   registry: MixerRuntimeRegistry,
   statement: MixerNodeDecl,
 ): MixerRuntimeNode {
-  const mixer = registry.handles.get(statement.base)
-  if (!mixer) {
+  const mixerGlobal = registry.handles.get(statement.base)
+  if (!mixerGlobal) {
     throw new Error(
       `Mixer node "${statement.variableName}" has invalid base "${statement.base}": ` +
         `the base is not a mixer handle.`,
@@ -71,7 +64,7 @@ export function registerMixerNode(
 
   const existing = registry.nodes.get(statement.variableName)
   if (existing) {
-    if (existing.global !== mixer.global || existing.kind !== statement.kind) {
+    if (existing.global !== mixerGlobal || existing.kind !== statement.kind) {
       throw new Error(
         `Mixer node "${statement.variableName}" is already declared as ${existing.kind}; ` +
           `it cannot be redeclared as ${statement.kind}.`,
@@ -92,14 +85,18 @@ export function registerMixerNode(
 
   let node: MixerRuntimeNode
   if (statement.kind === 'output') {
+    // `channels` is optional on the AST but the parser always populates it for
+    // `output`; the guard keeps the narrowing honest rather than casting.
     if (!statement.channels) {
       throw new Error(`Mixer output "${statement.variableName}" requires a channel pair.`)
     }
-    mixer.global.declareMixerRuntime()
-    node = { kind: 'output', global: mixer.global, channels: statement.channels }
+    mixerGlobal.declareMixerRuntime()
+    node = { kind: 'output', global: mixerGlobal, channels: statement.channels }
   } else {
-    const handle = mixer.global[statement.kind](statement.variableName)
-    node = { kind: statement.kind, global: mixer.global, handle }
+    // Deliberately goes through the same `Global.sum()` / `Global.aux()` the
+    // string form uses, so both syntaxes share one bus identity and one gate.
+    const handle = mixerGlobal[statement.kind](statement.variableName)
+    node = { kind: statement.kind, global: mixerGlobal, handle }
   }
   registry.nodes.set(statement.variableName, node)
   return node
@@ -119,17 +116,26 @@ export function resolveMixerNode(
   if (explicit) return explicit
   if (!global || name !== 'master') return undefined
 
-  const hasExplicitNode = [...registry.nodes.values()].some((node) => node.global === global)
-  return hasExplicitNode ? undefined : { kind: 'output', global, channels: [1, 2] as const }
+  for (const node of registry.nodes.values()) {
+    if (node.global === global) return undefined
+  }
+  return { kind: 'output', global, channels: [1, 2] as const }
 }
 
-export function mixerNodeReceiver(node: MixerRuntimeNode): MixerBusHandle | MixerRuntimeNode {
+/**
+ * The object a mixer node exposes as a statement receiver.
+ *
+ * Only sum/aux buses have one in v1: they are real daemon buses that already
+ * accept inserts. Output endpoints — including the implicit `master(1, 2)` —
+ * have no receiver surface at any channel pair, because routing to a physical
+ * output is what #484 D4 adds. Throwing for every output keeps the unimplemented
+ * path loud (SC.3.3 forbids swallowing it) instead of handing back an inert
+ * object that `callMethod` would silently no-op on.
+ */
+export function mixerNodeReceiver(node: MixerRuntimeNode): MixerBusHandle {
   if (node.kind !== 'output') return node.handle
-  if (node.channels[0] !== 1 || node.channels[1] !== 2) {
-    throw new Error(
-      `Mixer output channels (${node.channels.join(', ')}) are declared but cannot be routed ` +
-        `until #484 D4 adds multi-output engine support.`,
-    )
-  }
-  return node
+  throw new Error(
+    `Mixer output endpoints (channels ${node.channels.join(', ')}) cannot receive methods yet: ` +
+      `routing to a physical output lands with #484 D4.`,
+  )
 }

--- a/packages/engine/src/signal-chain/runtime.ts
+++ b/packages/engine/src/signal-chain/runtime.ts
@@ -1,0 +1,135 @@
+import { Global } from '../core/global'
+import type { MixerBusHandle } from '../core/global/mixer-manager'
+import type { MixerInit, MixerNodeDecl } from '../parser/types'
+
+export interface MixerRuntimeHandle {
+  readonly global: Global
+}
+
+export type MixerRuntimeNode =
+  | {
+      readonly kind: 'output'
+      readonly global: Global
+      readonly channels: readonly [number, number]
+    }
+  | {
+      readonly kind: 'sum' | 'aux'
+      readonly global: Global
+      readonly handle: MixerBusHandle
+    }
+
+export interface MixerRuntimeRegistry {
+  readonly handles: Map<string, MixerRuntimeHandle>
+  readonly nodes: Map<string, MixerRuntimeNode>
+}
+
+export function createMixerRuntimeRegistry(): MixerRuntimeRegistry {
+  return { handles: new Map(), nodes: new Map() }
+}
+
+export function registerMixerHandle(
+  registry: MixerRuntimeRegistry,
+  statement: MixerInit,
+  globals: Map<string, Global>,
+): MixerRuntimeHandle {
+  const global = globals.get(statement.globalVariable)
+  if (!global) {
+    throw new Error(
+      `Mixer base global not found: ${statement.globalVariable} ` +
+        `(var ${statement.variableName} = init ${statement.globalVariable}.mixer).`,
+    )
+  }
+
+  const existing = registry.handles.get(statement.variableName)
+  if (existing) {
+    if (existing.global !== global) {
+      throw new Error(
+        `Mixer handle "${statement.variableName}" is already bound to a different Global.`,
+      )
+    }
+    global.declareMixerRuntime()
+    return existing
+  }
+
+  global.declareMixerRuntime()
+  const handle = { global }
+  registry.handles.set(statement.variableName, handle)
+  return handle
+}
+
+export function registerMixerNode(
+  registry: MixerRuntimeRegistry,
+  statement: MixerNodeDecl,
+): MixerRuntimeNode {
+  const mixer = registry.handles.get(statement.base)
+  if (!mixer) {
+    throw new Error(
+      `Mixer node "${statement.variableName}" has invalid base "${statement.base}": ` +
+        `the base is not a mixer handle.`,
+    )
+  }
+
+  const existing = registry.nodes.get(statement.variableName)
+  if (existing) {
+    if (existing.global !== mixer.global || existing.kind !== statement.kind) {
+      throw new Error(
+        `Mixer node "${statement.variableName}" is already declared as ${existing.kind}; ` +
+          `it cannot be redeclared as ${statement.kind}.`,
+      )
+    }
+    if (
+      existing.kind === 'output' &&
+      (existing.channels[0] !== statement.channels?.[0] ||
+        existing.channels[1] !== statement.channels?.[1])
+    ) {
+      throw new Error(
+        `Mixer output "${statement.variableName}" is already declared for channels ` +
+          `(${existing.channels.join(', ')}).`,
+      )
+    }
+    return existing
+  }
+
+  let node: MixerRuntimeNode
+  if (statement.kind === 'output') {
+    if (!statement.channels) {
+      throw new Error(`Mixer output "${statement.variableName}" requires a channel pair.`)
+    }
+    mixer.global.declareMixerRuntime()
+    node = { kind: 'output', global: mixer.global, channels: statement.channels }
+  } else {
+    const handle = mixer.global[statement.kind](statement.variableName)
+    node = { kind: statement.kind, global: mixer.global, handle }
+  }
+  registry.nodes.set(statement.variableName, node)
+  return node
+}
+
+/**
+ * Resolve a declared node, or the compatibility master endpoint lazily when this
+ * Global has no explicit mixer nodes. The implicit endpoint is deliberately not
+ * inserted into the registry: InterpreterState survives separate REPL evals.
+ */
+export function resolveMixerNode(
+  registry: MixerRuntimeRegistry,
+  name: string,
+  global?: Global,
+): MixerRuntimeNode | undefined {
+  const explicit = registry.nodes.get(name)
+  if (explicit) return explicit
+  if (!global || name !== 'master') return undefined
+
+  const hasExplicitNode = [...registry.nodes.values()].some((node) => node.global === global)
+  return hasExplicitNode ? undefined : { kind: 'output', global, channels: [1, 2] as const }
+}
+
+export function mixerNodeReceiver(node: MixerRuntimeNode): MixerBusHandle | MixerRuntimeNode {
+  if (node.kind !== 'output') return node.handle
+  if (node.channels[0] !== 1 || node.channels[1] !== 2) {
+    throw new Error(
+      `Mixer output channels (${node.channels.join(', ')}) are declared but cannot be routed ` +
+        `until #484 D4 adds multi-output engine support.`,
+    )
+  }
+  return node
+}

--- a/packages/engine/src/signal-chain/runtime.ts
+++ b/packages/engine/src/signal-chain/runtime.ts
@@ -1,4 +1,5 @@
 import { Global } from '../core/global'
+import { MIXER_BUS_KINDS, isMixerBusHandle } from '../core/global/mixer-manager'
 import type { MixerBusHandle } from '../core/global/mixer-manager'
 import type { MixerInit, MixerNodeDecl } from '../parser/types'
 import type { InterpreterState } from '../interpreter/types'
@@ -29,7 +30,7 @@ export function createMixerRuntimeRegistry(): MixerRuntimeRegistry {
 
 const BUS_CHAIN_METHOD = 'effect'
 
-export function validateBusChainMethods(methods: readonly string[]): void {
+function validateBusChainMethods(methods: readonly string[]): void {
   const unsupported = methods.find((method) => method !== BUS_CHAIN_METHOD)
   if (unsupported) {
     throw new Error(
@@ -37,6 +38,36 @@ export function validateBusChainMethods(methods: readonly string[]): void {
         `plugin-name methods arrive in S2, while routing tails and send sugar arrive ` +
         `in S3 (#517).`,
     )
+  }
+}
+
+const BUS_PRODUCER_METHODS: ReadonlySet<string> = new Set(MIXER_BUS_KINDS)
+
+/**
+ * Gate the pending methods of a statement's call chain: `methods[0]` is about to
+ * be invoked on `receiver`, and the rest follow on each result in turn. Throws
+ * for the first method that would land on a mixer sum/aux bus without being
+ * supported in S1 (SC.3.3 forbids swallowing it — `callMethod` would otherwise
+ * log "Method not found" and hand the receiver back unchanged).
+ *
+ * The gate is attached to the *value*, not to a call site: `applyMethodChain`
+ * calls it before every dispatch, so a new statement handler cannot open this
+ * hole again by forgetting to validate. Two branches, in the order a bus can
+ * appear:
+ *
+ * 1. The receiver already *is* a bus (a declared `mix.sum` node, or the handle a
+ *    previous `effect()` returned) — validate everything still pending.
+ * 2. The receiver is a `Global` and the next call is `sum()`/`aux()`, which is
+ *    about to *make* one — validate the tail that will land on it, before the
+ *    call allocates a pool slot. Branch 1 alone would still reject the chain,
+ *    just one call too late; this branch is what keeps the rejection atomic.
+ */
+export function guardBusChain(receiver: unknown, methods: readonly string[]): void {
+  if (methods.length === 0) return
+  if (isMixerBusHandle(receiver)) {
+    validateBusChainMethods(methods)
+  } else if (receiver instanceof Global && BUS_PRODUCER_METHODS.has(methods[0])) {
+    validateBusChainMethods(methods.slice(1))
   }
 }
 
@@ -180,13 +211,12 @@ export function resolveMixerNode(
  * output is what #484 D4 adds. Throwing for every output keeps the unimplemented
  * path loud (SC.3.3 forbids swallowing it) instead of handing back an inert
  * object that `callMethod` would silently no-op on.
+ *
+ * Which methods the returned bus accepts is not decided here: {@link guardBusChain}
+ * decides that for every bus, however it was reached.
  */
-export function mixerNodeReceiver(
-  node: MixerRuntimeNode,
-  methods: readonly string[],
-): MixerBusHandle {
+export function mixerNodeReceiver(node: MixerRuntimeNode): MixerBusHandle {
   if (node.kind !== 'output') {
-    validateBusChainMethods(methods)
     return node.handle
   }
   throw new Error(

--- a/tests/audio-parser/signal-chain-syntax.spec.ts
+++ b/tests/audio-parser/signal-chain-syntax.spec.ts
@@ -1,8 +1,9 @@
 /**
  * Signal Chain DSL notation layer (#514 Phase B):
  * named arguments (SC.3), mixer declarations (SC.2.1), star import (SC.2.2),
- * and the shared name-resolution module. Execution (Phase C) is out of scope —
- * the new shapes throw explicit not-yet-executable errors, asserted below.
+ * and the shared name-resolution module. Execution landed later (#517): mixer
+ * declarations run as of S1 (see tests/interpreter/mixer-runtime.spec.ts), while
+ * named arguments still throw explicit not-yet-executable errors, asserted below.
  *
  * Spec: docs/specs-v2/SIGNAL_CHAIN_DSL_SPEC_v1.md
  */
@@ -155,15 +156,12 @@ describe('chain notation (SC.0 / SC.4)', () => {
     expect(statement.chain[6]).toMatchObject({ method: 'drums', args: [] })
   })
 
-  it('throws an explicit not-yet-executable error for mixer declarations at interpretation', async () => {
-    const { processStatement } = await import(
-      '../../packages/engine/src/interpreter/process-statement'
-    )
-    const statement = parseAudioDSL('var mix = init global.mixer').statements[0]!
-    await expect(
-      processStatement(statement, { globals: new Map(), sequences: new Map() } as never),
-    ).rejects.toThrow(/Phase C/)
-  })
+  // The mixer-declaration not-yet-executable guard that used to live here was
+  // retired when S1 (#517) made `var mix = init global.mixer` / `mix.sum` /
+  // `mix.aux` / `mix.output(ch, ch)` execute against the existing mixer
+  // primitives. Execution is now covered from the interpreter side by
+  // tests/interpreter/mixer-runtime.spec.ts; the parse-level assertions for the
+  // same shapes remain above.
 })
 
 describe('shared name resolution (SC.2 norm 3 / SC.3.2)', () => {

--- a/tests/audio-parser/signal-chain-syntax.spec.ts
+++ b/tests/audio-parser/signal-chain-syntax.spec.ts
@@ -51,17 +51,20 @@ describe('named arguments (SC.3)', () => {
   it('throws an explicit not-yet-executable error when a named arg reaches evaluation', async () => {
     await expect(
       processArguments('HogeComp', [{ type: 'named_arg', name: 'mix', value: 0.5 }]),
-    ).rejects.toThrow(/Phase C/)
+    ).rejects.toThrow(/S4.*#517/)
+    await expect(
+      processArguments('HogeComp', [{ type: 'named_arg', name: 'format', value: 'CLAP' }]),
+    ).rejects.toThrow(/S2.*#517/)
   })
 
-  it('fires the Phase C guard even when the method is not a real method (plugin names)', async () => {
-    // SC.3: plugin chain names are NOT methods on Sequence/Global until Phase C.
+  it('fires the #517 staged-execution guard even when the method is not a real method', async () => {
+    // SC.3: plugin chain names are NOT methods on Sequence/Global until S2.
     // The guard must run before the method-not-found swallow, or
     // `kick.HogeComp(threshold: -18)` would silently no-op.
     const receiver = {} // no HogeComp method — the realistic plugin-call shape
     await expect(
       callMethod(receiver, 'HogeComp', [{ type: 'named_arg', name: 'threshold', value: -18 }]),
-    ).rejects.toThrow(/Phase C/)
+    ).rejects.toThrow(/#517/)
   })
 
   it('rejects malformed named-arg values and missing separators explicitly', () => {
@@ -135,7 +138,7 @@ describe('star import (SC.2.2, decision #72)', () => {
 describe('chain notation (SC.0 / SC.4)', () => {
   it('parses the SC.0 track example: plugins, named args, send sugar, bare bus tail', () => {
     const ir = parseAudioDSL(
-      'kick.audioPath("kick.wav").chop(16).play(1, 5, 9, 13)\n' +
+      'kick.audio("kick.wav").chop(16).play(1, 5, 9, 13)\n' +
         '    .CLAPTestEffect(mix: 0.5)\n' +
         '    .HogeComp(threshold: -18, sidechain: duck)\n' +
         '    .verb(0.3)\n' +
@@ -143,7 +146,7 @@ describe('chain notation (SC.0 / SC.4)', () => {
         '    .drums',
     )
     const statement = ir.statements[0] as { chain: Array<{ method: string; args: unknown[] }> }
-    expect(statement).toMatchObject({ type: 'sequence', target: 'kick', method: 'audioPath' })
+    expect(statement).toMatchObject({ type: 'sequence', target: 'kick', method: 'audio' })
     expect(statement.chain.map((c) => c.method)).toEqual([
       'chop',
       'play',

--- a/tests/audio-parser/signal-chain-syntax.spec.ts
+++ b/tests/audio-parser/signal-chain-syntax.spec.ts
@@ -55,6 +55,23 @@ describe('named arguments (SC.3)', () => {
     await expect(
       processArguments('HogeComp', [{ type: 'named_arg', name: 'format', value: 'CLAP' }]),
     ).rejects.toThrow(/S2.*#517/)
+    await expect(
+      processArguments('HogeComp', [{ type: 'named_arg', name: 'vendor', value: 'Acme' }]),
+    ).rejects.toThrow(/S2.*#517/)
+    await expect(
+      processArguments('HogeComp', [
+        { type: 'named_arg', name: 'sidechain', value: { type: 'ref', name: 'duck' } },
+      ]),
+    ).rejects.toThrow(/#409/)
+    await expect(
+      processArguments('HogeComp', [{ type: 'named_arg', name: 'outs', value: 'kick' }]),
+    ).rejects.toThrow(/#408/)
+    await expect(
+      processArguments('HogeComp', [{ type: 'named_arg', name: 'preset', value: 'Wide' }]),
+    ).rejects.toThrow(/S4.*#517/)
+    await expect(
+      processArguments('HogeComp', [{ type: 'named_arg', name: 'enabled', value: true }]),
+    ).rejects.toThrow(/S4.*#517/)
   })
 
   it('fires the #517 staged-execution guard even when the method is not a real method', async () => {

--- a/tests/core/sequence-chord-dispatch.spec.ts
+++ b/tests/core/sequence-chord-dispatch.spec.ts
@@ -7,6 +7,7 @@ import { MidiOutput } from '../../packages/engine/src/midi/midi-output'
 import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
 import { processStatement } from '../../packages/engine/src/interpreter/process-statement'
 import { InterpreterState } from '../../packages/engine/src/interpreter/types'
+import { createMixerRuntimeRegistry } from '../../packages/engine/src/signal-chain/runtime'
 
 /**
  * Phase 3 (#231) — chord values end to end (§6): the global chord namespace,
@@ -166,6 +167,7 @@ describe('Phase 3 — interpreter routing for import / chord_binding (§6)', () 
     return {
       globals: new Map([['g', global]]),
       sequences: new Map(),
+      mixers: createMixerRuntimeRegistry(),
       currentGlobal: global,
       audioEngine: undefined as never,
       isBooted: true,

--- a/tests/core/sequence-pattern-dispatch.spec.ts
+++ b/tests/core/sequence-pattern-dispatch.spec.ts
@@ -7,6 +7,7 @@ import { MidiOutput } from '../../packages/engine/src/midi/midi-output'
 import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
 import { processStatement } from '../../packages/engine/src/interpreter/process-statement'
 import { InterpreterState } from '../../packages/engine/src/interpreter/types'
+import { createMixerRuntimeRegistry } from '../../packages/engine/src/signal-chain/runtime'
 
 /**
  * Phase R (#227) — pattern variables end to end (§6.5): namespace splice, `*n` on a
@@ -150,6 +151,7 @@ describe('Phase R — interpreter routing for pattern_binding (§6.5)', () => {
     return {
       globals: new Map([['g', global]]),
       sequences: new Map(),
+      mixers: createMixerRuntimeRegistry(),
       currentGlobal: global,
       audioEngine: undefined as never,
       isBooted: true,

--- a/tests/interpreter/mixer-runtime.spec.ts
+++ b/tests/interpreter/mixer-runtime.spec.ts
@@ -1,8 +1,24 @@
-import { describe, expect, it, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { Global } from '../../packages/engine/src/core/global'
-import { declaredNames } from '../../packages/engine/src/interpreter/process-file-import'
-import { processStatement } from '../../packages/engine/src/interpreter/process-statement'
+import {
+  createImportContext,
+  declaredNames,
+  processFileImports,
+} from '../../packages/engine/src/interpreter/process-file-import'
+import {
+  processGlobalInit,
+  processSequenceInit,
+} from '../../packages/engine/src/interpreter/process-initialization'
+import {
+  processGlobalStatement,
+  processSequenceStatement,
+  processStatement,
+} from '../../packages/engine/src/interpreter/process-statement'
 import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
 import {
   createMixerRuntimeRegistry,
@@ -26,12 +42,23 @@ function stateWith(global: Global) {
 }
 
 async function run(source: string, state: ReturnType<typeof stateWith>): Promise<void> {
-  for (const statement of parseAudioDSL(source).statements) {
+  const ir = parseAudioDSL(source)
+  if (ir.globalInit) await processGlobalInit(ir.globalInit, state)
+  for (const init of ir.sequenceInits) await processSequenceInit(init, state)
+  for (const statement of ir.statements) {
     await processStatement(statement, state)
   }
 }
 
 describe('Signal Chain mixer runtime namespace (SC.2)', () => {
+  const temporaryDirectories: string[] = []
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
   it('maps mixer handles and sum/aux nodes onto the existing Global primitives idempotently', async () => {
     const global = new Global(new RecordingScheduler())
     const sum = vi.spyOn(global, 'sum')
@@ -77,6 +104,18 @@ describe('Signal Chain mixer runtime namespace (SC.2)', () => {
     await expect(run('missing.effect("x")', state)).rejects.toThrow('Variable not found: missing')
   })
 
+  it.each(['sum', 'aux'] as const)(
+    'rejects unsupported methods on a declared %s bus, including chained calls',
+    async (kind) => {
+      const global = new Global(new RecordingScheduler())
+      const state = stateWith(global)
+      await run(`var mix = init global.mixer\nvar bus = mix.${kind}`, state)
+
+      await expect(run('bus.gain(0.5)', state)).rejects.toThrow(/S2.*S3.*#517/)
+      await expect(run('bus.effect("x").gain(0.5)', state)).rejects.toThrow(/S2.*S3.*#517/)
+    },
+  )
+
   it('refuses to use any output endpoint as a receiver, including the implicit master', async () => {
     // SC.3.3 forbids swallowing what the user wrote: an output endpoint has no
     // receiver surface until #484 D4, so it must throw rather than resolve to an
@@ -89,7 +128,7 @@ describe('Signal Chain mixer runtime namespace (SC.2)', () => {
     await expect(run('main.effect("Reverb.clap")', state)).rejects.toThrow('#484 D4')
   })
 
-  it('rejects invalid bases, duplicate kinds, and use of non-default output endpoints', async () => {
+  it('rejects invalid bases, duplicate kinds, and methods on declared output endpoints', async () => {
     const global = new Global(new RecordingScheduler())
     const state = stateWith(global)
     await expect(run('var verb = nope.aux', state)).rejects.toThrow('not a mixer handle')
@@ -97,6 +136,136 @@ describe('Signal Chain mixer runtime namespace (SC.2)', () => {
     await expect(run('var bus = mix.aux', state)).rejects.toThrow('cannot be redeclared')
     await run('var alt = mix.output(3, 4)', state)
     await expect(run('alt.effect("x")', state)).rejects.toThrow('#484 D4')
+  })
+
+  it('resolves a declared master output instead of the implicit fallback', async () => {
+    const global = new Global(new RecordingScheduler())
+    const state = stateWith(global)
+    await run('var mix = init global.mixer\nvar master = mix.output(3, 4)', state)
+
+    expect(resolveMixerNode(state.mixers, 'master', global)).toBe(state.mixers.nodes.get('master'))
+    expect(resolveMixerNode(state.mixers, 'master', global)).toMatchObject({
+      kind: 'output',
+      channels: [3, 4],
+    })
+  })
+
+  it('keeps implicit master fallback independent across Globals', async () => {
+    const g1 = new Global(new RecordingScheduler())
+    const g2 = new Global(new RecordingScheduler())
+    const state = stateWith(g1)
+    state.globals.set('g1', g1)
+    state.globals.set('g2', g2)
+    await run('var mix = init g1.mixer\nvar drums = mix.sum', state)
+
+    expect(resolveMixerNode(state.mixers, 'master', g1)).toBeUndefined()
+    expect(resolveMixerNode(state.mixers, 'master', g2)).toMatchObject({
+      kind: 'output',
+      global: g2,
+      channels: [1, 2],
+    })
+  })
+
+  it('executes mixer declarations through named and star file imports', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'orbs-mixer-import-'))
+    temporaryDirectories.push(directory)
+    fs.writeFileSync(
+      path.join(directory, 'mixer.orbs'),
+      'var global = init GLOBAL\nvar mix = init global.mixer\nvar drums = mix.sum\n',
+    )
+
+    for (const importClause of ['{ mix, drums }', '*']) {
+      const entry = path.join(directory, `main-${importClause === '*' ? 'star' : 'named'}.orbs`)
+      fs.writeFileSync(entry, `import ${importClause} from "./mixer.orbs"\n`)
+      const importedState = stateWith(new Global(new RecordingScheduler()))
+      const ir = parseAudioDSL(fs.readFileSync(entry, 'utf8'))
+      await processFileImports(
+        ir.fileImports ?? [],
+        directory,
+        importedState,
+        createImportContext(entry),
+      )
+      expect(importedState.mixers.handles.has('mix')).toBe(true)
+      expect(importedState.mixers.nodes.get('drums')).toMatchObject({ kind: 'sum' })
+    }
+  })
+
+  it('rejects rebinding a mixer handle to another Global', async () => {
+    const g1 = new Global(new RecordingScheduler())
+    const g2 = new Global(new RecordingScheduler())
+    const state = stateWith(g1)
+    state.globals.set('g1', g1)
+    state.globals.set('g2', g2)
+    await run('var mix = init g1.mixer', state)
+    await expect(run('var mix = init g2.mixer', state)).rejects.toThrow('different Global')
+  })
+
+  it('rejects redeclaring a mixer node against a handle for another Global', async () => {
+    const g1 = new Global(new RecordingScheduler())
+    const g2 = new Global(new RecordingScheduler())
+    const state = stateWith(g1)
+    state.globals.set('g1', g1)
+    state.globals.set('g2', g2)
+    await run('var m1 = init g1.mixer\nvar m2 = init g2.mixer\nvar bus = m1.sum', state)
+    await expect(run('var bus = m2.sum', state)).rejects.toThrow('cannot be redeclared')
+  })
+
+  it('treats repeated output declaration with the same channels as idempotent', async () => {
+    const global = new Global(new RecordingScheduler())
+    const state = stateWith(global)
+    await run('var mix = init global.mixer\nvar out = mix.output(3, 4)', state)
+    const first = state.mixers.nodes.get('out')
+    await run('var out = mix.output(3, 4)', state)
+    expect(state.mixers.nodes.get('out')).toBe(first)
+  })
+
+  it('reports both old and newly requested channels on output redeclaration', async () => {
+    const global = new Global(new RecordingScheduler())
+    const state = stateWith(global)
+    await run('var mix = init global.mixer\nvar out = mix.output(1, 2)', state)
+    await expect(run('var out = mix.output(3, 4)', state)).rejects.toThrow(
+      'already declared for channels (1, 2); cannot redeclare for (3, 4)',
+    )
+  })
+
+  it('rejects mixer names that collide with sequence/global names in either declaration order', async () => {
+    const global = new Global(new RecordingScheduler())
+
+    await expect(
+      run(
+        'var kick = init global.seq\nvar mix = init global.mixer\nvar kick = mix.sum',
+        stateWith(global),
+      ),
+    ).rejects.toThrow(/mixer.*sequence namespace/i)
+    const mixerBeforeSequence = stateWith(global)
+    await run('var mix = init global.mixer\nvar kick = mix.sum', mixerBeforeSequence)
+    await expect(run('var kick = init global.seq', mixerBeforeSequence)).rejects.toThrow(
+      /sequence.*mixer namespace/i,
+    )
+    await expect(run('var global = init global.mixer', stateWith(global))).rejects.toThrow(
+      /mixer.*global namespace/i,
+    )
+    const mixerFirst = stateWith(global)
+    await run('var mix = init global.mixer\nvar later = mix.aux', mixerFirst)
+    await expect(
+      processGlobalInit({ type: 'global_init', variableName: 'later' }, mixerFirst),
+    ).rejects.toThrow(/global.*mixer namespace/i)
+  })
+
+  it('throws from exported global/sequence handlers when their target is absent', async () => {
+    const state = stateWith(new Global(new RecordingScheduler()))
+    await expect(
+      processGlobalStatement(
+        { type: 'global', target: 'missing', method: 'tempo', args: [] },
+        state,
+      ),
+    ).rejects.toThrow('Variable not found: missing')
+    await expect(
+      processSequenceStatement(
+        { type: 'sequence', target: 'missing', method: 'play', args: [] },
+        state,
+      ),
+    ).rejects.toThrow('Variable not found: missing')
   })
 
   it('keeps every mixer declaration mutually exclusive with LinkAudio', async () => {

--- a/tests/interpreter/mixer-runtime.spec.ts
+++ b/tests/interpreter/mixer-runtime.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Global } from '../../packages/engine/src/core/global'
+import { declaredNames } from '../../packages/engine/src/interpreter/process-file-import'
+import { processStatement } from '../../packages/engine/src/interpreter/process-statement'
+import { parseAudioDSL } from '../../packages/engine/src/parser/audio-parser'
+import {
+  createMixerRuntimeRegistry,
+  resolveMixerNode,
+} from '../../packages/engine/src/signal-chain/runtime'
+import { RecordingScheduler } from '../audio/verify/recording-scheduler'
+
+function stateWith(global: Global) {
+  return {
+    globals: new Map([['global', global]]),
+    sequences: new Map(),
+    mixers: createMixerRuntimeRegistry(),
+    currentGlobal: global,
+    audioEngine: new RecordingScheduler(),
+    isBooted: true,
+    runGroup: new Set<string>(),
+    loopGroup: new Set<string>(),
+    muteGroup: new Set<string>(),
+    engineT0: Date.now(),
+  }
+}
+
+async function run(source: string, state: ReturnType<typeof stateWith>): Promise<void> {
+  for (const statement of parseAudioDSL(source).statements) {
+    await processStatement(statement, state)
+  }
+}
+
+describe('Signal Chain mixer runtime namespace (SC.2)', () => {
+  it('maps mixer handles and sum/aux nodes onto the existing Global primitives idempotently', async () => {
+    const global = new Global(new RecordingScheduler())
+    const sum = vi.spyOn(global, 'sum')
+    const aux = vi.spyOn(global, 'aux')
+    const state = stateWith(global)
+
+    await run('var mix = init global.mixer\nvar drums = mix.sum\nvar verb = mix.aux', state)
+    const firstHandle = state.mixers.handles.get('mix')
+    const firstSum = state.mixers.nodes.get('drums')
+    await run('var mix = init global.mixer\nvar drums = mix.sum\nvar verb = mix.aux', state)
+
+    expect(state.mixers.handles.get('mix')).toBe(firstHandle)
+    expect(state.mixers.nodes.get('drums')).toBe(firstSum)
+    expect(sum).toHaveBeenCalledTimes(1)
+    expect(aux).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves implicit master lazily across incremental evaluations', async () => {
+    const global = new Global(new RecordingScheduler())
+    const state = stateWith(global)
+
+    expect(resolveMixerNode(state.mixers, 'master', global)).toMatchObject({
+      kind: 'output',
+      channels: [1, 2],
+    })
+    await run('var mix = init global.mixer', state)
+    expect(resolveMixerNode(state.mixers, 'master', global)).toBeDefined()
+    await run('var verb = mix.aux', state)
+    expect(resolveMixerNode(state.mixers, 'master', global)).toBeUndefined()
+  })
+
+  it('dispatches a declared bus receiver and throws for unknown receivers', async () => {
+    const global = new Global(new RecordingScheduler())
+    const state = stateWith(global)
+    await run('var mix = init global.mixer\nvar verb = mix.aux', state)
+    const node = state.mixers.nodes.get('verb')
+    expect(node?.kind).toBe('aux')
+    const effect = vi.spyOn((node as Extract<typeof node, { kind: 'aux' }>).handle, 'effect')
+    effect.mockResolvedValue((node as Extract<typeof node, { kind: 'aux' }>).handle)
+
+    await run('verb.effect("Reverb.clap")', state)
+    expect(effect).toHaveBeenCalledWith('Reverb.clap')
+    await expect(run('missing.effect("x")', state)).rejects.toThrow('Variable not found: missing')
+  })
+
+  it('rejects invalid bases, duplicate kinds, and use of non-default output endpoints', async () => {
+    const global = new Global(new RecordingScheduler())
+    const state = stateWith(global)
+    await expect(run('var verb = nope.aux', state)).rejects.toThrow('not a mixer handle')
+    await run('var mix = init global.mixer\nvar bus = mix.sum', state)
+    await expect(run('var bus = mix.aux', state)).rejects.toThrow('cannot be redeclared')
+    await run('var alt = mix.output(3, 4)', state)
+    await expect(run('alt.effect("x")', state)).rejects.toThrow('#484 D4')
+  })
+
+  it('keeps every mixer declaration mutually exclusive with LinkAudio', async () => {
+    const before = new Global(new RecordingScheduler())
+    before.linkAudio()
+    await expect(run('var mix = init global.mixer', stateWith(before))).rejects.toThrow(/LinkAudio/)
+
+    const after = new Global(new RecordingScheduler())
+    const state = stateWith(after)
+    await run('var mix = init global.mixer\nvar master = mix.output(1, 2)', state)
+    expect(() => after.linkAudio()).toThrow(/plugin hosting/)
+  })
+
+  it('includes mixer handles and nodes in import declaration contracts', () => {
+    const names = declaredNames(
+      parseAudioDSL(
+        'var global = init GLOBAL\nvar mix = init global.mixer\nvar master = mix.output(1, 2)',
+      ),
+    )
+    expect(names).toEqual(new Set(['global', 'mix', 'master']))
+  })
+})

--- a/tests/interpreter/mixer-runtime.spec.ts
+++ b/tests/interpreter/mixer-runtime.spec.ts
@@ -116,6 +116,33 @@ describe('Signal Chain mixer runtime namespace (SC.2)', () => {
     },
   )
 
+  it.each(['sum', 'aux'] as const)(
+    'rejects unsupported methods on a string-form %s bus',
+    async (kind) => {
+      const global = new Global(new RecordingScheduler())
+      const state = stateWith(global)
+
+      await expect(run(`${kind}("bus").gain(0.5)`, state)).rejects.toThrow(/S2.*S3.*#517/)
+    },
+  )
+
+  it('dispatches effect() on string-form sum and aux buses', async () => {
+    const global = new Global(new RecordingScheduler())
+    const state = stateWith(global)
+    const sumHandle = global.sum('drums')
+    const auxHandle = global.aux('verb')
+    const sumEffect = vi.spyOn(sumHandle, 'effect').mockResolvedValue(sumHandle)
+    const auxEffect = vi.spyOn(auxHandle, 'effect').mockResolvedValue(auxHandle)
+    vi.spyOn(global, 'sum').mockReturnValue(sumHandle)
+    vi.spyOn(global, 'aux').mockReturnValue(auxHandle)
+
+    await run('sum("drums").effect("Comp.clap")', state)
+    await run('aux("verb").effect("Reverb.clap")', state)
+
+    expect(sumEffect).toHaveBeenCalledWith('Comp.clap')
+    expect(auxEffect).toHaveBeenCalledWith('Reverb.clap')
+  })
+
   it('refuses to use any output endpoint as a receiver, including the implicit master', async () => {
     // SC.3.3 forbids swallowing what the user wrote: an output endpoint has no
     // receiver surface until #484 D4, so it must throw rather than resolve to an
@@ -228,9 +255,14 @@ describe('Signal Chain mixer runtime namespace (SC.2)', () => {
     )
   })
 
-  it('rejects mixer names that collide with sequence/global names in either declaration order', async () => {
+  it('rejects mixer names that collide with sequence/global names in every declaration order', async () => {
     const global = new Global(new RecordingScheduler())
 
+    const sequenceBeforeHandle = stateWith(global)
+    await run('var kick = init global.seq', sequenceBeforeHandle)
+    await expect(run('var kick = init global.mixer', sequenceBeforeHandle)).rejects.toThrow(
+      /mixer.*sequence namespace/i,
+    )
     await expect(
       run(
         'var kick = init global.seq\nvar mix = init global.mixer\nvar kick = mix.sum',
@@ -245,11 +277,48 @@ describe('Signal Chain mixer runtime namespace (SC.2)', () => {
     await expect(run('var global = init global.mixer', stateWith(global))).rejects.toThrow(
       /mixer.*global namespace/i,
     )
+    const globalBeforeNode = stateWith(global)
+    await run('var mix = init global.mixer', globalBeforeNode)
+    await expect(run('var global = mix.sum', globalBeforeNode)).rejects.toThrow(
+      /mixer.*global namespace/i,
+    )
+    const handleBeforeGlobal = stateWith(global)
+    await run('var reserved = init global.mixer', handleBeforeGlobal)
+    await expect(
+      processGlobalInit({ type: 'global_init', variableName: 'reserved' }, handleBeforeGlobal),
+    ).rejects.toThrow(/global.*mixer namespace/i)
+    const handleBeforeSequence = stateWith(global)
+    await run('var reserved = init global.mixer', handleBeforeSequence)
+    await expect(run('var reserved = init global.seq', handleBeforeSequence)).rejects.toThrow(
+      /sequence.*mixer namespace/i,
+    )
     const mixerFirst = stateWith(global)
     await run('var mix = init global.mixer\nvar later = mix.aux', mixerFirst)
     await expect(
       processGlobalInit({ type: 'global_init', variableName: 'later' }, mixerFirst),
     ).rejects.toThrow(/global.*mixer namespace/i)
+  })
+
+  it('rejects mixer handle and node names that collide in either declaration order', async () => {
+    const global = new Global(new RecordingScheduler())
+    const nodeBeforeHandle = stateWith(global)
+    await run('var mix = init global.mixer\nvar bus = mix.sum', nodeBeforeHandle)
+    await expect(run('var bus = init global.mixer', nodeBeforeHandle)).rejects.toThrow(
+      /mixer.*node/i,
+    )
+
+    const handleBeforeNode = stateWith(global)
+    await run('var first = init global.mixer\nvar reserved = init global.mixer', handleBeforeNode)
+    await expect(run('var reserved = first.aux', handleBeforeNode)).rejects.toThrow(
+      /mixer.*handle/i,
+    )
+  })
+
+  it('rejects a mixer node declaration that uses its own handle name as the base', async () => {
+    const state = stateWith(new Global(new RecordingScheduler()))
+    await run('var mix = init global.mixer', state)
+
+    await expect(run('var mix = mix.sum', state)).rejects.toThrow(/mixer.*handle/i)
   })
 
   it('throws from exported global/sequence handlers when their target is absent', async () => {

--- a/tests/interpreter/mixer-runtime.spec.ts
+++ b/tests/interpreter/mixer-runtime.spec.ts
@@ -126,6 +126,66 @@ describe('Signal Chain mixer runtime namespace (SC.2)', () => {
     },
   )
 
+  it.each(['sum', 'aux'] as const)(
+    'rejects unsupported methods on a target-prefixed %s bus',
+    async (kind) => {
+      const global = new Global(new RecordingScheduler())
+      const state = stateWith(global)
+
+      await expect(run(`global.${kind}("bus").gain(0.5)`, state)).rejects.toThrow(/S2.*S3.*#517/)
+    },
+  )
+
+  it('dispatches effect() on target-prefixed sum and aux buses', async () => {
+    const global = new Global(new RecordingScheduler())
+    const state = stateWith(global)
+    const sumHandle = global.sum('drums')
+    const auxHandle = global.aux('verb')
+    const sumEffect = vi.spyOn(sumHandle, 'effect').mockResolvedValue(sumHandle)
+    const auxEffect = vi.spyOn(auxHandle, 'effect').mockResolvedValue(auxHandle)
+    vi.spyOn(global, 'sum').mockReturnValue(sumHandle)
+    vi.spyOn(global, 'aux').mockReturnValue(auxHandle)
+
+    await run('global.sum("drums").effect("Comp.clap")', state)
+    await run('global.aux("verb").effect("Reverb.clap")', state)
+
+    expect(sumEffect).toHaveBeenCalledWith('Comp.clap')
+    expect(auxEffect).toHaveBeenCalledWith('Reverb.clap')
+  })
+
+  it('rejects a bus chain before any of its calls run, on every entry form', async () => {
+    // The gate is atomic: nothing in the chain executes when a later method is
+    // unsupported, so no plugin is loaded and no bus pool slot is consumed.
+    const global = new Global(new RecordingScheduler())
+    const state = stateWith(global)
+    await run('var mix = init global.mixer\nvar verb = mix.aux', state)
+    const node = state.mixers.nodes.get('verb')
+    const declaredEffect = vi.spyOn(
+      (node as Extract<typeof node, { kind: 'aux' }>).handle,
+      'effect',
+    )
+
+    await expect(run('verb.effect("Reverb.clap").gain(0.5)', state)).rejects.toThrow(/#517/)
+    expect(declaredEffect).not.toHaveBeenCalled()
+
+    const sum = vi.spyOn(global, 'sum')
+    await expect(run('sum("drums").gain(0.5)', state)).rejects.toThrow(/#517/)
+    await expect(run('global.sum("drums").gain(0.5)', state)).rejects.toThrow(/#517/)
+    expect(sum).not.toHaveBeenCalled()
+  })
+
+  it('leaves non-bus chains untouched by the bus gate', async () => {
+    const global = new Global(new RecordingScheduler())
+    const state = stateWith(global)
+    await run('var kick = init global.seq', state)
+
+    // `gain` is unsupported on a bus but must stay a plain (non-throwing) call
+    // everywhere else: the gate keys off the receiver, not the method name.
+    await run('global.tempo(120).beat(4 by 4)', state)
+    await run('kick.gain(0.5)', state)
+    expect(global.tempo()).toBe(120)
+  })
+
   it('dispatches effect() on string-form sum and aux buses', async () => {
     const global = new Global(new RecordingScheduler())
     const state = stateWith(global)
@@ -303,14 +363,17 @@ describe('Signal Chain mixer runtime namespace (SC.2)', () => {
     const global = new Global(new RecordingScheduler())
     const nodeBeforeHandle = stateWith(global)
     await run('var mix = init global.mixer\nvar bus = mix.sum', nodeBeforeHandle)
+    // Anchored on the leading noun: both messages contain both words, so an
+    // unanchored /mixer.*node/ would also match the node-side message (and vice
+    // versa), letting a swap of the two messages pass unnoticed.
     await expect(run('var bus = init global.mixer', nodeBeforeHandle)).rejects.toThrow(
-      /mixer.*node/i,
+      /^Mixer handle .* existing mixer node namespace/i,
     )
 
     const handleBeforeNode = stateWith(global)
     await run('var first = init global.mixer\nvar reserved = init global.mixer', handleBeforeNode)
     await expect(run('var reserved = first.aux', handleBeforeNode)).rejects.toThrow(
-      /mixer.*handle/i,
+      /^Mixer node .* existing mixer handle namespace/i,
     )
   })
 
@@ -318,7 +381,9 @@ describe('Signal Chain mixer runtime namespace (SC.2)', () => {
     const state = stateWith(new Global(new RecordingScheduler()))
     await run('var mix = init global.mixer', state)
 
-    await expect(run('var mix = mix.sum', state)).rejects.toThrow(/mixer.*handle/i)
+    await expect(run('var mix = mix.sum', state)).rejects.toThrow(
+      /^Mixer node .* existing mixer handle namespace/i,
+    )
   })
 
   it('throws from exported global/sequence handlers when their target is absent', async () => {

--- a/tests/interpreter/mixer-runtime.spec.ts
+++ b/tests/interpreter/mixer-runtime.spec.ts
@@ -77,6 +77,18 @@ describe('Signal Chain mixer runtime namespace (SC.2)', () => {
     await expect(run('missing.effect("x")', state)).rejects.toThrow('Variable not found: missing')
   })
 
+  it('refuses to use any output endpoint as a receiver, including the implicit master', async () => {
+    // SC.3.3 forbids swallowing what the user wrote: an output endpoint has no
+    // receiver surface until #484 D4, so it must throw rather than resolve to an
+    // inert object that callMethod would silently no-op on.
+    const global = new Global(new RecordingScheduler())
+    const state = stateWith(global)
+    await expect(run('master.effect("Reverb.clap")', state)).rejects.toThrow('#484 D4')
+
+    await run('var mix = init global.mixer\nvar main = mix.output(1, 2)', state)
+    await expect(run('main.effect("Reverb.clap")', state)).rejects.toThrow('#484 D4')
+  })
+
   it('rejects invalid bases, duplicate kinds, and use of non-default output endpoints', async () => {
     const global = new Global(new RecordingScheduler())
     const state = stateWith(global)


### PR DESCRIPTION
Signal Chain DSL (#517) の **S1**。Phase B（#514 / PR #515）で AST として受理だけされていたミキサー宣言（SC.2.1）を、既存のミキサー実体へ写像して実行可能にする。

## 背景

Phase B までで新形状はパースできるが、interpreter に到達すると「Phase C で実装」の明示エラーで止まっていた。本 PR はそのうちミキサー宣言の実行を担当する。

なお #517 のスコープは、事前調査の結果（SC.0 の例は TS 側の写像だけでは原理的に実行できない）を受けて **Rust 拡張込みで「SC.0 完全実行まで」に改訂済み**。全体は S1〜S5 に分割され、本 PR はその1段目。

## 変更内容

### ミキサー宣言の実行
- `InterpreterState` に mixer registry（handle と typed node）を追加
- 新規 `packages/engine/src/signal-chain/runtime.ts` に registry と解決を集約
- `MixerInit`（`var mix = init global.mixer`）→ 同一 Global の卓への冪等な handle 取得（SC.2 規範1「卓は1枚」）
- `MixerNodeDecl` の写像
  - `mix.sum` → `Global.sum(変数名)`
  - `mix.aux` → `Global.aux(変数名)`
  - `mix.output(ch, ch)` → output endpoint のメタデータ（バスは確保しない）
- 不正な base・kind の再宣言・異なるチャンネルでの再宣言を明示エラー化
- `declaredNames()` に mixer 宣言を追加（import の契約検査に載せる）
- mixer node をレシーバとする文の dispatch を追加（SC.2 規範4「バス自身もレシーバ」）

### silent 素通りの廃止（SC.3.3）
- 未解決レシーバの `console.error` 継続を **throw** に変更
- output エンドポイント（暗黙 master を含む）をレシーバに使うと `#484 D4` を示す明示エラー

### LinkAudio 排他ゲート
- バスを確保しない Signal Chain 宣言（`init global.mixer` / `mix.output(...)`）でもゲートが効くよう `MixerManager` 側で記録。両方向（宣言後の `linkAudio()` / LinkAudio 有効時の宣言）で拒否

## 暗黙 master(1,2) の扱い（SC.2 規範6・決定 #75）

名前解決時の**遅延解決**とし、registry には登録しない。

`execute()` は REPL の評価単位ごとに呼ばれ `InterpreterState` は評価をまたいで持続するため、評価単位ごとの先読みにすると、宣言ブロックとトラック行を別々に評価した際に explicit mixer が宣言済みでも暗黙 master を誤登録してしまう。

仕様（SC.2 規範6）は静的な「ファイル」単位で書かれており、ライブ増分評価との橋渡しに明文がない。**spec への追記は follow-up**（本 PR では実装側のコメントに理由を残した）。

## 仕様の修正（先行）

SC.0 の例がシーケンスに対して存在しないメソッド `audioPath()` を呼んでいた誤記を修正した。シーケンスの音源指定は `Sequence.audio(filepath)`（`sequence.ts:681`）で、`audioPath(...)` は `Global` の検索パス設定（`global.ts:223`）。リポジトリ内の `.orbs` でも `.audio(` 158回 / `.audioPath(` 22回（後者は `global.` レシーバ）と使い分けられている。

仕様が正本のため実装に先立って spec 側を修正した。決定ログは当時の発言の記録のため変更していない。

## 互換性

- 既存の文字列形 API（`global.sum("drums")` / `global.aux("verb")` / `seq.output("drums")` / `effect("名前")` / `instrument("名前")`）はすべて存置（SC.8）。既存テストは無変更で通過
- `play()` 意味論は非変更（運用規則5）
- 未解決レシーバの throw 化で影響を受ける既存ファイルは `test-assets/scores/05_live_coding_session.orbs` の3行（`fixpitch` / `time` — 未実装機能の先取り記述）のみ。これらを実行するテストは存在しない。**手当ては S2 で明示エラー化と同時に行う**

## テスト

新規 `tests/interpreter/mixer-runtime.spec.ts` 7件:
- 冪等性（再評価で同一 handle / `sum`/`aux` の呼び出しは1回のみ）
- 暗黙 master の増分評価（評価を3回に分け、宣言が入った瞬間に消えること）
- バスレシーバの dispatch と未解決レシーバの throw
- output エンドポイントをレシーバに使えないこと（暗黙 master / 明示 `mix.output(1,2)` 両方）
- 不正な base・重複 kind・非既定 output endpoint の拒否
- LinkAudio 排他の両方向
- import の宣言名列挙

Phase B が置いた「まだ実行できない」ガードのテストは役目を終えたため撤去し、代替の所在を注釈として残した。

## 検証

| 項目 | 結果 |
|---|---|
| 全テスト | 1573 passed / 29 skipped |
| lint | エラー 0（既存 warning 2件のみ） |
| build | 通過 |

テストの検出力はミューテーションテストで確認済み（暗黙 master の遅延解決と output レシーバの明示エラーを意図的に壊すと、それぞれ対応するテストが落ちる）。

## レビュー経緯

`/simplify` 4観点（reuse / simplification / efficiency / altitude）を実施し、指摘6件を反映・3件を理由つきで見送り（`939b7f8`）。

反映のうち1件は挙動の穴だった: `mixerNodeReceiver` が既定チャンネル `(1,2)` に対して素のデータオブジェクトを返し、メソッド呼び出しが黙って素通りしていた（非既定チャンネルは明示エラーになるのに既定だけ黙る非対称）。simplification と altitude の両方から独立に指摘され、常に throw に統一した。

見送り3件:
- レシーバ解決のカスケードを `resolveReceiver()` として持ち上げる案 → S2 で `resolveChainName` を配線する際に同じ概念を扱うため、そこで一括
- `InterpreterState` のファクトリ導入 → 本差分以前からの既存事情でスコープ外
- `registerMixerNode` の channels 防御分岐 → AST 型が optional であるため型の絞り込みに必要

## 次段階

S2: `resolveChainName` の `callMethod` 配線 + プラグイン名ディスパッチ + 未知メソッドの明示エラー化。本 PR のブランチから枝を出す（stacked）。

Refs #517
