### PR TITLE
fix(daemon): stop respawning a child that keeps dying instantly

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,86 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.319 fix(daemon): 即死する child を tight loop で respawn し続ける穴を塞ぐ #573 (Jul 29, 2026)
+
+**Date**: 2026-07-29
+**Status**: ✅ 完了
+
+watchdog は child が起動直後に死に続ける状況で **20ms 間隔（`WATCHDOG_POLL`）で respawn を
+繰り返し続けていた**。上限も backoff も無い。`initial_attach_pending` による fast-fail は
+**初回 attach の間だけ**有効で、一度 attach に成功した後の即死ループは止まらない。
+
+### 発見の経緯 — #569 の議論から実証へ
+
+#569（respawn 時の state ファイル欠損）を検討する中で「20ms 間隔の respawn ループになる疑い」を
+持ったが、**机上推論のみで未実証**だった（issue にもそう明記した）。
+
+その後 **PR #572 の CI が落ち**、既存テスト
+`supervisor_respawn_passes_the_state_saved_after_initial_spawn`（PR #563 の `9e0994b`）の
+記録スクリプトが `sleep 0.2` で自分から終了するため **watchdog が繰り返し respawn している**ことが
+判明した。テストは「どの respawn の記録を掴むか」がタイミング依存で、
+`respawn must receive --state`（= state 記録**前**の respawn の記録を掴んだ）で落ちていた。
+
+**疑いが実証に変わった。** #569 とは別の問題（#569 は原因の1つを消すだけで、プラグイン本体の
+消失・load 時クラッシュ・OOM によるループは残る）なので #573 として切り出した。
+
+### 実装
+
+`outproc_respawn_guard.rs`（新規）に純関数 `advance_fast_respawn_streak` を置き、
+**effect / instrument の両 watchdog で共有**する。別々に持つと片方だけ閾値やロジックを
+直し忘れる非対称が生まれる（#548 で実際に踏んだ形）。
+
+- child の終了を検知したとき、`last_respawn_ns` からの経過が `FAST_RESPAWN_THRESHOLD`（2s）
+  未満なら「速い失敗」として連続カウント。**閾値以上生きていたらカウンタをリセット**する
+  （単発クラッシュからは従来どおり復帰する）
+- 連続の速い失敗が `MAX_CONSECUTIVE_FAST_RESPAWNS`（5）に達したら respawn をやめて `break`
+- 停止は **loud**: `tracing::error!` に**連続失敗回数**と**直近の終了ステータス**を含める。
+  既存の「恒久 spawn 失敗で `measurement_invalid` + break」と同じ形に揃えた
+- instrument 側に `last_respawn_ns` を新規追加して effect と対称化
+
+### 既存テストのタイミング依存も解消
+
+`supervisor_respawn_passes_the_state_saved_after_initial_spawn` /
+`supervisor_respawns_child_on_unexpected_exit` の respawn 先 stub は即終了していたため、
+(a) どの respawn を掴むかがタイミング依存で (b) 本変更後は breaker に引っかかる。
+**決定論的な長寿命 stub**（`exec sleep N`）に置き換えた。検証の意味は変えていない。
+
+### 指示外で見つかった実バグ: `exec` 無しの孤児化
+
+fixture スクリプトの末尾コマンドに `exec` が無いと、`Child::kill()` が**シェルだけを殺し、
+`sleep` 孫プロセスが孤児化する**（実機で確認・1件はパイプされたテスト出力を詰まらせた）。
+全 fixture の末尾を `exec sleep N` に統一した。#529 で扱った孤児プロセスと同じ類型。
+
+### 変異検証（実出力で確認）
+
+| 変異 | red になったテスト |
+|---|---|
+| 上限判定を無効化（`if false`） | `supervisor_stops_respawning_after_consecutive_fast_failures` / `supervisor_resets_fast_fail_streak_after_a_survivor` の **2件** |
+| リセット削除（常に +1） | `exactly_at_threshold_counts_as_survived` / `surviving_past_threshold_resets_the_streak` / `supervisor_resets_fast_fail_streak_after_a_survivor` の **3件** |
+
+reset 削除の red メッセージは
+`2 fast fails + 1 survivor (reset) + 4 fast fails must respawn exactly 7 times before giving up
+(without the reset, the streak would trip the breaker after only 4 respawns)` で、
+**リセットが無いと 7 回ではなく 4 回で止まる**ことを具体的に示している。
+
+### 検証
+
+- `cargo test --workspace --locked` ✅ **382 passed / 0 failed**
+- `--features outproc-effect` ✅ 143 / `outproc-instrument` ✅ 118 / 両方 ✅ 186（すべて 0 failed）
+- `cargo fmt --check` ✅ / `cargo clippy --workspace --all-targets -- -D warnings` ✅
+
+### 作業上の反省: 同一 working tree での並行作業の衝突
+
+実装を委譲した subagent の**完了通知**を受けて作業終了と判断し、同じ working tree で
+変異検証（ソースを壊す作業）を始めた。しかし subagent 自身の報告文は
+「**background cargo test の完了を待つ**」で、まだ稼働していた。
+
+結果、subagent は私の変異を「外部からの書き換え」と検知して再適用・再検証を繰り返した。
+しかも私が当てた変異は、**subagent がまさに red 化を検証しようとしていた変異と同一**だった。
+
+**完了通知はその turn が終わったことしか意味しない。** 破壊的な作業をする前に生存確認が要る
+（本来は worktree を分けるべき作業だった）。memory に記録済み。
+
 ### 6.317 fix(test): CI フレーク #529 の真因（ETXTBSY）を特定し構造的に除去 (Jul 29, 2026)
 
 **Date**: 2026-07-29

--- a/rust/crates/orbit-audio-daemon/src/lib.rs
+++ b/rust/crates/orbit-audio-daemon/src/lib.rs
@@ -27,6 +27,10 @@ pub mod outproc_effect;
 /// Out-of-process CLAP instrument production integration（Issue #420・default off・clack-free）。
 #[cfg(feature = "outproc-instrument")]
 pub mod outproc_instrument;
