### PR TITLE
fix(test): remove the ETXTBSY precondition behind CI flake #529

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,98 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.317 fix(test): CI フレーク #529 の真因（ETXTBSY）を特定し構造的に除去 (Jul 29, 2026)
+
+**Date**: 2026-07-29
+**Status**: ✅ 真因特定 + 除去（**真の検証は CI が握る** — 後述）
+
+### 真因は CI の実測で判明した — 診断改善が機能した
+
+PR #570 の CI で #529 が再発し、**PR #561 で入れた診断計装が原因を吐いた**:
+
+```
+first LoadPlugin call finished before the poller ever observed ChildSlot::Loading
+(slot is now Empty, after 2 polls / 5.079915ms); its result was
+Err(OutProcEffect("spawn outproc child \"/tmp/orbit-outproc-effect-6243-3.sh\":
+                  Text file busy (os error 26)"))
+```
+
+**ETXTBSY**。#529 本文の「✅ 有力な機序」が**そのまま当たっていた**:
+
+| 本文の予測 | 実測 |
+|---|---|
+| 「`Loading` に到達しなかった」のではなく「**既に離脱していた**」 | ✅ `slot is now Empty, after 2 polls / 5.079915ms` |
+| spawn 失敗 → `Loading → Empty` に即座に戻る。窓はサブミリ秒 | ✅ 5ms で 2 polls しか回っていない |
+| CI で断続的に spawn が失敗する既知の原因: **ETXTBSY** | ✅ `Text file busy (os error 26)` |
+| 実エラーが握り潰されて deadline timeout panic に化ける | ✅ **改善後は join して実エラーを載せたので即座に判明** |
+
+診断改善が無ければ、今回も「never reached ChildSlot::Loading within 30s」という
+**原因を何も語らない panic** になっていた。**対症でなく診断を先に直した判断の実証**。
+
+### 機序（独立裁定で検証・確信度 85-90%）
+
+1. スレッド A が `.sh` を書き込み用に open している
+2. その最中に別スレッドが `posix_spawn`（`clone(CLONE_VM|CLONE_VFORK)` + `execve`）する
+   → **子は A の write fd を継承する**
+3. A は close して chmod し、その `.sh` を exec する
+4. しかし**継承した子がまだ exec 前で write fd を握っている**ため、Linux カーネルの
+   `deny_write_access` / `i_writecount` チェックに引っかかり **ETXTBSY**
+
+**`O_CLOEXEC` は無効化しない** — CLOEXEC が閉じるのは**その子自身が exec した瞬間**で、
+fork〜exec の窓では継承 fd は生きている。
+
+**ETXTBSY の write-count 拒否は Linux 固有**（POSIX では optional・macOS/XNU は事実上チェックしない）。
+**Apple Silicon ローカルで一度も再現せず ubuntu-latest でだけ出る**という観測履歴と整合する —
+**ローカル再現失敗は負荷不足ではなく OS 差**だった。
+
+### 棄却した案（いずれも一次情報で確認）
+
+- **生存済みバイナリを使う**（当初 main の推奨）→ ❌ `CARGO_BIN_EXE_<name>` は
+  **integration test / bench のビルド時にしか設定されない**。当該テストは lib unit test なので
+  コンパイルエラーになる。**main が Cargo 仕様を確認せずに推奨していた**（#529 で訂正済み）
+- **`LazyLock` で1回だけ生成** → ❌ 初回アクセスは他テストが既に並走中に起きる。窓の縮小に留まる
+- **global mutex で直列化** → ❌ プロセス内の**全 fork**（特に **watchdog respawn スレッド**）が
+  lock に参加する必要があり、本番コード変更が要る（方針違反）
+- **fsync/close を挟む**（#529 本文の1案目）→ ❌ **無効**。`fs::write` は返る前に既に close している。
+  問題は「閉じ忘れ」ではなく「**閉じる前に他スレッドの fork が fd テーブルごと複製した**」こと
+
+### 採用: コミット済み fixture スクリプト
+
+`write_slow_child_script` / `write_exit_child_script` を廃止し、
+`rust/crates/orbit-audio-daemon/tests/fixtures/{slow-child,exit-child}.sh` を
+`env!("CARGO_MANIFEST_DIR")` 起点で参照する（git に **100755** でコミット）。
+
+**構造的解決である理由**: ETXTBSY の必要条件は「exec 時点でその inode を write-open している者が
+存在すること」。fixture は**テストプロセスの生存中に誰も一度も write-open しない**ので、
+継承させる write fd がそもそも発生しない。**確率を下げるのではなく前提条件を消している**。
+
+各テスト末尾の `remove_file(child_exe)` は削除（共有 fixture を消すと並走テストが壊れる）。
+
+### 変異検証で「他にも5件が同じ機序を抱えていた」ことが判明
+
+fixture パスを存在しないものに変える変異で **6件が red**:
+
+- `effect_load_outproc_concurrent_call_fails_fast_on_loading`（#529 の当該テスト）
+- `effect_load_outproc_early_exit_fast_fails_and_keeps_retry_shm`
+- `effect_load_outproc_role_mismatch_retries_same_slot`
+- 上記3つの instrument 版
+
+つまり **#529 として観測されていたのは氷山の一角**で、同じ機序の潜在フレークが他に5件あった。
+裁定の「`write_exit_child_script` も同時に置き換えるべき」という指摘どおり。
+
+### 検証
+
+- `cargo test --workspace --locked` ✅ 382 passed / 0 failed
+- `--features outproc-effect` ✅ 138 / `--features outproc-instrument` ✅ 113 /
+  `--features outproc-effect,outproc-instrument` ✅ 179（いずれも 0 failed。CI が走らせる全組み合わせ）
+- `cargo fmt --check` ✅ / `cargo clippy --workspace --all-targets -- -D warnings` ✅
+
+🔴 **ローカルの緑は修正の証明にならない** — このフレークは Linux 固有で macOS では再現しない。
+ローカルで確認できるのは「退行していないこと」だけで、**真の検証は CI が握る**。
+
+**反証条件**: fixture 化後もなお ETXTBSY が出たら、この機序は誤りで**外部 writer を疑い直す**。
+PR #561 の診断計装を残したのは、そのときの自白装置として。
+
 ### 6.315 test: prove the tone loop on real hardware — PR #563 のレビュー〜出荷 (Jul 29, 2026)
 
 **Date**: 2026-07-29

