### PR TITLE
fix(test): decouple unit tests from the gitignored extension engine build (#537)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,53 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.302 fix(test): ユニットテストのビルド生成物依存を解消 #537 (Jul 27, 2026)
+
+**Date**: 2026-07-27
+**Status**: 🔄 レビュー待ち
+
+**内容**:
+PR #535 のマージ後、**CI で main が赤くなった**。
+
+**症状**: `start-engine-for-agent.spec.ts` の成功パスが CI（Linux）でのみ失敗し、
+`ok: true` を期待して `ok: false` を受け取る。
+
+**原因（実証済み）**: このテストは `child_process.spawn` **のみ**をモックし、本物の
+`startEngine()` プリフライトを通す。そのプリフライトの `resolveDaemonForUI()` が
+`require('../engine/dist/audio/rust-engine/daemon-client')` を呼ぶが、
+**`packages/vscode-extension/engine/` は gitignore されたビルド生成物**である
+（`.gitignore:47`）。そして `.github/workflows/code-review.yml` は
+**`npm test` を `npm run build` より先に**実行する。よって CI のテスト時点で
+`engine/dist` が存在せず、daemon 解決に失敗して `startEngine()` が false を返す。
+
+**修正**: `require` の境界を `engine-startup-runtime.ts` に切り出し、ユニットテストが
+そこを差し替えられるようにした。本番の挙動は不変（呼び出しを1段挟むのみ）。
+
+**fail-before / pass-after を隔離 worktree で取得**:
+
+| | CI 相当環境（`engine/dist` なし） |
+|---|---|
+| 修正前（`origin/main`） | **4件以上 FAIL**（`engine-command-awaits.spec.ts` の全テスト） |
+| 修正後 | **1722 passed / 29 skipped** |
+
+**CI ログは最初の失敗しか見せておらず、影響範囲を過小評価していた** — 実際は当該 spec の
+全テストが同じ原因で落ちていた。
+
+**発注側の失敗（記録）**:
+
+1. **CI 確認とマージを同一コマンドで実行した**。`code-review fail` を見た時には既に
+   マージ済みだった。`merge --admin` の指示は「CI を見なくてよい」ではない。
+   **少なくとも失敗の存在を報告してから実行すべきだった**
+2. **検証手順が環境を壊しうる形だった**。「`engine/dist` を退避して `npm test`」という
+   条件を課したが、これは中断されると環境が壊れる。実際 API 529 エラーで Codex が中断され、
+   `dist.bak` のまま取り残された。**`git worktree` で隔離コピーを作るべきだった**
+   （ラウンド2のレビュアーは同じ状況で自主的にそうしていた）
+3. **swap 中の一瞬を観測して「復元されていない」と誤報した**。1回目の観測は
+   Codex が退避・復元している最中で、環境は無事だった。慌てて報告した
+
+**検証**: `npm test` 1722 passed / 29 skipped・CI 相当環境でも 1722 passed・
+`tsc --build` 通過・lint エラー0。
+
 ### 6.301 fix(extension): engine プロセスライフサイクルの残穴を塞ぐ #532/#533/#534 (Jul 27, 2026)
 
 **Date**: 2026-07-27

--- a/packages/vscode-extension/src/engine-startup-runtime.ts
+++ b/packages/vscode-extension/src/engine-startup-runtime.ts
@@ -1,0 +1,24 @@
+import * as fs from 'fs'
+
+export interface EngineBinaryResolution {
+  path: string
+  source: string
+}
+
+/**
+ * Runtime boundary for the engine build copied into the packaged extension.
+ *
+ * Keeping the dynamic require here lets unit tests replace this boundary
+ * without requiring the ignored extension build artifacts to exist.
+ */
+export function resolveDaemonBinaryForExtension(): EngineBinaryResolution {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const daemonModule = require('../engine/dist/audio/rust-engine/daemon-client') as {
+    resolveDaemonBinaryPath: (explicitPath?: string) => EngineBinaryResolution
+  }
+  return daemonModule.resolveDaemonBinaryPath()
+}
+
+export function extensionEngineFileExists(enginePath: string): boolean {
+  return fs.existsSync(enginePath)
+}

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -60,6 +60,10 @@ import {
   type EngineExitEffects,
 } from './engine-lifecycle'
 import {
+  extensionEngineFileExists,
+  resolveDaemonBinaryForExtension,
+} from './engine-startup-runtime'
+import {
   detectDslCompletionContext,
   extractDeclaredBusNames,
   extractTopLevelDeclaredNames,
@@ -661,11 +665,7 @@ function resolveScsynthForUI(): { path: string; source: string } | null {
  */
 function resolveDaemonForUI(): { path: string; source: string } | null {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-    const daemonModule = require('../engine/dist/audio/rust-engine/daemon-client') as {
-      resolveDaemonBinaryPath: (explicitPath?: string) => { path: string; source: string }
-    }
-    return daemonModule.resolveDaemonBinaryPath()
+    return resolveDaemonBinaryForExtension()
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err)
     outputChannel?.appendLine(`❌ daemon resolver failed: ${reason}`)
@@ -1054,7 +1054,7 @@ function getEnginePath(debugMode: boolean): { enginePath: string; engineSource: 
   outputChannel?.appendLine(`📦 Using: ${engineSource}`)
   outputChannel?.appendLine(`📍 Path: ${enginePath}`)
 
-  if (!fs.existsSync(enginePath)) {
+  if (!extensionEngineFileExists(enginePath)) {
     vscode.window.showErrorMessage(
       `Extension engine not found: ${enginePath}\n\n` +
         `This indicates a build issue. Please rebuild the extension:\n` +

--- a/tests/vscode-extension/engine-command-awaits.spec.ts
+++ b/tests/vscode-extension/engine-command-awaits.spec.ts
@@ -8,6 +8,14 @@ vi.mock('child_process', async (importOriginal) => {
   return { ...actual, spawn: vi.fn(actual.spawn), execFile: vi.fn(actual.execFile) }
 })
 
+vi.mock('../../packages/vscode-extension/src/engine-startup-runtime', () => ({
+  extensionEngineFileExists: vi.fn(() => true),
+  resolveDaemonBinaryForExtension: vi.fn(() => ({
+    path: '/unit-test/orbit-audio-daemon',
+    source: 'unit-test',
+  })),
+}))
+
 let child_process: typeof import('child_process')
 let ext: typeof import('../../packages/vscode-extension/src/extension')
 let vscode: typeof import('vscode')

--- a/tests/vscode-extension/start-engine-for-agent.spec.ts
+++ b/tests/vscode-extension/start-engine-for-agent.spec.ts
@@ -4,17 +4,16 @@
  *
  * Unlike extension-wiring.spec.ts (which calls the exported setup*Handler
  * functions directly, bypassing `startEngine()`'s pre-flight entirely), this
- * spec mocks ONLY `child_process.spawn` and exercises the REAL
- * `startEngine()` pre-flight (engine-kind resolution via
- * `require('../engine/dist/audio/engine-backend')`, daemon-path resolution
- * via `require('../engine/dist/audio/rust-engine/daemon-client')`, and the
- * `packages/vscode-extension/engine/dist/cli-audio.js` existence check) —
- * this is the only way to prove `startEngineForAgent` itself (not just
+ * spec mocks `child_process.spawn` plus the extension build-artifact boundary,
+ * then exercises the REAL `startEngine()` pre-flight and spawn-confirmation
+ * path. The boundary mock supplies a resolved daemon and confirms the
+ * extension-local CLI path is present; assertions below prove both pre-flight
+ * checks still ran. Engine-kind resolution remains real (and intentionally
+ * exercises its production fallback when ignored build artifacts are absent).
+ * This is the only way to prove `startEngineForAgent` itself (not just
  * `applyEngineError`'s pure logic, covered in engine-lifecycle.spec.ts)
- * detects a spawn failure. It depends on this checkout's build artifacts
- * under `packages/vscode-extension/engine/dist/` and
- * `rust/target/release/orbit-audio-daemon` — the same assumption
- * tests/audio/rust-engine/real-daemon-timing.spec.ts already makes.
+ * detects a spawn failure without making the unit test depend on a prior
+ * extension build.
  *
  * #533's core claim: `engineProcess.killed` cannot detect a spawn failure —
  * it only reflects whether WE sent a signal, and we never do on failure. A
@@ -30,6 +29,10 @@ import * as child_process from 'child_process'
 import * as vscode from 'vscode'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
+import {
+  extensionEngineFileExists,
+  resolveDaemonBinaryForExtension,
+} from '../../packages/vscode-extension/src/engine-startup-runtime'
 import * as ext from '../../packages/vscode-extension/src/extension'
 
 vi.mock('child_process', async (importOriginal) => {
@@ -39,6 +42,14 @@ vi.mock('child_process', async (importOriginal) => {
     spawn: vi.fn(actual.spawn),
   }
 })
+
+vi.mock('../../packages/vscode-extension/src/engine-startup-runtime', () => ({
+  extensionEngineFileExists: vi.fn(() => true),
+  resolveDaemonBinaryForExtension: vi.fn(() => ({
+    path: '/unit-test/orbit-audio-daemon',
+    source: 'unit-test',
+  })),
+}))
 
 interface FakeSpawnedProcess {
   proc: child_process.ChildProcess
@@ -69,6 +80,8 @@ describe('startEngineForAgent post-spawn detection (#533)', () => {
   let showInformationMessage: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    vi.mocked(extensionEngineFileExists).mockClear()
+    vi.mocked(resolveDaemonBinaryForExtension).mockClear()
     ext.__setEngineProcessForTest(null)
     ext.__setStatusBarItemForTest({ text: '', tooltip: '' })
     ext.__setOutputChannelForTest({ appendLine: () => {}, append: () => {} })
@@ -124,6 +137,11 @@ describe('startEngineForAgent post-spawn detection (#533)', () => {
     const result = await ext.startEngineForAgent({ debug: true })
 
     expect(result).toEqual({ ok: true, message: 'engine starting' })
+    expect(resolveDaemonBinaryForExtension).toHaveBeenCalledOnce()
+    expect(extensionEngineFileExists).toHaveBeenCalledOnce()
+    expect(extensionEngineFileExists).toHaveBeenCalledWith(
+      expect.stringContaining('packages/vscode-extension/engine/dist/cli-audio.js'),
+    )
     expect(showInformationMessage).toHaveBeenCalledTimes(1)
     expect(showInformationMessage).toHaveBeenCalledWith('✅ Engine started (Debug)')
   })


### PR DESCRIPTION
PR #535 のマージ後、**CI で main が赤くなった**件の修正です。

## 症状

`start-engine-for-agent.spec.ts` の成功パスが CI（Linux）でのみ失敗し、`ok: true` を期待して
`ok: false` を受け取る。ローカル（macOS）では通る。

## 原因（実証済み・推測ではありません）

このテストは `child_process.spawn` **のみ**をモックし、本物の `startEngine()` プリフライトを
通します。そのプリフライトの `resolveDaemonForUI()` が

```ts
require('../engine/dist/audio/rust-engine/daemon-client')
```

を呼びますが、**`packages/vscode-extension/engine/` は gitignore されたビルド生成物**です
（`.gitignore:47`）。

そして `.github/workflows/code-review.yml` は **`npm test` を `npm run build` より先に**実行します:

```yaml
- name: Run tests
  run: npm test
- name: Build project
  run: npm run build
```

よって CI のテスト時点で `engine/dist` が存在せず、daemon 解決に失敗して `startEngine()` が
`false` を返します。

## 修正

`require` の境界を `engine-startup-runtime.ts` に切り出し、ユニットテストがそこを
差し替えられるようにしました。**本番の挙動は不変**です（呼び出しを1段挟むのみ）。

**CI の順序入れ替え（build → test）は採りませんでした。** 全テストのフィードバックを遅くし、
「ユニットテストがビルド生成物に依存してよい」という前例を作るためです。

## fail-before / pass-after（隔離 worktree で取得）

| | CI 相当環境（`engine/dist` なし） |
|---|---|
| 修正前（`origin/main`） | **4件以上 FAIL**（`engine-command-awaits.spec.ts` の全テスト） |
| 修正後 | **1722 passed / 29 skipped** |

**CI ログは最初の失敗しか見せておらず、影響範囲を過小評価していました** — 実際は当該 spec の
全テストが同じ原因で落ちていました。

## 発注側（私）の失敗の記録

1. **CI 確認とマージを同一コマンドで実行した。** `code-review fail` を見た時には既に
   マージ済みだった。`merge --admin` の指示は「CI を見なくてよい」という意味ではない
2. **検証手順が環境を壊しうる形だった。** 「`engine/dist` を退避して `npm test`」という
   条件を委譲先に課したが、これは中断されると環境が壊れる。実際 API 529 エラーで中断され
   `dist.bak` のまま取り残された。**`git worktree` で隔離コピーを作るべきだった**
3. **swap 中の一瞬を観測して「復元されていない」と誤報した**

## 検証

- `npm test` **1722 passed / 29 skipped**
- **CI 相当環境（`engine/dist` なし）でも 1722 passed**
- `tsc --build` 通過 / `npm run lint` エラー0
- 本番差分を目視確認・一時コードの混入なし

Closes #537