+/// watchdog の「起動直後に死に続ける child を tight loop で respawn し続ける」検知ロジック（#573）。
+/// **effect と instrument で共有する**（規則を2箇所に持つと片方だけ直し忘れる — #548 と同種のリスク）。
+#[cfg(any(feature = "outproc-effect", feature = "outproc-instrument"))]
+pub(crate) mod outproc_respawn_guard;
 pub mod protocol;
 pub mod server;
 pub mod session;

--- a/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_effect.rs
@@ -40,6 +40,8 @@ use orbit_audio_sandbox::{
     open_shared, region_ptr, CommandMailboxHost, PipelinedEffectHost, CONTROL_QUIT,
 };
 
+use crate::outproc_respawn_guard::advance_fast_respawn_streak;
+
 /// watchdog が child の生存を poll する周期（非 RT・control thread）。
 const WATCHDOG_POLL: Duration = Duration::from_millis(20);
 /// QUIT 後に child の終了を待つ上限（超えたら kill にフォールバック）。`SandboxChildGuard` と同値。
@@ -50,6 +52,18 @@ const TEARDOWN_TIMEOUT: Duration = Duration::from_millis(500);
 /// `try_wait` が連続失敗した場合に supervise 不能とみなして escalate する閾値。`WATCHDOG_POLL`(20ms) と
 /// 合わせ ~1s 連続失敗で計測無効化 + 終了し、log flood を防ぐ（child handle が壊れた異常系の安全弁）。
 const TRY_WAIT_ERROR_LIMIT: u32 = 50;
+/// 「速い失敗」とみなす生存時間の閾値（#573）。child がこの時間未満で終了したら「起動直後に死んだ」と
+/// みなし連続 fast-fail カウンタを進める。以上生きていれば単発クラッシュとみなしカウンタをリセットし
+/// 従来どおり復帰する。`CHILD_READY_TIMEOUT`（`engine_wrap.rs`・10s・attach の READY 待ち上限）より十分
+/// 短く、`WATCHDOG_POLL`（20ms）よりずっと長い値にする: plugin の実際の初期化コスト（数百ms〜数秒）を
+/// fast-fail に含めたくない一方、attach 後に一瞬で死ぬパターンは確実に拾いたい。
+const FAST_RESPAWN_THRESHOLD: Duration = Duration::from_secs(2);
+/// 連続 fast-fail の上限（#573）。到達したら respawn をやめて watchdog を終了する（tight loop で
+/// child を無限に spawn し続けない安全弁）。`TRY_WAIT_ERROR_LIMIT`（50）と異なり閾値を低くしているのは、
+/// こちらは spawn 自体は成功し続ける異常系（無限に respawn する実害が毎回すぐ出る）だから: 5 回連続で
+/// `FAST_RESPAWN_THRESHOLD` 未満の生存が続くのは統計的な偶然ではなく構造的な即死とみなせる
+/// （単発クラッシュはこの回数に達する前にカウンタがリセットされる）。
+const MAX_CONSECUTIVE_FAST_RESPAWNS: u32 = 5;
 
 /// 同一プロセス内で複数の OOP effect を起動した時に shm ファイル名が衝突しないための連番。
 static SHM_SEQ: AtomicU64 = AtomicU64::new(0);
