### PR TITLE
fix(engine): make plugin format invisible to users — bundle VST3 effect child and resolve format per plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Build OOP-both Rust daemon and CLAP child binaries
         run: |
           cargo build --release -p orbit-audio-daemon --features outproc-effect,outproc-instrument --manifest-path rust/Cargo.toml
-          cargo build --release -p orbit-clap-effect-child -p orbit-clap-instrument-child -p orbit-vst3-instrument-child --manifest-path rust/Cargo.toml
+          cargo build --release -p orbit-clap-effect-child -p orbit-clap-instrument-child -p orbit-vst3-effect-child -p orbit-vst3-instrument-child --manifest-path rust/Cargo.toml
           cargo build --release -p orbit-plugin-scan --manifest-path rust/Cargo.toml
 
       - name: Build engine + extension TypeScript
@@ -138,7 +138,7 @@ jobs:
           fi
           echo "orbit-audio-daemon present and executable in packaged .vsix"
 
-          for CHILD_BIN in orbit-clap-effect-child orbit-clap-instrument-child orbit-vst3-instrument-child; do
+          for CHILD_BIN in orbit-clap-effect-child orbit-clap-instrument-child orbit-vst3-effect-child orbit-vst3-instrument-child; do
             CHILD_PATH="$VSIX_CHECK/extension/engine/bin/darwin-arm64/$CHILD_BIN"
             if [ ! -f "$CHILD_PATH" ]; then
               echo "::error::$CHILD_BIN missing from packaged .vsix at engine/bin/darwin-arm64/ — OOP plugin hosting cannot start its child" >&2

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -69,8 +69,35 @@ post-package gate（`for CHILD_BIN in ...`）が `orbit-vst3-effect-child` を�
 **本バグの再発を防ぐはずのセーフティネット自身が同じ欠落を抱えていた**。ビルド一覧
 （`:89`）と gate（`:141`）の両方を修正し、テストの台帳を release.yml まで拡張した。
 
-**検証**: TS 1739 passed（+4）/ Rust 127 passed（+4）/ fmt・clippy clean /
+**検証**: TS 1739 passed（+4）/ fmt・clippy clean /
 **env を一切設定せずに VST3 エフェクトが `orbit-vst3-effect-child` を起動**することを実機で確認。
+
+**`/simplify` の指摘を反映（3エージェントが一致して挙げた重複）**:
+
+effect 側に新規追加した `from_plugin_path` / `child_exe_for_attach` は、instrument 側の
+同名関数と**列挙型名以外は逐語的に同一**だった。doc コメント自身が「instrument 側と同一規則」
+「effect 側と対称」と互いを参照し合っており、**規則を直したとき片方だけ直し忘れる運用**に
+頼っていた。#548 がまさに「片方だけ入っていなかった」バグである以上、同じ形を増やすのは筋が悪い。
+
+`outproc_child_exe` モジュールへ規則そのものを抽出し、各 role は**binary 名の対だけ**を渡す形に:
+
+- `is_vst3_plugin_path` / `child_exe_for_attach(current, plugin, clap_name, vst3_name)`
+- ログ用の `exe_label`（両 supervisor で重複していた6行）も集約
+- 抽出の結果、両 enum の `from_plugin_path` が**デッドコードになったので削除**した
+- unit テストは削除した内部メソッドではなく**公開の入口** `child_exe_for_attach` 経由へ付け替えた
+  （実際に attach で使われる経路を守る形になる）
+
+**変異検証（4種・すべて red）**: (a) 拡張子判定の反転 (b) 明示指定ガードの無効化
+(c) clap/vst3 名の入れ替え (d) ディレクトリを捨てて sibling 解決を壊す。
+**いずれも effect と instrument の両方のテストが落ちた** — 規則が本当に共有されている証拠。
+
+**doc の誤りも訂正**: `ORBIT_EFFECT_FORMAT` の存置理由を「gated テストが使うため」と
+書いていたが、repo 全体を grep すると**利用者は本ファイルとドキュメントのみ**で、gated テストは
+`OutProcEffectConfig` を直接組み立てており env を経由しない。実態（無効値の loud な起動失敗という
+既存挙動を黙って変えないため）に書き換えた。
+
+**検証**: Rust workspace 全 green（daemon は `--features outproc-effect,outproc-instrument` で 132 passed）/
+TS 1739 passed / fmt・clippy clean。
 
 ### 6.307 docs(specs-v2): Phase 0 設計 spec 3本 正本化 #547 (Jul 28, 2026)
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,10 +17,48 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
-### 6.307 docs(specs-v2): Phase 0 設計 spec 3本 正本化 #547 (Jul 28, 2026)
+### 6.308 fix(build): bundle orbit-vst3-effect-child #548 (Jul 28, 2026)
 
 **Date**: 2026-07-28
 **Status**: 🔄 PR 準備中
+
+**実害**: 出荷された OrbitStudio で VST3 エフェクトを使うと child の spawn が失敗していた。
+daemon は `ORBIT_EFFECT_FORMAT=vst3` のとき `orbit-vst3-effect-child` を spawn しようとする
+（`outproc_effect.rs:84`・既定パスは daemon と同一ディレクトリ）のに、`copy-daemon-bin.sh` の
+再ビルド一覧にも copy 一覧にも含まれていなかった。
+
+**実機で再現・修正を確認**:
+
+```
+修正前: ERROR: Failed to load plugin: [OUTPROC_EFFECT_RUNTIME] spawn outproc child
+        ".../orbit-vst3-effect-child": No such file or directory (os error 2)
+修正後: 52012 .../engine/bin/darwin-arm64/orbit-vst3-effect-child
+        --plugin /Library/Audio/Plug-Ins/VST3/Tape Echo v6.vst3 ...
+```
+
+**なぜ既存テストで検出できなかったか**: gated テスト（`outproc_effect_vst3_gated.rs:28`）は
+自前で `cargo build -p orbit-vst3-effect-child` してから走るため、**バンドル経路を通らない**。
+ソースツリーを見るテストでは同じ穴が再発する。
+
+**修正**:
+1. `scripts/copy-daemon-bin.sh` の cargo 再ビルド一覧と `copy_binary` 一覧の両方に追加
+2. **二重台帳の回帰テスト**（`tests/vscode-extension/bundled-child-binaries.spec.ts`）:
+   台帳A = daemon Rust ソース中の child 名リテラル / 台帳B = コピー対象 + バンドル実体。
+   A ⊆ B を検査するので、**daemon に format を足すと自動的に要求が増える**
+
+**変異検証（5種・すべて red を確認）**: ①`copy_binary` 削除（元のバグ再現）②`cargo -p` 削除
+（stale コピー・#487 再発）③バンドル実体のみ削除 ④daemon literal のリネーム ⑤抽出パターン破壊。
+
+> **④で初版テストの欠陥が発覚**: `orbit-[a-z0-9-]+-child` と綴りを決め打ちしていたため、
+> リネームすると**台帳Aが黙って縮んで pass** していた（silent partial coverage）。
+> 綴り非依存のパターンに変え、**モジュールごとの抽出件数**を検査するよう修正した。
+
+**検証**: 全スイート 1738 passed（+3）/ ビルド + 実機 MCP E2E で child の実起動を確認。
+
+### 6.307 docs(specs-v2): Phase 0 設計 spec 3本 正本化 #547 (Jul 28, 2026)
+
+**Date**: 2026-07-28
+**Status**: ✅ **PR #550 MERGED**（main `cab5c85`・2026-07-28・#547 CLOSED）
 
 **内容**: Epic #546 Phase 0（設計確定）の成果物を spec として正本化。owner が5論点を承認し、
 **プラグイン形式に依存しない UX** が中核制約として追加されたことを受けた設計。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -53,7 +53,24 @@ daemon は `ORBIT_EFFECT_FORMAT=vst3` のとき `orbit-vst3-effect-child` を sp
 > リネームすると**台帳Aが黙って縮んで pass** していた（silent partial coverage）。
 > 綴り非依存のパターンに変え、**モジュールごとの抽出件数**を検査するよう修正した。
 
