### PR TITLE
test(vst3): prove out-of-process instrument audio matches in-process

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,60 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.318 test(vst3): out-of-process instrument の音声 parity を CLAP と対称にする #565 (Jul 29, 2026)
+
+**Date**: 2026-07-29
+**Status**: ✅ 完了
+
+**VST3 instrument が out-of-process で実際に音を出すことを、どの層も検証していなかった。**
+CLAP には `orbit-clap-instrument-child/tests/instrument_parity_gated.rs` があるのに VST3 には無く、
+**形式間で検証の厚みが非対称**だった（PR #563 の全長 E2E 実装時に発覚）。
+
+`rust/crates/orbit-vst3-instrument-child/tests/instrument_parity_gated.rs` を新規追加し、
+in-process `Vst3InstrumentProcessor` と out-of-process child のレンダ結果が
+**bit-exact に一致すること**（`max_abs_diff == 0.0`）を検証する。
+
+### CLAP 版との構造的な差異
+
+**VST3 の in-process API は CLAP と違う。** CLAP 版は `push_neutral_event` + `EventBuffer` を使うが、
+VST3 は `push_note_on(channel, pitch, velocity, sample_offset)` / `push_note_off(...)` を使う。
+
+したがって OOP 側へ渡す `NeutralEvent` 列と、in-process 側の呼び出しは**翻訳**で対応させる。
+**この翻訳が間違っていると「両方同じように壊れている」を見逃しうる**ため、
+翻訳箇所に sample_offset / channel / velocity の対応をコメントで明記した。
+
+### 変異検証（3種・実出力で確認）
+
+| 変異 | 結果 |
+|---|---|
+| in-process 側の note pitch を +1 | red（`left: 0.2499993 / right: 0.0`） |
+| OOP 側の events から NoteOff を削除 | red |
+| pitch +1 のまま `max_abs_diff` の assert を無効化 | **green**（= 対照実験。閾値が実際に検出していることの証明） |
+
+3つ目は対照実験で、1つ目の red が本当に `max_abs_diff == 0.0` によるものだと示している。
+
+### bundle が用意できないときは silent pass にしない
+
+当初 `package_bundle()` が `None` を返したら `eprintln!` して `return` する形だった
+（既存 `orbit-vst3-host/tests/offline.rs` のハウススタイル）。しかし
+**`return` するテストは passed として集計される** — ビルド失敗が緑になる false green。
+
+既存のあれらは `#[ignore]` ではなく通常の `cargo test` で走るので skip が意図的な移植性配慮だが、
+**本テストは `#[ignore]` で、実行者が `--ignored` を付けて明示的にこの検証を求めた時にしか走らない**。
+対になる CLAP 版は `assert!` で落とす。**#565 は検証の非対称を消すための issue なので、
+失敗の仕方の非対称を新たに導入してはいけない** → `panic!` に変更した。
+
+あわせて `orbit-vst3-synth-oracle` の `package_bundle()` の doc から
+「呼び出し側は loud skip する」を削除（この変更で事実と食い違うようになったため。
+放置すれば #567 で潰したのと同じ嘘のコメントになる）。
+
+### 検証
+
+- `cargo test --workspace --locked` ✅ **382 passed / 0 failed**
+- `cargo test -p orbit-vst3-instrument-child --test instrument_parity_gated -- --ignored` ✅ 1 passed
+- 通常の `cargo test` では **1 ignored**（CI を壊さない・CLAP 版と同じ扱い）
+- `cargo fmt --check` ✅ / `cargo clippy --workspace --all-targets -- -D warnings` ✅
+
 ### 6.317 fix(test): CI フレーク #529 の真因（ETXTBSY）を特定し構造的に除去 (Jul 29, 2026)
 
 **Date**: 2026-07-29