--- a/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
+++ b/rust/crates/orbit-audio-daemon/src/engine_wrap.rs
@@ -5466,35 +5466,24 @@ mod outproc_load_error_test_support {
         ));
     }
 
-    /// テスト専用の「slow」child 実行可能ファイル。CLI 引数（`--shm`/`--plugin`/`--sample-rate`
-    /// 等）をすべて無視してただ sleep するだけの POSIX shell script。`load_outproc_plugin` が
-    /// 経由する `spawn_outproc_child` はこれらの引数を固定で付与するため、素の coreutils
-    /// （`sleep`/`cat` 等）は未知オプションとして即 exit してしまい「lock 外で長時間ブロックする」
-    /// 状態を再現できない（実際に `sleep` へこれらの引数を渡すと `illegal option` で即終了する）。
-    /// このクレートの CI は ubuntu-latest のみを対象とする（Windows 非対応）ので unix 専用で問題ない。
-    fn write_slow_child_script(unique_path: &impl Fn() -> PathBuf) -> PathBuf {
-        use std::os::unix::fs::PermissionsExt;
-        let script_path = unique_path().with_extension("sh");
-        std::fs::write(&script_path, "#!/bin/sh\nexec sleep 20\n")
-            .expect("write slow child script");
-        let mut perms = std::fs::metadata(&script_path)
-            .expect("stat slow child script")
-            .permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&script_path, perms).expect("chmod slow child script");
-        script_path
+    /// テスト専用 child はコミット済み fixture を参照する。ETXTBSY の必要条件は、exec 時点で
+    /// 対象 inode を誰かが write-open していること。fixture はテストプロセスの生存中に一度も
+    /// write-open しないため、別スレッドの spawn へ継承される write fd 自体が発生しない。
+    fn child_script_fixture(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join(name)
     }
 