-**検証**: 全スイート 1738 passed（+3）/ ビルド + 実機 MCP E2E で child の実起動を確認。
+**#552 も同時に修正**（owner 判断: テスト負債になる前に潰す）: effect の plugin format が
+`ORBIT_EFFECT_FORMAT` による **process-global** だったため、CLAP と VST3 のエフェクトを
+同一チェーンに混在できなかった。**プラグイン形式は利用者に見えてはならない実装の詳細**
+（CAP.6-1）であり、instrument 側（`from_plugin_path`）と同じ per-plugin 解決へ揃えた。
+`select_child_exe` トレイトの seam は既にあり、effect 実装が no-op だっただけ。
+
+**🔴 変異検証で配線の穴が発覚**: 純関数 `child_exe_for_attach` のユニットテスト3件を書いても、
+**`select_child_exe` を no-op に戻す変異（= 元のバグそのもの）が green のまま生き残った**。
+純関数と load 経路を繋ぐ**配線**は別物であり、instrument 側と対称の配線テスト
+（`effect_select_child_exe_swaps_default_child_by_extension`）を追加して初めて red になった。
+
+**altitude レビューで出荷ゲートの穴も発覚**: `.github/workflows/release.yml` の
+post-package gate（`for CHILD_BIN in ...`）が `orbit-vst3-effect-child` を検査しておらず、
+**本バグの再発を防ぐはずのセーフティネット自身が同じ欠落を抱えていた**。ビルド一覧
+（`:89`）と gate（`:141`）の両方を修正し、テストの台帳を release.yml まで拡張した。
+
+**検証**: TS 1739 passed（+4）/ Rust 127 passed（+4）/ fmt・clippy clean /
+**env を一切設定せずに VST3 エフェクトが `orbit-vst3-effect-child` を起動**することを実機で確認。
 
 ### 6.307 docs(specs-v2): Phase 0 設計 spec 3本 正本化 #547 (Jul 28, 2026)
 

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -1193,9 +1193,18 @@ impl OutProcRole for EffectRole {
         stats.current_child_pid.store(pid, Ordering::Relaxed);
     }
     fn select_child_exe(
-        _launch: &mut ChildLaunch<Self>,
-        _path: &std::path::Path,
+        launch: &mut ChildLaunch<Self>,
+        path: &std::path::Path,
     ) -> Result<(), String> {
+        // #552: 拡張子ベースの読み替え（.vst3 → VST3 child・それ以外 → CLAP child）。
+        // 明示指定された child exe（デフォルト名以外）は保持される。instrument 側と同一の規則で、
+        // 詳細は `outproc_effect::child_exe_for_attach` の doc を参照。
+        launch.child_exe = crate::outproc_effect::child_exe_for_attach(&launch.child_exe, path);
+        tracing::debug!(
+            ?path,
+            child_exe = ?launch.child_exe,
+            "effect child selected for attach"
+        );
         Ok(())
     }
     #[cfg(test)]
@@ -5324,11 +5333,15 @@ mod outproc_load_error_test_support {
 /// `EngineWrap` に対して real child を spawn せず `Some(OutProcControl)` を注入できる。
 #[cfg(all(test, feature = "outproc-effect"))]
 mod outproc_health_tests {
-    use super::{ChildSlot, EffectRole, EngineWrap, OutProcControl, OutProcRole, WrapError};
+    use super::{
+        ChildLaunch, ChildSlot, EffectRole, EngineWrap, OutProcControl, OutProcRole, WrapError,
+    };
     use crate::backend::StubBackend;
     use crate::outproc_effect::OutProcEffectStats;
     use orbit_audio_native::CallbackTimeStats;
     use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::AtomicBool;
     use std::sync::atomic::Ordering;
     use std::sync::{Arc, Mutex, Weak};
 
@@ -5374,6 +5387,58 @@ mod outproc_health_tests {
             bus_sends: HashMap::new(),
         });
         (wrap, child_slot)
+    }
+
+    /// #552 配線ピン: effect の `select_child_exe` が**実際に読み替えを行う**ことを検証する。
+    ///
+    /// `outproc_effect::child_exe_for_attach` の純関数ユニットテストだけでは足りない —
+    /// trait 実装が no-op（修正前の状態）に戻っても、純関数のテストは green のままだった
+    /// （変異検証で実証）。**純関数と load 経路を繋ぐ配線そのもの**をここで押さえる。
+    #[test]
+    fn effect_select_child_exe_swaps_default_child_by_extension() {
+        let stats = EffectRole::new_stats();
+        let mut launch = ChildLaunch::<EffectRole> {
+            shm_path: PathBuf::from("/tmp/unused-effect-select-child-exe.shm"),
+            child_exe: PathBuf::from("/opt/orbitscore/orbit-clap-effect-child"),
+            sample_rate: 48_000,
+            stats: stats.clone(),
+            engaged: Arc::new(AtomicBool::new(false)),
+            cleanup_shm_on_drop: false,
+        };
+
+        EffectRole::select_child_exe(&mut launch, Path::new("Tape Echo.vst3"))
+            .expect("select_child_exe must not error on default child name");
+        assert_eq!(
+            launch.child_exe.file_name().and_then(|name| name.to_str()),
+            Some("orbit-vst3-effect-child"),
+            "VST3 エフェクトを attach したら VST3 child に読み替わらねばならない（#552）"
+        );
+
+        // 対称: 次に .clap を attach すると CLAP child へ戻る（混在チェーンの前提）。
+        EffectRole::select_child_exe(&mut launch, Path::new("Surge.clap"))
+            .expect("select_child_exe must not error on default child name");
+        assert_eq!(
+            launch.child_exe.file_name().and_then(|name| name.to_str()),
+            Some("orbit-clap-effect-child"),
+            "CLAP エフェクトを attach したら CLAP child へ戻らねばならない（#552）"
+        );
+
+        // 明示指定（デフォルト名以外）は touch しない = ORBIT_EFFECT_CHILD_BIN / gated 直指定の保護。
+        let mut explicit_launch = ChildLaunch::<EffectRole> {
+            shm_path: PathBuf::from("/tmp/unused-effect-select-child-exe-explicit.shm"),
+            child_exe: PathBuf::from("/opt/orbitscore/custom-effect-child"),
+            sample_rate: 48_000,
+            stats,
+            engaged: Arc::new(AtomicBool::new(false)),
+            cleanup_shm_on_drop: false,
+        };
+        EffectRole::select_child_exe(&mut explicit_launch, Path::new("Tape Echo.vst3"))
+            .expect("select_child_exe must not error on explicit child name");
+        assert_eq!(
+            explicit_launch.child_exe,
+            PathBuf::from("/opt/orbitscore/custom-effect-child"),
+            "明示指定された child exe は読み替えてはならない"
+        );
     }
 
     #[test]

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -1102,7 +1102,11 @@ pub(crate) trait OutProcRole: Sized {
     fn set_child_early_exit(stats: &Self::Stats, value: bool);
     fn child_early_exit(stats: &Self::Stats) -> bool;
     fn set_current_child_pid(stats: &Self::Stats, pid: u32);
-    /// Attach path で plugin format に依存する child を選び直す。effect は env 設定のまま。
+    /// Attach する plugin のパスから、その format に対応する child を選び直す。
+    ///
+    /// **#552 以降、effect と instrument の両 role が per-plugin 解決を行う**（利用者に
+    /// プラグイン形式を見せないため・CAP.6-1）。デフォルト名以外の child exe は明示指定と
+    /// 見なして保持する。詳細は各 role の `child_exe_for_attach` doc を参照。
     fn select_child_exe(
         launch: &mut ChildLaunch<Self>,
         path: &std::path::Path,

--- a/rust/crates/orbit-audio-daemon/src/lib.rs
+++ b/rust/crates/orbit-audio-daemon/src/lib.rs
@@ -16,6 +16,10 @@ pub mod engine_wrap;
 /// コンパイルされ、GPL crate `orbit-link-audio` を保持する consumer thread を起動する。
 #[cfg(feature = "link-audio")]
 pub mod link_audio;
+/// attach する plugin の拡張子から child binary を選ぶ規則。**effect と instrument で共有する**
+/// （規則を2箇所に持つと、片方だけ直し忘れる — #548 がまさにその形のバグだった）。
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+pub(crate) mod outproc_child_exe;
 /// γ M1 PR-C: out-of-process effect の daemon 配線。feature `outproc-effect`（default off・clack-free）
 /// でのみコンパイルされ、別プロセスの実 CLAP effect child へ共有メモリ transport 越しに audio を流す。
 #[cfg(feature = "outproc-effect")]

--- a/rust/crates/orbit-audio-daemon/src/outproc_child_exe.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_child_exe.rs
@@ -1,0 +1,125 @@
+//! attach する plugin の拡張子から out-of-process child binary を選ぶ規則（#552）。
+//!
+//! **effect と instrument で共有する。** 両者は「フォーマット別デフォルト名なら同ディレクトリで
+//! 読み替え、そうでなければ明示指定として触らない」という同一の規則を持ち、違うのは
+//! **binary 名の対だけ**。別々に持つと、規則を直したとき片方だけ直し忘れる形になる
+//! （まさに #548 が「片方だけ入っていなかった」バグだった）。
+
+use std::path::{Path, PathBuf};
+
+/// plugin path が VST3 か。**未知拡張子は VST3 ではない**（= CLAP へフォールバックする）。
+///
+/// CLAP は VST3 対応前から唯一サポートされていた format なので、未知拡張子のフォールバック先
+/// として妥当。gated テストは未バンドルの raw `.dylib`（clap-test-synth）を attach するため、
+/// ここで未知拡張子を reject すると既存経路が壊れる。不正な plugin path の失敗は従来どおり
+/// child 側の load エラーとして表面化する。
+pub(crate) fn is_vst3_plugin_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("vst3"))
+}
+
+/// attach する plugin に合わせて child binary を読み替える（純関数）。
+///
+/// - `current_child_exe` の file name が `clap_name` / `vst3_name` のどちらでもない場合は
+///   **明示指定と見なして触らない**（`ORBIT_*_CHILD_BIN` override と gated テストの
+///   config 直指定を保護する）。
+/// - デフォルト名の場合は**同じディレクトリ**でフォーマットに応じた binary に読み替える。
+///   `current_exe` からの再導出はしない（テストハーネスでは `current_exe` が
+///   `target/debug/deps/` 配下になり sibling 解決が壊れるため）。
+/// - **冪等かつ対称**: retryable な attach 失敗で `ChildLaunch` が再利用されても毎回この
+///   読み替えが走るので、`.vst3` → `.clap` の attach し直しで元の child に戻る。
+///
+/// 🔴 デフォルト名は呼び出し側が `default_child_name()` から渡すこと（手打ちリテラルにしない）。
+/// 決め打ちだと child をリネームしたとき判定が常に false へ倒れ、**per-plugin のフォーマット
+/// 切替が無音のまま無効化される**。
+pub(crate) fn child_exe_for_attach(
+    current_child_exe: &Path,
+    plugin_path: &Path,
+    clap_name: &'static str,
+    vst3_name: &'static str,
+) -> PathBuf {
+    let current_name = current_child_exe.file_name().and_then(|name| name.to_str());
+    let is_default_name = current_name.is_some_and(|name| name == clap_name || name == vst3_name);
+    if !is_default_name {
+        return current_child_exe.to_path_buf();
+    }
+    let desired = if is_vst3_plugin_path(plugin_path) {
+        vst3_name
+    } else {
+        clap_name
+    };
+    match current_child_exe.parent() {
+        Some(dir) => dir.join(desired),
+        None => PathBuf::from(desired),
+    }
+}
+
+/// ログ表示用に child binary の名前を取り出す。取れなければ `fallback`。
+pub(crate) fn exe_label(exe: &Path, fallback: &str) -> String {
+    exe.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(fallback)
+        .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CLAP: &str = "orbit-clap-effect-child";
+    const VST3: &str = "orbit-vst3-effect-child";
+
+    #[test]
+    fn default_child_is_swapped_by_extension_within_the_same_directory() {
+        let current = Path::new("/opt/orbit/bin").join(CLAP);
+        assert_eq!(
+            child_exe_for_attach(&current, Path::new("/plugins/Reverb.vst3"), CLAP, VST3),
+            Path::new("/opt/orbit/bin").join(VST3),
+            "同ディレクトリで読み替えていない"
+        );
+        // 逆向きも成立する（冪等・対称）。
+        let vst3_current = Path::new("/opt/orbit/bin").join(VST3);
+        assert_eq!(
+            child_exe_for_attach(&vst3_current, Path::new("/plugins/Delay.clap"), CLAP, VST3),
+            Path::new("/opt/orbit/bin").join(CLAP)
+        );
+    }
+
+    #[test]
+    fn an_explicitly_named_child_is_left_alone() {
+        let explicit = Path::new("/custom/my-own-child");
+        assert_eq!(
+            child_exe_for_attach(explicit, Path::new("/plugins/Reverb.vst3"), CLAP, VST3),
+            explicit,
+            "明示指定の child を書き換えた（override が壊れる）"
+        );
+    }
+
+    #[test]
+    fn an_unknown_extension_falls_back_to_clap() {
+        let current = Path::new("/opt/orbit/bin").join(VST3);
+        assert_eq!(
+            child_exe_for_attach(&current, Path::new("/plugins/raw.dylib"), CLAP, VST3),
+            Path::new("/opt/orbit/bin").join(CLAP),
+            "未知拡張子が CLAP へ落ちていない（raw .dylib の gated テストが壊れる）"
+        );
+    }
+
+    #[test]
+    fn vst3_detection_ignores_case_and_rejects_lookalikes() {
+        assert!(is_vst3_plugin_path(Path::new("/p/A.VST3")));
+        assert!(is_vst3_plugin_path(Path::new("/p/A.vst3")));
+        assert!(!is_vst3_plugin_path(Path::new("/p/A.vst")));
+        assert!(!is_vst3_plugin_path(Path::new("/p/vst3")), "拡張子ではない");
+    }
+
+    #[test]
+    fn exe_label_falls_back_when_the_path_has_no_file_name() {
+        assert_eq!(
+            exe_label(Path::new("/opt/bin/child-x"), "fallback"),
+            "child-x"
+        );
+        assert_eq!(exe_label(Path::new("/"), "fallback"), "fallback");
+    }
+}