@@ -224,7 +238,8 @@ pub struct OutProcEffectStats {
     pub respawn_count: AtomicU64,
     /// 直近 respawn のタイムスタンプ（supervisor 起動からの経過 ns・0 = 未 respawn）。
     pub last_respawn_ns: AtomicU64,
-    /// respawn が失敗した（child binary 不在等）= 計測無効。gated harness が verdict を捨てる。
+    /// watchdog が supervise を諦めた（respawn 失敗 / try_wait 連続失敗 / #573: 起動直後に死に続ける
+    /// child の respawn を連続上限で打ち切った）= 計測無効。gated harness が verdict を捨てる。
     pub measurement_invalid: AtomicBool,
     /// shm の `child_process_error_count`（child の per-block 処理失敗累積）を watchdog がミラーした値。
     pub child_process_error_count: AtomicU64,
@@ -525,6 +540,9 @@ impl EffectChildSupervisor {
                 };
                 // try_wait の連続失敗回数（Ok で reset）。閾値超過で supervise 不能とみなし escalate する。
                 let mut try_wait_errors: u32 = 0;
+                // #573: 連続 fast-fail（`FAST_RESPAWN_THRESHOLD` 未満で死んだ respawn）の回数。
+                // `FAST_RESPAWN_THRESHOLD` 以上生きた respawn（正常な単発クラッシュからの復帰）でリセット。
+                let mut consecutive_fast_fails: u32 = 0;
                 loop {
                     if shutdown_thread.load(Ordering::Acquire) {
                         break;
@@ -565,6 +583,26 @@ impl EffectChildSupervisor {
                                     "{child_name_wd} exited during initial attach ({status})"
                                 );
                                 stats.child_early_exit.store(true, Ordering::Release);
+                                break;
+                            }
+                            // #573: 起動直後に死に続ける child を tight loop で respawn し続けない。
+                            // `last_respawn_ns`（初期値 0 = supervisor 起動時刻 `base`）からの経過時間で
+                            // 直前 spawn の生存時間を測る。
+                            let elapsed_since_spawn = base.elapsed().saturating_sub(
+                                Duration::from_nanos(stats.last_respawn_ns.load(Ordering::Relaxed)),
+                            );
+                            consecutive_fast_fails = advance_fast_respawn_streak(
+                                consecutive_fast_fails,
+                                elapsed_since_spawn,
+                                FAST_RESPAWN_THRESHOLD,
+                            );
+                            if consecutive_fast_fails >= MAX_CONSECUTIVE_FAST_RESPAWNS {
+                                tracing::error!(
+                                    "{child_name_wd} が {consecutive_fast_fails} 回連続で \
+                                     {FAST_RESPAWN_THRESHOLD:?} 未満の生存時間で終了（直近の終了 \
+                                     ステータス: {status}）→ respawn loop を打ち切る（計測無効）"
+                                );
+                                stats.measurement_invalid.store(true, Ordering::Release);
                                 break;
                             }
                             tracing::warn!(
@@ -977,10 +1015,18 @@ mod tests {
     }
 
     // Important 2（test-coverage review）: 異常終了した child を watchdog が respawn し respawn_count を進める
-    // （成功側の状態機械 = PID publish / count / last_respawn_ns）。CI で device 無し検証。respawn 先は
-    // `sleep`（transport 引数を理解しないので即 exit → fast respawn loop だが respawn_count>=1 で十分）。
+    // （成功側の状態機械 = PID publish / count / last_respawn_ns）。CI で device 無し検証。
+    //
+    // #573: respawn 先は元々 bare `sleep`（transport 引数 `--shm`/`--plugin`/`--sample-rate` を
+    // 数値と誤解して即 exit → fast respawn loop）だった。fast-fail 対策導入前は無害な副作用
+    // だったが、導入後はこの respawn 先自体が「起動直後に死に続ける child」に該当し
+    // `MAX_CONSECUTIVE_FAST_RESPAWNS` 回で watchdog が諦めてしまう（`measurement_invalid` が
+    // 立ち、本テストの assertion と矛盾する）。respawn 成功の状態機械だけを検証したいので、
+    // 引数を無視して生き続ける stub script に差し替える。
     #[test]
     fn supervisor_respawns_child_on_unexpected_exit() {
+        use std::os::unix::fs::PermissionsExt;
+
         let shm = make_shm();
         let stats = OutProcEffectStats::new();
         // #441 の regression: host がまだこのフラグをクリアしていない間も READY は見えうる。
@@ -994,12 +1040,26 @@ mod tests {
             .arg("0.2")
             .spawn()
             .expect("spawn stub child");
-        // PATH 解決の `sleep` を respawn 先にする（binary は存在し spawn は成功 = respawn_count++）。
+        // 引数（--shm/--plugin/--sample-rate）を無視して生き続ける respawn 先（spawn は成功 =
+        // respawn_count++、かつ #573 の fast-fail 検知に引っかからない）。
+        let respawn_target = std::env::temp_dir().join(format!(
+            "orbit-effect-respawn-target-{}-{}.sh",
+            std::process::id(),
+            SHM_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::write(&respawn_target, "#!/bin/sh\nexec sleep 30\n")
+            .expect("write respawn target stub");
+        let mut permissions = std::fs::metadata(&respawn_target)
+            .expect("respawn target metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&respawn_target, permissions)
+            .expect("make respawn target executable");
         let sup = EffectChildSupervisor::spawn(
             first,
             shm.clone(),
             stats.clone(),
-            PathBuf::from("sleep"),
+            respawn_target.clone(),
             PathBuf::from("/ignored.clap"),
             None,
             48_000,
@@ -1014,8 +1074,14 @@ mod tests {
         );
         drop(sup);
         let _ = std::fs::remove_file(&shm);
+        let _ = std::fs::remove_file(&respawn_target);
     }
 
+    // #573: この respawn 先の script は元々 `sleep 0.2` で自分から終了していた。すると
+    // watchdog がそれを異常終了として検知して**さらに respawn**してしまい、「どの respawn の
+    // 記録を掴むか」がタイミング依存になっていた（fast-fail 対策の導入で連続 fast-fail の上限に
+    // 達し respawn 自体が止まってしまう可能性もある）。長寿命（記録後は寝続ける）にすることで
+    // respawn が「初回 child の強制 kill による1回」だけに確定し、決定論的なテストになる。
     #[test]
     fn supervisor_respawn_passes_the_state_saved_after_initial_spawn() {
         use std::os::unix::fs::PermissionsExt;
@@ -1030,7 +1096,7 @@ mod tests {
         let child_script = fixture_dir.join("record-respawn-args.sh");
         std::fs::write(
             &child_script,
-            "#!/bin/sh\nscript_dir=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\nprintf '%s\\n' \"$@\" > \"$script_dir/respawn-args.txt\"\nsleep 0.2\n",
+            "#!/bin/sh\nscript_dir=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\nprintf '%s\\n' \"$@\" > \"$script_dir/respawn-args.txt\"\nexec sleep 3600\n",
         )
         .expect("write respawn argument recorder");
         let mut permissions = std::fs::metadata(&child_script)
@@ -1137,6 +1203,137 @@ mod tests {
         drop(sup);
         std::fs::remove_dir_all(fixture_dir).expect("remove respawn fixture directory");
         let _ = std::fs::remove_file(shm);
+    }
+
+    // #573: 起動直後に死に続ける child を watchdog が tight loop で respawn し続けない。respawn 先を
+    // 即死する `true` にして、`MAX_CONSECUTIVE_FAST_RESPAWNS` 回連続の速い失敗で respawn をやめる
+    // （measurement_invalid を立てて break する）ことを検証する。
+    //
+    // 変異検証: 上限判定（`consecutive_fast_fails >= MAX_CONSECUTIVE_FAST_RESPAWNS` の break）を
+    // 外すと `true` が即死し続けるので respawn_count は無限に増え続け、「頭打ちで安定する」
+    // assertion が red になる（実測は本 PR の報告を参照）。
+    #[test]
+    fn supervisor_stops_respawning_after_consecutive_fast_failures() {
+        let shm = make_shm();
+        let stats = OutProcEffectStats::new();
+        let first = Command::new("true")
+            .spawn()
+            .expect("spawn immediately-exiting stub");
+        let sup = EffectChildSupervisor::spawn(
+            first,
+            shm.clone(),
+            stats.clone(),
+            PathBuf::from("true"),
+            PathBuf::from("/ignored.clap"),
+            None,
+            48_000,
+        )
+        .expect("supervisor spawn");
+
+        let gave_up = poll_until(5, || stats.measurement_invalid.load(Ordering::Acquire));
+        assert!(
+            gave_up,
+            "consecutive fast failures must trip measurement_invalid"
+        );
+
+        let stopped_at = stats.respawn_count.load(Ordering::Relaxed);
+        assert_eq!(
+            stopped_at,
+            (MAX_CONSECUTIVE_FAST_RESPAWNS - 1) as u64,
+            "respawn must stop exactly MAX_CONSECUTIVE_FAST_RESPAWNS-1 respawns after the \
+             fast-failing streak begins (the Nth death that reaches the limit does not spawn \
+             a replacement)"
+        );
+        // 打ち切り後も respawn_count が増え続けていないこと（本当に止まった証拠。tight loop の
+        // 再発を検出する）。
+        std::thread::sleep(Duration::from_millis(200));
+        assert_eq!(
+            stats.respawn_count.load(Ordering::Relaxed),
+            stopped_at,
+            "respawn_count must not keep climbing after the watchdog gave up"
+        );
+
+        drop(sup);
+        let _ = std::fs::remove_file(&shm);
+    }
+
+    /// `dir` に、自身の起動回数（sidecar counter file）を記録し、`slow_at` 回目の起動のときだけ
+    /// `FAST_RESPAWN_THRESHOLD` を超えて生き続ける（それ以外は即終了する）script を書く。連続
+    /// fast-fail カウンタが「閾値以上生きた respawn でリセットされる」ことを検証するための stub。
+    fn write_variable_lifetime_script(dir: &Path, slow_at: u32) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let script = dir.join("variable-lifetime.sh");
+        std::fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nscript_dir=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\n\
+                 count_file=\"$script_dir/invocation-count.txt\"\n\
+                 n=$(cat \"$count_file\" 2>/dev/null || echo 0)\n\
+                 n=$((n+1))\n\
+                 printf '%s' \"$n\" > \"$count_file\"\n\
+                 if [ \"$n\" -eq {slow_at} ]; then\n  exec sleep 2.2\nfi\nexit 0\n"
+            ),
+        )
+        .expect("write variable-lifetime script");
+        let mut permissions = std::fs::metadata(&script)
+            .expect("variable-lifetime script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script, permissions)
+            .expect("make variable-lifetime script executable");
+        script
+    }
+
+    // #573: 単発クラッシュ（`FAST_RESPAWN_THRESHOLD` 以上生きてから死ぬ）は連続 fast-fail カウンタを
+    // リセットする——壊れた child だと誤判定されず従来どおり復帰し続けられる。3 回目の起動だけ
+    // 2.2s 生きてから死ぬ script を使い、reset の前後に fast fail を積んで検証する（2 fast fails →
+    // 1 survivor(reset) → 4 fast fails = 7 respawn 後に 2 度目のストリークで上限に達する）。
+    //
+    // 変異検証: リセット（`advance_fast_respawn_streak` の `else 0`）を「常に加算する」よう変異させると、
+    // 3 回目の survivor 死も加算されてしまい、合算が本来より早く上限へ達する。respawn_count は 7 では
+    // なく 4 で頭打ちになり、`final_respawn_count == 7` assertion が red になる（実測は本 PR の報告を
+    // 参照）。
+    #[test]
+    fn supervisor_resets_fast_fail_streak_after_a_survivor() {
+        let fixture_dir = std::env::temp_dir().join(format!(
+            "orbit-effect-fast-fail-reset-{}-{}",
+            std::process::id(),
+            SHM_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&fixture_dir).expect("create fast-fail-reset fixture directory");
+        let script = write_variable_lifetime_script(&fixture_dir, 3);
+
+        let shm = make_shm();
+        let stats = OutProcEffectStats::new();
+        let first = Command::new(&script)
+            .spawn()
+            .expect("spawn variable-lifetime stub (invocation 1)");
+        let sup = EffectChildSupervisor::spawn(
+            first,
+            shm.clone(),
+            stats.clone(),
+            script.clone(),
+            PathBuf::from("/ignored.clap"),
+            None,
+            48_000,
+        )
+        .expect("supervisor spawn");
+
+        let gave_up = poll_until(10, || stats.measurement_invalid.load(Ordering::Acquire));
+        assert!(
+            gave_up,
+            "the second fast-fail streak (after the reset) must eventually trip the breaker too"
+        );
+        assert_eq!(
+            stats.respawn_count.load(Ordering::Relaxed),
+            7,
+            "2 fast fails + 1 survivor (reset) + 4 fast fails must respawn exactly 7 times before \
+             giving up (without the reset, the streak would trip the breaker after only 4 respawns)"
+        );
+
+        drop(sup);
+        std::fs::remove_dir_all(&fixture_dir).expect("remove fast-fail-reset fixture directory");
+        let _ = std::fs::remove_file(&shm);
     }
 
     // Critical 2（test-coverage / code review）: open_shared 失敗時に first_child を orphan 化させず reap する。

--- a/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_instrument.rs
@@ -20,10 +20,18 @@ use orbit_audio_sandbox::{
     TransportContext, VoiceKey, BUF_LEN, CONTROL_QUIT,
 };
 
+use crate::outproc_respawn_guard::advance_fast_respawn_streak;
+
 const WATCHDOG_POLL: Duration = Duration::from_millis(20);
 const REAP_TIMEOUT: Duration = Duration::from_secs(2);
 const TEARDOWN_TIMEOUT: Duration = Duration::from_millis(500);
 const TRY_WAIT_ERROR_LIMIT: u32 = 50;
+/// 「速い失敗」とみなす生存時間の閾値（#573）。`outproc_effect::FAST_RESPAWN_THRESHOLD` と同値・
+/// 同じ理由（`CHILD_READY_TIMEOUT` より十分短く `WATCHDOG_POLL` よりずっと長い）。effect 側の
+/// doc comment を参照。
+const FAST_RESPAWN_THRESHOLD: Duration = Duration::from_secs(2);
+/// 連続 fast-fail の上限（#573）。`outproc_effect::MAX_CONSECUTIVE_FAST_RESPAWNS` と同値・同じ理由。
+const MAX_CONSECUTIVE_FAST_RESPAWNS: u32 = 5;
 pub const NOTE_RING_CAPACITY: usize = 1024;
 /// Fixed probe voice (A4 / port 0 / channel 0 / key 69) used by the gated cross-process
 /// NOTE_END test. `pub` so the gated test references this instead of re-hardcoding the triple.
@@ -188,6 +196,12 @@ pub struct OutProcInstrumentStats {
     pub fresh: AtomicU64,
     pub callback_count: AtomicU64,
     pub respawn_count: AtomicU64,
+    /// 直近 respawn のタイムスタンプ（supervisor 起動からの経過 ns・0 = 未 respawn）。#573 の
+    /// fast-fail 検知が直前 spawn の生存時間を測るのに使う。`outproc_effect::OutProcEffectStats`
+    /// の同名フィールドと同じ意味論。
+    pub last_respawn_ns: AtomicU64,
+    /// watchdog が supervise を諦めた（respawn 失敗 / try_wait 連続失敗 / #573: 起動直後に死に続ける
+    /// child の respawn を連続上限で打ち切った）= 計測無効。gated harness が verdict を捨てる。
     pub measurement_invalid: AtomicBool,
     pub child_process_error_count: AtomicU64,
     /// child-local spill FIFO(§4.2 output 方向)自体が尽きた場合のみ増分(真の drop)。child の
@@ -225,6 +239,7 @@ impl OutProcInstrumentStats {
             fresh: self.fresh.load(Ordering::Relaxed),
             callback_count: self.callback_count.load(Ordering::Relaxed),
             respawn_count: self.respawn_count.load(Ordering::Relaxed),
+            last_respawn_ns: self.last_respawn_ns.load(Ordering::Relaxed),
             measurement_invalid: self.measurement_invalid.load(Ordering::Relaxed),
             child_process_error_count: self.child_process_error_count.load(Ordering::Relaxed),
             output_event_dropped_count: self.output_event_dropped_count.load(Ordering::Relaxed),
@@ -245,6 +260,7 @@ pub struct OutProcInstrumentSnapshot {
     pub fresh: u64,
     pub callback_count: u64,
     pub respawn_count: u64,
+    pub last_respawn_ns: u64,
     pub measurement_invalid: bool,
     pub child_process_error_count: u64,
     pub output_event_dropped_count: u64,
@@ -487,6 +503,8 @@ impl InstrumentChildSupervisor {
         // クラッシュが CLAP child の障害に見える）。
         let child_name_wd =
             crate::outproc_child_exe::exe_label(&child_exe, "orbit-instrument-child");
+        // #573: `last_respawn_ns` の基準時刻（初回 child の spawn とほぼ同時刻）。effect 側と同じ。
+        let base = Instant::now();
         let (child_tx, child_rx) = std::sync::mpsc::channel::<Child>();
 
         let watchdog = match std::thread::Builder::new()
@@ -498,6 +516,9 @@ impl InstrumentChildSupervisor {
                     Err(_) => return,
                 };
                 let mut try_wait_errors = 0u32;
+                // #573: 連続 fast-fail（`FAST_RESPAWN_THRESHOLD` 未満で死んだ respawn）の回数。
+                // `FAST_RESPAWN_THRESHOLD` 以上生きた respawn（正常な単発クラッシュからの復帰）でリセット。
+                let mut consecutive_fast_fails: u32 = 0;
                 loop {
                     if shutdown_thread.load(Ordering::Acquire) {
                         break;
@@ -553,6 +574,28 @@ impl InstrumentChildSupervisor {
                                 stats.child_early_exit.store(true, Ordering::Release);
                                 break;
                             }
+                            // #573: 起動直後に死に続ける child を tight loop で respawn し続けない。
+                            // `last_respawn_ns`（初期値 0 = supervisor 起動時刻 `base`）からの経過時間で
+                            // 直前 spawn の生存時間を測る。
+                            let elapsed_since_spawn = base.elapsed().saturating_sub(
+                                Duration::from_nanos(stats.last_respawn_ns.load(Ordering::Relaxed)),
+                            );
+                            consecutive_fast_fails = advance_fast_respawn_streak(
+                                consecutive_fast_fails,
+                                elapsed_since_spawn,
+                                FAST_RESPAWN_THRESHOLD,
+                            );
+                            if consecutive_fast_fails >= MAX_CONSECUTIVE_FAST_RESPAWNS {
+                                tracing::error!(
+                                    plugin = ?plugin,
+                                    "{child_name_wd} exited {consecutive_fast_fails} times in a row \
+                                     within less than {FAST_RESPAWN_THRESHOLD:?} of being spawned \
+                                     (last exit status: {status}); giving up on the respawn loop \
+                                     (measurement invalid)"
+                                );
+                                stats.measurement_invalid.store(true, Ordering::Release);
+                                break;
+                            }
                             tracing::warn!(
                                 plugin = ?plugin,
                                 "{child_name_wd} exited ({status}); respawning"
@@ -591,6 +634,9 @@ impl InstrumentChildSupervisor {
                                         .store(replacement.id(), Ordering::Relaxed);
                                     child = replacement;
                                     stats.respawn_count.fetch_add(1, Ordering::Relaxed);
+                                    stats
+                                        .last_respawn_ns
+                                        .store(base.elapsed().as_nanos() as u64, Ordering::Relaxed);
                                     // The audio-thread adapter observes this generation counter
                                     // and resets its host-side voice bookkeeping on its next block.
                                 }
@@ -1138,8 +1184,16 @@ mod tests {
     // `outproc_effect::tests::supervisor_respawns_child_on_unexpected_exit`: an unexpectedly
     // exited child triggers a real respawn (PID publish + `respawn_count` incrementing) without
     // `measurement_invalid` being set.
+    //
+    // #573: respawn 先は元々 bare `sleep`（transport 引数を数値と誤解して即 exit → fast respawn
+    // loop）だった。fast-fail 対策導入前は無害な副作用だったが、導入後はこの respawn 先自体が
+    // 「起動直後に死に続ける child」に該当し `MAX_CONSECUTIVE_FAST_RESPAWNS` 回で watchdog が
+    // 諦めてしまう（`measurement_invalid` が立ち、本テストの assertion と矛盾する）。respawn
+    // 成功の状態機械だけを検証したいので、引数を無視して生き続ける stub script に差し替える。
     #[test]
     fn supervisor_respawns_child_on_unexpected_exit() {
+        use std::os::unix::fs::PermissionsExt;
+
         let shm = make_shm();
         let stats = OutProcInstrumentStats::new();
         // #441 の regression: attach 保留中の post-READY crash は respawn しなければならない。
@@ -1153,11 +1207,26 @@ mod tests {
             .spawn()
             .expect("spawn stub child");
         let first_pid = first.id();
+        // 引数（--shm/--plugin/--sample-rate）を無視して生き続ける respawn 先（spawn は成功 =
+        // respawn_count++、かつ #573 の fast-fail 検知に引っかからない）。
+        let respawn_target = std::env::temp_dir().join(format!(
+            "orbit-instrument-respawn-target-{}-{}.sh",
+            std::process::id(),
+            SHM_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::write(&respawn_target, "#!/bin/sh\nexec sleep 30\n")
+            .expect("write respawn target stub");
+        let mut permissions = std::fs::metadata(&respawn_target)
+            .expect("respawn target metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&respawn_target, permissions)
+            .expect("make respawn target executable");
         let sup = InstrumentChildSupervisor::spawn(
             first,
             shm.clone(),
             stats.clone(),
-            PathBuf::from("sleep"),
+            respawn_target.clone(),
             PathBuf::from("/ignored.clap"),
             None,
             48_000,
@@ -1182,8 +1251,14 @@ mod tests {
         );
         drop(sup);
         let _ = std::fs::remove_file(&shm);
+        let _ = std::fs::remove_file(&respawn_target);
     }
 
+    // #573: この respawn 先の script は元々 `sleep 0.2` で自分から終了していた。すると
+    // watchdog がそれを異常終了として検知して**さらに respawn**してしまい、「どの respawn の
+    // 記録を掴むか」がタイミング依存になっていた（fast-fail 対策の導入で連続 fast-fail の上限に
+    // 達し respawn 自体が止まってしまう可能性もある）。長寿命（記録後は寝続ける）にすることで
+    // respawn が「初回 child の強制 kill による1回」だけに確定し、決定論的なテストになる。
     #[test]
     fn supervisor_respawn_passes_the_state_saved_after_initial_spawn() {
         use std::os::unix::fs::PermissionsExt;
@@ -1198,7 +1273,7 @@ mod tests {
         let child_script = fixture_dir.join("record-respawn-args.sh");
         std::fs::write(
             &child_script,
-            "#!/bin/sh\nscript_dir=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\nprintf '%s\\n' \"$@\" > \"$script_dir/respawn-args.txt\"\nsleep 0.2\n",
+            "#!/bin/sh\nscript_dir=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\nprintf '%s\\n' \"$@\" > \"$script_dir/respawn-args.txt\"\nexec sleep 3600\n",
         )
         .expect("write respawn argument recorder");
         let mut permissions = std::fs::metadata(&child_script)
@@ -1305,6 +1380,142 @@ mod tests {
         drop(sup);
         std::fs::remove_dir_all(fixture_dir).expect("remove respawn fixture directory");
         let _ = std::fs::remove_file(shm);
+    }
+
+    // #573: 起動直後に死に続ける child を watchdog が tight loop で respawn し続けない。respawn 先を
+    // 即死する `true` にして、`MAX_CONSECUTIVE_FAST_RESPAWNS` 回連続の速い失敗で respawn をやめる
+    // （measurement_invalid を立てて break する）ことを検証する。effect 側
+    // `supervisor_stops_respawning_after_consecutive_fast_failures` のミラー。
+    //
+    // 変異検証: 上限判定（`consecutive_fast_fails >= MAX_CONSECUTIVE_FAST_RESPAWNS` の break）を
+    // 外すと `true` が即死し続けるので respawn_count は無限に増え続け、「頭打ちで安定する」
+    // assertion が red になる（実測は本 PR の報告を参照）。
+    #[test]
+    fn supervisor_stops_respawning_after_consecutive_fast_failures() {
+        let shm = make_shm();
+        let stats = OutProcInstrumentStats::new();
+        let first = Command::new("true")
+            .spawn()
+            .expect("spawn immediately-exiting stub");
+        let sup = InstrumentChildSupervisor::spawn(
+            first,
+            shm.clone(),
+            stats.clone(),
+            PathBuf::from("true"),
+            PathBuf::from("/ignored.clap"),
+            None,
+            48_000,
+            None,
+        )
+        .expect("supervisor spawn");
+
+        let gave_up = poll_until(5, || stats.measurement_invalid.load(Ordering::Acquire));
+        assert!(
+            gave_up,
+            "consecutive fast failures must trip measurement_invalid"
+        );
+
+        let stopped_at = stats.respawn_count.load(Ordering::Relaxed);
+        assert_eq!(
+            stopped_at,
+            (MAX_CONSECUTIVE_FAST_RESPAWNS - 1) as u64,
+            "respawn must stop exactly MAX_CONSECUTIVE_FAST_RESPAWNS-1 respawns after the \
+             fast-failing streak begins (the Nth death that reaches the limit does not spawn \
+             a replacement)"
+        );
+        // 打ち切り後も respawn_count が増え続けていないこと（本当に止まった証拠。tight loop の
+        // 再発を検出する）。
+        std::thread::sleep(Duration::from_millis(200));
+        assert_eq!(
+            stats.respawn_count.load(Ordering::Relaxed),
+            stopped_at,
+            "respawn_count must not keep climbing after the watchdog gave up"
+        );
+
+        drop(sup);
+        let _ = std::fs::remove_file(&shm);
+    }
+
+    /// `dir` に、自身の起動回数（sidecar counter file）を記録し、`slow_at` 回目の起動のときだけ
+    /// `FAST_RESPAWN_THRESHOLD` を超えて生き続ける（それ以外は即終了する）script を書く。連続
+    /// fast-fail カウンタが「閾値以上生きた respawn でリセットされる」ことを検証するための stub。
+    /// effect 側 `write_variable_lifetime_script` のミラー。
+    fn write_variable_lifetime_script(dir: &Path, slow_at: u32) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let script = dir.join("variable-lifetime.sh");
+        std::fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nscript_dir=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\n\
+                 count_file=\"$script_dir/invocation-count.txt\"\n\
+                 n=$(cat \"$count_file\" 2>/dev/null || echo 0)\n\
+                 n=$((n+1))\n\
+                 printf '%s' \"$n\" > \"$count_file\"\n\
+                 if [ \"$n\" -eq {slow_at} ]; then\n  exec sleep 2.2\nfi\nexit 0\n"
+            ),
+        )
+        .expect("write variable-lifetime script");
+        let mut permissions = std::fs::metadata(&script)
+            .expect("variable-lifetime script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script, permissions)
+            .expect("make variable-lifetime script executable");
+        script
+    }
+
+    // #573: 単発クラッシュ（`FAST_RESPAWN_THRESHOLD` 以上生きてから死ぬ）は連続 fast-fail カウンタを
+    // リセットする——壊れた child だと誤判定されず従来どおり復帰し続けられる。3 回目の起動だけ
+    // 2.2s 生きてから死ぬ script を使い、reset の前後に fast fail を積んで検証する（2 fast fails →
+    // 1 survivor(reset) → 4 fast fails = 7 respawn 後に 2 度目のストリークで上限に達する）。effect 側
+    // `supervisor_resets_fast_fail_streak_after_a_survivor` のミラー。
+    //
+    // 変異検証: リセット（`advance_fast_respawn_streak` の `else 0`）を「常に加算する」よう変異させると、
+    // 3 回目の survivor 死も加算されてしまい、合算が本来より早く上限へ達する。respawn_count は 7 では
+    // なく 4 で頭打ちになり、`final_respawn_count == 7` assertion が red になる（実測は本 PR の報告を
+    // 参照）。
+    #[test]
+    fn supervisor_resets_fast_fail_streak_after_a_survivor() {
+        let fixture_dir = std::env::temp_dir().join(format!(
+            "orbit-instrument-fast-fail-reset-{}-{}",
+            std::process::id(),
+            SHM_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&fixture_dir).expect("create fast-fail-reset fixture directory");
+        let script = write_variable_lifetime_script(&fixture_dir, 3);
+
+        let shm = make_shm();
+        let stats = OutProcInstrumentStats::new();
+        let first = Command::new(&script)
+            .spawn()
+            .expect("spawn variable-lifetime stub (invocation 1)");
+        let sup = InstrumentChildSupervisor::spawn(
+            first,
+            shm.clone(),
+            stats.clone(),
+            script.clone(),
+            PathBuf::from("/ignored.clap"),
+            None,
+            48_000,
+            None,
+        )
+        .expect("supervisor spawn");
+
+        let gave_up = poll_until(10, || stats.measurement_invalid.load(Ordering::Acquire));
+        assert!(
+            gave_up,
+            "the second fast-fail streak (after the reset) must eventually trip the breaker too"
+        );
+        assert_eq!(
+            stats.respawn_count.load(Ordering::Relaxed),
+            7,
+            "2 fast fails + 1 survivor (reset) + 4 fast fails must respawn exactly 7 times before \
+             giving up (without the reset, the streak would trip the breaker after only 4 respawns)"
+        );
+
+        drop(sup);
+        std::fs::remove_dir_all(&fixture_dir).expect("remove fast-fail-reset fixture directory");
+        let _ = std::fs::remove_file(&shm);
     }
 
     // pr-test-analyzer (item 3, PR #422 review): the watchdog's per-tick mirror of `SharedRegion`'s

--- a/rust/crates/orbit-audio-daemon/src/outproc_respawn_guard.rs
+++ b/rust/crates/orbit-audio-daemon/src/outproc_respawn_guard.rs
@@ -1,0 +1,61 @@
+//! watchdog の「起動直後に死に続ける child を tight loop で respawn し続ける」検知ロジック（#573）。
+//! effect と instrument で共有する。
+//!
+//! 判定そのものは [`crate::outproc_child_exe::child_exe_for_attach`] と同じ理由で共有する:
+//! 別々に持つと片方だけ閾値やロジックを直し忘れる非対称が生まれる（#548 で実際に踏んだ形のバグ）。
+
+use std::time::Duration;
+
+/// 直前の spawn からの経過時間（`elapsed_since_spawn`）が `threshold` 未満なら「速い失敗」として
+/// 連続カウンタを進め、`threshold` 以上生きていれば（単発クラッシュからの正常な復帰とみなし）
+/// カウンタをリセットする純関数。
+///
+/// watchdog 側は `elapsed_since_spawn` を `now - last_spawn_ns` として計算する。`last_respawn_ns`
+/// は初期値 0（= supervisor 起動時刻 `base` を指す）なので、まだ一度も respawn していない
+/// 初回 child の生存時間もこの式で正しく測れる（`base` は初回 child の spawn とほぼ同時刻に
+/// 記録されるため）。
+pub(crate) fn advance_fast_respawn_streak(
+    consecutive_fast_fails: u32,
+    elapsed_since_spawn: Duration,
+    threshold: Duration,
+) -> u32 {
+    if elapsed_since_spawn < threshold {
+        consecutive_fast_fails + 1
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fast_death_increments_the_streak() {
+        assert_eq!(
+            advance_fast_respawn_streak(0, Duration::from_millis(100), Duration::from_secs(2)),
+            1
+        );
+        assert_eq!(
+            advance_fast_respawn_streak(4, Duration::from_millis(100), Duration::from_secs(2)),
+            5
+        );
+    }
+
+    #[test]
+    fn surviving_past_threshold_resets_the_streak() {
+        assert_eq!(
+            advance_fast_respawn_streak(4, Duration::from_secs(3), Duration::from_secs(2)),
+            0
+        );
+    }
+
+    #[test]
+    fn exactly_at_threshold_counts_as_survived() {
+        // `elapsed_since_spawn < threshold` のみを速い失敗とみなす（境界は「生きていた」側）。
+        assert_eq!(
+            advance_fast_respawn_streak(4, Duration::from_secs(2), Duration::from_secs(2)),
+            0
+        );
+    }
+}


### PR DESCRIPTION
Closes #573
Refs #569 #572 #563

## 実害

watchdog は child が起動直後に死に続ける状況で **20ms 間隔（`WATCHDOG_POLL`）で respawn を
繰り返し続けていました**。上限も backoff もありません。

`initial_attach_pending` による fast-fail は**初回 attach の間だけ**有効で、
**一度 attach に成功した後**の即死ループは止まりません。

実運用で起きる条件: プラグイン本体がアップデートや移動で消えた / load 時にクラッシュする /
メモリ不足で起動直後に落ちる。

## 疑いから実証へ

#569 の検討中に「respawn ループになるのでは」と疑いましたが、**机上推論のみで未実証**でした
（issue にもそう明記しました）。

その後 **PR #572 の CI が落ち**、既存テスト
`supervisor_respawn_passes_the_state_saved_after_initial_spawn`（PR #563 の `9e0994b`）の
記録スクリプトが `sleep 0.2` で自分から終了するため、**watchdog が実際に繰り返し respawn している**
ことが判明しました。

```
panicked at outproc_effect.rs:1130: respawn must receive --state
test result: FAILED. 135 passed; 1 failed
```

`poll_until` は通っている（respawn は起きて記録スクリプトも走った）のに `--state` が無い —
**state 記録前の respawn の記録を掴んでいた**という出方です。**疑いが実証に変わりました。**

## 実装

`outproc_respawn_guard.rs`（新規）に純関数 `advance_fast_respawn_streak` を置き、
**effect / instrument の両 watchdog で共有**します。別々に持つと片方だけ閾値やロジックを
直し忘れる非対称が生まれます（#548 で実際に踏んだ形）。

- child の終了時、`last_respawn_ns` からの経過が `FAST_RESPAWN_THRESHOLD`（2s）未満なら
  「速い失敗」として連続カウント。**閾値以上生きていたらリセット**（単発クラッシュからは
  従来どおり復帰する）
- 連続の速い失敗が `MAX_CONSECUTIVE_FAST_RESPAWNS`（5）に達したら respawn をやめて `break`
- **停止は loud**: `tracing::error!` に**連続失敗回数**と**直近の終了ステータス**を含める。
  既存の「恒久 spawn 失敗で `measurement_invalid` + break」と同じ形に揃えた
- instrument 側に `last_respawn_ns` を新規追加して effect と対称化

境界の扱い（閾値ちょうどは「生きていた」側）も専用テストで固定しています。

## 既存テストのタイミング依存も解消

`supervisor_respawn_passes_the_state_saved_after_initial_spawn` /
`supervisor_respawns_child_on_unexpected_exit` の respawn 先 stub は即終了していたため、
(a) どの respawn を掴むかがタイミング依存で (b) 本変更後は breaker に引っかかります。

**決定論的な長寿命 stub**（`exec sleep N`）に置き換えました。**検証の意味は変えていません。**

## 指示外で見つかった実バグ: `exec` 無しの孤児化

fixture スクリプトの末尾コマンドに `exec` が無いと、`Child::kill()` が**シェルだけを殺し、
`sleep` 孫プロセスが孤児化します**（実機で確認・1件はパイプされたテスト出力を詰まらせました）。
全 fixture の末尾を `exec sleep N` に統一しました。#529 で扱った孤児プロセスと同じ類型です。

## 変異検証（実出力で確認）

| 変異 | red になったテスト |
|---|---|
| 上限判定を無効化（`if false`） | `supervisor_stops_respawning_after_consecutive_fast_failures` / `supervisor_resets_fast_fail_streak_after_a_survivor` の **2件** |
| リセット削除（常に +1） | `exactly_at_threshold_counts_as_survived` / `surviving_past_threshold_resets_the_streak` / `supervisor_resets_fast_fail_streak_after_a_survivor` の **3件** |

reset 削除の red メッセージは具体的です:

```
2 fast fails + 1 survivor (reset) + 4 fast fails must respawn exactly 7 times before giving up
(without the reset, the streak would trip the breaker after only 4 respawns)
  left: 4
 right: 7
```

**リセットが無いと 7 回ではなく 4 回で止まる**ことを示しています。

## 検証

| コマンド | 結果 |
|---|---|
| `cargo test --workspace --locked` | **382 passed / 0 failed** |
| `--features outproc-effect` | 143 passed / 0 failed |
| `--features outproc-instrument` | 118 passed / 0 failed |
| `--features outproc-effect,outproc-instrument` | 186 passed / 0 failed |
| `cargo fmt --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |

CI が実際に走らせる全組み合わせです。

## #569 との関係

**#569（daemon 私有 state コピー）は原因の1つを消すだけで、この問題は残ります。**
プラグイン本体の消失やクラッシュは #569 の対象外なので、本 PR は独立に必要です。

## PR #572 について

本 PR がマージされれば、#572 の CI 赤（同じタイミング依存テスト）が解消されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PafN8xAMtGRx3nCHyenQN8