### PR TITLE
feat(engine): auto-restore plugin state from project.yaml at declaration time

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,98 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.316 feat(engine): project.yaml から plugin state を宣言時に自動復元 #541 (Jul 29, 2026)
+
+**Date**: 2026-07-29
+**Status**: ✅ 実装・変異検証・**実機 gated E2E 完了**（受け入れ基準達成）
+
+`project.yaml` の `states:` を、instrument / master effect / per-sequence effect の新規宣言時に
+SC.5 identity で引き、明示 `statePath` が無い場合だけ daemon の `loadPlugin` へ渡す経路を追加。
+manifest は保存側と同じ parser / identity key を使い、未生成は no-op、壊れた manifest は throw、
+登記済み state ファイルの欠損は stderr へ診断したうえで state 無しの load へ degrade する。
+
+ライブコーディングの再評価を壊さないため、slot の `.orbs` 宣言値 `declaredStatePath` と
+初回 load の実効値 `statePath` を分離。冪等判定は前者だけを見て、respawn self-heal は後者を
+再利用する。sum / aux はアドレス指定が未決のため #564 のまま対象外。
+
+U1–U10 はすべて3 manager の public API 経由で検証。resolver 無効化、優先順位逆転、
+declared/effective 統合、欠損時 throw / 診断削除、manifest parse 握り潰し、`seq:` receiver 混入、
+role 除去、空 documentDirectory guard 除去、不在 manifest throw、self-heal の実効値再利用削除を
+それぞれ red にし、重複 `loadPlugin` 呼び出しも `toHaveBeenCalledTimes(1)` で検出した。変異後は
+`/tmp/claude-501/541-mutation-backup/` の原本と全対象を `cmp` し、一致を確認。
+
+**検証**:
+
+- `npm run build` ✅
+- `npm test` ✅ **1789 passed / 30 skipped / 0 failed**（ベースライン 1773 + 新規 16）
+- `npm run lint` ✅ error 0（warning 2件はいずれも本変更と無関係の既存ファイル:
+  `plugin-catalog-reader.ts` と `audio-slicer.spec.ts`）
+- **実機 gated E2E ✅ 2 passed**（`npm run test:e2e:gated`）— 受け入れ基準の本体
+
+### 実機で初めて見えた不具合（ユニット全緑・受け入れ監査通過をすり抜けた）
+
+**1回目の実機実行は落ちた。** `restored 261.63Hz must match saved 392.00Hz` — default C4 に
+落ちており、自動復元が発火していなかった。ユニット 1789 件は全緑、Fable の受け入れ監査も
+「このままマージ可」だった状態でこれである。
+
+一時プローブ（`console.error` → engine stderr → `get_log`）で実値を観測して確定した原因:
+
+```
+dir=/Users/yamato/Src/proj_orbitscore/orbitscore  ← REPO_ROOT。tmpRoot ではない
+key=stSeq/instrument/CLAPTestSynth/0              ← key は正しい
+manifest not found at <REPO_ROOT>/project.yaml
+```
+
+**実装ではなく E2E ハーネスの問題だった。** 拡張は documentDirectory を2経路で渡す:
+
+| 経路 | documentDirectory |
+|---|---|
+| `run_selection`（`extension.ts:2699`） | `path.dirname(editor.document.uri.fsPath)` = 開いているファイルのディレクトリ |
+| `evaluate_orbitscore`（`extension.ts:2839`） | **workspace root** |
+
+gated E2E はアプリを REPO_ROOT を workspace として起動していたため、tmpRoot 内の fixture を
+`run_selection` で評価する先行フェーズは tmpRoot になる一方、`evaluate_orbitscore` しか使わない
+復元フェーズは REPO_ROOT になっていた。**テストが直前行で `global.setDocumentDirectory(root)` を
+呼んでも効かない** — REPL は毎 eval のメタ行 `//#documentDirectory <workspace>` を
+`sessionDocumentDirectory` として保持し、**バッファ実行のたびに冒頭で再適用する**ため上書きされる。
+
+修正: **アプリの workspace を tmpRoot で開く**。両経路が一致し、テスト側の脆い
+`setDocumentDirectory` 手当て3箇所も不要になった。ユーザーが曲フォルダを開く実際の使い方にも近い。
+
+その副作用で先行テストが `auto-started engine running` タイムアウトになった。
+`autoStartConfiguredRustEngine` は `resolveAudioDeviceSetting()` が空だと即 return し、その値は
+`vscode.workspace.getConfiguration('orbitscore').inspect('audioDevice').workspaceValue`
+= `<workspace>/.vscode/settings.json` 由来。リポジトリにはあるが新規 tmpRoot には無かった。
+セットアップで `<tmpRoot>/.vscode/settings.json` を生成して解決（デバイス名はマシン依存を避け、
+実装がサポートするセンチネル `__default__` を使う）。
+
+### 診断が暴いたテストの穴（同 PR で塞いだ）
+
+復元テストは `saved.path` のバイト一致しか見ておらず、**保存がどのディレクトリに落ちたかを
+一度も検証していなかった** — 保存が別ディレクトリでも通る。同ファイル内の先行フェーズは
+`projectFile` まで assert しているのに、復元フェーズだけが緩かった。
+`identityKey` / `projectFile` / `states/` 配下の3点を追加し、次に同型で転んだときに
+「保存が違う場所」か「復元が読めていない」かが**テストの失敗メッセージだけで切り分けられる**ようにした
+（今回は切り分けにプローブを1往復挟む必要があった）。
+
+**検証環境についての注記**: 実装を委譲した Codex 側の sandbox では `listen EPERM 127.0.0.1`
+により mock daemon / MCP HTTP 系の 95件が落ちていた。**これは sandbox の artifact であって
+退行ではない** — 同一差分を sandbox 外で回すと上記のとおり全緑になる。委譲先の
+「何件 failed」報告は、実行環境を確認せずに退行と読んではいけない（逆に、緑報告も
+そのまま信じない）。
+
+**本変更で残る follow-up（issue 化済み）**:
+
+- **#569**: 宣言時に登記済み state ファイルが欠損していれば state 無しへ degrade して音を出せる
+  一方、初回 load 後に同じファイルが消えた respawn では再 load が失敗し `pluginActive=false` の
+  まま note が drop される。respawn 全体の失敗処理を含むため #541 では現状維持
+- **#568**: 同名・別 path の plugin は SC.5 key が衝突しうる。`normalizePluginInstanceName` が
+  パスを捨てるため。fingerprint 併記は `version: 1` の `states:` 値型を変えるため別 schema issue
+- **#567**: OrbitStudio `get_log` は要求行数を黙って末尾 500 行へ cap する。E2E の ERROR 件数
+  前後比較はスライディングウィンドウ上の補助判定に留まる（復元の主判定は non-default pitch）。
+  既存テストの `RESTORE_LOG_LINES = 2000` は実際には効いておらず、
+  「窓を広げて計測を安定させる」というコメントが事実と食い違っていたので実態に合わせた
+
 ### 6.315 test: prove the tone loop on real hardware — PR #563 のレビュー〜出荷 (Jul 29, 2026)
 
 **Date**: 2026-07-29

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -40,7 +40,9 @@ role 除去、空 documentDirectory guard 除去、不在 manifest throw、self-
 **検証**:
 
 - `npm run build` ✅
-- `npm test` ✅ **1789 passed / 30 skipped / 0 failed**（ベースライン 1773 + 新規 16）
+- `npm test` ✅ **1798 passed / 30 skipped / 0 failed**（ベースライン 1773 + 新規 25）。
+  内訳は初回実装 16 / ラウンド1修正 +7 / ラウンド2修正 +2 で、
+  **レビューのラウンドごとにテストが増えている**（いずれも変異で red を実測）
 - `npm run lint` ✅ error 0（warning 2件はいずれも本変更と無関係の既存ファイル:
   `plugin-catalog-reader.ts` と `audio-slicer.spec.ts`）
 - **実機 gated E2E ✅ 2 passed**（`npm run test:e2e:gated`）— 受け入れ基準の本体
@@ -91,6 +93,82 @@ gated E2E はアプリを REPO_ROOT を workspace として起動していたた
 「保存が違う場所」か「復元が読めていない」かが**テストの失敗メッセージだけで切り分けられる**ようにした
 （今回は切り分けにプローブを1往復挟む必要があった）。
 