--- a/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
@@ -78,11 +78,54 @@ impl PluginFormat {
         }
     }
 
+    /// 拡張子 `.vst3`（大文字小文字不問）のみ VST3。**それ以外はすべて Clap**。
+    /// instrument 側（`outproc_instrument::InstrumentPluginFormat::from_plugin_path`）と同一規則。
+    ///
+    /// CLAP は VST3 対応前から唯一サポートされていた format なので、未知拡張子の
+    /// フォールバック先として妥当（raw `.dylib` の CLAP を attach する gated テストがある）。
+    /// 不正な plugin path の失敗は従来どおり child 側の load エラーとして表面化する。
+    fn from_plugin_path(path: &Path) -> Self {
+        match path.extension().and_then(|extension| extension.to_str()) {
+            Some(extension) if extension.eq_ignore_ascii_case("vst3") => Self::Vst3,
+            _ => Self::Clap,
+        }
+    }
+
     fn default_child_name(self) -> &'static str {
         match self {
             Self::Clap => "orbit-clap-effect-child",
             Self::Vst3 => "orbit-vst3-effect-child",
         }
+    }
+}
+
+/// attach する plugin の拡張子から effect child binary を選ぶ（純関数・unit テスト対象）。
+///
+/// **#552**: 従来 effect の format は `ORBIT_EFFECT_FORMAT` による **process-global** だったため、
+/// 1つのチェーンに CLAP と VST3 のエフェクトを混在させられなかった。プラグイン形式は
+/// 利用者に見えてはならない実装の詳細であり（`PLUGIN_CAPABILITY_ABSTRACTION_v1.md` CAP.6-1
+/// 「上位は能力 ID だけを知り、形式分岐を持たない」）、instrument 側と同じ per-plugin 解決へ揃える。
+///
+/// - `current_child_exe` の file name がフォーマット別デフォルト名でない場合は
+///   **明示指定と見なして触らない**（`ORBIT_EFFECT_CHILD_BIN` override と gated テストの
+///   config 直指定を保護する）。
+/// - デフォルト名の場合は**同じディレクトリ**でフォーマットに応じた binary に読み替える。
+///   `current_exe` からの再導出はしない（テストハーネスでは `current_exe` が
+///   `target/debug/deps/` 配下になり sibling 解決が壊れるため）。
+/// - 冪等かつ対称: retryable な attach 失敗で `ChildLaunch` が再利用されても毎回この読み替えが
+///   走るので、`.vst3` → `.clap` の attach し直しで元の child に戻る。
+pub(crate) fn child_exe_for_attach(current_child_exe: &Path, plugin_path: &Path) -> PathBuf {
+    let is_default_name = matches!(
+        current_child_exe.file_name().and_then(|name| name.to_str()),
+        Some("orbit-clap-effect-child") | Some("orbit-vst3-effect-child")
+    );
+    if !is_default_name {
+        return current_child_exe.to_path_buf();
+    }
+    let desired = PluginFormat::from_plugin_path(plugin_path).default_child_name();
+    match current_child_exe.parent() {
+        Some(dir) => dir.join(desired),
+        None => PathBuf::from(desired),
     }
 }
 
@@ -997,6 +1040,52 @@ mod tests {
         );
         stop.store(true, Ordering::Relaxed);
         handle.join().expect("process loop thread joins");
+    }
+
+    // #552: effect の format は attach する plugin ごとに決まる（process-global ではない）。
+    // 利用者にプラグイン形式は見えてはならず、CLAP と VST3 のエフェクトは同一チェーンに
+    // 混在できなければならない（CAP.6-1「上位は形式分岐を持たない」）。
+    #[test]
+    fn effect_plugin_format_selects_child_name_from_extension() {
+        assert_eq!(
+            PluginFormat::from_plugin_path(Path::new("reverb.clap")).default_child_name(),
+            "orbit-clap-effect-child"
+        );
+        assert_eq!(
+            PluginFormat::from_plugin_path(Path::new("Tape Echo.VST3")).default_child_name(),
+            "orbit-vst3-effect-child"
+        );
+        // 未知拡張子は CLAP へフォールバック（raw .dylib の CLAP を attach する gated テストがある）。
+        assert_eq!(
+            PluginFormat::from_plugin_path(Path::new("libclap_test_effect.dylib"))
+                .default_child_name(),
+            "orbit-clap-effect-child"
+        );
+    }
+
+    #[test]
+    fn effect_child_exe_for_attach_swaps_within_same_directory() {
+        let clap_child = PathBuf::from("/opt/orbit/bin/orbit-clap-effect-child");
+        assert_eq!(
+            child_exe_for_attach(&clap_child, Path::new("/plugins/Tape Echo.vst3")),
+            PathBuf::from("/opt/orbit/bin/orbit-vst3-effect-child"),
+        );
+        // 対称・冪等: VST3 child から .clap を attach し直すと CLAP child へ戻る。
+        let vst3_child = PathBuf::from("/opt/orbit/bin/orbit-vst3-effect-child");
+        assert_eq!(
+            child_exe_for_attach(&vst3_child, Path::new("/plugins/Surge.clap")),
+            PathBuf::from("/opt/orbit/bin/orbit-clap-effect-child"),
+        );
+    }
+
+    #[test]
+    fn effect_child_exe_for_attach_preserves_explicit_override() {
+        // ORBIT_EFFECT_CHILD_BIN / gated テストの直指定を壊さない（デフォルト名以外は触らない）。
+        let explicit = PathBuf::from("/custom/my-effect-host");
+        assert_eq!(
+            child_exe_for_attach(&explicit, Path::new("/plugins/Tape Echo.vst3")),
+            explicit,
+        );
     }
 
     // C2（pr-review-team）: format 選択の純関数は device/child プロセス不要で CI 常時実行できるのに

