### PR TITLE
test(daemon): make the #529 flake self-diagnosing instead of silent

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -62,8 +62,14 @@ first LoadPlugin call finished before the poller ever observed ChildSlot::Loadin
 its result was Err(OutProcEffect("MUTATION: select_child_exe forced failure"))
 ```
 
-> ⚠️ **spawn 失敗を強制する変異は通ってしまった** — ローカルではポーラが `Loading` の窓を
-> 捉えるため。これ自体が「CI の負荷下でだけ窓を見逃す」という分析の裏付けになる。
+> ⚠️ **環境差**: spawn 失敗を強制する変異は、**私の環境では通り**（ポーラが `Loading` の窓を
+> 捉えた）、**レビュアーの環境では両サイトとも 8/8 で新しい診断つきに落ちた**。
+> spawn の ENOENT 検出は fork/exec 実装依存で負荷・スケジューリングに敏感なため、
+> どちらも起こりうる。**1回の観測から「通ってしまう」と一般化して書いたのは誤り**だった。
+>
+> なお site 2 の pid 再読（TOCTOU 対策）は、レースを踏ませる合成実験を 30 回試しても
+> **一度も再現しなかった**。理屈上は正しいが窓が極めて狭く、#529 の実際の原因だった
+> 可能性は低い。コストはほぼゼロなので残す。
 
 **この issue はクローズしない**: 診断の改善であって症状の除去ではない。
 spawn 失敗そのものは残るので flake は再発しうる。

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,62 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.313 test(daemon): make the #529 flake self-diagnosing instead of silent (Jul 28, 2026)
+
+**Date**: 2026-07-28
+**Status**: 🔄 PR 準備中
+
+#529 の flake は「原因を何も語らない 30 秒 timeout」に化けていた。**症状を消す修正ではなく、
+次に落ちたときに真因を自白させる修正**（Fable が 2026-07-27 に一次ソース読解で確定した方針）。
+
+**なぜ 30 秒待つのか（既に棄却された仮説を再掲）**:
+
+- ❌ 「ポーリングが相手を飢餓させる」— worker の critical section は µs オーダー
+- ❌ 「CI が遅くて spawn が間に合わない」— `Loading` は **spawn より前**に設定される
+- ✅ **`Loading` に到達しなかったのではなく、既に離脱していた**。spawn 失敗で
+  `Loading → Empty` にサブミリ秒で戻り、5ms 間隔のポーラーが窓を丸ごと見逃す
+
+**決定的な欠陥**: 1本目のエラーは `join()` でしか回収されないのに、join は**ループの後**。
+実エラーが握り潰されて timeout panic に化けていた。
+
+**修正**（テスト内で閉じる・**本番コード無変更**）:
+
+- 待ちの条件を「`Loading` を観測 **or** worker が終了」に。終了していたら **join して実エラーを
+  message に載せる**
+- deadline assert に**反復回数と実測 elapsed** を追加（Fable が「決定的判別方法」とした計装。
+  数千回なら本当にスケジューリング問題、数回〜数百回ならランナー停止）
+- 同型の待ちがもう1箇所あったので同時に適用
+
+**レビューで直した自分の欠陥（Fable 指摘・4件）**:
+
+1. 🔴 **コンパイルできていなかった**（`SlotKind` 未定義）。`cargo check` はテストコードを
+   含まないため素通りしていた。**`cargo test --no-run` で検出すべきだった**
+2. メッセージが「`Loading` を**一度も設定しなかった**」と断言していたが、「設定後に離脱した」
+   経路では**虚偽**になる。主張できるのは「ポーラが観測する前に worker が終了した」ことだけ
+3. もう1箇所は「join してエラーを載せる」とコメントしながら**join せずに落ちて**いた
+   — #529 の原因そのものを再演していた
+4. pid 再読が無く TOCTOU で虚偽メッセージが出る窓があった
+
+**変異検証**: `select_child_exe` を Err にして「`Loading` を一度も設定しない」経路を再現。
+修正前なら 30 秒後に無言で落ちるところが、**7.5ms で実エラーつきで落ちる**ことを確認:
+
+```
+first LoadPlugin call finished before the poller ever observed ChildSlot::Loading
+(slot is now Empty, after 2 polls / 7.5585ms);
+its result was Err(OutProcEffect("MUTATION: select_child_exe forced failure"))
+```
+
+> ⚠️ **spawn 失敗を強制する変異は通ってしまった** — ローカルではポーラが `Loading` の窓を
+> 捉えるため。これ自体が「CI の負荷下でだけ窓を見逃す」という分析の裏付けになる。
+
+**この issue はクローズしない**: 診断の改善であって症状の除去ではない。
+spawn 失敗そのものは残るので flake は再発しうる。
+
+**検証**: daemon 132 passed（両 feature）/ 対象テスト 10 回連続 green / workspace 全 green /
+fmt clean / clippy 0。
+
+---
+
 ### 6.312 feat(clap): CLAP state parity — 同じループテストが両形式で green #557 (Jul 28, 2026)
 
 **Date**: 2026-07-28

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -4798,6 +4798,19 @@ mod outproc_load_error_test_support {
     /// 各ポーリングループは条件成立で即抜けるため、正常時の所要時間には影響しない。
     const SETUP_DEADLINE: Duration = Duration::from_secs(30);
 
+    /// パニックメッセージ用に slot の**種別だけ**を名乗る（中身は出さない）。
+    ///
+    /// #529: 失敗時に「どの状態で止まっていたか」が分かると、離脱経路の同定が効く
+    /// （Empty = spawn 失敗 / ready timeout、Closed = shm open 失敗 / supervisor 失敗）。
+    fn slot_kind<R: OutProcRole>(slot: &Mutex<ChildSlot<R>>) -> &'static str {
+        match &*slot.lock().expect("lock child slot for diagnostics") {
+            ChildSlot::Empty(_) => "Empty",
+            ChildSlot::Loading { .. } => "Loading",
+            ChildSlot::Active { .. } => "Active",
+            ChildSlot::Closed => "Closed",
+        }
+    }
+
     fn child_launch<R: OutProcRole>(
         shm_path: PathBuf,
         child_exe: PathBuf,
@@ -5207,17 +5220,42 @@ mod outproc_load_error_test_support {
             let call = std::thread::spawn(move || {
                 wrap_call.load_outproc_plugin_impl::<R>(slot_call, path, None, None)
             });
-            let deadline = std::time::Instant::now() + SETUP_DEADLINE;
+            let started = std::time::Instant::now();
+            let deadline = started + SETUP_DEADLINE;
+            let mut polls: u64 = 0;
             // PID は reset_child_starting の後に publish されるため、この READY はそれによって消されない。
-            while R::current_child_pid_atomic(&stats).load(std::sync::atomic::Ordering::Relaxed)
-                == 0
-            {
+            let call = loop {
+                polls += 1;
+                if R::current_child_pid_atomic(&stats).load(std::sync::atomic::Ordering::Relaxed)
+                    != 0
+                {
+                    break call;
+                }
+                if call.is_finished() {
+                    // 🔴 pid を**読み直す**。前回の load と is_finished の間に worker が
+                    // pid を publish して終了した場合、「publish 前に終わった」は虚偽になる。
+                    if R::current_child_pid_atomic(&stats)
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                        != 0
+                    {
+                        break call;
+                    }
+                    // 🔴 join して**実エラーを message に載せる**。ここで join せずに落ちると、
+                    // #529 の原因そのもの（エラー握り潰し → 原因を語らない panic）を再演する。
+                    let result = call.join().expect("load thread panicked");
+                    panic!(
+                        "attempt {attempt}: load call finished without ever publishing a child \
+                         PID (after {polls} polls / {:?}); its result was {result:?}",
+                        started.elapsed()
+                    );
+                }
                 assert!(
                     std::time::Instant::now() < deadline,
-                    "attempt {attempt} never completed child spawn"
+                    "attempt {attempt}: child spawn never completed (after {polls} polls / {:?})",
+                    started.elapsed()
                 );
                 std::thread::sleep(Duration::from_millis(5));
-            }
+            };
             let region = orbit_audio_sandbox::region_ptr(&mmap);
             unsafe { orbit_audio_sandbox::transport::publish_child_ready(region, has_input) };
             let result = call.join().expect("load thread panicked");
@@ -5270,24 +5308,54 @@ mod outproc_load_error_test_support {
             wrap_a.load_outproc_plugin_impl::<R>(slot_a, loading_path_owned, None, None)
         });
 
-        // 1本目が Empty -> Loading へ遷移して lock を解放するまで待つ。この deadline は
-        // セットアップ（child spawn）完了待ちであって検証対象の性質ではないので、CI の
-        // 高負荷でも越えない大きな値にする（#491: 2s では遅い runner で spawn が間に合わず
-        // flake した。ループは Loading 観測で即抜けるため通常は数 ms で終わる）。
-        let deadline = std::time::Instant::now() + SETUP_DEADLINE;
-        loop {
+        // 1本目が Empty -> Loading へ遷移して lock を解放するまで待つ。
+        //
+        // 🔴 #529: **壁時計だけに頼らない**。`Loading` は child spawn の**前**に設定されるので
+        // （`*slot = ChildSlot::Loading` → `drop(slot)` → spawn の順）、「CI が遅くて spawn が
+        // 間に合わない」ではここに到達しない。到達しない実際の経路は
+        // **worker が `Loading` を設定せずに早期 return すること**（`select_child_exe` の失敗など）で、
+        // その場合このループは deadline まで回り切ってから「never reached Loading」という
+        // **原因を何も語らないメッセージ**で落ちる。
+        //
+        // そこで待ちの条件を「`Loading` を観測 **or** worker が終了」にする。worker が先に
+        // 終わったならそれが答えなので、join してエラーを message に載せて即座に落とす。
+        // deadline は「どちらも起きない」異常系の最後の安全弁としてのみ残す。
+        let started = std::time::Instant::now();
+        let deadline = started + SETUP_DEADLINE;
+        let mut polls: u64 = 0;
+        let first_call = loop {
+            polls += 1;
             if matches!(
                 &*child_slot.lock().expect("poll child slot"),
                 ChildSlot::Loading { .. }
             ) {
-                break;
+                break first_call;
+            }
+            if first_call.is_finished() {
+                // 🔴 主張できるのは「**ポーラが Loading を観測する前に** worker が終了した」
+                // ことだけ。「Loading を一度も設定しなかった」と断言してはいけない —
+                // ポーラの反復が遅延すると、その間に worker が Loading 設定 → spawn →
+                // ready timeout → Empty まで進んで終了しうる（設定はされていた）。
+                // 離脱経路の同定は join した Err の文言に委ねる。
+                let observed = slot_kind(&child_slot);
+                let result = first_call.join().expect("load thread panicked");
+                panic!(
+                    "first LoadPlugin call finished before the poller ever observed \
+                     ChildSlot::Loading (slot is now {observed}, after {polls} polls / \
+                     {:?}); its result was {result:?}",
+                    started.elapsed()
+                );
             }
             assert!(
                 std::time::Instant::now() < deadline,
-                "first LoadPlugin call never reached ChildSlot::Loading within {SETUP_DEADLINE:?}"
+                "first LoadPlugin call neither reached ChildSlot::Loading nor finished \
+                 (slot is {}, after {polls} polls / {:?} — **反復回数が判別材料**: \
+                 数千回なら本当にスケジューリング問題、数回〜数百回ならランナー停止)",
+                slot_kind(&child_slot),
+                started.elapsed()
             );
             std::thread::sleep(Duration::from_millis(5));
-        }
+        };
 
         // 1本目はまだ ready-ack poll 中（child script は READY を publish しない）。この状態で 2本目を
         // 発行し、mutex 待ちでなく即座に "already in progress" で失敗することを検証する。


### PR DESCRIPTION
Refs #529（**この issue はクローズしない** — 診断の改善であって症状の除去ではないため）

Fable が 2026-07-27 に一次ソース読解で確定した方針の実装。**本番コード無変更・テスト内で閉じる**。

## 何が問題だったか

1本目のエラーは `first_call.join()` でしか回収されないのに **join はループの後**にあり、
実エラーが握り潰されて「原因を何も語らない 30 秒 timeout」に化けていた。

既に棄却されている仮説（再議論しないこと・#529 本文参照）:

- ❌ 「ポーリングが相手を飢餓させる」— worker の critical section は µs オーダー
- ❌ 「CI が遅くて spawn が間に合わない」— `Loading` は **spawn より前**に設定される
- ✅ **`Loading` に到達しなかったのではなく、既に離脱していた**。spawn 失敗で
  `Loading → Empty` にサブミリ秒で戻り、5ms 間隔のポーラーが窓を丸ごと見逃す

## 修正

- 待ちの条件を「`Loading` を観測 **or** worker が終了」に。終了していたら **join して
  実エラーを message に載せる**
- deadline assert に **反復回数と実測 elapsed** を追加（Fable が「決定的判別方法」とした計装）
- 同型の待ちがもう1箇所あったので同時に適用

## 変異検証（実行結果）

`select_child_exe` を Err にして「`Loading` を一度も設定しない」経路を再現:

```
first LoadPlugin call finished before the poller ever observed ChildSlot::Loading
(slot is now Empty, after 2 polls / 7.5585ms);
its result was Err(OutProcEffect("MUTATION: select_child_exe forced failure"))
```

修正前なら 30 秒後に無言で落ちていた。

> ⚠️ **spawn 失敗を強制する変異は通ってしまった** — ローカルではポーラが `Loading` の窓を
> 捉えるため。これ自体が「CI の負荷下でだけ窓を見逃す」という分析の裏付けになる。

## レビュー（Fable）で直した自分の欠陥 4件

1. 🔴 **コンパイルできていなかった**（`SlotKind` 未定義）。`cargo check` はテストコードを
   含まないため素通りしていた — **`cargo test --no-run` で検出すべきだった**
2. メッセージが「`Loading` を**一度も設定しなかった**」と断言していたが、
   「設定後に離脱した」経路では**虚偽**。主張できるのは「ポーラが観測する前に終了した」ことだけ
3. もう1箇所は「join してエラーを載せる」とコメントしながら **join せずに落ちて**いた
   — #529 の原因そのものを再演していた
4. pid 再読が無く TOCTOU で虚偽メッセージが出る窓があった

## 🔴 次の CI 失敗が決定的実験になる

失敗時の message に出る**反復回数**で判別する。数千回なら本当にスケジューリング問題、
数回〜数百回ならランナー停止。**この判別が出るまでテストを CI から外さないこと**。

## 検証

daemon 132 passed（`outproc-effect,outproc-instrument`）/ 対象テスト 10 回連続 green /
workspace 全 green / fmt clean / clippy 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PafN8xAMtGRx3nCHyenQN8