+### PR レビュー（5名並行）で塞いだもの
+
+`/simplify`（4観点）→ `/code:pr-review-team` ラウンド1（code-reviewer / silent-failure-hunter /
+pr-test-analyzer / comment-analyzer）+ **Fable 独立監査をラウンド1に並行投入**した。
+
+**🔴 pr-test-analyzer が実証した false green**: `resolveRegisteredPluginStatePath` の
+`if (code !== 'ENOENT') throw error` を削除して**全 fs エラーを握り潰す変異**を入れても、
+当初の 16 件が**全部通った**（worktree を切って実測）。自分の変異検証がこの分岐を漏らしていた。
+
+**Fable が見つけた2つの実質的な穴**（いずれも一次ソース照合つき）:
+
+1. **`access(F_OK)` が弱すぎた** — F_OK は存在しか見ず、**ディレクトリでも成功し、可読性を検査しない**。
+   CLAP/VST3 両 child とも state 読取失敗は `?` で即死する（`orbit-clap-instrument-child/src/main.rs:186` /
+   `orbit-vst3-instrument-child/src/main.rs:279` 付近）ため、chmod 000 の state・ディレクトリを指す登記・
+   空文字登記が「degrade できたはずなのに硬い load 失敗」に化けていた。
+   `stat` + `isFile()` + `access(R_OK)` に置換し、**失敗の種類にかかわらず degrade へ合流**
+2. **保存後の daemon respawn で default 音色に戻る窓** — 登記が無い状態で load した slot は
+   `loadedPlugins` cache に `statePath=undefined` が凍結される。その後 `savePluginState` で登記されても、
+   respawn の再ロードは state 無しになる。**初回セッションで最も起きやすい流れ**なので follow-up にせず
+   本 PR に取り込み、保存成功時に cache の `statePath` を `saved.path` へ更新するようにした
+
+**失敗ポリシーの線引きを Fable の案に差し替えた**: 当初は「非 ENOENT は一律 fail」としていたが、
+**「登記簿そのもの（manifest）が読めない = fail、派生データ（state ファイル）が読めない = degrade」**
+の方が #541 の「楽譜を機械の派生データの問題でブロックしない」原則の延長として筋が通る。
+
+**観測性は Fable 案を採用**: 「no-op 経路に breadcrumb」ではなく
+**「復元が適用されたときだけ1行出す」**（`[plugin-state] restoring '<key>' from <path>`）。
+正常系はゼロ行のまま、故障位置が「ディレクトリ違い / manifest 不在 / key 不一致」に三分割される。
+`console.log` は engine stdout → `shouldFilterLine`（既知パターン以外は通す）→ `outputChannel` →
+`get_log` に届き、`ERROR:` 接頭辞が付かないので既存の「ERROR 行が増えないこと」assert を壊さない
+（配線は実コードで裏取り済み）。
+
+### ラウンド2（fix-scoped 縮小レビュー）— **自分の修正が作り込んだ穴を検出した**
+
+ラウンド1の指摘はすべて original-diff 起因だったため、規約どおり provenance で縮小し、
+**fix 差分に対して2問だけ**（「この修正が導入する新しい故障モードは何か」
+「新コードはどの実行コンテキストで走るか」）を問うた。
+
+**Important 1件が出た。上の穴2を塞ぐ修正が、別の穴を開けていた。**
+
+`RustEnginePlayer.savePluginState` の cache 更新は、呼び出し元 `ProjectStateStore.saveBody` の
+`bytesWritten > 0` 検証**より前**に走る。`daemon-client` は `bytes_written` が有限数かしか
+検証しないので **`0` は例外を投げずに通り**、cache だけ書き換わってから上位が throw する。
+
+結果、**呼び出し元には失敗と見えるのに in-memory cache だけがこっそり更新される**。
+manifest には登記されないので次セッションでは再現せず、**同一セッション内の次の respawn で
+遅延顕在化する** silent failure。修正前は passthrough だったのでこの窓は無かった。
+
+修正: cache 更新を `saved.bytesWritten > 0` のガード内に入れ、
+「cache 更新」と「呼び出し元への成功宣言」が同じ検証を共有するようにした。
+
+**規約「fixer の差分はラウンドを閉じる前に再点検する」が実際に機能した例**。
+ラウンド1で閉じていれば、この silent failure はそのまま出荷されていた。
+
+Minor もう1件: `stat` は通ったが `access(R_OK)` が ENOENT で落ちる TOCTOU 窓で、診断が
+「is not readable」に丸められて「存在しない」という理由が失われていた
+（下の「Cannot parse → Cannot read」と**同じ嘘の診断類型**）。正確な文言に修正。
+
+### 新しい観測可能な表面を E2E で押さえた
+
+この PR は復元適用時のログという**新しい観測可能な表面**を足したのに、当初それを E2E で
+押さえていなかった（規約「その PR が追加した観測可能な表面を必ず1つ以上 E2E で押さえる」違反）。
+
+Cycle B の `get_log` に `[plugin-state] restoring` と identity key が**同じ行に**現れることを
+assert に追加し、**実機で緑を確認**。これで
+**engine stdout → extension outputChannel → `get_log`** というプロセス境界を跨ぐ配線が実証された。
+ユニットテストは `vi.spyOn(console, 'error')` で同一プロセス内を見ているだけなので、
+この境界は E2E でしか守れない（silent-failure-hunter の指摘どおり）。
+
+**差分精読で見つけた2点**（レビュアー指摘ではない）:
+
+- `parseManifest` の「Cannot **parse**」が catch で「Cannot **read**」に包み直されて
+  **一次ラベルが嘘になっていた**（#563 の `Unknown sequence`・#567 の嘘コメントと同型）。
+  `parseManifest` を try の外へ出して素通しに
+- cache 更新が daemon の戻り値ではなく要求値のパスを使っていた → `saved.path` に
+
 **検証環境についての注記**: 実装を委譲した Codex 側の sandbox では `listen EPERM 127.0.0.1`
 により mock daemon / MCP HTTP 系の 95件が落ちていた。**これは sandbox の artifact であって
 退行ではない** — 同一差分を sandbox 外で回すと上記のとおり全緑になる。委譲先の
@@ -100,8 +178,13 @@ gated E2E はアプリを REPO_ROOT を workspace として起動していたた
 **本変更で残る follow-up（issue 化済み）**:
 
 - **#569**: 宣言時に登記済み state ファイルが欠損していれば state 無しへ degrade して音を出せる