--- a/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
@@ -78,19 +78,6 @@ impl PluginFormat {
         }
     }
 
-    /// 拡張子 `.vst3`（大文字小文字不問）のみ VST3。**それ以外はすべて Clap**。
-    /// instrument 側（`outproc_instrument::InstrumentPluginFormat::from_plugin_path`）と同一規則。
-    ///
-    /// CLAP は VST3 対応前から唯一サポートされていた format なので、未知拡張子の
-    /// フォールバック先として妥当（raw `.dylib` の CLAP を attach する gated テストがある）。
-    /// 不正な plugin path の失敗は従来どおり child 側の load エラーとして表面化する。
-    fn from_plugin_path(path: &Path) -> Self {
-        match path.extension().and_then(|extension| extension.to_str()) {
-            Some(extension) if extension.eq_ignore_ascii_case("vst3") => Self::Vst3,
-            _ => Self::Clap,
-        }
-    }
-
     fn default_child_name(self) -> &'static str {
         match self {
             Self::Clap => "orbit-clap-effect-child",
@@ -115,23 +102,15 @@ impl PluginFormat {
 /// - 冪等かつ対称: retryable な attach 失敗で `ChildLaunch` が再利用されても毎回この読み替えが
 ///   走るので、`.vst3` → `.clap` の attach し直しで元の child に戻る。
 pub(crate) fn child_exe_for_attach(current_child_exe: &Path, plugin_path: &Path) -> PathBuf {
-    // 🔴 デフォルト名は `default_child_name()` から導出する（手打ちリテラルにしない）。
-    // 決め打ちだと child をリネームしたとき is_default_name が常に false になり、
-    // **per-plugin のフォーマット切替が無音のまま無効化される**（#552 が退行しても
-    // 古いリテラル前提のテストは気づけない）。
-    let current_name = current_child_exe.file_name().and_then(|name| name.to_str());
-    let is_default_name = current_name.is_some_and(|name| {
-        name == PluginFormat::Clap.default_child_name()
-            || name == PluginFormat::Vst3.default_child_name()
-    });
-    if !is_default_name {
-        return current_child_exe.to_path_buf();
-    }
-    let desired = PluginFormat::from_plugin_path(plugin_path).default_child_name();
-    match current_child_exe.parent() {
-        Some(dir) => dir.join(desired),
-        None => PathBuf::from(desired),
-    }
+    // 規則そのものは instrument と共有する（`outproc_child_exe`）。ここが持つのは
+    // 「effect の binary 名の対」だけ。デフォルト名は `default_child_name()` から導出する
+    // （手打ちリテラルだとリネーム時に判定が false へ倒れ、切替が無音で無効化される）。
+    crate::outproc_child_exe::child_exe_for_attach(
+        current_child_exe,
+        plugin_path,
+        PluginFormat::Clap.default_child_name(),
+        PluginFormat::Vst3.default_child_name(),
+    )
 }
 
 /// OOP effect の起動設定。plugin は post-boot attach では不要で、eager start と gated test のみ使う。
@@ -163,8 +142,13 @@ impl OutProcEffectConfig {
     /// 置き換わる。プラグイン形式を利用者に見せないための設計（CAP.6-1）。
     ///
     /// 既知の非対称（許容）: 無効値（例 `ORBIT_EFFECT_FORMAT=nonsense`）は起動時エラーで
-    /// daemon を落とすが、有効値は実際の child 選択に影響しない。gated テストが初期 child を
-    /// 指定する用途で本 env を使っているため存置している。
+    /// daemon を落とすが、有効値は実際の child 選択に影響しない。
+    ///
+    /// **存置の理由**: repo 内に本 env の利用者は無い（`ORBIT_EFFECT_FORMAT` の参照は本
+    /// ファイルとドキュメントのみ。gated テストは `OutProcEffectConfig` を直接組み立てており
+    /// env を経由しない）。それでも消していないのは、既に外部から渡している運用があった場合に
+    /// **無効値の loud な起動失敗**という既存挙動を黙って変えないため。削除するなら
+    /// 「env を読まなくなった」ことが分かる形で別 PR にする。
     /// - `ORBIT_EFFECT_PLUGIN`: plugin bundle path（任意。post-boot attach は `LoadPlugin` で渡す）。
     /// - `ORBIT_EFFECT_PLUGIN_ID`: plugin id（任意）。
     pub fn from_env() -> Result<Self, String> {
@@ -492,11 +476,7 @@ impl EffectChildSupervisor {
         let shm_path_wd = shm_path.clone();
         // #552: VST3 / CLAP どちらの child かをログに出すため実際の名前を持ち込む
         // （決め打ちだと VST3 child のクラッシュが CLAP child の障害に見える）。
-        let child_name_wd = child_exe
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("orbit-effect-child")
-            .to_owned();
+        let child_name_wd = crate::outproc_child_exe::exe_label(&child_exe, "orbit-effect-child");
         // first_child は **closure に直接 move しない**: thread spawn が失敗すると closure ごと drop され
         // first_child が orphan 化して shm を spin し続ける（`Child::drop` は kill しない）。thread spawn
         // 成功を確認してから channel で渡し、spawn 失敗時は first_child を本 scope に残して reap できるようにする。
@@ -1071,18 +1051,20 @@ mod tests {
     // 混在できなければならない（CAP.6-1「上位は形式分岐を持たない」）。
     #[test]
     fn effect_plugin_format_selects_child_name_from_extension() {
-        assert_eq!(
-            PluginFormat::from_plugin_path(Path::new("reverb.clap")).default_child_name(),
-            "orbit-clap-effect-child"
-        );
-        assert_eq!(
-            PluginFormat::from_plugin_path(Path::new("Tape Echo.VST3")).default_child_name(),
-            "orbit-vst3-effect-child"
-        );
+        // 内部の format 判定ではなく**公開の入口**を通す（実際に attach で使われる経路）。
+        let current = Path::new("/opt/orbit/bin/orbit-clap-effect-child");
+        let child_for = |plugin: &str| {
+            child_exe_for_attach(current, Path::new(plugin))
+                .file_name()
+                .and_then(|name| name.to_str())
+                .expect("child name")
+                .to_owned()
+        };
+        assert_eq!(child_for("reverb.clap"), "orbit-clap-effect-child");
+        assert_eq!(child_for("Tape Echo.VST3"), "orbit-vst3-effect-child");
         // 未知拡張子は CLAP へフォールバック（raw .dylib の CLAP を attach する gated テストがある）。
         assert_eq!(
-            PluginFormat::from_plugin_path(Path::new("libclap_test_effect.dylib"))
-                .default_child_name(),
+            child_for("libclap_test_effect.dylib"),
             "orbit-clap-effect-child"
         );
     }

--- a/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
@@ -115,10 +115,15 @@ impl PluginFormat {
 /// - 冪等かつ対称: retryable な attach 失敗で `ChildLaunch` が再利用されても毎回この読み替えが
 ///   走るので、`.vst3` → `.clap` の attach し直しで元の child に戻る。
 pub(crate) fn child_exe_for_attach(current_child_exe: &Path, plugin_path: &Path) -> PathBuf {
-    let is_default_name = matches!(
-        current_child_exe.file_name().and_then(|name| name.to_str()),
-        Some("orbit-clap-effect-child") | Some("orbit-vst3-effect-child")
-    );
+    // 🔴 デフォルト名は `default_child_name()` から導出する（手打ちリテラルにしない）。
+    // 決め打ちだと child をリネームしたとき is_default_name が常に false になり、
+    // **per-plugin のフォーマット切替が無音のまま無効化される**（#552 が退行しても
+    // 古いリテラル前提のテストは気づけない）。
+    let current_name = current_child_exe.file_name().and_then(|name| name.to_str());
+    let is_default_name = current_name.is_some_and(|name| {
+        name == PluginFormat::Clap.default_child_name()
+            || name == PluginFormat::Vst3.default_child_name()
+    });
     if !is_default_name {
         return current_child_exe.to_path_buf();
     }
@@ -147,9 +152,19 @@ pub struct OutProcEffectConfig {
 
 impl OutProcEffectConfig {
     /// 環境変数から設定を組む（production `start()` 用）:
-    /// - `ORBIT_EFFECT_FORMAT`: `clap` | `vst3`（省略時 `clap`）。
+    /// - `ORBIT_EFFECT_FORMAT`: `clap` | `vst3`（省略時 `clap`）。**初期値のみ**。
     /// - `ORBIT_EFFECT_CHILD_BIN`: child binary path（省略時は daemon exe と同一ディレクトリの
     ///   format 対応 child）。
+    ///
+    /// **🔴 #552: `ORBIT_EFFECT_FORMAT` は post-boot attach の child 選択を決めない。**
+    /// `LoadPlugin` はあらゆる経路で `select_child_exe` を通り、child exe がデフォルト名なら
+    /// **plugin パスの拡張子**で上書きされる（[`child_exe_for_attach`]）。したがってここで
+    /// 決まる `child_exe` は「最初の attach までの初期値」であり、実運用では即座に
+    /// 置き換わる。プラグイン形式を利用者に見せないための設計（CAP.6-1）。
+    ///
+    /// 既知の非対称（許容）: 無効値（例 `ORBIT_EFFECT_FORMAT=nonsense`）は起動時エラーで
+    /// daemon を落とすが、有効値は実際の child 選択に影響しない。gated テストが初期 child を
+    /// 指定する用途で本 env を使っているため存置している。
     /// - `ORBIT_EFFECT_PLUGIN`: plugin bundle path（任意。post-boot attach は `LoadPlugin` で渡す）。
     /// - `ORBIT_EFFECT_PLUGIN_ID`: plugin id（任意）。
     pub fn from_env() -> Result<Self, String> {
@@ -408,7 +423,7 @@ pub fn spawn_effect_child(
 
 /// QUIT 済み（または crash した）child を bounded に reap する。timeout 超過で kill にフォールバック。
 /// `SandboxChildGuard` の reap と同じ意味論（非 RT・spin でなく yield）。
-fn reap(child: &mut Child) {
+fn reap(child: &mut Child, child_name: &str) {
     let deadline = Instant::now() + REAP_TIMEOUT;
     loop {
         match child.try_wait() {
@@ -416,7 +431,7 @@ fn reap(child: &mut Child) {
             Ok(None) if Instant::now() < deadline => std::thread::yield_now(),
             Ok(None) => {
                 tracing::warn!(
-                    "orbit-clap-effect-child が {REAP_TIMEOUT:?} 以内に終了せず kill にフォールバック"
+                    "{child_name} が {REAP_TIMEOUT:?} 以内に終了せず kill にフォールバック"
                 );
                 let _ = child.kill();
                 let _ = child.wait();
@@ -475,6 +490,13 @@ impl EffectChildSupervisor {
         let base = Instant::now();
         // respawn 用に closure へ move する shm_path（struct 側は unlink 用に原本を保持する）。
         let shm_path_wd = shm_path.clone();
+        // #552: VST3 / CLAP どちらの child かをログに出すため実際の名前を持ち込む
+        // （決め打ちだと VST3 child のクラッシュが CLAP child の障害に見える）。
+        let child_name_wd = child_exe
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("orbit-effect-child")
+            .to_owned();
         // first_child は **closure に直接 move しない**: thread spawn が失敗すると closure ごと drop され
         // first_child が orphan 化して shm を spin し続ける（`Child::drop` は kill しない）。thread spawn
         // 成功を確認してから channel で渡し、spawn 失敗時は first_child を本 scope に残して reap できるようにする。
@@ -528,12 +550,14 @@ impl EffectChildSupervisor {
                                         != orbit_audio_sandbox::transport::CHILD_STATUS_READY
                                 }
                             {
-                                tracing::warn!("orbit-clap-effect-child exited during initial attach ({status})");
+                                tracing::warn!(
+                                    "{child_name_wd} exited during initial attach ({status})"
+                                );
                                 stats.child_early_exit.store(true, Ordering::Release);
                                 break;
                             }
                             tracing::warn!(
-                                "orbit-clap-effect-child が異常終了（{status}）→ respawn する"
+                                "{child_name_wd} が異常終了（{status}）→ respawn する"
                             );
                             // SAFETY: region は watchdog が所有する生存 ctl_mmap を指す。
                             // 前 incarnation の READY を消してから replacement を spawn する。
@@ -588,7 +612,7 @@ impl EffectChildSupervisor {
                 unsafe {
                     (*region).control.store(CONTROL_QUIT, Ordering::Release);
                 }
-                reap(&mut child);
+                reap(&mut child, &child_name_wd);
                 // ここで ctl_mmap が drop（thread 終了）。shm unlink は supervisor drop が join 後に行う。
             }) {
             Ok(handle) => handle,

--- a/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
@@ -145,19 +145,6 @@ enum InstrumentPluginFormat {
 }
 
 impl InstrumentPluginFormat {
-    /// 拡張子 `.vst3`（大文字小文字不問）のみ VST3。**それ以外はすべて Clap** —
-    /// CLAP は VST3 対応前から唯一サポートされていた instrument フォーマットだった
-    /// ため、未知拡張子のフォールバック先として妥当。一例として、CLAP gated テストは
-    /// 未バンドルの raw `.dylib`（clap-test-synth）を attach するため、ここで未知
-    /// 拡張子を reject すると既存経路が壊れる（本ブランチの実機 gated RUN で検出済み）。
-    /// 不正な plugin path の失敗は従来どおり child 側の load エラーとして表面化する。
-    fn from_plugin_path(path: &Path) -> Self {
-        match path.extension().and_then(|extension| extension.to_str()) {
-            Some(extension) if extension.eq_ignore_ascii_case("vst3") => Self::Vst3,
-            _ => Self::Clap,
-        }
-    }
-
     fn default_child_name(self) -> &'static str {
         match self {
             Self::Clap => "orbit-clap-instrument-child",
@@ -177,22 +164,14 @@ impl InstrumentPluginFormat {
 ///   `ChildLaunch` が再利用されても、毎回この読み替えが走るので .vst3 → .clap の
 ///   attach し直しで元の child に戻る（対称・冪等）。
 pub(crate) fn child_exe_for_attach(current_child_exe: &Path, plugin_path: &Path) -> PathBuf {
-    // effect 側（`outproc_effect::child_exe_for_attach`）と対称: デフォルト名は
-    // `default_child_name()` から導出する。手打ちリテラルだとリネーム時に判定が常に
-    // false へ倒れ、フォーマット切替が無音で無効化される。
-    let current_name = current_child_exe.file_name().and_then(|name| name.to_str());
-    let is_default_name = current_name.is_some_and(|name| {
-        name == InstrumentPluginFormat::Clap.default_child_name()
-            || name == InstrumentPluginFormat::Vst3.default_child_name()
-    });
-    if !is_default_name {
-        return current_child_exe.to_path_buf();
-    }
-    let desired = InstrumentPluginFormat::from_plugin_path(plugin_path).default_child_name();
-    match current_child_exe.parent() {
-        Some(dir) => dir.join(desired),
-        None => PathBuf::from(desired),
-    }
+    // 規則そのものは effect と共有する（`outproc_child_exe`）。ここが持つのは
+    // 「instrument の binary 名の対」だけ。
+    crate::outproc_child_exe::child_exe_for_attach(
+        current_child_exe,
+        plugin_path,
+        InstrumentPluginFormat::Clap.default_child_name(),
+        InstrumentPluginFormat::Vst3.default_child_name(),
+    )
 }
 
 fn default_child_exe() -> Result<PathBuf, String> {
@@ -481,11 +460,8 @@ impl InstrumentChildSupervisor {
         let watchdog_shm_path = shm_path.clone();
         // #552 と対称: VST3 / CLAP どちらの child かをログに出す（決め打ちだと VST3 child の
         // クラッシュが CLAP child の障害に見える）。
-        let child_name_wd = child_exe
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("orbit-instrument-child")
-            .to_owned();
+        let child_name_wd =
+            crate::outproc_child_exe::exe_label(&child_exe, "orbit-instrument-child");
         let (child_tx, child_rx) = std::sync::mpsc::channel::<Child>();
 
         let watchdog = match std::thread::Builder::new()
@@ -1232,18 +1208,20 @@ mod tests {
     }
     #[test]
     fn instrument_plugin_format_selects_child_name_from_extension() {
+        // 内部の format 判定ではなく**公開の入口**を通す（実際に attach で使われる経路）。
+        let current = Path::new("/opt/orbit/bin/orbit-clap-instrument-child");
+        let child_for = |plugin: &str| {
+            child_exe_for_attach(current, Path::new(plugin))
+                .file_name()
+                .and_then(|name| name.to_str())
+                .expect("child name")
+                .to_owned()
+        };
+        assert_eq!(child_for("synth.clap"), "orbit-clap-instrument-child");
+        assert_eq!(child_for("synth.VST3"), "orbit-vst3-instrument-child");
+        // 未知拡張子は CLAP へフォールバック（raw .dylib の CLAP を attach する gated テストがある）。
         assert_eq!(
-            InstrumentPluginFormat::from_plugin_path(Path::new("synth.clap")).default_child_name(),
-            "orbit-clap-instrument-child"
-        );
-        assert_eq!(
-            InstrumentPluginFormat::from_plugin_path(Path::new("synth.VST3")).default_child_name(),
-            "orbit-vst3-instrument-child"
-        );
-        // 未知拡張子・raw dylib は従来どおり CLAP child（CLAP gated は未バンドル .dylib を使う）。
-        assert_eq!(
-            InstrumentPluginFormat::from_plugin_path(Path::new("libclap_test_synth.dylib"))
-                .default_child_name(),
+            child_for("libclap_test_synth.dylib"),
             "orbit-clap-instrument-child"
         );
     }

--- a/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
@@ -177,10 +177,14 @@ impl InstrumentPluginFormat {
 ///   `ChildLaunch` が再利用されても、毎回この読み替えが走るので .vst3 → .clap の
 ///   attach し直しで元の child に戻る（対称・冪等）。
 pub(crate) fn child_exe_for_attach(current_child_exe: &Path, plugin_path: &Path) -> PathBuf {
-    let is_default_name = matches!(
-        current_child_exe.file_name().and_then(|name| name.to_str()),
-        Some("orbit-clap-instrument-child") | Some("orbit-vst3-instrument-child")
-    );
+    // effect 側（`outproc_effect::child_exe_for_attach`）と対称: デフォルト名は
+    // `default_child_name()` から導出する。手打ちリテラルだとリネーム時に判定が常に
+    // false へ倒れ、フォーマット切替が無音で無効化される。
+    let current_name = current_child_exe.file_name().and_then(|name| name.to_str());
+    let is_default_name = current_name.is_some_and(|name| {
+        name == InstrumentPluginFormat::Clap.default_child_name()
+            || name == InstrumentPluginFormat::Vst3.default_child_name()
+    });
     if !is_default_name {
         return current_child_exe.to_path_buf();
     }
@@ -410,16 +414,14 @@ pub fn spawn_instrument_child(
     instrument_child_command(child_exe, shm_path, plugin, plugin_id, sample_rate, state).spawn()
 }
 
-fn reap(child: &mut Child) {
+fn reap(child: &mut Child, child_name: &str) {
     let deadline = Instant::now() + REAP_TIMEOUT;
     loop {
         match child.try_wait() {
             Ok(Some(_)) => return,
             Ok(None) if Instant::now() < deadline => std::thread::yield_now(),
             Ok(None) => {
-                tracing::warn!(
-                    "orbit-clap-instrument-child did not exit within {REAP_TIMEOUT:?}; killing"
-                );
+                tracing::warn!("{child_name} did not exit within {REAP_TIMEOUT:?}; killing");
                 let _ = child.kill();
                 let _ = child.wait();
                 return;
@@ -477,6 +479,13 @@ impl InstrumentChildSupervisor {
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_thread = shutdown.clone();
         let watchdog_shm_path = shm_path.clone();
+        // #552 と対称: VST3 / CLAP どちらの child かをログに出す（決め打ちだと VST3 child の
+        // クラッシュが CLAP child の障害に見える）。
+        let child_name_wd = child_exe
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("orbit-instrument-child")
+            .to_owned();
         let (child_tx, child_rx) = std::sync::mpsc::channel::<Child>();
 
         let watchdog = match std::thread::Builder::new()
@@ -539,13 +548,13 @@ impl InstrumentChildSupervisor {
                                         != orbit_audio_sandbox::transport::CHILD_STATUS_READY
                                 }
                             {
-                                tracing::warn!(plugin = ?plugin, "orbit-clap-instrument-child exited during initial attach ({status})");
+                                tracing::warn!(plugin = ?plugin, "{child_name_wd} exited during initial attach ({status})");
                                 stats.child_early_exit.store(true, Ordering::Release);
                                 break;
                             }
                             tracing::warn!(
                                 plugin = ?plugin,
-                                "orbit-clap-instrument-child exited ({status}); respawning"
+                                "{child_name_wd} exited ({status}); respawning"
                             );
                             // SAFETY: region は watchdog が所有する生存 ctl_mmap を指す。
                             // 前 incarnation の READY を消してから replacement を spawn する。
@@ -597,7 +606,7 @@ impl InstrumentChildSupervisor {
                 unsafe {
                     (*region).control.store(CONTROL_QUIT, Ordering::Release);
                 }
-                reap(&mut child);
+                reap(&mut child, &child_name_wd);
             }) {
             Ok(handle) => handle,
             Err(error) => {

--- a/scripts/copy-daemon-bin.sh
+++ b/scripts/copy-daemon-bin.sh
@@ -82,7 +82,8 @@ if command -v cargo >/dev/null 2>&1; then
   # （TS 専業 contributor 等）でも npm run build を落とさず、既存バイナリへ縮退する。
   if ! (cd "$PROJECT_ROOT/rust" \
     && cargo build --release -p orbit-audio-daemon --features outproc-effect,outproc-instrument \
-    && cargo build --release -p orbit-clap-effect-child -p orbit-clap-instrument-child -p orbit-vst3-instrument-child \
+    && cargo build --release -p orbit-clap-effect-child -p orbit-clap-instrument-child \
+      -p orbit-vst3-effect-child -p orbit-vst3-instrument-child \
     && cargo build --release -p orbit-plugin-scan); then
     echo "⚠️  release rebuild failed — bundling whatever exists in rust/target/release (may be stale)." >&2
   fi
@@ -93,5 +94,6 @@ fi
 copy_binary "orbit-audio-daemon"
 copy_binary "orbit-clap-effect-child"
 copy_binary "orbit-clap-instrument-child"
+copy_binary "orbit-vst3-effect-child"
 copy_binary "orbit-vst3-instrument-child"
 copy_binary "orbit-plugin-scan"

--- a/tests/vscode-extension/bundled-child-binaries.spec.ts
+++ b/tests/vscode-extension/bundled-child-binaries.spec.ts
@@ -191,6 +191,10 @@ describe('#548 bundled out-of-process child binaries', () => {
         `ビルド失敗が fail-loud 経路を通らず、copy-daemon-bin.sh の best-effort に落ちる`,
     ).toEqual([])
 
+    // NOTE: 「gate が実際に落ちるか」は次の it が bash を実走して検証する（そちらが本命）。
+    // ここのテキスト照合を残しているのは、**壊れ方が読み取れる形で先に落ちる**ため。
+    // 実走テストは「exit code が 0 だった」としか言えないが、ここは欠けている binary 名を
+    // 名指しできる。実走側に包含される冗長なチェックであることを承知の上で置いている。
     const gated = checkedByReleaseGate(workflow)
     expect(gated.length, 'post-package gate の CHILD_BIN ループを抽出できていない').toBeGreaterThan(
       0,

--- a/tests/vscode-extension/bundled-child-binaries.spec.ts
+++ b/tests/vscode-extension/bundled-child-binaries.spec.ts
@@ -1,4 +1,6 @@
+import { execFileSync } from 'child_process'
 import * as fs from 'fs'
+import * as os from 'os'
 import * as path from 'path'
 
 import { describe, it, expect } from 'vitest'
@@ -98,6 +100,49 @@ function checkedByReleaseGate(workflow: string): string[] {
   return m[1].trim().split(/\s+/).sort()
 }
 
+/**
+ * `release.yml` の post-package gate（`for CHILD_BIN … done`）を **原文のまま抜き出す**。
+ *
+ * 台帳照合（テキスト）だけでは `exit 1` が消えても検出できない — 実際に走らせて
+ * 終了コードを見るための素材を取る。YAML の `run: |` ブロック内なので共通インデントを剥がす。
+ */
+function extractReleaseGateScript(workflow: string): string {
+  const start = workflow.indexOf('          for CHILD_BIN in')
+  if (start < 0) return ''
+  const endMarker = '\n          done\n'
+  const end = workflow.indexOf(endMarker, start)
+  if (end < 0) return ''
+  return workflow
+    .slice(start, end + endMarker.length)
+    .split('\n')
+    .map((line) => line.replace(/^ {10}/, ''))
+    .join('\n')
+}
+
+/** 抽出した gate を、与えたバイナリ集合を持つ一時 .vsix 展開ディレクトリに対して実行する。 */
+function runReleaseGate(gateScript: string, presentBinaries: string[]): number {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-gate-'))
+  try {
+    const binDir = path.join(root, 'extension/engine/bin/darwin-arm64')
+    fs.mkdirSync(binDir, { recursive: true })
+    for (const name of presentBinaries) {
+      const p = path.join(binDir, name)
+      fs.writeFileSync(p, '#!/bin/sh\nexit 0\n')
+      fs.chmodSync(p, 0o755)
+    }
+    try {
+      execFileSync('bash', ['-c', `set -euo pipefail\nVSIX_CHECK="${root}"\n${gateScript}`], {
+        stdio: 'pipe',
+      })
+      return 0
+    } catch (error) {
+      return (error as { status?: number }).status ?? -1
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+}
+
 describe('#548 bundled out-of-process child binaries', () => {
   it('daemon が spawn しうる child はすべて copy-daemon-bin.sh のコピー対象である', () => {
     const byModule = requiredChildBinariesByModule()
@@ -157,6 +202,32 @@ describe('#548 bundled out-of-process child binaries', () => {
       `post-package gate が出荷 .vsix で検査しない child: ${notGated.join(', ')} — ` +
         `copy_binary の行が将来削除されても検出できず、同じ実害が無警告で再出荷される`,
     ).toEqual([])
+  })
+
+  // 🔴 台帳照合（テキスト）だけでは `exit 1` が消えても検出できない — gate から
+  // `exit 1` を抜いてもリスト抽出結果は同一なので上のテストは green のままになる。
+  // **gate を実際に走らせて終了コードを見る**ことでしか、fail-loud は保証できない。
+  it('post-package gate は child が欠けていると実際に非ゼロ終了する', () => {
+    const workflow = fs.readFileSync(RELEASE_WORKFLOW, 'utf8')
+    const gateScript = extractReleaseGateScript(workflow)
+    expect(
+      gateScript,
+      'release.yml から post-package gate の for ループを抽出できていない',
+    ).toContain('CHILD_BIN')
+
+    const required = requiredChildBinaries()
+
+    // 全部揃っていれば通過する（gate が常に落ちるだけの無意味な検査になっていないことの確認）。
+    expect(runReleaseGate(gateScript, required), 'すべて揃っているのに gate が落ちた').toBe(0)
+
+    // 1つずつ欠かして、**必ず**非ゼロ終了することを確認する。
+    for (const omitted of required) {
+      const present = required.filter((name) => name !== omitted)
+      expect(
+        runReleaseGate(gateScript, present),
+        `${omitted} が欠けているのに gate が通過した — 出荷ゲートが fail-loud でない`,
+      ).not.toBe(0)
+    }
   })
 
   it('ビルド済みなら、バンドル実体にも required child がすべて存在する', () => {

--- a/tests/vscode-extension/bundled-child-binaries.spec.ts
+++ b/tests/vscode-extension/bundled-child-binaries.spec.ts
@@ -1,0 +1,127 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+import { describe, it, expect } from 'vitest'
+
+/**
+ * #548 回帰ピン: daemon が spawn しうる out-of-process child が、拡張のバンドルに
+ * 含まれていることを保証する。
+ *
+ * **なぜ二重台帳か**: `orbit-vst3-effect-child` は daemon 側（`outproc_effect.rs`）が
+ * `ORBIT_EFFECT_FORMAT=vst3` のとき spawn しようとするのに、`copy-daemon-bin.sh` の
+ * コピー対象から漏れていた。出荷された拡張で VST3 エフェクトの spawn が
+ * `No such file or directory (os error 2)` で失敗する（実機で再現確認済み）。
+ *
+ * この欠落を **gated テストは構造的に検出できない** — gated テストは自前で
+ * `cargo build -p orbit-vst3-effect-child` してから走るため、バンドル経路を通らない。
+ *
+ * 台帳A（要求）= daemon Rust ソース中の child 実行ファイル名リテラル
+ * 台帳B（供給）= `copy-daemon-bin.sh` のコピー対象 + 実際にバンドルされたファイル
+ *
+ * A ⊆ B を検査する。daemon に新しい format を足すと自動的に本テストが要求を増やす。
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../..')
+const DAEMON_SRC = path.join(REPO_ROOT, 'rust/crates/orbit-audio-daemon/src')
+const COPY_SCRIPT = path.join(REPO_ROOT, 'scripts/copy-daemon-bin.sh')
+
+/** daemon の outproc モジュールと、それぞれが必ず持つ format 分岐の数（Clap / Vst3）。 */
+const OUTPROC_MODULES = ['outproc_effect.rs', 'outproc_instrument.rs'] as const
+const FORMATS_PER_MODULE = 2
+
+/**
+ * 台帳A: daemon が spawn しうる child 実行ファイル名（Rust ソースのリテラルから導出）。
+ *
+ * **パターンを名前の形に依存させない**: 初版は `orbit-[a-z0-9-]+-child` と綴りを決め打ちして
+ * いたため、child をリネームすると**抽出が黙って取りこぼして台帳Aが縮み、テストが pass して
+ * しまう**（変異検証で発覚）。`=>` の右辺の `orbit-*` リテラルをすべて拾い、件数で
+ * 取りこぼしを検出する。
+ */
+function requiredChildBinariesByModule(): Map<string, string[]> {
+  const byModule = new Map<string, string[]>()
+  for (const file of OUTPROC_MODULES) {
+    const src = fs.readFileSync(path.join(DAEMON_SRC, file), 'utf8')
+    // `Self::Vst3 => "orbit-vst3-effect-child",` の形の match アームから抽出する。
+    const names = new Set([...src.matchAll(/=>\s*"(orbit-[^"]+)"/g)].map((m) => m[1]))
+    byModule.set(file, [...names].sort())
+  }
+  return byModule
+}
+
+function requiredChildBinaries(): string[] {
+  const all = new Set<string>()
+  for (const names of requiredChildBinariesByModule().values()) {
+    for (const n of names) all.add(n)
+  }
+  return [...all].sort()
+}
+
+/** 台帳B-1: `copy-daemon-bin.sh` が copy_binary で運ぶ名前。 */
+function copiedByScript(): string[] {
+  const script = fs.readFileSync(COPY_SCRIPT, 'utf8')
+  return [...script.matchAll(/^copy_binary\s+"([^"]+)"/gm)].map((m) => m[1]).sort()
+}
+
+/** 台帳B-2: 実際にバンドルされたファイル（ビルド済みのときのみ存在。gitignore 対象）。 */
+function bundledBinaries(): string[] | undefined {
+  const dir = path.join(
+    REPO_ROOT,
+    'packages/vscode-extension/engine/bin',
+    `${process.platform}-${process.arch}`,
+  )
+  if (!fs.existsSync(dir)) return undefined
+  return fs.readdirSync(dir).sort()
+}
+
+describe('#548 bundled out-of-process child binaries', () => {
+  it('daemon が spawn しうる child はすべて copy-daemon-bin.sh のコピー対象である', () => {
+    const required = requiredChildBinaries()
+    const copied = copiedByScript()
+
+    // 🔴 台帳Aの取りこぼしを検出する。空振り（0件）だけでなく **部分的な縮み** も
+    // success にしない — 各 outproc モジュールは Clap / Vst3 の2分岐を必ず持つ。
+    // format を増やしたらここが落ちるので、バンドル側の追従が強制される。
+    for (const [file, names] of requiredChildBinariesByModule()) {
+      expect(
+        names.length,
+        `${file} から抽出した child 名が ${names.length} 件（期待: ${FORMATS_PER_MODULE} 以上）— ` +
+          `抽出パターンが実装に追従できていないか、format が増減した`,
+      ).toBeGreaterThanOrEqual(FORMATS_PER_MODULE)
+    }
+
+    const missing = required.filter((name) => !copied.includes(name))
+    expect(
+      missing,
+      `daemon は spawn しようとするのに copy-daemon-bin.sh がコピーしない child: ` +
+        `${missing.join(', ')} — 出荷版で spawn が ENOENT で失敗する`,
+    ).toEqual([])
+  })
+
+  it('コピー対象は cargo の再ビルド対象にも含まれている', () => {
+    const script = fs.readFileSync(COPY_SCRIPT, 'utf8')
+    // `cargo build --release -p A -p B ...` 群に現れる package 名を集める。
+    const built = new Set([...script.matchAll(/-p\s+(orbit-[a-z0-9-]+)/g)].map((m) => m[1]))
+
+    const notBuilt = copiedByScript().filter((name) => !built.has(name))
+    expect(
+      notBuilt,
+      `copy_binary の対象なのに cargo build の -p に無い: ${notBuilt.join(', ')} — ` +
+        `stale なバイナリが黙ってコピーされる（#487 の再発）`,
+    ).toEqual([])
+  })
+
+  it('ビルド済みなら、バンドル実体にも required child がすべて存在する', () => {
+    const bundled = bundledBinaries()
+    if (bundled === undefined) {
+      // 未ビルド環境（fresh clone / CI の build 前）では実体が無い。ここを skip にしても
+      // 上2つの台帳照合が原因側を押さえているので穴にはならない。
+      return
+    }
+    const missing = requiredChildBinaries().filter((name) => !bundled.includes(name))
+    expect(
+      missing,
+      `バンドル実体に無い child: ${missing.join(', ')} — ` +
+        `スクリプトは正しいがビルド成果物が古い可能性がある（npm run build:clean を試す）`,
+    ).toEqual([])
+  })
+})

--- a/tests/vscode-extension/bundled-child-binaries.spec.ts
+++ b/tests/vscode-extension/bundled-child-binaries.spec.ts
@@ -24,6 +24,7 @@ import { describe, it, expect } from 'vitest'
 const REPO_ROOT = path.resolve(__dirname, '../..')
 const DAEMON_SRC = path.join(REPO_ROOT, 'rust/crates/orbit-audio-daemon/src')
 const COPY_SCRIPT = path.join(REPO_ROOT, 'scripts/copy-daemon-bin.sh')
+const RELEASE_WORKFLOW = path.join(REPO_ROOT, '.github/workflows/release.yml')
 
 /** daemon の outproc モジュールと、それぞれが必ず持つ format 分岐の数（Clap / Vst3）。 */
 const OUTPROC_MODULES = ['outproc_effect.rs', 'outproc_instrument.rs'] as const
@@ -57,12 +58,23 @@ function requiredChildBinaries(): string[] {
 }
 
 /** 台帳B-1: `copy-daemon-bin.sh` が copy_binary で運ぶ名前。 */
-function copiedByScript(): string[] {
-  const script = fs.readFileSync(COPY_SCRIPT, 'utf8')
+function copiedByScript(script: string): string[] {
   return [...script.matchAll(/^copy_binary\s+"([^"]+)"/gm)].map((m) => m[1]).sort()
 }
 
-/** 台帳B-2: 実際にバンドルされたファイル（ビルド済みのときのみ存在。gitignore 対象）。 */
+/** `cargo build ... -p NAME` 群に現れる package 名（copy-daemon-bin.sh / release.yml 共通）。 */
+function cargoBuiltPackages(text: string): Set<string> {
+  return new Set([...text.matchAll(/-p\s+(orbit-[a-z0-9-]+)/g)].map((m) => m[1]))
+}
+
+/**
+ * 台帳B-2: 実際にバンドルされたファイル（ビルド済みのときのみ存在。gitignore 対象）。
+ *
+ * `<platform>-<arch>` のディレクトリ命名は Node 慣習で、production 側の
+ * `plugin-catalog-reader.ts`（`resolvePluginScanBinaryPath`）と
+ * `daemon-client.ts`（`resolveDaemonBinaryPath`）が同じ規則で組み立てている。
+ * 共有ヘルパは存在しないため、ここでも同じ規則を再現している（規則を変えるときは3箇所同時）。
+ */
 function bundledBinaries(): string[] | undefined {
   const dir = path.join(
     REPO_ROOT,
@@ -73,15 +85,29 @@ function bundledBinaries(): string[] | undefined {
   return fs.readdirSync(dir).sort()
 }
 
+/**
+ * 台帳C: `release.yml` の post-package gate が **出荷 `.vsix` に対して**存在を検査する child 名。
+ *
+ * **この gate が本バグの唯一のセーフティネットである** — `copy_binary` の行が将来誤って
+ * 削除されても、gate が検査していれば出荷前に落ちる。gate 自身が台帳から漏れていると、
+ * 同じ実害が無警告で再出荷される（初版はまさにこの状態だった）。
+ */
+function checkedByReleaseGate(workflow: string): string[] {
+  const m = workflow.match(/for\s+CHILD_BIN\s+in\s+([^;]+);/)
+  if (!m) return []
+  return m[1].trim().split(/\s+/).sort()
+}
+
 describe('#548 bundled out-of-process child binaries', () => {
   it('daemon が spawn しうる child はすべて copy-daemon-bin.sh のコピー対象である', () => {
-    const required = requiredChildBinaries()
-    const copied = copiedByScript()
+    const byModule = requiredChildBinariesByModule()
+    const required = [...new Set([...byModule.values()].flat())].sort()
+    const copied = copiedByScript(fs.readFileSync(COPY_SCRIPT, 'utf8'))
 
     // 🔴 台帳Aの取りこぼしを検出する。空振り（0件）だけでなく **部分的な縮み** も
     // success にしない — 各 outproc モジュールは Clap / Vst3 の2分岐を必ず持つ。
     // format を増やしたらここが落ちるので、バンドル側の追従が強制される。
-    for (const [file, names] of requiredChildBinariesByModule()) {
+    for (const [file, names] of byModule) {
       expect(
         names.length,
         `${file} から抽出した child 名が ${names.length} 件（期待: ${FORMATS_PER_MODULE} 以上）— ` +
@@ -99,14 +125,37 @@ describe('#548 bundled out-of-process child binaries', () => {
 
   it('コピー対象は cargo の再ビルド対象にも含まれている', () => {
     const script = fs.readFileSync(COPY_SCRIPT, 'utf8')
-    // `cargo build --release -p A -p B ...` 群に現れる package 名を集める。
-    const built = new Set([...script.matchAll(/-p\s+(orbit-[a-z0-9-]+)/g)].map((m) => m[1]))
+    const built = cargoBuiltPackages(script)
 
-    const notBuilt = copiedByScript().filter((name) => !built.has(name))
+    const notBuilt = copiedByScript(script).filter((name) => !built.has(name))
     expect(
       notBuilt,
       `copy_binary の対象なのに cargo build の -p に無い: ${notBuilt.join(', ')} — ` +
         `stale なバイナリが黙ってコピーされる（#487 の再発）`,
+    ).toEqual([])
+  })
+
+  it('release.yml が required child をビルドし、post-package gate で検査している', () => {
+    const workflow = fs.readFileSync(RELEASE_WORKFLOW, 'utf8')
+    const required = requiredChildBinaries()
+
+    const notBuilt = required.filter((name) => !cargoBuiltPackages(workflow).has(name))
+    expect(
+      notBuilt,
+      `release.yml の cargo build に無い child: ${notBuilt.join(', ')} — ` +
+        `ビルド失敗が fail-loud 経路を通らず、copy-daemon-bin.sh の best-effort に落ちる`,
+    ).toEqual([])
+
+    const gated = checkedByReleaseGate(workflow)
+    expect(gated.length, 'post-package gate の CHILD_BIN ループを抽出できていない').toBeGreaterThan(
+      0,
+    )
+
+    const notGated = required.filter((name) => !gated.includes(name))
+    expect(
+      notGated,
+      `post-package gate が出荷 .vsix で検査しない child: ${notGated.join(', ')} — ` +
+        `copy_binary の行が将来削除されても検出できず、同じ実害が無警告で再出荷される`,
     ).toEqual([])
   })
 


### PR DESCRIPTION
Closes #548
Closes #552

**プラグイン形式は利用者に見えてはならない実装の詳細である**（owner 確定・`PLUGIN_CAPABILITY_ABSTRACTION_v1.md` CAP.6-1「上位は能力 ID だけを知り、形式分岐を持たない」）。

利用者がカタログからエフェクトを選ぶとき、それが VST3 か CLAP かは関心事ではない。**選んだものが動く**ことだけが要件。この PR は、そこを塞いでいた2つの欠陥を同時に潰す。

## #548: `orbit-vst3-effect-child` がバンドルされていなかった

daemon は `outproc_effect.rs:84` で spawn しようとするのに `copy-daemon-bin.sh` がコピーしていなかった。**出荷版で VST3 エフェクトの spawn が ENOENT で失敗する**（実機再現済み）。

## #552: effect の format が process-global だった

`ORBIT_EFFECT_FORMAT` で daemon 起動時に1つだけ決まるため、**CLAP と VST3 のエフェクトを同一チェーンに混在できなかった**。

| | format の決まり方 | 混在 |
|---|---|---|
| instrument | プラグインパスの**拡張子**から per-plugin | ✅ |
| effect（修正前） | **環境変数**で process-global | ❌ |

`select_child_exe` トレイトの seam は既に存在し、**effect 実装が no-op だっただけ**。instrument と対称の `child_exe_for_attach` を実装して揃えた。`ORBIT_EFFECT_CHILD_BIN` と gated テストの直指定は「デフォルト名以外は触らない」規則で保護される。

## 🔴 変異検証が「テストが修正を検証していない」ことを暴いた

純関数 `child_exe_for_attach` のユニットテストを3件書いても、**`select_child_exe` を no-op に戻す変異（= 元のバグそのもの）が green のまま生き残った。**

| 変異 | 配線テスト前 | 後 |
|---|---|---|
| 拡張子判定を固定値に置換 | red | red |
| **`select_child_exe` を no-op へ** | **green（すり抜け）** | **red** |
| override 保護を外す | red | red |

純関数と load 経路を繋ぐ**配線**は別物（CLAUDE.md「配線はロジックと別にテストする」）。instrument と対称の配線テストを足して初めて red になった。**変異検証をしていなければ「テストがあるのに修正が効いていない」状態で出荷していた。**

## 🔴 `/simplify` の altitude レビューが出荷ゲートの穴を発見

`.github/workflows/release.yml` の post-package gate（`for CHILD_BIN in ...`）が `orbit-vst3-effect-child` を検査しておらず、**本バグの再発を防ぐはずのセーフティネット自身が同じ欠落を抱えていた**。`copy_binary` の行が将来削除されても検出できず、同じ実害が無警告で再出荷される状態だった。ビルド一覧（`:89`）と gate（`:141`）の両方を修正。

## 回帰テスト（三重台帳）

| 台帳 | 内容 |
|---|---|
| **A（要求）** | daemon Rust ソースの child 名リテラル |
| **B（供給）** | `copy_binary` + `cargo -p` + バンドル実体 |
| **C（出荷ゲート）** | `release.yml` のビルド一覧 + post-package gate |

A ⊆ B かつ A ⊆ C を検査。**daemon に format を足すと自動的に要求が増える。**

台帳Aの抽出は当初 `orbit-[a-z0-9-]+-child` と綴りを決め打ちしており、**リネームで台帳が黙って縮んで pass** していた（変異検証で発覚）。綴り非依存にし、モジュールごとの抽出件数を検査するよう修正済み。

## `/simplify` の反映

- **altitude**: `release.yml` の2箇所（上記・最重要）
- **simplification**: 同一テスト内の二重読み込みを解消・`cargoBuiltPackages` を共通化
- **reuse**: `<platform>-<arch>` 命名が production 2箇所と同規則である旨を参照コメントで明示（共有ヘルパは存在しない）
- **efficiency**: 二重読み込みは実測 2〜3ms で無視可 → simplification 側で構造的に解消済み

## 検証

- TS **1739 passed**（+4）/ Rust **127 passed**（+4）/ `cargo fmt --check` clean / clippy 0
- `npm run build` でバンドル **6本**を確認（従来5本）
- **実機 E2E: `ORBIT_EFFECT_FORMAT` を一切設定せずに** VST3 エフェクトを評価 → `orbit-vst3-effect-child` が起動（`--plugin .../Tape Echo v6.vst3`）・`get_log` に ERROR なし

> `evaluate_orbitscore` は修正前も `ok` を返していた。エンジン側の失敗は `get_log` にしか現れない。