--- a/rust/crates/orbit-vst3-instrument-child/tests/instrument_parity_gated.rs
+++ b/rust/crates/orbit-vst3-instrument-child/tests/instrument_parity_gated.rs
@@ -1,0 +1,124 @@
+//! 同一 VST3 synth oracle の in-process / OOP event render が bit-exact に一致することを検証。
+//!
+//! 実 bundle を要するため `#[ignore]`。事前ビルド:
+//!   crates/orbit-vst3-synth-oracle/package-oracle.sh
+//! 実行:
+//!   cargo test -p orbit-vst3-instrument-child --test instrument_parity_gated -- --ignored --nocapture
+
+#![cfg(target_os = "macos")]
+
+use std::path::Path;
+
+use orbit_audio_sandbox::offline::render_instrument_through_child_sync_with_options;
+use orbit_audio_sandbox::{
+    max_abs_diff, NeutralEvent, RenderOptions, VoiceAddr, CHANNELS, MAX_FRAMES,
+};
+use orbit_vst3_host::Vst3InstrumentProcessor;
+
+const SAMPLE_RATE: f64 = 48_000.0;
+
+fn voice(key: i16) -> VoiceAddr {
+    VoiceAddr {
+        note_id: -1,
+        port_index: 0,
+        channel: 0,
+        key,
+        _pad: 0,
+    }
+}
+
+fn render_in_process(
+    bundle: &Path,
+    block_frames: usize,
+    events_by_block: &[Vec<NeutralEvent>],
+) -> Vec<f32> {
+    let (mut instrument, info) =
+        Vst3InstrumentProcessor::load(bundle, SAMPLE_RATE, MAX_FRAMES as i32, None)
+            .expect("load VST3 synth oracle (side A)");
+    assert!(!info.is_effect, "oracle must be detected as an instrument");
+
+    let mut out = Vec::with_capacity(events_by_block.len() * block_frames * CHANNELS);
+    for events in events_by_block {
+        for event in events {
+            // This is the in-process equivalent of the OOP child's NeutralEvent translation:
+            // sample_offset maps unchanged to the VST3 i32 offset, addr.channel to channel,
+            // addr.key to pitch, and the same f64 velocity is narrowed to f32 on both sides.
+            match *event {
+                NeutralEvent::NoteOn {
+                    sample_offset,
+                    addr,
+                    velocity,
+                    ..
+                } => instrument.push_note_on(
+                    addr.channel,
+                    addr.key,
+                    velocity as f32,
+                    i32::try_from(sample_offset).expect("sample offset fits VST3 i32"),
+                ),
+                NeutralEvent::NoteOff {
+                    sample_offset,
+                    addr,
+                    velocity,
+                } => instrument.push_note_off(
+                    addr.channel,
+                    addr.key,
+                    velocity as f32,
+                    i32::try_from(sample_offset).expect("sample offset fits VST3 i32"),
+                ),
+                other => panic!("unsupported parity event: {other:?}"),
+            }
+        }
+        let mut block = vec![0.0; block_frames * CHANNELS];
+        assert!(instrument.process_block(&mut block));
+        out.extend_from_slice(&block);
+    }
+    out
+}
+
+#[test]
+#[ignore = "needs a freshly packaged VST3 synth oracle bundle (local only)"]
+fn real_vst3_instrument_oop_event_parity() {
+    let Some(bundle) = orbit_vst3_synth_oracle::package_bundle() else {
+        panic!(
+            "VST3 synth oracle bundle が用意できない — 先に \
+             `crates/orbit-vst3-synth-oracle/package-oracle.sh` を実行し、\
+             `package_bundle()` が stderr に出力した失敗の詳細も確認"
+        );
+    };
+    let bundle_str = bundle.to_str().expect("bundle path is UTF-8");
+    let child_exe = Path::new(env!("CARGO_BIN_EXE_orbit-vst3-instrument-child"));
+    let block_frames = 128;
+    let key = 60;
+    let events_by_block = vec![
+        vec![NeutralEvent::NoteOn {
+            sample_offset: 0,
+            addr: voice(key),
+            velocity: 1.0,
+            tuning_cents: 0.0,
+            length_frames: 0,
+        }],
+        vec![],
+        vec![NeutralEvent::NoteOff {
+            sample_offset: 0,
+            addr: voice(key),
+            velocity: 0.0,
+        }],
+        vec![],
+    ];
+
+    let side_a = render_in_process(&bundle, block_frames, &events_by_block);
+    let (side_b, stats) = render_instrument_through_child_sync_with_options(
+        child_exe,
+        &["--plugin", bundle_str, "--sample-rate", "48000"],
+        block_frames,
+        &events_by_block,
+        RenderOptions::default(),
+    )
+    .expect("render through OOP VST3 instrument child");
+
+    assert_eq!(stats.processed, events_by_block.len() as u64);
+    assert_eq!(stats.process_errors, 0);
+    assert!(side_a.iter().any(|&sample| sample != 0.0));
+    assert!(side_b.iter().any(|&sample| sample != 0.0));
+    assert_eq!(max_abs_diff(&side_a, &side_b), 0.0);
+}