-  一方、初回 load 後に同じファイルが消えた respawn では再 load が失敗し `pluginActive=false` の
-  まま note が drop される。respawn 全体の失敗処理を含むため #541 では現状維持
+  一方、初回 load 後に同じファイルが消えた respawn では再 load が失敗する。
+  **🔴 本 PR がこの issue の露出範囲を広げた**: PR 前は statePath を持つのが
+  `instrument(path, statePath)` と明示的に書いた宣言だけ（`.vstpreset` 明示指定は互換入力に降格済みで
+  実質ほぼ存在しない）だったのに対し、PR 後は**一度でも state を保存した宣言はすべて**該当し、
+  それが通常経路になる。さらに watchdog を読むと、初回 attach 後の child 死亡は fast-fail ではなく
+  通常の respawn 経路に入るため、**20ms（`WATCHDOG_POLL`）間隔の respawn ループになる疑いがある**
+  （**未実証** — 再現テストで確定させること）。owner の音楽的判断待ち
 - **#568**: 同名・別 path の plugin は SC.5 key が衝突しうる。`normalizePluginInstanceName` が
   パスを捨てるため。fingerprint 併記は `version: 1` の `states:` 値型を変えるため別 schema issue
 - **#567**: OrbitStudio `get_log` は要求行数を黙って末尾 500 行へ cap する。E2E の ERROR 件数

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -756,7 +756,15 @@ export class RustEnginePlayer implements AudioEngineBackend {
     target: import('../types').PluginStateSaveTarget,
     absolutePath: string,
   ): Promise<import('../types').PluginStateSaveResult> {
-    return this.daemon.savePluginState(target, absolutePath)
+    const saved = await this.daemon.savePluginState(target, absolutePath)
+    const key = RustEnginePlayer.pluginKey(
+      target.role,
+      target.role === 'effect' ? target.bus : undefined,
+      target.role === 'instrument' ? target.instance : undefined,
+    )
+    const cached = this.loadedPlugins.get(key)
+    if (cached && saved.bytesWritten > 0) cached.statePath = saved.path
+    return saved
   }
 
   pluginNoteOn(key: number, channel: number, velocity: number, instance?: string): Promise<void> {

--- a/packages/engine/src/core/global/effect-slot.ts
+++ b/packages/engine/src/core/global/effect-slot.ts
@@ -10,6 +10,7 @@
 import * as path from 'path'
 
 import type { AudioEngine } from '../../audio/types'
+import type { PluginStateIdentity } from '../project-state-store'
 
 import { AudioManager } from './audio-manager'
 import { LinkAudioManager } from './link-audio-manager'
@@ -61,10 +62,9 @@ interface PluginSlotBase {
   readonly normalizedName: string
   readonly resolvedPath: string
   readonly pluginId?: string
-  /**
-   * 保存済み state ファイル（#540 P2・現状 instrument のみが設定する）。ロード identity の
-   * 一部として idempotence 判定に参加する（effect では常に undefined 同士の比較）。
-   */
+  /** `.orbs` 宣言が明示した state path。冪等再宣言の同一性判定はこの値だけを見る。 */
+  readonly declaredStatePath?: string
+  /** 実際の load に渡した state path（明示値、または project.yaml のフォールバック）。 */
   readonly statePath?: string
   readonly load: Promise<void>
 }
@@ -99,10 +99,24 @@ export interface PluginDeclaration {
    */
   readonly instance?: string
   /**
-   * 保存済みプラグイン state ファイルの解決済みパス（'instrument' role 専用・#540 P2）。
-   * ロード identity の一部 — 同 path/pluginId でも state が違えば別宣言（v1 は差し替え拒否）。
+   * `.orbs` が明示した保存済みプラグイン state ファイルの解決済みパス（#540 P2）。
+   * project.yaml から得る実効値とは分離し、冪等判定にはこの宣言値だけを使う。
    */
   readonly statePath?: string
+}
+
+export type PluginStatePathFallbackResolver = (
+  identity: PluginStateIdentity,
+) => Promise<string | undefined>
+
+export interface EffectChainMapOptions<K> {
+  readonly maxLength?: number
+  readonly statePathFallback?: PluginStatePathFallbackResolver
+  /**
+   * project.yaml の SC.5 identity に使う外向き receiver 名。`receiverId` が返す内部
+   * namespace (`seq:<name>` 等) とは異なる。
+   */
+  readonly externalReceiverId?: (key: K) => string
 }
 
 export class EffectSlotLimitError extends Error {
@@ -124,6 +138,9 @@ export class EffectSlotLimitError extends Error {
  */
 export class EffectChainMap<K> {
   private readonly chains = new Map<K, PluginSlot[]>()
+  private readonly maxLength: number
+  private readonly statePathFallback?: PluginStatePathFallbackResolver
+  private readonly externalReceiverId?: (key: K) => string
   // key ごとの直列化キュー（#527 review Important 1）。値は「前呼び出しの決着
   // （成功/失敗いずれも）待ち」で、前呼び出しの成否は自分の結果に影響させない
   // （catch で握りつぶし、必ず次の呼び出しへ進める）。
@@ -132,8 +149,12 @@ export class EffectChainMap<K> {
   constructor(
     private readonly audioEngine: AudioEngine,
     private readonly receiverId: (key: K) => string,
-    private readonly maxLength = 1,
-  ) {}
+    options: EffectChainMapOptions<K> = {},
+  ) {
+    this.maxLength = options.maxLength ?? 1
+    this.statePathFallback = options.statePathFallback
+    this.externalReceiverId = options.externalReceiverId
+  }
 
   has(key: K): boolean {
     return (this.chains.get(key)?.length ?? 0) > 0
@@ -212,7 +233,7 @@ export class EffectChainMap<K> {
         existing.role === spec.role &&
         existing.resolvedPath === spec.resolvedPath &&
         existing.pluginId === spec.pluginId &&
-        existing.statePath === spec.statePath
+        existing.declaredStatePath === spec.statePath
       ) {
         await existing.load
         // Self-heal: respawn 後の復元失敗で engine 側だけ宣言が消えている場合、
@@ -242,11 +263,32 @@ export class EffectChainMap<K> {
     if (!this.audioEngine.loadPlugin) {
       throw new Error('Plugin hosting requires the Rust engine backend.')
     }
-    const { role, bus, normalizedName, resolvedPath, pluginId, instance, statePath } = spec
-    // bus 無し（master insert）は 3 引数のまま呼ぶ（既存の呼び出し契約を変えない —
-    // explicit undefined でも実 engine は等価だが、契約をピンするテスト/モックがある）。
-    // bus / instance / statePath は末尾 optional（#540 P1/P2）— 分岐を列挙する代わりに
-    // 末尾の undefined を落として「与えられた引数だけを渡す」契約を保つ。
+    const { role, bus, normalizedName, resolvedPath, pluginId, instance } = spec
+    const chain = this.chains.get(key) ?? []
+    const occurrence =
+      replacing?.occurrence ??
+      chain.filter((slot) => slot !== replacing && slot.normalizedName === normalizedName).length
+    const receiver = replacing?.receiver ?? this.receiverId(key)
+    const instanceId = replacing?.instanceId ?? `${receiver}/${normalizedName}#${occurrence + 1}`
+    // manifest は宣言値が無い新規 slot だけで参照する。respawn self-heal では、初回 load で
+    // 確定した実効値を常に優先して同じパスを指し続ける（ファイル内容は再読込されうる）。
+    const externalReceiver =
+      replacing === undefined && spec.statePath === undefined
+        ? this.externalReceiverId?.(key)
+        : undefined
+    const fallbackStatePath =
+      externalReceiver !== undefined && this.statePathFallback !== undefined
+        ? await this.statePathFallback({
+            receiver: externalReceiver,
+            role,
+            normalizedName,
+            occurrence,
+          })
+        : undefined
+    const statePath = replacing?.statePath ?? spec.statePath ?? fallbackStatePath
+    // bus / instance / statePath は末尾 optional（#540 P1/P2）。末尾の undefined を落とし、
+    // 「必要な位置までの引数だけを渡す」契約を保つ。したがって statePath の無い master
+    // insert は従来どおり 3 引数だが、statePath があればその位置までの undefined も渡す。
     const optionalArgs: (string | undefined)[] = [bus, instance, statePath]
     while (optionalArgs.length > 0 && optionalArgs[optionalArgs.length - 1] === undefined) {
       optionalArgs.pop()
@@ -254,12 +296,6 @@ export class EffectChainMap<K> {
     const load = this.audioEngine
       .loadPlugin(resolvedPath, pluginId, role, ...(optionalArgs as [string?, string?, string?]))
       .then(() => undefined)
-    const chain = this.chains.get(key) ?? []
-    const occurrence =
-      replacing?.occurrence ??
-      chain.filter((slot) => slot !== replacing && slot.normalizedName === normalizedName).length
-    const receiver = replacing?.receiver ?? this.receiverId(key)
-    const instanceId = replacing?.instanceId ?? `${receiver}/${normalizedName}#${occurrence + 1}`
     const entry: PluginSlot =
       role === 'effect'
         ? {
@@ -271,6 +307,8 @@ export class EffectChainMap<K> {
             normalizedName,
             resolvedPath,
             pluginId,
+            declaredStatePath: spec.statePath,
+            statePath,
             load,
           }
         : {
@@ -282,6 +320,7 @@ export class EffectChainMap<K> {
             normalizedName,
             resolvedPath,
             pluginId,
+            declaredStatePath: spec.statePath,
             statePath,
             load,
           }

--- a/packages/engine/src/core/global/effect-slot.ts
+++ b/packages/engine/src/core/global/effect-slot.ts
@@ -113,8 +113,9 @@ export interface EffectChainMapOptions<K> {
   readonly maxLength?: number
   readonly statePathFallback?: PluginStatePathFallbackResolver
   /**
-   * project.yaml の SC.5 identity に使う外向き receiver 名。`receiverId` が返す内部
-   * namespace (`seq:<name>` 等) とは異なる。
+   * project.yaml の SC.5 identity に使う外向き receiver 名。sequence effect / instrument
+   * では `receiverId` が返す内部 namespace (`seq:<name>`) と異なり、master effect では
+   * どちらも `'master'` で同値。
    */
   readonly externalReceiverId?: (key: K) => string
 }
@@ -286,6 +287,11 @@ export class EffectChainMap<K> {
           })
         : undefined
     const statePath = replacing?.statePath ?? spec.statePath ?? fallbackStatePath
+    if (fallbackStatePath !== undefined) {
+      console.log(
+        `[plugin-state] restoring '${externalReceiver}/${role}/${normalizedName}/${occurrence}' from ${fallbackStatePath}`,
+      )
+    }
     // bus / instance / statePath は末尾 optional（#540 P1/P2）。末尾の undefined を落とし、
     // 「必要な位置までの引数だけを渡す」契約を保つ。したがって statePath の無い master
     // insert は従来どおり 3 引数だが、statePath があればその位置までの undefined も渡す。

--- a/packages/engine/src/core/global/mixer-manager.ts
+++ b/packages/engine/src/core/global/mixer-manager.ts
@@ -92,6 +92,7 @@ export class MixerManager {
   ) {
     const makeKind = (kind: MixerKind, prefix: string): KindState => ({
       buses: new Map(),
+      // #564 でアドレス指定が未決のため、sum/aux は state 自動復元の対象外。
       inserts: new EffectChainMap(audioEngine, (name) => `${kind}:${name}`),
       pool: new BusPool(
         prefix,

--- a/packages/engine/src/core/global/plugin-effect-manager.ts
+++ b/packages/engine/src/core/global/plugin-effect-manager.ts
@@ -1,4 +1,5 @@
 import type { AudioEngine } from '../../audio/types'
+import { createStatePathFallback } from '../project-state-store'
 
 import { AudioManager } from './audio-manager'
 import { LinkAudioManager } from './link-audio-manager'
@@ -19,7 +20,10 @@ export class PluginEffectManager {
     private readonly audioManager: AudioManager,
     private readonly linkAudioManager: LinkAudioManager,
   ) {
-    this.slots = new EffectChainMap(audioEngine, () => 'master')
+    this.slots = new EffectChainMap(audioEngine, () => 'master', {
+      externalReceiverId: () => 'master',
+      statePathFallback: createStatePathFallback(audioManager),
+    })
   }
 
   hasDeclaration(): boolean {

--- a/packages/engine/src/core/global/plugin-instrument-manager.ts
+++ b/packages/engine/src/core/global/plugin-instrument-manager.ts
@@ -1,4 +1,5 @@
 import type { AudioEngine } from '../../audio/types'
+import { createStatePathFallback } from '../project-state-store'
 
 import { AudioManager } from './audio-manager'
 import { resolvePathDirect } from './audio-resolver'
@@ -21,7 +22,10 @@ export class PluginInstrumentManager {
     private readonly audioManager: AudioManager,
     private readonly linkAudioManager: LinkAudioManager,
   ) {
-    this.slots = new EffectChainMap(audioEngine, (seqName) => `seq:${seqName}`)
+    this.slots = new EffectChainMap(audioEngine, (seqName) => `seq:${seqName}`, {
+      externalReceiverId: (seqName) => seqName,
+      statePathFallback: createStatePathFallback(audioManager),
+    })
   }
 
   hasDeclaration(): boolean {

--- a/packages/engine/src/core/global/sequence-effect-manager.ts
+++ b/packages/engine/src/core/global/sequence-effect-manager.ts
@@ -1,4 +1,5 @@
 import type { AudioEngine } from '../../audio/types'
+import { createStatePathFallback } from '../project-state-store'
 
 import { AudioManager } from './audio-manager'
 import { LinkAudioManager } from './link-audio-manager'
@@ -51,7 +52,10 @@ export class SequenceEffectManager {
     private readonly audioManager: AudioManager,
     private readonly linkAudioManager: LinkAudioManager,
   ) {
-    this.slots = new EffectChainMap(audioEngine, (sequenceName) => `seq:${sequenceName}`)
+    this.slots = new EffectChainMap(audioEngine, (sequenceName) => `seq:${sequenceName}`, {
+      externalReceiverId: (sequenceName) => sequenceName,
+      statePathFallback: createStatePathFallback(audioManager),
+    })
   }
 
   hasDeclaration(sequenceName: string): boolean {

--- a/packages/engine/src/core/project-state-store.ts
+++ b/packages/engine/src/core/project-state-store.ts
@@ -85,6 +85,11 @@ function parseManifest(source: string, manifestPath: string): ProjectManifest {
  * document context が無い場合と manifest / identity が未登記の場合は通常状態として no-op。
  * manifest 自体の破損は parseManifest の既存契約どおり throw し、登記済みファイルだけが
  * 欠損している場合は音を止めず state 無しへ degrade する（stderr には診断を残す）。
+ *
+ * project.yaml は `.orbs` と同じローカルプロジェクト内にあり、同一の信頼ドメインとして扱う。
+ * そのため手編集された登記値の絶対パスや `../` による project 外参照はユーザーの責任範囲。
+ * 書き込み側は常に `projectDirectory/states/<決定論的ファイル名>` を使うため、保存処理から
+ * project 外へ書き出すことは構造的にできない。
  */
 export async function resolveRegisteredPluginStatePath(
   projectDirectory: string,
@@ -96,32 +101,59 @@ export async function resolveRegisteredPluginStatePath(
     return undefined
   }
 
+  const key = identityKey(identity)
   const manifestPath = path.join(projectDirectory, 'project.yaml')
-  let manifest: ProjectManifest
+  let source: string
   try {
-    const source = await fs.promises.readFile(manifestPath, 'utf8')
-    manifest = parseManifest(source, manifestPath)
+    source = await fs.promises.readFile(manifestPath, 'utf8')
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return undefined
     }
-    throw error
+    // 原因を本文に連結する（PluginInstrumentManager.resolveStatePath と同型）。
+    // `{ cause }` は tsconfig の lib が ES2022.Error を含まないため使わない。
+    const cause = error instanceof Error ? ` (cause: ${error.message})` : ''
+    throw new Error(
+      `Cannot read plugin state manifest '${manifestPath}' for identity '${key}'.${cause}`,
+    )
   }
+  const manifest = parseManifest(source, manifestPath)
 
-  const key = identityKey(identity)
   const registeredPath = manifest.states[key]
   if (registeredPath === undefined) {
     return undefined
   }
 
   const absoluteStatePath = path.resolve(projectDirectory, registeredPath)
+  let stateStats: fs.Stats
   try {
-    await fs.promises.access(absoluteStatePath, fs.constants.F_OK)
+    stateStats = await fs.promises.stat(absoluteStatePath)
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    const code = (error as NodeJS.ErrnoException).code
+    const detail = error instanceof Error ? ` (${code ?? 'unknown'}: ${error.message})` : ''
     console.error(
-      `Registered plugin state '${absoluteStatePath}' for '${key}' does not exist; ` +
+      `Registered plugin state '${absoluteStatePath}' for '${key}' ${
+        code === 'ENOENT' ? 'does not exist' : `is not readable${detail}`
+      }; loading the plugin without state.`,
+    )
+    return undefined
+  }
+  if (!stateStats.isFile()) {
+    console.error(
+      `Registered plugin state '${absoluteStatePath}' for '${key}' is not a file; ` +
         'loading the plugin without state.',
+    )
+    return undefined
+  }
+  try {
+    await fs.promises.access(absoluteStatePath, fs.constants.R_OK)
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    const detail = error instanceof Error ? ` (${code ?? 'unknown'}: ${error.message})` : ''
+    console.error(
+      `Registered plugin state '${absoluteStatePath}' for '${key}' ${
+        code === 'ENOENT' ? 'does not exist' : `is not readable${detail}`
+      }; loading the plugin without state.`,
     )
     return undefined
   }

--- a/packages/engine/src/core/project-state-store.ts
+++ b/packages/engine/src/core/project-state-store.ts
@@ -79,6 +79,62 @@ function parseManifest(source: string, manifestPath: string): ProjectManifest {
   return manifest as ProjectManifest
 }
 
+/**
+ * project.yaml の SC.5 identity 登記を、daemon に渡せる絶対 state path へ解決する。
+ *
+ * document context が無い場合と manifest / identity が未登記の場合は通常状態として no-op。
+ * manifest 自体の破損は parseManifest の既存契約どおり throw し、登記済みファイルだけが
+ * 欠損している場合は音を止めず state 無しへ degrade する（stderr には診断を残す）。
+ */
+export async function resolveRegisteredPluginStatePath(
+  projectDirectory: string,
+  identity: PluginStateIdentity,
+): Promise<string | undefined> {
+  // AudioManager.getDocumentDirectory() は未設定時に空文字列を返す。ここを path.join() より
+  // 前で止めないと、engine の cwd にある project.yaml を暗黙に読むことになる。
+  if (!projectDirectory) {
+    return undefined
+  }
+
+  const manifestPath = path.join(projectDirectory, 'project.yaml')
+  let manifest: ProjectManifest
+  try {
+    const source = await fs.promises.readFile(manifestPath, 'utf8')
+    manifest = parseManifest(source, manifestPath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return undefined
+    }
+    throw error
+  }
+
+  const key = identityKey(identity)
+  const registeredPath = manifest.states[key]
+  if (registeredPath === undefined) {
+    return undefined
+  }
+
+  const absoluteStatePath = path.resolve(projectDirectory, registeredPath)
+  try {
+    await fs.promises.access(absoluteStatePath, fs.constants.F_OK)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    console.error(
+      `Registered plugin state '${absoluteStatePath}' for '${key}' does not exist; ` +
+        'loading the plugin without state.',
+    )
+    return undefined
+  }
+  return absoluteStatePath
+}
+
+export function createStatePathFallback(directoryProvider: {
+  getDocumentDirectory(): string
+}): (identity: PluginStateIdentity) => Promise<string | undefined> {
+  return (identity) =>
+    resolveRegisteredPluginStatePath(directoryProvider.getDocumentDirectory(), identity)
+}
+
 async function syncDirectory(directory: string): Promise<void> {
   const handle = await fs.promises.open(directory, 'r')
   try {

--- a/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
+++ b/tests/audio/rust-engine/rust-engine-player-plugin-respawn.spec.ts
@@ -12,6 +12,7 @@ interface FakeDaemon {
   loadPlugin: ReturnType<typeof vi.fn>
   pluginNoteOn: ReturnType<typeof vi.fn>
   pluginNoteOff: ReturnType<typeof vi.fn>
+  savePluginState: ReturnType<typeof vi.fn>
   setBusRouting: ReturnType<typeof vi.fn>
   quit: ReturnType<typeof vi.fn>
 }
@@ -33,6 +34,12 @@ function createHarness() {
     loadPlugin: vi.fn().mockResolvedValue(ECHO_LOAD_RESULT),
     pluginNoteOn: vi.fn().mockResolvedValue(undefined),
     pluginNoteOff: vi.fn().mockResolvedValue(undefined),
+    savePluginState: vi.fn().mockImplementation((_target, absolutePath) =>
+      Promise.resolve({
+        path: absolutePath,
+        bytesWritten: 12,
+      }),
+    ),
     setBusRouting: vi.fn().mockResolvedValue(undefined),
     quit: vi.fn().mockResolvedValue(undefined),
   }
@@ -228,6 +235,121 @@ describe('RustEnginePlayer plugin recovery after daemon respawn', () => {
       undefined,
       'plugin:lead',
       '/songs/lead.vstpreset',
+    )
+  })
+
+  it('uses the daemon-returned saved path when reloading the cached plugin after respawn', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    await player.loadPlugin(
+      '/plugins/kontakt.vst3',
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+    )
+    const requestedStatePath = '/songs/states/requested-lead.state'
+    const savedStatePath = '/daemon/states/actual-lead.state'
+    daemon.savePluginState.mockResolvedValueOnce({
+      path: savedStatePath,
+      bytesWritten: 12,
+    })
+
+    await player.savePluginState(
+      { role: 'instrument', instance: 'plugin:lead' },
+      requestedStatePath,
+    )
+
+    expect(daemon.savePluginState).toHaveBeenCalledTimes(1)
+    expect(daemon.savePluginState).toHaveBeenCalledWith(
+      { role: 'instrument', instance: 'plugin:lead' },
+      requestedStatePath,
+    )
+    daemon.loadPlugin.mockClear()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await (player as any).respawnLoop()
+
+    expect(daemon.loadPlugin).toHaveBeenCalledTimes(1)
+    expect(daemon.loadPlugin).toHaveBeenCalledWith(
+      '/plugins/kontakt.vst3',
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+      savedStatePath,
+    )
+  })
+
+  it('does not update the respawn cache when saving plugin state fails', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    await player.loadPlugin(
+      '/plugins/kontakt.vst3',
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+    )
+    daemon.savePluginState.mockRejectedValueOnce(new Error('state save failed'))
+
+    await expect(
+      player.savePluginState(
+        { role: 'instrument', instance: 'plugin:lead' },
+        '/songs/states/failed.state',
+      ),
+    ).rejects.toThrow('state save failed')
+
+    daemon.loadPlugin.mockClear()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await (player as any).respawnLoop()
+
+    expect(daemon.loadPlugin).toHaveBeenCalledTimes(1)
+    expect(daemon.loadPlugin).toHaveBeenCalledWith(
+      '/plugins/kontakt.vst3',
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+      undefined,
+    )
+  })
+
+  it('does not update the respawn cache when saving plugin state writes zero bytes', async () => {
+    const { player, daemon } = createHarness()
+    players.push(player)
+    await player.loadPlugin(
+      '/plugins/kontakt.vst3',
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+    )
+    const failedStatePath = '/songs/states/zero-byte.state'
+    daemon.savePluginState.mockResolvedValueOnce({
+      path: failedStatePath,
+      bytesWritten: 0,
+    })
+
+    await expect(
+      player.savePluginState({ role: 'instrument', instance: 'plugin:lead' }, failedStatePath),
+    ).resolves.toEqual({
+      path: failedStatePath,
+      bytesWritten: 0,
+    })
+
+    daemon.loadPlugin.mockClear()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await (player as any).respawnLoop()
+
+    expect(daemon.loadPlugin).toHaveBeenCalledTimes(1)
+    expect(daemon.loadPlugin).toHaveBeenCalledWith(
+      '/plugins/kontakt.vst3',
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+      undefined,
     )
   })
 

--- a/tests/core/plugin-state-restore.spec.ts
+++ b/tests/core/plugin-state-restore.spec.ts
@@ -1,0 +1,384 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { stringify } from 'yaml'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { AudioManager } from '../../packages/engine/src/core/global/audio-manager'
+import { LinkAudioManager } from '../../packages/engine/src/core/global/link-audio-manager'
+import { PluginEffectManager } from '../../packages/engine/src/core/global/plugin-effect-manager'
+import { PluginInstrumentManager } from '../../packages/engine/src/core/global/plugin-instrument-manager'
+import { SequenceEffectManager } from '../../packages/engine/src/core/global/sequence-effect-manager'
+
+const temporaryDirectories: string[] = []
+
+function temporaryDirectory(prefix = 'orbit-plugin-state-restore-'): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+function harness(options: { documentDirectory?: boolean; active?: boolean } = {}) {
+  const directory = temporaryDirectory()
+  const audio = {
+    loadPlugin: vi.fn().mockResolvedValue({}),
+    ...(options.active === undefined
+      ? {}
+      : { isPluginActive: vi.fn().mockReturnValue(options.active) }),
+  } as any
+  const audioManager = new AudioManager(audio)
+  if (options.documentDirectory !== false) audioManager.setDocumentDirectory(directory)
+  const linkAudioManager = new LinkAudioManager()
+  return {
+    directory,
+    audio,
+    instrument: new PluginInstrumentManager(audio, audioManager, linkAudioManager),
+    masterEffect: new PluginEffectManager(audio, audioManager, linkAudioManager),
+    sequenceEffect: new SequenceEffectManager(audio, audioManager, linkAudioManager),
+  }
+}
+
+function register(
+  directory: string,
+  entries: Record<string, string>,
+  existingStatePaths: readonly string[] = Object.values(entries),
+): void {
+  for (const relativeStatePath of existingStatePaths) {
+    const absoluteStatePath = path.resolve(directory, relativeStatePath)
+    fs.mkdirSync(path.dirname(absoluteStatePath), { recursive: true })
+    fs.writeFileSync(absoluteStatePath, 'non-default-oracle-state')
+  }
+  fs.writeFileSync(path.join(directory, 'project.yaml'), stringify({ version: 1, states: entries }))
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('project.yaml plugin state auto-restore (#541)', () => {
+  const managerCases = [
+    {
+      label: 'PluginInstrumentManager.instrument',
+      key: 'lead/instrument/Synth/0',
+      wrongKey: 'seq:lead/instrument/Synth/0',
+      declare: async (h: ReturnType<typeof harness>) =>
+        h.instrument.instrument('lead', './Synth.clap'),
+      expectedArgs: (directory: string, statePath: string) => [
+        path.join(directory, 'Synth.clap'),
+        undefined,
+        'instrument',
+        undefined,
+        'plugin:lead',
+        statePath,
+      ],
+    },
+    {
+      label: 'PluginEffectManager.effect',
+      key: 'master/effect/Limiter/0',
+      wrongKey: 'seq:master/effect/Limiter/0',
+      declare: async (h: ReturnType<typeof harness>) => h.masterEffect.effect('./Limiter.clap'),
+      expectedArgs: (directory: string, statePath: string) => [
+        path.join(directory, 'Limiter.clap'),
+        undefined,
+        'effect',
+        undefined,
+        undefined,
+        statePath,
+      ],
+    },
+    {
+      label: 'SequenceEffectManager.effect',
+      key: 'lead/effect/Echo/0',
+      wrongKey: 'seq:lead/effect/Echo/0',
+      declare: async (h: ReturnType<typeof harness>) =>
+        h.sequenceEffect.effect('lead', './Echo.clap'),
+      expectedArgs: (directory: string, statePath: string) => [
+        path.join(directory, 'Echo.clap'),
+        undefined,
+        'effect',
+        'seq-bus-0',
+        undefined,
+        statePath,
+      ],
+    },
+  ]
+
+  it.each(managerCases)(
+    'U1 restores registered state through $label',
+    async ({ key, declare, expectedArgs }) => {
+      const h = harness()
+      const relativeStatePath = 'states/non-default.state'
+      const absoluteStatePath = path.join(h.directory, 'states', 'non-default.state')
+      register(h.directory, { [key]: relativeStatePath })
+
+      await declare(h)
+
+      expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+        ...expectedArgs(h.directory, absoluteStatePath),
+      )
+      expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+    },
+  )
+
+  it('U2 gives an explicitly declared statePath priority over project.yaml registration', async () => {
+    const h = harness()
+    const registeredStatePath = 'states/registered.state'
+    const explicitStatePath = path.join(h.directory, 'explicit.state')
+    register(h.directory, { 'lead/instrument/Synth/0': registeredStatePath })
+    fs.writeFileSync(explicitStatePath, 'explicit-non-default-state')
+
+    await h.instrument.instrument('lead', './Synth.clap', undefined, explicitStatePath)
+
+    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+      path.join(h.directory, 'Synth.clap'),
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+      explicitStatePath,
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+  })
+
+  it('U3 treats repeated declarations as idempotent using only the declared statePath', async () => {
+    const h = harness()
+    const relativeStatePath = 'states/registered.state'
+    const absoluteStatePath = path.join(h.directory, 'states', 'registered.state')
+    register(h.directory, { 'lead/instrument/Synth/0': relativeStatePath })
+
+    await h.instrument.instrument('lead', './Synth.clap')
+    await expect(h.instrument.instrument('lead', './Synth.clap')).resolves.toBeUndefined()
+
+    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+      path.join(h.directory, 'Synth.clap'),
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+      absoluteStatePath,
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+
+    // Live-coding regression case: the first declaration predates project.yaml, then a save
+    // registers state before the same source line is evaluated again. Manifest fallback must
+    // not be resolved for the already-existing slot.
+    const registeredLater = harness()
+    await registeredLater.instrument.instrument('lead', './Synth.clap')
+    register(registeredLater.directory, {
+      'lead/instrument/Synth/0': 'states/registered-later.state',
+    })
+    await expect(
+      registeredLater.instrument.instrument('lead', './Synth.clap'),
+    ).resolves.toBeUndefined()
+    expect(registeredLater.audio.loadPlugin).toHaveBeenCalledWith(
+      path.join(registeredLater.directory, 'Synth.clap'),
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+    )
+    expect(registeredLater.audio.loadPlugin).toHaveBeenCalledTimes(1)
+  })
+
+  it('U4 degrades loudly when a registered state file is missing', async () => {
+    const h = harness()
+    const relativeStatePath = 'states/missing.state'
+    const absoluteStatePath = path.join(h.directory, 'states', 'missing.state')
+    register(h.directory, { 'lead/instrument/Synth/0': relativeStatePath }, [])
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await h.instrument.instrument('lead', './Synth.clap')
+
+    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+      path.join(h.directory, 'Synth.clap'),
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Registered plugin state '${absoluteStatePath}' for 'lead/instrument/Synth/0' does not exist`,
+      ),
+    )
+  })
+
+  it('U5 throws with the manifest path when project.yaml is malformed', async () => {
+    const h = harness()
+    const manifestPath = path.join(h.directory, 'project.yaml')
+    fs.writeFileSync(manifestPath, 'version: 1\nstates: [\n')
+
+    await expect(h.masterEffect.effect('./Limiter.clap')).rejects.toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining(manifestPath),
+      }),
+    )
+    expect(h.audio.loadPlugin).not.toHaveBeenCalled()
+  })
+
+  it('U5b isolates an explicitly declared statePath from a malformed project.yaml', async () => {
+    const h = harness()
+    const explicitStatePath = path.join(h.directory, 'explicit.state')
+    fs.writeFileSync(explicitStatePath, 'explicit-non-default-state')
+    fs.writeFileSync(path.join(h.directory, 'project.yaml'), 'version: 1\nstates: [\n')
+
+    await expect(
+      h.instrument.instrument('lead', './Synth.clap', undefined, explicitStatePath),
+    ).resolves.toBeUndefined()
+
+    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+      path.join(h.directory, 'Synth.clap'),
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+      explicitStatePath,
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(managerCases)(
+    'U6 uses the external receiver namespace for $label',
+    async ({ key, wrongKey, declare, expectedArgs }) => {
+      const h = harness()
+      const correctStatePath = `states/${key.replaceAll('/', '-')}.state`
+      const wrongStatePath = `states/${wrongKey.replaceAll('/', '-')}.state`
+      register(h.directory, { [key]: correctStatePath, [wrongKey]: wrongStatePath })
+
+      await declare(h)
+
+      expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+        ...expectedArgs(h.directory, path.resolve(h.directory, correctStatePath)),
+      )
+      expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+    },
+  )
+
+  it('U7 includes occurrence and role in the registration key', async () => {
+    const h = harness()
+    register(h.directory, {
+      'lead/Synth/0': 'states/role-omitted.state',
+      'lead/instrument/Synth': 'states/occurrence-omitted.state',
+      'lead/effect/Synth/0': 'states/wrong-role.state',
+      'lead/instrument/Synth/1': 'states/wrong-occurrence.state',
+    })
+
+    await h.instrument.instrument('lead', './Synth.clap')
+
+    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+      path.join(h.directory, 'Synth.clap'),
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+  })
+
+  it('U8 ignores a cwd project.yaml when documentDirectory is unset', async () => {
+    const h = harness({ documentDirectory: false })
+    const decoyDirectory = temporaryDirectory('orbit-plugin-state-cwd-decoy-')
+    register(decoyDirectory, {
+      'lead/instrument/Synth/0': 'states/cwd-decoy.state',
+    })
+    const originalCwd = process.cwd()
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    try {
+      process.chdir(decoyDirectory)
+      await h.instrument.instrument('lead', '/plugins/Synth.clap')
+    } finally {
+      process.chdir(originalCwd)
+    }
+
+    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+      '/plugins/Synth.clap',
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+    expect(error).not.toHaveBeenCalled()
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('U9 silently skips restoration when project.yaml does not exist', async () => {
+    const h = harness()
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    await h.instrument.instrument('lead', './Synth.clap')
+
+    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+      path.join(h.directory, 'Synth.clap'),
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+    expect(error).not.toHaveBeenCalled()
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('U10 reuses the initial effective statePath during respawn self-heal', async () => {
+    const h = harness({ active: false })
+    const initialRelativeStatePath = 'states/initial.state'
+    const replacementRelativeStatePath = 'states/replacement.state'
+    const initialStatePath = path.join(h.directory, 'states', 'initial.state')
+    register(h.directory, {
+      'lead/instrument/Synth/0': initialRelativeStatePath,
+    })
+
+    await h.instrument.instrument('lead', './Synth.clap')
+    register(h.directory, {
+      'lead/instrument/Synth/0': replacementRelativeStatePath,
+    })
+    await h.instrument.instrument('lead', './Synth.clap')
+
+    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+      path.join(h.directory, 'Synth.clap'),
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+      initialStatePath,
+    )
+    expect(h.audio.loadPlugin).toHaveBeenNthCalledWith(
+      2,
+      path.join(h.directory, 'Synth.clap'),
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+      initialStatePath,
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(2)
+  })
+
+  it('U11 preserves an absolute state path registered in project.yaml', async () => {
+    const h = harness()
+    const externalDirectory = temporaryDirectory('orbit-plugin-state-absolute-')
+    const absoluteStatePath = path.join(externalDirectory, 'absolute.state')
+    register(h.directory, { 'lead/instrument/Synth/0': absoluteStatePath })
+
+    await h.instrument.instrument('lead', './Synth.clap')
+
+    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+      path.join(h.directory, 'Synth.clap'),
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+      absoluteStatePath,
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/core/plugin-state-restore.spec.ts
+++ b/tests/core/plugin-state-restore.spec.ts
@@ -3,10 +3,11 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 
 import { stringify } from 'yaml'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AudioManager } from '../../packages/engine/src/core/global/audio-manager'
 import { LinkAudioManager } from '../../packages/engine/src/core/global/link-audio-manager'
+import { MixerManager } from '../../packages/engine/src/core/global/mixer-manager'
 import { PluginEffectManager } from '../../packages/engine/src/core/global/plugin-effect-manager'
 import { PluginInstrumentManager } from '../../packages/engine/src/core/global/plugin-instrument-manager'
 import { SequenceEffectManager } from '../../packages/engine/src/core/global/sequence-effect-manager'
@@ -36,6 +37,7 @@ function harness(options: { documentDirectory?: boolean; active?: boolean } = {}
     instrument: new PluginInstrumentManager(audio, audioManager, linkAudioManager),
     masterEffect: new PluginEffectManager(audio, audioManager, linkAudioManager),
     sequenceEffect: new SequenceEffectManager(audio, audioManager, linkAudioManager),
+    mixer: new MixerManager(audio, audioManager, linkAudioManager),
   }
 }
 
@@ -51,6 +53,10 @@ function register(
   }
   fs.writeFileSync(path.join(directory, 'project.yaml'), stringify({ version: 1, states: entries }))
 }
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => undefined)
+})
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -121,6 +127,10 @@ describe('project.yaml plugin state auto-restore (#541)', () => {
         ...expectedArgs(h.directory, absoluteStatePath),
       )
       expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+      expect(console.log).toHaveBeenCalledWith(
+        `[plugin-state] restoring '${key}' from ${absoluteStatePath}`,
+      )
+      expect(console.log).toHaveBeenCalledTimes(1)
     },
   )
 
@@ -142,6 +152,7 @@ describe('project.yaml plugin state auto-restore (#541)', () => {
       explicitStatePath,
     )
     expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+    expect(console.log).toHaveBeenCalledTimes(0)
   })
 
   it('U3 treats repeated declarations as idempotent using only the declared statePath', async () => {
@@ -206,6 +217,114 @@ describe('project.yaml plugin state auto-restore (#541)', () => {
         `Registered plugin state '${absoluteStatePath}' for 'lead/instrument/Synth/0' does not exist`,
       ),
     )
+    expect(error).toHaveBeenCalledTimes(1)
+  })
+
+  it('U4b degrades loudly when a registered state file is not readable', async () => {
+    const h = harness()
+    const relativeStatePath = 'states/unreadable.state'
+    const absoluteStatePath = path.join(h.directory, 'states', 'unreadable.state')
+    register(h.directory, { 'lead/instrument/Synth/0': relativeStatePath })
+    const permissionError = Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    const access = vi.spyOn(fs.promises, 'access').mockRejectedValueOnce(permissionError)
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await h.instrument.instrument('lead', './Synth.clap')
+
+    expect(access).toHaveBeenCalledWith(absoluteStatePath, fs.constants.R_OK)
+    expect(access).toHaveBeenCalledTimes(1)
+    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+      path.join(h.directory, 'Synth.clap'),
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Registered plugin state '${absoluteStatePath}' for 'lead/instrument/Synth/0' is not readable (EACCES: permission denied)`,
+      ),
+    )
+    expect(error).toHaveBeenCalledTimes(1)
+  })
+
+  it('U4c reports a registered state file removed before access as missing', async () => {
+    const h = harness()
+    const relativeStatePath = 'states/removed-before-access.state'
+    const absoluteStatePath = path.join(h.directory, 'states', 'removed-before-access.state')
+    register(h.directory, { 'lead/instrument/Synth/0': relativeStatePath })
+    const missingError = Object.assign(new Error('no such file or directory'), { code: 'ENOENT' })
+    const access = vi.spyOn(fs.promises, 'access').mockRejectedValueOnce(missingError)
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await h.instrument.instrument('lead', './Synth.clap')
+
+    expect(access).toHaveBeenCalledWith(absoluteStatePath, fs.constants.R_OK)
+    expect(access).toHaveBeenCalledTimes(1)
+    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+      path.join(h.directory, 'Synth.clap'),
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Registered plugin state '${absoluteStatePath}' for 'lead/instrument/Synth/0' does not exist`,
+      ),
+    )
+    expect(error).toHaveBeenCalledTimes(1)
+  })
+
+  it('U4d degrades loudly when a registered state path is a directory', async () => {
+    const h = harness()
+    const relativeStatePath = 'states/not-a-file.state'
+    const absoluteStatePath = path.join(h.directory, 'states', 'not-a-file.state')
+    fs.mkdirSync(absoluteStatePath, { recursive: true })
+    register(h.directory, { 'lead/instrument/Synth/0': relativeStatePath }, [])
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await h.instrument.instrument('lead', './Synth.clap')
+
+    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+      path.join(h.directory, 'Synth.clap'),
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Registered plugin state '${absoluteStatePath}' for 'lead/instrument/Synth/0' is not a file`,
+      ),
+    )
+    expect(error).toHaveBeenCalledTimes(1)
+  })
+
+  it('U4e degrades loudly when the registered state path is empty', async () => {
+    const h = harness()
+    register(h.directory, { 'lead/instrument/Synth/0': '' }, [])
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await h.instrument.instrument('lead', './Synth.clap')
+
+    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+      path.join(h.directory, 'Synth.clap'),
+      undefined,
+      'instrument',
+      undefined,
+      'plugin:lead',
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Registered plugin state '${h.directory}' for 'lead/instrument/Synth/0' is not a file`,
+      ),
+    )
+    expect(error).toHaveBeenCalledTimes(1)
   })
 
   it('U5 throws with the manifest path when project.yaml is malformed', async () => {
@@ -213,12 +332,28 @@ describe('project.yaml plugin state auto-restore (#541)', () => {
     const manifestPath = path.join(h.directory, 'project.yaml')
     fs.writeFileSync(manifestPath, 'version: 1\nstates: [\n')
 
-    await expect(h.masterEffect.effect('./Limiter.clap')).rejects.toThrow(
-      expect.objectContaining({
-        message: expect.stringContaining(manifestPath),
-      }),
-    )
+    const failure = await h.masterEffect.effect('./Limiter.clap').catch((error) => error)
+
+    expect(failure).toBeInstanceOf(Error)
+    expect((failure as Error).message).toContain('Cannot parse plugin state manifest')
+    expect((failure as Error).message).not.toContain('Cannot read plugin state manifest')
+    expect((failure as Error).message).toContain(manifestPath)
     expect(h.audio.loadPlugin).not.toHaveBeenCalled()
+  })
+
+  it('U5c wraps a non-ENOENT manifest read failure with the manifest path and identity', async () => {
+    const h = harness()
+    const manifestPath = path.join(h.directory, 'project.yaml')
+    const permissionError = Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    vi.spyOn(fs.promises, 'readFile').mockRejectedValueOnce(permissionError)
+
+    const failure = await h.instrument.instrument('lead', './Synth.clap').catch((error) => error)
+
+    expect(failure).toBeInstanceOf(Error)
+    expect((failure as Error).message).toContain('Cannot read plugin state manifest')
+    expect((failure as Error).message).toContain(manifestPath)
+    expect((failure as Error).message).toContain('lead/instrument/Synth/0')
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(0)
   })
 
   it('U5b isolates an explicitly declared statePath from a malformed project.yaml', async () => {
@@ -307,6 +442,7 @@ describe('project.yaml plugin state auto-restore (#541)', () => {
     expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
     expect(error).not.toHaveBeenCalled()
     expect(warn).not.toHaveBeenCalled()
+    expect(console.log).toHaveBeenCalledTimes(0)
   })
 
   it('U9 silently skips restoration when project.yaml does not exist', async () => {
@@ -326,6 +462,7 @@ describe('project.yaml plugin state auto-restore (#541)', () => {
     expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
     expect(error).not.toHaveBeenCalled()
     expect(warn).not.toHaveBeenCalled()
+    expect(console.log).toHaveBeenCalledTimes(0)
   })
 
   it('U10 reuses the initial effective statePath during respawn self-heal', async () => {
@@ -380,5 +517,24 @@ describe('project.yaml plugin state auto-restore (#541)', () => {
       absoluteStatePath,
     )
     expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+  })
+
+  it('U12 keeps sum/aux inserts outside project.yaml auto-restore', async () => {
+    const h = harness()
+    register(h.directory, {
+      'drum/effect/GlueComp/0': 'states/external-receiver-decoy.state',
+      'sum:drum/effect/GlueComp/0': 'states/internal-receiver-decoy.state',
+    })
+
+    await h.mixer.sum('drum').effect('./GlueComp.clap')
+
+    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+      path.join(h.directory, 'GlueComp.clap'),
+      undefined,
+      'effect',
+      'sum-bus-0',
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
+    expect(console.log).toHaveBeenCalledTimes(0)
   })
 })

--- a/tests/e2e/orbitstudio-mcp-gated.spec.ts
+++ b/tests/e2e/orbitstudio-mcp-gated.spec.ts
@@ -911,6 +911,10 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
         countAttachFailures(afterRestoredAttachLog),
         `Cycle B instrument attach must add no OUTPROC_ATTACH_FAILED. Log tail: ${afterRestoredAttachLog.slice(-1200)}`,
       ).toBe(attachFailuresBeforeRestored)
+      expect(
+        afterRestoredAttachLog,
+        `Cycle B must surface the automatic project-state restore. Log tail: ${afterRestoredAttachLog.slice(-1200)}`,
+      ).toMatch(/\[plugin-state\] restoring[^\r\n]*stSeq\/instrument\/CLAPTestSynth\/0/)
 
       const playRestored = await activeClient.call('evaluate_orbitscore', {
         code: ['stSeq.play(1)', 'RUN(stSeq)'].join('\n'),

--- a/tests/e2e/orbitstudio-mcp-gated.spec.ts
+++ b/tests/e2e/orbitstudio-mcp-gated.spec.ts
@@ -187,6 +187,23 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
       const extensionsDir = path.join(tmpRoot, 'extensions')
       fs.mkdirSync(userDataDir, { recursive: true })
       fs.mkdirSync(extensionsDir, { recursive: true })
+      // tmpRoot を workspace にしたため、リポジトリの .vscode/settings.json は効かない。
+      // autoStartConfiguredRustEngine は保存済み audioDevice が無いと即 return するので、
+      // デバイス名の存在確認をスキップするセンチネル __default__ を設定し、
+      // マシン固有のデバイス名に依存せず拡張の auto-start を有効化する。
+      const workspaceSettingsDir = path.join(tmpRoot, '.vscode')
+      fs.mkdirSync(workspaceSettingsDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(workspaceSettingsDir, 'settings.json'),
+        JSON.stringify(
+          {
+            'orbitscore.audioDevice': '__default__',
+            'orbitscore.engineDebug': false,
+          },
+          null,
+          2,
+        ) + '\n',
+      )
       const captureWavPath = path.join(tmpRoot, 'capture.wav')
       // Scratch copy of the kick-loop fixture (basename preserved so the
       // languageId/path assertions below still hold): save_file writes here,
@@ -236,7 +253,10 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
           `--extensionDevelopmentPath=${EXTENSION_DEV_PATH}`,
           `--user-data-dir=${userDataDir}`,
           `--extensions-dir=${extensionsDir}`,
-          REPO_ROOT,
+          // `evaluate_orbitscore` は workspace root を documentDirectory として渡すので、
+          // プロジェクト（project.yaml / states/）を置く tmpRoot を workspace として開く。
+          // これはユーザーが曲フォルダを開く実際の使い方とも一致する。
+          tmpRoot,
         ],
         {
           env: { ...process.env, ORBITSCORE_MCP_PORT: String(port) },
@@ -741,10 +761,9 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
       const activeClient = client
       const root = tmpRoot
 
-      // この復元フェーズは2サイクル分（約26秒）のログを跨いで ERROR/attach 失敗の
-      // 増分を見るため、既存フェーズの 500 行窓では古い行が流れて偽陰性になりうる
-      // （独立監査の指摘）。窓を広げて計測の土台を安定させる。
-      const RESTORE_LOG_LINES = 2000
+      // get_log は要求値にかかわらず末尾 500 行へ cap する。ERROR/attach 失敗の前後比較は
+      // このスライディングウィンドウ内の補助判定で、復元の主判定は下の pitch assert。
+      const RESTORE_LOG_LINES = 500
       const fixturesDir = path.join(root, 'fixtures')
       fs.mkdirSync(fixturesDir, { recursive: true })
       const handStatePath = path.join(fixturesDir, 'orc1-offset7.state')
@@ -815,11 +834,7 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
         (await activeClient.call('get_log', { lines: RESTORE_LOG_LINES })).text,
       )
       const stopShifted = await activeClient.call('evaluate_orbitscore', {
-        code: [
-          'stSeq.stop()',
-          'global.stop()',
-          `global.setDocumentDirectory(${JSON.stringify(root)})`,
-        ].join('\n'),
+        code: ['stSeq.stop()', 'global.stop()'].join('\n'),
       })
       expect(stopShifted.isError, stopShifted.text).toBe(false)
       await waitUntil(
@@ -839,8 +854,17 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
         index: 0,
       })
       expect(saveShifted.isError, saveShifted.text).toBe(false)
-      const saved = JSON.parse(saveShifted.text) as { path: string; bytesWritten: number }
+      const saved = JSON.parse(saveShifted.text) as {
+        path: string
+        bytesWritten: number
+        identityKey: string
+        projectFile: string
+        projectStatePath: string
+      }
       expect(saved.bytesWritten).toBe(handState.length)
+      expect(saved.identityKey).toBe('stSeq/instrument/CLAPTestSynth/0')
+      expect(saved.projectFile).toBe(path.join(root, 'project.yaml'))
+      expect(saved.path.startsWith(path.join(root, 'states') + path.sep)).toBe(true)
       expect(
         fs.readFileSync(saved.path).equals(handState),
         'MCP-saved state must be byte-identical to the Cycle A input',
@@ -856,7 +880,7 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
         `Cycle A must add no ERROR: lines. Log tail: ${afterCycleALog.slice(-1200)}`,
       ).toBe(errorsBeforeCycleA)
 
-      // ── Cycle B: the MCP output (never the hand fixture) is the restore input.
+      // ── Cycle B: project.yaml registration from the MCP save is the restore input.
       const errorsBeforeCycleB = countErrors(afterCycleALog)
       const startRestored = await activeClient.call('start_engine', { capture_wav: restoredWav })
       expect(startRestored.isError, startRestored.text).toBe(false)
@@ -868,7 +892,7 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
           'var global = init GLOBAL',
           'global.key("C")',
           'global.start()',
-          'var rsSeq = init global.seq',
+          'var stSeq = init global.seq',
         ].join('\n'),
       })
       expect(initRestored.isError, initRestored.text).toBe(false)
@@ -876,7 +900,7 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
         (await activeClient.call('get_log', { lines: RESTORE_LOG_LINES })).text,
       )
       const attachRestored = await activeClient.call('evaluate_orbitscore', {
-        code: `rsSeq.instrument(${JSON.stringify(CLAP_TEST_SYNTH_PATH)}, ${JSON.stringify(saved.path)})`,
+        code: `stSeq.instrument(${JSON.stringify(CLAP_TEST_SYNTH_PATH)})`,
       })
       expect(attachRestored.isError, attachRestored.text).toBe(false)
       await sleep(6000)
@@ -889,7 +913,7 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
       ).toBe(attachFailuresBeforeRestored)
 
       const playRestored = await activeClient.call('evaluate_orbitscore', {
-        code: ['rsSeq.play(1)', 'RUN(rsSeq)'].join('\n'),
+        code: ['stSeq.play(1)', 'RUN(stSeq)'].join('\n'),
       })
       expect(playRestored.isError, playRestored.text).toBe(false)
       await sleep(3000)
@@ -898,7 +922,7 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
         (await activeClient.call('get_log', { lines: RESTORE_LOG_LINES })).text,
       )
       const stopRestored = await activeClient.call('evaluate_orbitscore', {
-        code: ['rsSeq.stop()', 'global.stop()'].join('\n'),
+        code: ['stSeq.stop()', 'global.stop()'].join('\n'),
       })
       expect(stopRestored.isError, stopRestored.text).toBe(false)
       await waitUntil(


### PR DESCRIPTION
Closes #541
Refs #546 #563 #564 #567 #568 #569

## 何が変わるか

`instrument(path, statePath)` と**手で指した時だけ**復元されていた音色が、
`project.yaml` の `states:` 登記から**自動で**復元されるようになります。

Epic #546 の「宣言 → 音色を作る → 自動記録 → 終了 → 再起動 → 同じ音で鳴る」ループが、
これで人間が普通に使う形で閉じます。

## 実機で証明済み

```
✓ restores an MCP-saved non-default instrument state across an engine restart
  with the same measured pitch  26365ms
✓ drives real OrbitStudio end-to-end: diagnostics-on-open, run_selection,
  live edit, capture verification  50849ms
```

保存 → `stop_engine` / `start_engine` → **`stSeq.instrument(path)` だけで再宣言** →
capture WAV の基本周波数が 392.00Hz（offset 7）で一致。`statePath` を手渡す行は削除済み。
期待値は MIDI 標準式 `440 * 2^((m-69)/12)` から導出しており、実装からハードコードしていません。

## 設計判断

### 発火点 = 宣言の評価時（選択ではなく強制）

manifest は owner 決定により **plugin path を持たない**（DSL と重なるフィールドを持たない）。
engine start の時点では「何をロードすべきか」の情報が存在せず、`.orbs` が評価されて初めて
SC.5 identity `(receiver, role, normalizedName, occurrence)` が定まります。

### 対象 = 保存側が到達できる全レシーバ

instrument / master effect / per-sequence effect。**instrument だけに絞ると、#563 の保存側が
既に書き込む effect の登記が永久に読まれない死んだエントリになります** — silent failure そのもの。

sum / aux はアドレス指定が未決のため対象外（#564）。`MixerManager` に resolver も
`externalReceiverId` も渡さないことで、**フィールドの書き忘れではなく構造で除外**しています。

### declared / effective の分離

素朴に実装すると「宣言 → 保存 → 同じ行を再評価」で `v1 does not support replacing it` が出て
**ライブコーディングが壊れます**。slot に `declaredStatePath`（`.orbs` の明示値・冪等判定は
これだけを見る）と `statePath`（実効値）を分け、manifest 解決は新規 slot 作成時のみ行います。

### 失敗時 — TS が検査できるものは degrade + loud、できないものは fail

| 事象 | 扱い |
|---|---|
| manifest 不在 | 静かに no-op（プロジェクト未生成は正常状態） |
| manifest 破損 | throw（登記簿全体が読めない。次の save も throw する既存挙動と整合） |
| 登記済み state ファイルの欠損 | **statePath 無しでロード（音は出る）+ stderr へ診断** |
| state のバイト列が不正 | 明示指定と同じ loud fail（TS からは判定できない） |

## テスト

**U1-U11 の 16 件**。すべて **3 manager の public API 経由**で、`toHaveBeenCalledWith`（全引数）
+ `toHaveBeenCalledTimes(n)` で検証します。解決器を単体で叩くテストは書いていません —
effect 側は statePath の経路が**まったく無く全部が新規配線**なので、単体テストでは配線の欠落を
検出できないためです（#527 の教訓と同型）。

全 16 件について**変異で red になることを実出力で確認済み**。抜粋:

| 変異 | 観測した red |
|---|---|
| resolver を常に undefined に | 3 manager すべてで statePath 引数が欠落 |
| 明示 > 登記 の優先順位を逆転 | registered path が渡る |
| declared/effective の分離を撤去 | `does not support replacing it` で再宣言が失敗 |
| `externalReceiverId` を内部 `receiverId` に差し替え | `seq:lead/...` の囮を掴む |
| 空 documentDirectory ガードを除去 | cwd の囮 project.yaml を拾う |
| self-heal の実効値再利用を削除 | 2回目から初回 statePath が欠落 |
| `path.resolve` → `path.join` | 絶対パス登記が壊れて連結される |

## 実機で初めて見えた不具合（ユニット全緑・受け入れ監査通過をすり抜けた）

**1回目の実機実行は落ちました。** `restored 261.63Hz must match saved 392.00Hz` — default C4。
ユニット 1789 件が全緑、独立監査も「このままマージ可」だった状態でです。

一時プローブで実値を観測した結果、**実装ではなく E2E ハーネスの問題**でした。
拡張は documentDirectory を2経路で渡します:

| 経路 | documentDirectory |
|---|---|
| `run_selection` | 開いているファイルのディレクトリ |
| `evaluate_orbitscore` | **workspace root** |

E2E はアプリを REPO_ROOT を workspace として起動していたため、tmpRoot の fixture を
`run_selection` で評価する先行フェーズは tmpRoot、`evaluate_orbitscore` しか使わない復元フェーズは
REPO_ROOT になっていました。しかも**テストが直前行で `setDocumentDirectory` を呼んでも効きません** —
REPL は毎 eval のメタ行を `sessionDocumentDirectory` として保持し、バッファ実行のたびに
冒頭で再適用するためです。

修正: **アプリの workspace を tmpRoot で開く**。両経路が一致し、テスト側の脆い手当ても不要に。
ユーザーが曲フォルダを開く実際の使い方にも近づきました。

その副作用で先行テストの engine 自動起動が止まったので、`<tmpRoot>/.vscode/settings.json` を
生成して解決しています（デバイス名はマシン依存を避け、実装がサポートするセンチネル `__default__`）。

## 診断が暴いたテストの穴（同 PR で塞ぎました）

復元テストは `saved.path` のバイト一致しか見ておらず、**保存がどのディレクトリに落ちたかを
一度も検証していませんでした** — 保存が別ディレクトリでも通ります。同ファイル内の先行フェーズは
`projectFile` まで assert しているのに、復元フェーズだけが緩い状態でした。

`identityKey` / `projectFile` / `states/` 配下の3点を追加し、次に同型で転んだときに
「保存が違う場所」か「復元が読めていない」かが**テストの失敗メッセージだけで切り分けられる**
ようにしています（今回は切り分けにプローブを1往復挟む必要がありました）。

## 検証

| 項目 | 結果 |
|---|---|
| `npm run build` | 成功 |
| `npm test` | **1789 passed / 30 skipped / 0 failed**（ベースライン 1773 + 新規 16） |
| `npm run lint` | error 0（warning 2 は本変更と無関係の既存ファイル） |
| **実機 gated E2E** | **2 passed** |

## スコープ外（issue 化済み・先送り判断も検証済み）

- **#567** `get_log` が要求行数を黙って 500 に cap する
- **#568** 同名別 path の plugin で SC.5 key が衝突しうる（`fingerprints:` を別トップレベルキーに
  足せば `states:` も `version:` も触らずに済むため、二度組みにはならないことを確認済み）
- **#569** respawn 時に state 欠損で degrade しない。**残る論点は「ライブ演奏中に無音 vs 別音色の
  どちらが悪いか」という音楽的判断**で、コストの問題ではありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PafN8xAMtGRx3nCHyenQN8