-    fn write_exit_child_script(unique_path: &impl Fn() -> PathBuf) -> PathBuf {
-        use std::os::unix::fs::PermissionsExt;
-        let script_path = unique_path().with_extension("sh");
-        std::fs::write(&script_path, "#!/bin/sh\nexit 1\n").expect("write exit child script");
-        let mut perms = std::fs::metadata(&script_path)
-            .expect("stat exit script")
-            .permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&script_path, perms).expect("chmod exit script");
-        script_path
+    /// CLI 引数（`--shm`/`--plugin`/`--sample-rate` 等）をすべて無視して sleep する
+    /// POSIX shell script。素の coreutils は未知オプションで即 exit するため fixture を使う。
+    fn slow_child_script() -> PathBuf {
+        child_script_fixture("slow-child.sh")
+    }
+
+    fn exit_child_script() -> PathBuf {
+        child_script_fixture("exit-child.sh")
     }
 
     pub(super) fn early_exit_fast_fails_and_keeps_retry_shm<R: OutProcRole>(
@@ -5505,7 +5494,7 @@ mod outproc_load_error_test_support {
         let shm_path = unique_path();
         let _ = std::fs::remove_file(&shm_path);
         let mmap = orbit_audio_sandbox::create_shared(&shm_path).expect("create shared memory");
-        let child_exe = write_exit_child_script(&unique_path);
+        let child_exe = exit_child_script();
         let stats = R::new_stats();
         let (wrap, slot) = inject(
             ChildSlot::Empty(child_launch::<R>(
@@ -5539,7 +5528,6 @@ mod outproc_load_error_test_support {
             unsafe { (*region).control.load(std::sync::atomic::Ordering::Acquire) },
             orbit_audio_sandbox::CONTROL_RUN
         );
-        let _ = std::fs::remove_file(child_exe);
     }
 
     pub(super) fn role_mismatch_retries_same_slot<R: OutProcRole + 'static>(
@@ -5552,7 +5540,7 @@ mod outproc_load_error_test_support {
         let shm_path = unique_path();
         let _ = std::fs::remove_file(&shm_path);
         let mmap = orbit_audio_sandbox::create_shared(&shm_path).expect("create shared memory");
-        let child_exe = write_slow_child_script(&unique_path);
+        let child_exe = slow_child_script();
         let stats = R::new_stats();
         let (wrap, slot) = inject(
             ChildSlot::Empty(child_launch::<R>(
@@ -5624,7 +5612,6 @@ mod outproc_load_error_test_support {
                 assert!(matches!(*slot.lock().unwrap(), ChildSlot::Active { .. }));
             }
         }
-        let _ = std::fs::remove_file(child_exe);
     }
 
     /// Important finding 1: f36e99c の regression guard。`Loading` 中の 2 本目の `LoadPlugin` は、
@@ -5645,7 +5632,7 @@ mod outproc_load_error_test_support {
         let shm_path = unique_path();
         let _ = std::fs::remove_file(&shm_path);
         let _mmap = orbit_audio_sandbox::create_shared(&shm_path).expect("create shared memory");
-        let child_exe = write_slow_child_script(&unique_path);
+        let child_exe = slow_child_script();
 
         let stats = R::new_stats();
         let launch = child_launch::<R>(shm_path.clone(), child_exe.clone(), stats.clone());
@@ -5739,7 +5726,6 @@ mod outproc_load_error_test_support {
             .join()
             .expect("first LoadPlugin call thread panicked")
             .expect("first LoadPlugin call must succeed once READY is published");
-        let _ = std::fs::remove_file(&child_exe);
     }
 }
 

--- a/rust/crates/orbit-audio-daemon/tests/fixtures/exit-child.sh
+++ b/rust/crates/orbit-audio-daemon/tests/fixtures/exit-child.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 1

--- a/rust/crates/orbit-audio-daemon/tests/fixtures/slow-child.sh
+++ b/rust/crates/orbit-audio-daemon/tests/fixtures/slow-child.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec sleep 20


### PR DESCRIPTION
Closes #529
Refs #561 #570

## 真因は CI の実測で判明した — 診断改善が機能した

PR #570 の CI で #529 が再発し、**PR #561 で入れた診断計装が原因を吐きました**。

```
first LoadPlugin call finished before the poller ever observed ChildSlot::Loading
(slot is now Empty, after 2 polls / 5.079915ms); its result was
Err(OutProcEffect("spawn outproc child "/tmp/orbit-outproc-effect-6243-3.sh":
                  Text file busy (os error 26)"))
```

**ETXTBSY**。#529 本文の「有力な機序」が**そのまま当たっていました**。

| 本文の予測 | 実測 |
|---|---|
| 「`Loading` に到達しなかった」のではなく「**既に離脱していた**」 | ✅ `slot is now Empty, after 2 polls / 5.079915ms` |
| spawn 失敗 → `Loading → Empty` に即座に戻る。窓はサブミリ秒 | ✅ 5ms で 2 polls しか回っていない |
| CI で断続的に spawn が失敗する既知の原因: **ETXTBSY** | ✅ `Text file busy (os error 26)` |
| 実エラーが握り潰されて deadline timeout panic に化ける | ✅ **改善後は join して実エラーを載せたので即座に判明** |

診断改善が無ければ、今回も `never reached ChildSlot::Loading within 30s` という
**原因を何も語らない panic** でした。対症でなく診断を先に直した判断の実証です。

## 機序（独立裁定で検証・確信度 85-90%）

テストが `.sh` を書いて chmod して即 exec する形だったため:

1. スレッド A が `.sh` を書き込み用に open している
2. その最中に別スレッドが `posix_spawn`（`clone(CLONE_VM|CLONE_VFORK)` + `execve`）する
   → **子は A の write fd を継承する**
3. A は close して chmod し、その `.sh` を exec する
4. **継承した子がまだ exec 前で write fd を握っている**ため、Linux カーネルの
   `deny_write_access` / `i_writecount` チェックに引っかかり **ETXTBSY**

**`O_CLOEXEC` は無効化しません** — CLOEXEC が閉じるのは**その子自身が exec した瞬間**で、
fork〜exec の窓では継承 fd は生きています。

**write-count 拒否は Linux 固有**（POSIX では optional・macOS/XNU は事実上チェックしない）。
**Apple Silicon ローカルで一度も再現せず ubuntu-latest でだけ出る**という観測履歴と整合します。
**ローカル再現失敗は負荷不足ではなく OS 差**でした。

## 修正: コミット済み fixture スクリプト

`write_slow_child_script` / `write_exit_child_script` を廃止し、
`tests/fixtures/{slow-child,exit-child}.sh`（git に **100755**）を
`env!("CARGO_MANIFEST_DIR")` 起点で参照します。スクリプトの内容は**バイト単位で同一**です。

**構造的解決である理由**: ETXTBSY の必要条件は「exec 時点でその inode を write-open している者が
存在すること」。fixture は**テストプロセスの生存中に誰も一度も write-open しない**ので、
継承させる write fd がそもそも発生しません。**確率を下げるのではなく前提条件を消しています。**

各テスト末尾の `remove_file(child_exe)` は削除しました（共有 fixture を消すと並走テストが壊れるため）。

### 棄却した案（いずれも一次情報で確認）

| 案 | 判定 |
|---|---|
| **生成済みバイナリを使う** | ❌ `CARGO_BIN_EXE_<name>` は **integration test / bench のビルド時にしか設定されない**。当該テストは lib unit test なのでコンパイルエラー |
| `LazyLock` で1回だけ生成 | ❌ 初回アクセスは他テストが既に並走中に起きる。窓の縮小に留まる |
| global mutex で直列化 | ❌ プロセス内の**全 fork**（特に **watchdog respawn スレッド**）が lock に参加する必要があり、本番コード変更が要る |
| **fsync/close を挟む**（#529 本文の1案目） | ❌ **無効**。`fs::write` は返る前に既に close している。問題は「閉じ忘れ」ではなく「**閉じる前に他スレッドの fork が fd テーブルごと複製した**」こと |

## 変異検証が示したこと — 観測されていたのは氷山の一角だった

fixture パスを存在しないものに変える変異で **6件が red**:

- `effect_load_outproc_concurrent_call_fails_fast_on_loading`（#529 の当該テスト）
- `effect_load_outproc_early_exit_fast_fails_and_keeps_retry_shm`
- `effect_load_outproc_role_mismatch_retries_same_slot`
- 上記3つの **instrument 版**

**同じ機序の潜在フレークが他に5件ありました。**

## 検証力は落ちていません

子プロセスの挙動は**バイト単位で同一**です。「READY を publish せず lock 外の ready-ack poll で
1本目をブロックさせ、その最中に2本目が mutex 待ちでなく `Loading` を即観測して fail-fast する」という
f36e99c regression guard の検証対象には一切触れていません。変わるのは「スクリプトをいつ誰が書くか」だけです。

PR #561 の診断計装（`is_finished()` + join + 反復回数）は**そのまま残しています**。

## 検証

| コマンド | 結果 |
|---|---|
| `cargo test --workspace --locked` | **382 passed / 0 failed** |
| `--features outproc-effect` | 138 passed / 0 failed |
| `--features outproc-instrument` | 113 passed / 0 failed |
| `--features outproc-effect,outproc-instrument` | 179 passed / 0 failed |
| `cargo fmt --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |

CI が実際に走らせる全組み合わせです。

## 🔴 ローカルの緑は修正の証明になりません

このフレークは **Linux 固有**なので macOS では再現しません。ローカルで確認できるのは
「**退行していないこと**」だけで、**真の検証は CI が握ります**。

**反証条件**: fixture 化後もなお ETXTBSY が出たら、この機序は誤りで**外部 writer を疑い直す**
ことになります。PR #561 の診断計装を残したのは、そのときの自白装置としてです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PafN8xAMtGRx3nCHyenQN8