--- a/rust/crates/orbit-vst3-synth-oracle/src/lib.rs
+++ b/rust/crates/orbit-vst3-synth-oracle/src/lib.rs
@@ -537,8 +537,8 @@ extern "system" fn GetPluginFactory() -> *mut IPluginFactory {
 /// 手順が変わったときに片方だけ直し忘れる。oracle 自身が「自分をどう package するか」を
 /// 知っているのが最も腐りにくい。
 ///
-/// ビルドに失敗したら `None` を返す（呼び出し側は loud skip する）。プロセス内で一度だけ
-/// 実行し、結果をキャッシュする。
+/// ビルドに失敗したら詳細を stderr に出力して `None` を返す。プロセス内で一度だけ実行し、
+/// 結果をキャッシュする。
 pub fn package_bundle() -> Option<std::path::PathBuf> {
     use std::sync::OnceLock;
     static BUNDLE: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();


### PR DESCRIPTION
Closes #565
Refs #546 #563

## 実害

**VST3 instrument が out-of-process で実際に音を出すことを、どの層も検証していませんでした。**
CLAP には `orbit-clap-instrument-child/tests/instrument_parity_gated.rs` があるのに VST3 には無く、
**形式間で検証の厚みが非対称**でした（PR #563 の全長 E2E 実装時に発覚）。

VST3 を第一級で扱うのがこのプロジェクトの方針（#395 / Epic #424）である以上、
この非対称は残すべきではありません。壊れても気づけるのが「実機で人間が耳で聞いた時だけ」になります。

## やったこと

`rust/crates/orbit-vst3-instrument-child/tests/instrument_parity_gated.rs` を新規追加。
in-process `Vst3InstrumentProcessor` と out-of-process child のレンダ結果が
**bit-exact に一致すること**（`max_abs_diff == 0.0`）を検証します。

CLAP 版の `real_clap_instrument_oop_event_parity` と同型で、`#[ignore]`（実バンドルを要するためローカル限定）。

## CLAP 版との構造的な差異 — ここが翻訳になる

**VST3 の in-process API は CLAP と違います。** CLAP 版は `push_neutral_event` + `EventBuffer` ですが、
VST3 は `push_note_on(channel, pitch, velocity, sample_offset)` / `push_note_off(...)` です。

したがって OOP 側へ渡す `NeutralEvent` 列と in-process 側の呼び出しは**翻訳**で対応させます。
**この翻訳が間違っていると「両方同じように壊れている」を見逃しうる**ので、
翻訳箇所に sample_offset / channel / velocity の対応をコメントで明記しました。

## 変異検証（3種・実出力で確認）

| 変異 | 結果 |
|---|---|
| in-process 側の note pitch を +1 | red（`left: 0.2499993 / right: 0.0`） |
| OOP 側の events から NoteOff を削除 | red |
| pitch +1 のまま `max_abs_diff` の assert を無効化 | **green** |

3つ目は**対照実験**です。1つ目の red が本当に `max_abs_diff == 0.0` によるものだと示しています。

## bundle が用意できないときに silent pass にしない

当初は `package_bundle()` が `None` を返したら `eprintln!` して `return` する形でした
（既存 `orbit-vst3-host/tests/offline.rs` のハウススタイル・3箇所）。

しかし **`return` するテストは passed として集計されます** — ビルド失敗が緑になる false green です。

既存のあれらは `#[ignore]` ではなく通常の `cargo test` で走るので、VST3 SDK が無いマシンでの
skip は意図的な移植性配慮です。一方**本テストは `#[ignore]` で、実行者が `--ignored` を付けて
明示的にこの検証を求めた時にしか走りません**。対になる CLAP 版は `assert!` で落とします。

**#565 は検証の非対称を消すための issue なので、失敗の仕方の非対称を新たに導入してはいけません。**
`panic!` に変更しました。

あわせて `orbit-vst3-synth-oracle` の `package_bundle()` の doc から
「呼び出し側は loud skip する」を削除しています（この変更で事実と食い違うため。
放置すれば #567 で潰したのと同じ嘘のコメントになります）。

## 検証

| 項目 | 結果 |
|---|---|
| `cargo test --workspace --locked` | **382 passed / 0 failed** |
| 当該 gated テスト（`--ignored`） | 1 passed（実バンドルで実行） |
| 通常の `cargo test` | **1 ignored**（CI を壊さない・CLAP 版と同じ扱い） |
| `cargo fmt --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |

## Epic #546 について

本 PR は Epic #546 の完了条件に含まれる「VST3 instrument の可聴検証」に対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PafN8xAMtGRx3nCHyenQN8