### PR TITLE
feat(engine): address mixer-bus inserts for plugin state save

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,127 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.327 feat(engine): address mixer-bus inserts for plugin state — #564 (Jul 29, 2026)
+
+**Date**: 2026-07-29
+**Status**: ✅ 実機 E2E green。sum/aux が sequence と同じ土俵に乗った
+
+`global.sum("drum").effect("Pro-Q 4")` の音色が**保存できなかった**。DSL 上は挿せて音も出るのに、
+`resolvePluginStateTarget` が `master` だけを特別扱いしており sum/aux 名に到達できなかった。
+
+| レシーバ | before | after |
+|---|---|---|
+| sequence / master | ✅ 保存できる | ✅ |
+| **sum / aux** | ❌ **`not supported`** | ✅ **保存・復元できる** |
+
+#### 接頭辞方式（owner 確定）
+
+```
+save_plugin_state("sum:drum", 1)     // sum バスの drum
+save_plugin_state("aux:reverb", 1)   // aux バスの reverb
+save_plugin_state("drum", 1)         // 従来どおり sequence（後方互換）
+```
+
+**採用理由**: `mixer-manager.ts` の `EffectChainMap` が既に identity として
+`` `${kind}:${name}` `` を使っている。**新概念を増やさず内部表記を外に出すだけ**で済む。
+
+**衝突は実在した**: `declareBus` が弾くのは空文字と `"master"` だけで、sum と aux の
+名前重複は止まらない。`resolveNode` は sum → aux の順なので、**同名なら黙って sum が勝つ**。
+
+```
+global.sum("drum").effect("Pro-Q 4")
+global.aux("drum").effect("Valhalla")   // 両方通る
+```
+
+この状態で `"drum"` を保存すると **Pro-Q 4 が保存され、エラーは出ない**。
+そこで **`resolveNode()` を state 解決に持ち込まず**、両 kind を列挙して
+**次の一手を示す診断**にした:
+
+```
+Unknown sequence 'drum'; a same-named mixer bus exists.
+Use 'sum:drum' or 'aux:drum' to save its insert state.
+```
+
+#### 🔴 ゴールポストを下げないための仕掛け
+
+Epic #546 のループ「宣言 → 音色を作る → **自動記録** → 再起動 → 同じ音」のうち、
+**「自動記録」はどのレシーバ種別にも存在しない**ことが判明した（保存経路は
+`save_plugin_state` と `//#savePluginState` の2つだけ。#541 の E2E ですら MCP で叩いている）。
+
+main は当初、E2E のステップ3「自動記録される」を**黙って明示保存に差し替えよう**としていた。
+**自分で issue に記録した決定の無断下方修正**であり、owner の「ゴールポストから遠ざかってない?」は
+ここを突いていた（Fable 裁定で確定）。
+
+対処: **E2E を最終形の5ステップで書き、ステップ3だけを明示マークした1行にする。**
+
+```ts
+// INTERIM(#577): 自動記録が未実装のため明示保存で代替。#577 完了時にこの行を削除すると
+// そのまま受け入れテストになる。
+```
+
+**ゴールとの差分が `grep INTERIM` で見つかる形に固定**した。#541 で使ったのと同じパターン。
+併せて **#577**（自動記録）を立て、受け入れ基準を
+「sequence / master / sum / aux の**いずれでも**、明示保存を**一度も使わずに**ループが成立」とした。
+
+#### E2E は DSL 経由（owner 確定）
+
+> LLM が第一級ユーザーだからといって API を直接呼ぶのは良い振る舞いではない。
+> **E2E も DSL の振る舞いを確認しないと意味がない** — 人間のユーザーと同じように扱う。
+
+宣言・評価・音の確認はすべて `run_selection` 経由。API を使うのは暫定1行のみ。
+
+#### false green を避けた形
+
+- **default 0.5 に対し non-default 0.125** で判定（既定値だと壊れていても通る）
+- **decoy を2つ仕込む**: 接頭辞なしキー（0.9）と kind 違いの aux キー（0.8）。
+  **3つとも異なるゲイン**なので、間違ったキーを拾えば**どれを拾ったかが音で判別できる**
+- **default との比**（`peakRatio < 0.35` / `rmsRatio < 0.4`）と**再起動前後の一致**の両方
+
+#### 分類テストが2件捕まえた
+
+`signal-chain-dispatch.spec.ts` の「全 public メソッドを DSL 語彙か内部 API に分類する」検査が
+`parsePluginStateBusReceiver` を未分類として落とした。
+
+**除外リストには足さなかった。** #528 で「除外リストへの誤分類はテストが緑のまま通り
+実行時だけ壊れる」事故が起きている。この関数は `this` を使わない純粋関数なので
+**クラス外のモジュール関数に出し、分類の対象から外した**（誤分類が構造的に不可能になる）。
+同じ状態だった `resolveMixerPluginStateChain` も同様に出した。
+
+#### 変異検証（実出力を確認）
+
+| 変異 | 結果 |
+|---|---|
+| 接頭辞解析の削除 | 4 failed |
+| kind の入れ替え | 4 failed |
+| **`resolveNode()` への差し戻し** | **1 failed**（sum は通り **aux だけ落ちる** = silent failure の形そのもの） |
+| identity の接頭辞除去 | 2 failed |
+| index +1 | 3 failed |
+
+関数をクラス外へ出した後も検出力が落ちていないことを再確認
+（`Unknown sequence 'sum:x'` で 5 failed）。
+
+#### 検証（すべて main が sandbox 外で実行）
+
+- `cargo test --workspace --locked`: **410 passed / 0 failed**（**Rust は1行も触っていない**）
+- outproc-effect 143 / outproc-instrument 118 / both 186（すべて 0 failed）
+- `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings`: pass
+- `npm test`: **1811 passed / 32 skipped / 0 failed**（1806 から +5）
+- **実行後の残留プロセス: 0**
+
+#### マージ前ゲート: ビルド + 実機 E2E
+
+```
+✓ restores a non-default sum-bus insert across restart through its prefixed receiver identity  24.8s
+✓ restores an MCP-saved non-default instrument state across an engine restart with the same measured pitch
+✓ rescans catalog v2 through MCP, reports a broken bundle, and preserves a known CLAP fixture
+✓ drives real OrbitStudio end-to-end: diagnostics-on-open, run_selection, live edit, capture verification
+Test Files 1 passed / Tests 4 passed
+```
+
+**E2E 実行後の残留プロセスも 0**（OrbitStudio / repl / daemon）。
+
+---
+
 ### 6.326 fix(scan): PR #575 review round 2 — fix-scoped hang + test process leak (Jul 29, 2026)
 
 **Date**: 2026-07-29

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -19,8 +19,9 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ### 6.327 feat(engine): address mixer-bus inserts for plugin state — #564 (Jul 29, 2026)
 
-**Date**: 2026-07-29
-**Status**: ✅ 実機 E2E green。sum/aux が sequence と同じ土俵に乗った
+**Date**: 2026-07-29（レビューラウンド1の修正を反映した最終形。`/simplify` 5952aa0 で
+撤回した中間設計の記述は本セクションから除去済み — 現行仕様はここだけで読める）
+**Status**: ✅ ユニット/統合 green・レビューラウンド1適用済み。sum/aux が sequence と同じ土俵に乗った
 
 `global.sum("drum").effect("Pro-Q 4")` の音色が**保存できなかった**。DSL 上は挿せて音も出るのに、
 `resolvePluginStateTarget` が `master` だけを特別扱いしており sum/aux 名に到達できなかった。
@@ -41,6 +42,13 @@ save_plugin_state("drum", 1)         // 従来どおり sequence（後方互換�
 **採用理由**: `mixer-manager.ts` の `EffectChainMap` が既に identity として
 `` `${kind}:${name}` `` を使っている。**新概念を増やさず内部表記を外に出すだけ**で済む。
 
+**語彙（レビューラウンド1で統一）**: `master` は「**master 出力エンドポイント**」であり、
+sum / aux の「**mixer バス**」とは別概念。`declareBus` が `master` という名前の sum/aux バス
+宣言を明示的に禁止しており、実装が既にこの区別を強制している。MCP tool description・
+spec UIH.5 の冒頭定義と責務表をこの語彙に揃えた。`open_plugin_ui` / `close_plugin_ui` は
+**未実装**のため「UI open/close は v1 では sequence 限定」と spec に明記
+（receiver 一般化が v1 で効くのは state 保存・復元のみ）。
+
 **衝突は実在した**: `declareBus` が弾くのは空文字と `"master"` だけで、sum と aux の
 名前重複は止まらない。`resolveNode` は sum → aux の順なので、**同名なら黙って sum が勝つ**。
 
@@ -58,6 +66,30 @@ Unknown sequence 'drum'; a same-named mixer bus exists.
 Use 'sum:drum' or 'aux:drum' to save its insert state.
 ```
 
+#### wire format は `formatReceiverId` / `parseReceiverId` に一元化（最終形）
+
+接頭辞付き receiver id の生成・解析は `mixer-manager.ts` の
+**`formatReceiverId(kind, name)` / `parseReceiverId(id)` のペアだけ**が持つ。
+接頭辞そのものも `formatReceiverId(kind, '')` から導出するため、**区切り文字を変えると
+生成・解析・診断文言が一緒に変わる**（片側だけ変わる縫い目が存在しない）。
+`parseReceiverId` は **先頭アンカーの `startsWith`** で判定し、`my-sum:x` のような
+sequence 形の名前をバス扱いしない。この2関数には**直接ユニットテスト**を置いた
+（空 name・複数コロン・接頭辞なし・**接頭辞が先頭に無い形**・往復性。
+`plugin-state-save.spec.ts` の `prefixed receiver id wire format (#564)`）。
+
+daemon target へ渡すのは receiverId から接頭辞を剥いだ文字列ではなく、
+**宣言名で解決した物理バス（chain slot が保持する `sum-bus-0` 等の pool 割り当て名）**。
+剥いだ宣言名は当該 kind 名前空間のルックアップキーとしてのみ使う（spec UIH.5 も同旨に修正）。
+
+#### bus 分岐は `pluginStateBusChain`（private・除外リスト登録）
+
+master / `sum:` / `aux:` の chain 解決は `Global` の private ヘルパー
+`pluginStateBusChain` が担う。この関数は **`this` を3回使う**
+（`pluginEffectManager.chain()` / `mixerManager.resolveBus` / `mixerManager.chainFor`）ため
+クラス外へ出せず、`signal-chain-dispatch.spec.ts` の分類検査では**除外リストに追加**した。
+規則は「除外リストを増やすな」ではなく**「外に出せるものを除外リストで黙らせるな」**
+（#528 の事故は「外に出せるのに除外した」誤分類が原因。出せないものの登録は正当）。
+
 #### 🔴 ゴールポストを下げないための仕掛け
 
 Epic #546 のループ「宣言 → 音色を作る → **自動記録** → 再起動 → 同じ音」のうち、
@@ -68,23 +100,25 @@ main は当初、E2E のステップ3「自動記録される」を**黙って�
 **自分で issue に記録した決定の無断下方修正**であり、owner の「ゴールポストから遠ざかってない?」は
 ここを突いていた（Fable 裁定で確定）。
 
-対処: **E2E を最終形の5ステップで書き、ステップ3だけを明示マークした1行にする。**
-
-```ts
-// INTERIM(#577): 自動記録が未実装のため明示保存で代替。#577 完了時にこの行を削除すると
-// そのまま受け入れテストになる。
-```
-
-**ゴールとの差分が `grep INTERIM` で見つかる形に固定**した。#541 で使ったのと同じパターン。
+対処: **E2E を最終形の5ステップで書き、ステップ3だけを `INTERIM(#577)` マーク付きの
+明示保存にする。** ゴールとの差分が `grep INTERIM` で見つかる形に固定（#541 と同じパターン）。
 併せて **#577**（自動記録）を立て、受け入れ基準を
 「sequence / master / sum / aux の**いずれでも**、明示保存を**一度も使わずに**ループが成立」とした。
+
+**INTERIM 行を消せる条件は無条件ではない**（レビューラウンド1・Fable 指摘）:
+この E2E ではパラメータ編集が一度も起きず、非既定 gain は state ファイルの load で入る。
+`setState` を受けただけのプラグインは通常 dirty にならないため、#577 の停止時 snapshot が
+dirty ゲート付きだと行を消したテストは赤になる。**「停止時 snapshot は dirty ゲートを
+かけず loaded 全プラグインを対象にする」ことが削除条件**であり、E2E コメントと
+#577 の受け入れ基準の両方に明記した（manifest の外科的削除と checkpoint の競合も同様に
+#577 側で引き取る旨を記載）。
 
 #### E2E は DSL 経由（owner 確定）
 
 > LLM が第一級ユーザーだからといって API を直接呼ぶのは良い振る舞いではない。
 > **E2E も DSL の振る舞いを確認しないと意味がない** — 人間のユーザーと同じように扱う。
 
-宣言・評価・音の確認はすべて `run_selection` 経由。API を使うのは暫定1行のみ。
+宣言・評価・音の確認はすべて `run_selection` 経由。API を使うのは暫定の明示保存のみ。
 
 #### false green を避けた形
 
@@ -92,49 +126,31 @@ main は当初、E2E のステップ3「自動記録される」を**黙って�
 - **decoy を2つ仕込む**: 接頭辞なしキー（0.9）と kind 違いの aux キー（0.8）。
   **3つとも異なるゲイン**なので、間違ったキーを拾えば**どれを拾ったかが音で判別できる**
 - **default との比**（`peakRatio < 0.35` / `rmsRatio < 0.4`）と**再起動前後の一致**の両方
+- **aux は実機で往復させる**（レビューラウンド1）: フル音声オラクルは複製せず、
+  同じ E2E 内で aux バスを DSL 宣言 → `save_plugin_state("aux:wet", 1)` → 再起動 →
+  **`get_log` の `[plugin-state] restoring 'aux:wet/…'` 行**を assert。
+  TS 側は `makeKind` 1本で sum/aux 対称だが、aux 側だけの配線忘れ・prefix 生成バグは
+  mock ユニットでは検出できないため、daemon 往復までを実機で1点証明する
 
-#### 分類テストが2件捕まえた
+#### 変異検証（レビューラウンド1適用後に再計測・実出力確認済み）
 
-`signal-chain-dispatch.spec.ts` の「全 public メソッドを DSL 語彙か内部 API に分類する」検査が
-`parsePluginStateBusReceiver` を未分類として落とした。
-
-**除外リストには足さなかった。** #528 で「除外リストへの誤分類はテストが緑のまま通り
-実行時だけ壊れる」事故が起きている。この関数は `this` を使わない純粋関数なので
-**クラス外のモジュール関数に出し、分類の対象から外した**（誤分類が構造的に不可能になる）。
-同じ状態だった `resolveMixerPluginStateChain` も同様に出した。
-
-#### 変異検証（実出力を確認）
+対象: `plugin-state-save.spec.ts` + `plugin-state-restore.spec.ts`（計45件）
 
 | 変異 | 結果 |
 |---|---|
-| 接頭辞解析の削除 | 4 failed |
-| kind の入れ替え | 4 failed |
-| **`resolveNode()` への差し戻し** | **1 failed**（sum は通り **aux だけ落ちる** = silent failure の形そのもの） |
-| identity の接頭辞除去 | 2 failed |
-| index +1 | 3 failed |
+| 接頭辞解析の削除（`parseReceiverId` が常に undefined） | **8 failed** |
+| 生成側破壊（`formatReceiverId` の区切り `:` → `/`） | **8 failed** |
+| kind の入れ替え（parse 結果の sum ⇄ aux） | **8 failed** |
+| **アンカー緩め（`startsWith` → `includes`）** | **3 failed**（すべて新設の直接テスト。**ラウンド1前は 0 failed で素通りしていた**穴を塞いだ） |
 
-関数をクラス外へ出した後も検出力が落ちていないことを再確認
-（`Unknown sequence 'sum:x'` で 5 failed）。
+#### 検証（レビューラウンド1適用後）
 
-#### 検証（すべて main が sandbox 外で実行）
-
-- `cargo test --workspace --locked`: **410 passed / 0 failed**（**Rust は1行も触っていない**）
-- outproc-effect 143 / outproc-instrument 118 / both 186（すべて 0 failed）
-- `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings`: pass
-- `npm test`: **1811 passed / 32 skipped / 0 failed**（1806 から +5）
-- **実行後の残留プロセス: 0**
-
-#### マージ前ゲート: ビルド + 実機 E2E
-
-```
-✓ restores a non-default sum-bus insert across restart through its prefixed receiver identity  24.8s
-✓ restores an MCP-saved non-default instrument state across an engine restart with the same measured pitch
-✓ rescans catalog v2 through MCP, reports a broken bundle, and preserves a known CLAP fixture
-✓ drives real OrbitStudio end-to-end: diagnostics-on-open, run_selection, live edit, capture verification
-Test Files 1 passed / Tests 4 passed
-```
-
-**E2E 実行後の残留プロセスも 0**（OrbitStudio / repl / daemon）。
+- `npm test`: **1816 passed / 32 skipped / 0 failed**（1811 から +5 = wire format 直接テスト）
+- `npm run lint`: 0 errors（warning 1件は本 PR 非接触ファイルの既存分）
+- `cargo fmt --check`: pass（**Rust は1行も触っていない**。feature commit 時点の
+  `cargo test --workspace --locked` は 410 passed / 0 failed）
+- 実機 E2E（sum 音声オラクル 3面 + 再起動一致）は feature commit 時点で green。
+  aux 追加分を含む再実行は**マージ前ゲートで実施**する
 
 ---
 

--- a/docs/specs-v2/PLUGIN_UI_HOSTING_SPEC_v1.md
+++ b/docs/specs-v2/PLUGIN_UI_HOSTING_SPEC_v1.md
@@ -409,12 +409,18 @@ engine 側は影響を受けない。
 
 **この規則が無いと、呼び出し側が index の数え方を推測することになる**（#562 で空白が判明）。
 
-> **v1 スコープ**: `resolvePluginStateTarget` がアドレス解決する receiver は
-> **sequence と master のみ**。sum / aux バスにも insert chain 自体はあるが、state 保存対象としての
-> アドレス指定は未対応である。現在の `(receiver, index)` は平坦な receiver 名前空間を前提にする一方、
-> 実際の sequence / sum / aux は別名前空間で同名を許すため、どれを指すか衝突しうる。
-> **解決順や暗黙の優先順位は定めない**。それを行うと別プラグインの state を保存して成功扱いする
-> silent failure を作るため、名前空間を含むアドレス方式が決まるまでは loud に未対応を返す。
+> **receiver 名前空間（規範）**: sum / aux バスは receiver にそれぞれ `sum:` / `aux:` を
+> 字句的に前置して指定する（例: `sum:drum`, `aux:reverb`）。接頭辞付き receiver は指定した
+> kind の同名バスだけを指し、sum → aux の解決順、`resolveNode()`、sequence への fallback を
+> 使用してはならない。daemon target には接頭辞を除いた実 bus 名を渡し、SC.5 の永続 identity
+> には接頭辞付き receiver をそのまま使う。
+>
+> 接頭辞なし receiver は従来どおり sequence だけを指し、`master` だけは master バスを指す。
+> 接頭辞なしの名前と同名の sum / aux バスが存在してもバスへ暗黙解決してはならない。sequence が
+> 存在しない一方で同名バスが存在するときは、`sum:<name>` / `aux:<name>` の明示指定を促す
+> loud エラーにする。これにより、同名の sequence / sum / aux 間で別プラグインの state を保存して
+> 成功扱いする silent failure を防ぐ。`sum:x` という文字列は常に sum バス receiver と解釈し、
+> 同名 sequence への fallback は設けない。
 
 1. **index 0 = ソーススロット。** レシーバの信号源（SC.1 規範(2) の構造トポロジーで先頭に立つもの）
    に予約する。

--- a/docs/specs-v2/PLUGIN_UI_HOSTING_SPEC_v1.md
+++ b/docs/specs-v2/PLUGIN_UI_HOSTING_SPEC_v1.md
@@ -391,16 +391,22 @@ Closing / Closed 中に到達した追加の要求:
 
 ## UIH.5 アドレッシング — テキスト位置ではない
 
-**UI の対象指定は `(シーケンス名, chain index)` で行う。**
+**対象指定は `(receiver, chain index)` で行う。** receiver は sequence 名・`master`
+（**master 出力エンドポイント** — sum / aux の **mixer バス**とは別概念）・
+`sum:<name>` / `aux:<name>`（mixer バス）のいずれか。
 
 テキスト位置（エディタのカーソル）は人間専用の概念であり、これを下位層まで持ち込むと
 LLM 側と非対称になる（DESIGN_PRINCIPLES §3 違反）。
 
 | 層 | 責務 |
 |---|---|
-| エディタ（右クリック） | テキスト位置 → `(シーケンス名, chain index)` の**解決のみ** |
-| MCP | `open_plugin_ui(sequence, index)` / `close_plugin_ui(sequence, index)` |
-| daemon 以下 | `(シーケンス名, chain index)` だけを知る |
+| エディタ（右クリック） | テキスト位置 → `(receiver, chain index)` の**解決のみ** |
+| MCP | `save_plugin_state(receiver, index)`（実装済） / `open_plugin_ui(sequence, index)`・`close_plugin_ui(sequence, index)`（**未実装**） |
+| daemon 以下 | 解決済みの target（daemon bus / instance）と chain index だけを知る |
+
+> **UI open/close の v1 スコープ**: `open_plugin_ui` / `close_plugin_ui` は**未実装**であり、
+> **v1 では receiver を sequence に限定する**。receiver 一般化（`master` / `sum:` / `aux:`）が
+> v1 で適用されるのは state 保存・復元（`save_plugin_state` / PRJ.1 auto-restore）のみ。
 
 これにより #474 の regex 依存はエディタ層に閉じ込められ、#495 言語サービス導入時も
 engine 側は影響を受けない。
@@ -412,15 +418,28 @@ engine 側は影響を受けない。
 > **receiver 名前空間（規範）**: sum / aux バスは receiver にそれぞれ `sum:` / `aux:` を
 > 字句的に前置して指定する（例: `sum:drum`, `aux:reverb`）。接頭辞付き receiver は指定した
 > kind の同名バスだけを指し、sum → aux の解決順、`resolveNode()`、sequence への fallback を
-> 使用してはならない。daemon target には接頭辞を除いた実 bus 名を渡し、SC.5 の永続 identity
-> には接頭辞付き receiver をそのまま使う。
+> 使用してはならない。接頭辞を剥がした宣言名は当該 kind の名前空間でのルックアップキーとして
+> **のみ**使い、daemon target には**宣言名で解決した物理バス**（chain slot が保持する
+> pool 割り当て済みバス名。例: `sum-bus-0`）を渡す。receiverId から接頭辞を除いた文字列を
+> そのまま daemon に渡してはならない。SC.5 の永続 identity には接頭辞付き receiver を
+> そのまま使う。
 >
-> 接頭辞なし receiver は従来どおり sequence だけを指し、`master` だけは master バスを指す。
+> 接頭辞なし receiver は従来どおり sequence だけを指し、`master` だけは master 出力
+> エンドポイントを指す。
 > 接頭辞なしの名前と同名の sum / aux バスが存在してもバスへ暗黙解決してはならない。sequence が
 > 存在しない一方で同名バスが存在するときは、`sum:<name>` / `aux:<name>` の明示指定を促す
 > loud エラーにする。これにより、同名の sequence / sum / aux 間で別プラグインの state を保存して
 > 成功扱いする silent failure を防ぐ。`sum:x` という文字列は常に sum バス receiver と解釈し、
 > 同名 sequence への fallback は設けない。
+>
+> **暗黙の不変条件（規範）**: 接頭辞解釈が字句的である帰結として、`sum:` / `aux:` で始まる
+> **sequence 名は receiver 解決で常にバス扱い**になり、state 保存の対象として直接アドレス
+> できない（DSL の識別子文法は `:` を受理しないため DSL からは到達不能だが、内部 API 経由では
+> 起こりうる）。また、永続 identity キー `receiver/role/正規化名/出現順` の**単射性**は次の
+> 3点に依存する: (1) role が `instrument` / `effect` の固定語彙であること、(2) 正規化名が
+> basename 由来で `/` を含み得ないこと、(3) 出現順が数値であること。これらのいずれかを
+> 緩める変更は、キー衝突（別プラグインの state を同一キーへ登記する silent failure）の
+> 再検討なしに行ってはならない。
 
 1. **index 0 = ソーススロット。** レシーバの信号源（SC.1 規範(2) の構造トポロジーで先頭に立つもの）
    に予約する。

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -27,7 +27,7 @@ import { MidiTransportScheduler } from './global/midi-transport-scheduler'
 import { PluginEffectManager } from './global/plugin-effect-manager'
 import { PluginInstrumentManager } from './global/plugin-instrument-manager'
 import { SequenceEffectManager } from './global/sequence-effect-manager'
-import { MixerManager, MixerBusHandle } from './global/mixer-manager'
+import { MixerManager, MixerBusHandle, type MixerKind } from './global/mixer-manager'
 import type { PluginSlot } from './global/effect-slot'
 import {
   ProjectStateStore,
@@ -38,6 +38,32 @@ import {
 export interface ResolvedPluginStateTarget {
   identity: PluginStateIdentity
   daemonTarget: { role: 'effect'; bus?: string } | { role: 'instrument'; instance: string }
+}
+
+function parsePluginStateBusReceiver(
+  receiverId: string,
+): { kind: MixerKind; name: string } | undefined {
+  for (const kind of ['sum', 'aux'] as const) {
+    const prefix = `${kind}:`
+    if (receiverId.startsWith(prefix)) {
+      return { kind, name: receiverId.slice(prefix.length) }
+    }
+  }
+  return undefined
+}
+
+function resolveMixerPluginStateChain(
+  mixerManager: MixerManager,
+  receiver: { kind: MixerKind; name: string },
+): readonly PluginSlot[] {
+  const bus = mixerManager.resolveBus(receiver.kind, receiver.name)
+  if (bus === undefined) {
+    throw new Error(
+      `Unknown ${receiver.kind} bus '${receiver.name}'; no plugin chain is registered for ` +
+        `'${receiver.kind}:${receiver.name}'.`,
+    )
+  }
+  return mixerManager.chainFor(receiver.kind, receiver.name)
 }
 
 export class Global {
@@ -619,41 +645,56 @@ export class Global {
   }
 
   /**
-   * UIH.5 の揮発アドレス `(sequence,index)` を、現在のchainからSC.5 identityとdaemon slotへ
+   * UIH.5 の揮発アドレス `(receiver,index)` を、現在のchainからSC.5 identityとdaemon slotへ
    * 同時に解決する。indexを永続キーへ流用しない。
    */
-  resolvePluginStateTarget(sequence: string, index: number): ResolvedPluginStateTarget {
+  resolvePluginStateTarget(receiverId: string, index: number): ResolvedPluginStateTarget {
     if (!Number.isInteger(index) || index < 0) {
       throw new Error(`Plugin chain index must be a non-negative integer; received ${index}.`)
     }
 
     let slot: PluginSlot | undefined
     let valid: { index: number; slot: PluginSlot }[]
-    if (sequence === 'master') {
-      const effects = this.pluginEffectManager.chain()
+    const prefixedBus = parsePluginStateBusReceiver(receiverId)
+    if (receiverId === 'master' || prefixedBus) {
+      const effects =
+        receiverId === 'master'
+          ? this.pluginEffectManager.chain()
+          : resolveMixerPluginStateChain(this.mixerManager, prefixedBus!)
       valid = effects.map((effect, offset) => ({ index: offset + 1, slot: effect }))
       if (index === 0) {
         throw this.pluginIndexError(
-          sequence,
+          receiverId,
           index,
           valid,
-          'master is a bus and has no source slot; effects start at index 1',
+          `${receiverId} is a bus and has no source slot; effects start at index 1`,
         )
       }
       slot = effects[index - 1]
     } else {
-      const receiver = this.sequenceRegistry.getSequence(sequence)
+      const receiver = this.sequenceRegistry.getSequence(receiverId)
       if (!receiver) {
-        const mixerBus = this.mixerManager.resolveNode(sequence)
-        if (mixerBus) {
+        const matchingBusKinds = (
+          [
+            ['sum', this.mixerManager.resolveSum(receiverId)],
+            ['aux', this.mixerManager.resolveAux(receiverId)],
+          ] as const
+        )
+          .filter((entry): entry is readonly [MixerKind, string] => entry[1] !== undefined)
+          .map(([kind]) => kind)
+        if (matchingBusKinds.length > 0) {
+          const explicitReceivers = matchingBusKinds
+            .map((kind) => `'${kind}:${receiverId}'`)
+            .join(' or ')
           throw new Error(
-            `'${sequence}' is a ${mixerBus.kind} bus; saving state for mixer-bus inserts is not supported in v1 (see PLUGIN_UI_HOSTING_SPEC_v1 UIH.5).`,
+            `Unknown sequence '${receiverId}'; a same-named mixer bus exists. ` +
+              `Use ${explicitReceivers} to save its insert state.`,
           )
         }
-        throw new Error(`Unknown sequence '${sequence}'; no plugin chain is registered.`)
+        throw new Error(`Unknown sequence '${receiverId}'; no plugin chain is registered.`)
       }
-      const instruments = this.pluginInstrumentManager.chainFor(sequence)
-      const effects = this.sequenceEffectManager.chainFor(sequence)
+      const instruments = this.pluginInstrumentManager.chainFor(receiverId)
+      const effects = this.sequenceEffectManager.chainFor(receiverId)
       valid = [
         ...instruments.map((instrument) => ({ index: 0, slot: instrument })),
         ...effects.map((effect, offset) => ({ index: offset + 1, slot: effect })),
@@ -666,7 +707,7 @@ export class Global {
             : receiver.isMidi()
               ? 'the MIDI source is not a hosted plugin and is not addressable'
               : 'no plugin instrument is declared'
-          throw this.pluginIndexError(sequence, index, valid, sourceReason)
+          throw this.pluginIndexError(receiverId, index, valid, sourceReason)
         }
       } else {
         slot = effects[index - 1]
@@ -675,14 +716,14 @@ export class Global {
 
     if (!slot) {
       throw this.pluginIndexError(
-        sequence,
+        receiverId,
         index,
         valid!,
         'the requested chain slot does not exist',
       )
     }
     const identity: PluginStateIdentity = {
-      receiver: sequence,
+      receiver: receiverId,
       role: slot.role,
       normalizedName: slot.normalizedName,
       occurrence: slot.occurrence,
@@ -699,11 +740,11 @@ export class Global {
     }
   }
 
-  async savePluginState(sequence: string, index: number): Promise<SavedProjectPluginState> {
+  async savePluginState(receiverId: string, index: number): Promise<SavedProjectPluginState> {
     if (this.isTransportRunning()) {
       throw new Error('Plugin state cannot be saved while the transport is running; stop first.')
     }
-    const resolved = this.resolvePluginStateTarget(sequence, index)
+    const resolved = this.resolvePluginStateTarget(receiverId, index)
     const projectDirectory = this.audioManager.getDocumentDirectory()
     if (!projectDirectory) {
       throw new Error(

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -27,7 +27,12 @@ import { MidiTransportScheduler } from './global/midi-transport-scheduler'
 import { PluginEffectManager } from './global/plugin-effect-manager'
 import { PluginInstrumentManager } from './global/plugin-instrument-manager'
 import { SequenceEffectManager } from './global/sequence-effect-manager'
-import { MixerManager, MixerBusHandle, type MixerKind } from './global/mixer-manager'
+import {
+  MixerManager,
+  MixerBusHandle,
+  formatReceiverId,
+  parseReceiverId,
+} from './global/mixer-manager'
 import type { PluginSlot } from './global/effect-slot'
 import {
   ProjectStateStore,
@@ -38,32 +43,6 @@ import {
 export interface ResolvedPluginStateTarget {
   identity: PluginStateIdentity
   daemonTarget: { role: 'effect'; bus?: string } | { role: 'instrument'; instance: string }
-}
-
-function parsePluginStateBusReceiver(
-  receiverId: string,
-): { kind: MixerKind; name: string } | undefined {
-  for (const kind of ['sum', 'aux'] as const) {
-    const prefix = `${kind}:`
-    if (receiverId.startsWith(prefix)) {
-      return { kind, name: receiverId.slice(prefix.length) }
-    }
-  }
-  return undefined
-}
-
-function resolveMixerPluginStateChain(
-  mixerManager: MixerManager,
-  receiver: { kind: MixerKind; name: string },
-): readonly PluginSlot[] {
-  const bus = mixerManager.resolveBus(receiver.kind, receiver.name)
-  if (bus === undefined) {
-    throw new Error(
-      `Unknown ${receiver.kind} bus '${receiver.name}'; no plugin chain is registered for ` +
-        `'${receiver.kind}:${receiver.name}'.`,
-    )
-  }
-  return mixerManager.chainFor(receiver.kind, receiver.name)
 }
 
 export class Global {
@@ -645,6 +624,29 @@ export class Global {
   }
 
   /**
+   * The insert chain when `receiverId` addresses a bus — the `master` output
+   * endpoint (a distinct concept from sum/aux buses) or a `sum:`/`aux:`-prefixed
+   * mixer bus. Undefined when the id names no bus (sequence receivers). Throws
+   * for a prefixed id whose bus is undeclared.
+   */
+  private pluginStateBusChain(receiverId: string): readonly PluginSlot[] | undefined {
+    if (receiverId === 'master') {
+      return this.pluginEffectManager.chain()
+    }
+    const receiver = parseReceiverId(receiverId)
+    if (!receiver) {
+      return undefined
+    }
+    if (this.mixerManager.resolveBus(receiver.kind, receiver.name) === undefined) {
+      throw new Error(
+        `Unknown ${receiver.kind} bus '${receiver.name}'; no plugin chain is registered for ` +
+          `'${formatReceiverId(receiver.kind, receiver.name)}'.`,
+      )
+    }
+    return this.mixerManager.chainFor(receiver.kind, receiver.name)
+  }
+
+  /**
    * UIH.5 の揮発アドレス `(receiver,index)` を、現在のchainからSC.5 identityとdaemon slotへ
    * 同時に解決する。indexを永続キーへ流用しない。
    */
@@ -655,13 +657,9 @@ export class Global {
 
     let slot: PluginSlot | undefined
     let valid: { index: number; slot: PluginSlot }[]
-    const prefixedBus = parsePluginStateBusReceiver(receiverId)
-    if (receiverId === 'master' || prefixedBus) {
-      const effects =
-        receiverId === 'master'
-          ? this.pluginEffectManager.chain()
-          : resolveMixerPluginStateChain(this.mixerManager, prefixedBus!)
-      valid = effects.map((effect, offset) => ({ index: offset + 1, slot: effect }))
+    const busEffects = this.pluginStateBusChain(receiverId)
+    if (busEffects !== undefined) {
+      valid = busEffects.map((effect, offset) => ({ index: offset + 1, slot: effect }))
       if (index === 0) {
         throw this.pluginIndexError(
           receiverId,
@@ -670,21 +668,14 @@ export class Global {
           `${receiverId} is a bus and has no source slot; effects start at index 1`,
         )
       }
-      slot = effects[index - 1]
+      slot = busEffects[index - 1]
     } else {
       const receiver = this.sequenceRegistry.getSequence(receiverId)
       if (!receiver) {
-        const matchingBusKinds = (
-          [
-            ['sum', this.mixerManager.resolveSum(receiverId)],
-            ['aux', this.mixerManager.resolveAux(receiverId)],
-          ] as const
-        )
-          .filter((entry): entry is readonly [MixerKind, string] => entry[1] !== undefined)
-          .map(([kind]) => kind)
+        const matchingBusKinds = this.mixerManager.kindsWithBus(receiverId)
         if (matchingBusKinds.length > 0) {
           const explicitReceivers = matchingBusKinds
-            .map((kind) => `'${kind}:${receiverId}'`)
+            .map((kind) => `'${formatReceiverId(kind, receiverId)}'`)
             .join(' or ')
           throw new Error(
             `Unknown sequence '${receiverId}'; a same-named mixer bus exists. ` +
@@ -718,7 +709,7 @@ export class Global {
       throw this.pluginIndexError(
         receiverId,
         index,
-        valid!,
+        valid,
         'the requested chain slot does not exist',
       )
     }

--- a/packages/engine/src/core/global/mixer-manager.ts
+++ b/packages/engine/src/core/global/mixer-manager.ts
@@ -36,6 +36,29 @@ export const MIXER_BUS_KINDS = ['sum', 'aux'] as const
 export type MixerKind = (typeof MIXER_BUS_KINDS)[number]
 
 /**
+ * Round-trip converters for the prefixed receiver identity (`sum:<name>` /
+ * `aux:<name>`) that addresses a mixer bus in plugin-state persistence (#564).
+ * This pair is the ONLY home of the wire format: producers (the
+ * `EffectChainMap` receiver ids below), the parser, and every diagnostic that
+ * spells out a prefixed id must go through it, so changing the separator
+ * changes generation, parsing, and error guidance together.
+ */
+export function formatReceiverId(kind: MixerKind, name: string): string {
+  return `${kind}:${name}`
+}
+
+/** Inverse of {@link formatReceiverId}; undefined when `id` carries no sum/aux prefix. */
+export function parseReceiverId(id: string): { kind: MixerKind; name: string } | undefined {
+  for (const kind of MIXER_BUS_KINDS) {
+    const prefix = formatReceiverId(kind, '')
+    if (id.startsWith(prefix)) {
+      return { kind, name: id.slice(prefix.length) }
+    }
+  }
+  return undefined
+}
+
+/**
  * Brand marking a value as a mixer bus handle. Carried by the handle itself
  * rather than inferred from its shape, so {@link isMixerBusHandle} identifies
  * buses exactly — a `Sequence` also has an `effect()` method, and any future
@@ -92,20 +115,23 @@ export class MixerManager {
     private readonly audioManager: AudioManager,
     private readonly linkAudioManager: LinkAudioManager,
   ) {
-    const makeKind = (kind: MixerKind, prefix: string): KindState => ({
-      buses: new Map(),
-      inserts: new EffectChainMap(audioEngine, (name) => `${kind}:${name}`, {
-        externalReceiverId: (name) => `${kind}:${name}`,
-        statePathFallback: createStatePathFallback(audioManager),
-      }),
-      pool: new BusPool(
-        prefix,
-        MIXER_BUS_POOL_SIZE,
-        (name) =>
-          `global.${kind}("${name}"): ${kind} bus pool exhausted — v1 supports at most ` +
-          `${MIXER_BUS_POOL_SIZE} concurrent ${kind} buses.`,
-      ),
-    })
+    const makeKind = (kind: MixerKind, prefix: string): KindState => {
+      const receiverId = (name: string) => formatReceiverId(kind, name)
+      return {
+        buses: new Map(),
+        inserts: new EffectChainMap(audioEngine, receiverId, {
+          externalReceiverId: receiverId,
+          statePathFallback: createStatePathFallback(audioManager),
+        }),
+        pool: new BusPool(
+          prefix,
+          MIXER_BUS_POOL_SIZE,
+          (name) =>
+            `global.${kind}("${name}"): ${kind} bus pool exhausted — v1 supports at most ` +
+            `${MIXER_BUS_POOL_SIZE} concurrent ${kind} buses.`,
+        ),
+      }
+    }
     this.kinds = { sum: makeKind('sum', SUM_BUS_PREFIX), aux: makeKind('aux', AUX_BUS_PREFIX) }
   }
 
@@ -152,6 +178,11 @@ export class MixerManager {
   /** Resolves a declared bus in the explicitly selected receiver namespace. */
   resolveBus(kind: MixerKind, name: string): string | undefined {
     return this.kinds[kind].buses.get(name)
+  }
+
+  /** The kinds (sum / aux) that currently have a bus declared under `name`. */
+  kindsWithBus(name: string): MixerKind[] {
+    return MIXER_BUS_KINDS.filter((kind) => this.kinds[kind].buses.has(name))
   }
 
   /** Current insert chain for an explicitly selected mixer receiver. */

--- a/packages/engine/src/core/global/mixer-manager.ts
+++ b/packages/engine/src/core/global/mixer-manager.ts
@@ -1,4 +1,5 @@
 import type { AudioEngine } from '../../audio/types'
+import { createStatePathFallback } from '../project-state-store'
 
 import { AudioManager } from './audio-manager'
 import { LinkAudioManager } from './link-audio-manager'
@@ -7,6 +8,7 @@ import {
   EffectChainMap,
   normalizePluginInstanceName,
   resolveEffectSpec,
+  type PluginSlot,
 } from './effect-slot'
 
 /**
@@ -31,7 +33,7 @@ export const MIXER_BUS_POOL_SIZE = 4
  */
 export const MIXER_BUS_KINDS = ['sum', 'aux'] as const
 
-type MixerKind = (typeof MIXER_BUS_KINDS)[number]
+export type MixerKind = (typeof MIXER_BUS_KINDS)[number]
 
 /**
  * Brand marking a value as a mixer bus handle. Carried by the handle itself
@@ -92,8 +94,10 @@ export class MixerManager {
   ) {
     const makeKind = (kind: MixerKind, prefix: string): KindState => ({
       buses: new Map(),
-      // #564 でアドレス指定が未決のため、sum/aux は state 自動復元の対象外。
-      inserts: new EffectChainMap(audioEngine, (name) => `${kind}:${name}`),
+      inserts: new EffectChainMap(audioEngine, (name) => `${kind}:${name}`, {
+        externalReceiverId: (name) => `${kind}:${name}`,
+        statePathFallback: createStatePathFallback(audioManager),
+      }),
       pool: new BusPool(
         prefix,
         MIXER_BUS_POOL_SIZE,
@@ -143,6 +147,16 @@ export class MixerManager {
   /** Resolves a declared aux bus name to its allocated bus, or undefined if undeclared. */
   resolveAux(name: string): string | undefined {
     return this.kinds.aux.buses.get(name)
+  }
+
+  /** Resolves a declared bus in the explicitly selected receiver namespace. */
+  resolveBus(kind: MixerKind, name: string): string | undefined {
+    return this.kinds[kind].buses.get(name)
+  }
+
+  /** Current insert chain for an explicitly selected mixer receiver. */
+  chainFor(kind: MixerKind, name: string): readonly PluginSlot[] {
+    return this.kinds[kind].inserts.chainFor(name)
   }
 
   resolveNode(name: string): { kind: MixerKind; bus: string } | undefined {

--- a/packages/vscode-extension/src/mcp-server.ts
+++ b/packages/vscode-extension/src/mcp-server.ts
@@ -799,8 +799,9 @@ function buildServer(
           'Save the current state of a running plugin into the project states directory and ' +
           'register it in project.yaml. Address the current chain with receiver and index ' +
           '(the input field remains named sequence for compatibility): plain names select ' +
-          'sequences, "master" selects the master bus, and "sum:<name>"/"aux:<name>" select ' +
-          'mixer buses. Index 0 is a note-sequence instrument; effects start at index 1. ' +
+          'sequences, "master" selects the master output endpoint, and "sum:<name>"/' +
+          '"aux:<name>" select mixer buses. Index 0 is a note-sequence instrument; effects ' +
+          'start at index 1. ' +
           'Playback must be stopped.',
         inputSchema: {
           sequence: z

--- a/packages/vscode-extension/src/mcp-server.ts
+++ b/packages/vscode-extension/src/mcp-server.ts
@@ -231,7 +231,7 @@ export interface OrbitScoreToolHandlers {
   listPlugins(): Promise<ListPluginsResult> | ListPluginsResult
   /** rescan_plugins (#463 PC.4/C1b): run the scanner and return its summary. */
   rescanPlugins(): Promise<RescanPluginsResult> | RescanPluginsResult
-  /** 明示plugin state保存。UIH.5の揮発アドレス `(sequence,index)` を受ける。 */
+  /** 明示plugin state保存。互換フィールド `sequence` で UIH.5 の `(receiver,index)` を受ける。 */
   savePluginState?(
     sequence: string,
     index: number,
@@ -797,11 +797,15 @@ function buildServer(
         title: 'Save Plugin State',
         description:
           'Save the current state of a running plugin into the project states directory and ' +
-          'register it in project.yaml. Address the current chain with sequence and index: ' +
-          'index 0 is a note-sequence instrument; effects start at index 1; use sequence ' +
-          '"master" with index 1 for the master effect. Playback must be stopped.',
+          'register it in project.yaml. Address the current chain with receiver and index ' +
+          '(the input field remains named sequence for compatibility): plain names select ' +
+          'sequences, "master" selects the master bus, and "sum:<name>"/"aux:<name>" select ' +
+          'mixer buses. Index 0 is a note-sequence instrument; effects start at index 1. ' +
+          'Playback must be stopped.',
         inputSchema: {
-          sequence: z.string().describe('Sequence name, or the reserved name "master"'),
+          sequence: z
+            .string()
+            .describe('Receiver: sequence name, "master", "sum:<bus-name>", or "aux:<bus-name>"'),
           index: z.number().describe('UIH.5 chain index (instrument 0, effects 1-based)'),
         },
       },

--- a/tests/core/plugin-state-restore.spec.ts
+++ b/tests/core/plugin-state-restore.spec.ts
@@ -519,22 +519,50 @@ describe('project.yaml plugin state auto-restore (#541)', () => {
     expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
   })
 
-  it('U12 keeps sum/aux inserts outside project.yaml auto-restore', async () => {
+  it('U12 restores same-named sum/aux inserts only from their prefixed receiver keys', async () => {
     const h = harness()
+    const sumStatePath = 'states/sum-correct.state'
+    const auxStatePath = 'states/aux-correct.state'
     register(h.directory, {
-      'drum/effect/GlueComp/0': 'states/external-receiver-decoy.state',
-      'sum:drum/effect/GlueComp/0': 'states/internal-receiver-decoy.state',
+      'sum:drum/effect/GlueComp/0': sumStatePath,
+      'aux:drum/effect/GlueComp/0': auxStatePath,
+      'drum/effect/GlueComp/0': 'states/unprefixed-decoy.state',
     })
 
     await h.mixer.sum('drum').effect('./GlueComp.clap')
+    await h.mixer.aux('drum').effect('./GlueComp.clap')
 
-    expect(h.audio.loadPlugin).toHaveBeenCalledWith(
+    expect(h.audio.loadPlugin).toHaveBeenNthCalledWith(
+      1,
       path.join(h.directory, 'GlueComp.clap'),
       undefined,
       'effect',
       'sum-bus-0',
+      undefined,
+      path.resolve(h.directory, sumStatePath),
     )
-    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(1)
-    expect(console.log).toHaveBeenCalledTimes(0)
+    expect(h.audio.loadPlugin).toHaveBeenNthCalledWith(
+      2,
+      path.join(h.directory, 'GlueComp.clap'),
+      undefined,
+      'effect',
+      'aux-bus-0',
+      undefined,
+      path.resolve(h.directory, auxStatePath),
+    )
+    expect(h.audio.loadPlugin).toHaveBeenCalledTimes(2)
+    expect(console.log).toHaveBeenCalledWith(
+      `[plugin-state] restoring 'sum:drum/effect/GlueComp/0' from ${path.resolve(
+        h.directory,
+        sumStatePath,
+      )}`,
+    )
+    expect(console.log).toHaveBeenCalledWith(
+      `[plugin-state] restoring 'aux:drum/effect/GlueComp/0' from ${path.resolve(
+        h.directory,
+        auxStatePath,
+      )}`,
+    )
+    expect(console.log).toHaveBeenCalledTimes(2)
   })
 })

--- a/tests/core/plugin-state-save.spec.ts
+++ b/tests/core/plugin-state-save.spec.ts
@@ -6,6 +6,11 @@ import { parse } from 'yaml'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { Global } from '../../packages/engine/src/core/global'
+import {
+  MIXER_BUS_KINDS,
+  formatReceiverId,
+  parseReceiverId,
+} from '../../packages/engine/src/core/global/mixer-manager'
 import { Sequence } from '../../packages/engine/src/core/sequence'
 import { stateFileNameForIdentity } from '../../packages/engine/src/core/project-state-store'
 
@@ -327,5 +332,39 @@ describe('plugin state address resolution and project registration (#562)', () =
     await expect(global.savePluginState('lead', 0)).rejects.toThrow('transport is running')
     expect(audio.savePluginState).not.toHaveBeenCalled()
     expect(audio.stop).not.toHaveBeenCalled()
+  })
+})
+
+describe('prefixed receiver id wire format (#564)', () => {
+  it.each(MIXER_BUS_KINDS.map((kind) => [kind] as const))(
+    'round-trips %s receiver ids for plain, empty, and separator-bearing names',
+    (kind) => {
+      for (const name of ['drum', '', 'a:b', 'sum', 'aux', 'sum:x']) {
+        expect(parseReceiverId(formatReceiverId(kind, name))).toEqual({ kind, name })
+      }
+    },
+  )
+
+  it('keeps everything after the first separator as the bus name', () => {
+    expect(parseReceiverId('sum:')).toEqual({ kind: 'sum', name: '' })
+    expect(parseReceiverId('sum:a:b')).toEqual({ kind: 'sum', name: 'a:b' })
+    expect(parseReceiverId('aux:sum:x')).toEqual({ kind: 'aux', name: 'sum:x' })
+  })
+
+  it('returns undefined for ids without a bus prefix', () => {
+    expect(parseReceiverId('sum')).toBeUndefined()
+    expect(parseReceiverId('aux')).toBeUndefined()
+    expect(parseReceiverId('master')).toBeUndefined()
+    expect(parseReceiverId('drum')).toBeUndefined()
+    expect(parseReceiverId('')).toBeUndefined()
+  })
+
+  it('requires the prefix to be anchored at the start of the id', () => {
+    // A drifting match (e.g. `includes` instead of `startsWith`) would classify
+    // these sequence-shaped names as bus receivers and break sequence saves.
+    expect(parseReceiverId('my-sum:x')).toBeUndefined()
+    expect(parseReceiverId('my-aux:x')).toBeUndefined()
+    expect(parseReceiverId('xsum:x')).toBeUndefined()
+    expect(parseReceiverId('lead sum:x')).toBeUndefined()
   })
 })

--- a/tests/core/plugin-state-save.spec.ts
+++ b/tests/core/plugin-state-save.spec.ts
@@ -152,6 +152,77 @@ describe('plugin state address resolution and project registration (#562)', () =
     )
   })
 
+  it('resolves explicitly prefixed sum/aux receivers to distinct identities and daemon buses', async () => {
+    const { global } = harness()
+    await global.sum('x').effect('./SumTone.clap')
+    await global.aux('x').effect('./AuxTone.clap')
+
+    expect(global.resolvePluginStateTarget('sum:x', 1)).toEqual({
+      identity: {
+        receiver: 'sum:x',
+        role: 'effect',
+        normalizedName: 'SumTone',
+        occurrence: 0,
+      },
+      daemonTarget: { role: 'effect', bus: 'sum-bus-0' },
+    })
+    expect(global.resolvePluginStateTarget('aux:x', 1)).toEqual({
+      identity: {
+        receiver: 'aux:x',
+        role: 'effect',
+        normalizedName: 'AuxTone',
+        occurrence: 0,
+      },
+      daemonTarget: { role: 'effect', bus: 'aux-bus-0' },
+    })
+  })
+
+  it.each([
+    ['sum', 'drum'],
+    ['aux', 'reverb'],
+  ] as const)(
+    'reports index 0 and a missing effect index loudly for %s buses',
+    async (kind, name) => {
+      const { global } = harness()
+      await global[kind](name).effect('./GlueComp.clap')
+
+      expect(() => global.resolvePluginStateTarget(`${kind}:${name}`, 0)).toThrow(
+        new RegExp(
+          `${kind}:${name} is a bus and has no source slot; effects start at index 1.*` +
+            'Valid indices: 1 \\(effect, GlueComp\\)',
+        ),
+      )
+      expect(() => global.resolvePluginStateTarget(`${kind}:${name}`, 2)).toThrow(
+        /requested chain slot does not exist.*Valid indices: 1 \(effect, GlueComp\)/,
+      )
+    },
+  )
+
+  it('saves a sum insert under its prefixed receiver identity', async () => {
+    const { directory, audio, global } = harness()
+    await global.sum('drum').effect('./GlueComp.clap')
+
+    const saved = await global.savePluginState('sum:drum', 1)
+    const identity = {
+      receiver: 'sum:drum',
+      role: 'effect' as const,
+      normalizedName: 'GlueComp',
+      occurrence: 0,
+    }
+    const expectedRelative = `states/${stateFileNameForIdentity(identity)}`
+
+    expect(saved.identityKey).toBe('sum:drum/effect/GlueComp/0')
+    expect(saved.projectStatePath).toBe(expectedRelative)
+    expect(audio.savePluginState).toHaveBeenCalledWith(
+      { role: 'effect', bus: 'sum-bus-0' },
+      path.join(directory, ...expectedRelative.split('/')),
+    )
+    expect(parse(fs.readFileSync(path.join(directory, 'project.yaml'), 'utf8'))).toEqual({
+      version: 1,
+      states: { 'sum:drum/effect/GlueComp/0': expectedRelative },
+    })
+  })
+
   it('does not expose the built-in audio source at sequence index 0', () => {
     const { global, sequence } = harness()
     sequence.audio('./kick.wav')
@@ -170,20 +241,42 @@ describe('plugin state address resolution and project registration (#562)', () =
     )
   })
 
-  it.each([
-    ['drum', 'sum'],
-    ['reverb', 'aux'],
-  ] as const)(
-    'reports declared %s mixer buses as unsupported instead of unknown sequences',
-    (name, kind) => {
-      const { global } = harness()
-      global[kind](name)
+  it('keeps an unprefixed receiver sequence-only even when a same-named bus exists', async () => {
+    const { global } = harness()
+    await global.instrument('lead', './Massive-X.clap')
+    await global.sum('lead').effect('./WrongBusEffect.clap')
 
-      expect(() => global.resolvePluginStateTarget(name, 1)).toThrow(
-        `'${name}' is a ${kind} bus; saving state for mixer-bus inserts is not supported in v1 (see PLUGIN_UI_HOSTING_SPEC_v1 UIH.5).`,
-      )
-    },
-  )
+    expect(global.resolvePluginStateTarget('lead', 0)).toEqual({
+      identity: {
+        receiver: 'lead',
+        role: 'instrument',
+        normalizedName: 'Massive-X',
+        occurrence: 0,
+      },
+      daemonTarget: { role: 'instrument', instance: 'plugin:lead' },
+    })
+  })
+
+  it('gives a lexical bus prefix priority over a same-named registered sequence', async () => {
+    const { audio, global } = harness()
+    const prefixedNameSequence = new Sequence(global, audio)
+    prefixedNameSequence.setName('sum:x')
+    await global.instrument('sum:x', './SequenceOnlySynth.clap')
+
+    expect(() => global.resolvePluginStateTarget('sum:x', 0)).toThrow(
+      "Unknown sum bus 'x'; no plugin chain is registered for 'sum:x'.",
+    )
+  })
+
+  it('diagnoses every matching bus prefix when an unprefixed sequence is absent', () => {
+    const { global } = harness()
+    global.sum('x')
+    global.aux('x')
+
+    expect(() => global.resolvePluginStateTarget('x', 1)).toThrow(
+      "Unknown sequence 'x'; a same-named mixer bus exists. Use 'sum:x' or 'aux:x' to save its insert state.",
+    )
+  })
 
   it('does not update project.yaml when the daemon state save fails', async () => {
     const { directory, audio, global } = harness()

--- a/tests/e2e/orbitstudio-mcp-gated.spec.ts
+++ b/tests/e2e/orbitstudio-mcp-gated.spec.ts
@@ -1081,12 +1081,16 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
       const receiverKey = 'sum:drum/effect/CLAPTestEffect/0'
       const unprefixedDecoyKey = 'drum/effect/CLAPTestEffect/0'
       const wrongKindDecoyKey = 'aux:drum/effect/CLAPTestEffect/0'
+      // 音声オラクルは sum 側だけに置く。aux 側は「daemon 往復まで実機で通る」ことを
+      // get_log の restore 行で1点だけ証明する（フル音声オラクルの複製はコスト不適合）。
+      const auxReceiverKey = 'aux:wet/effect/CLAPTestEffect/0'
 
       const dslLines = [
         'var global = init GLOBAL',
         'global.tempo(120)',
         'global.beat(4 by 4)',
         `global.sum("drum").effect(${JSON.stringify(CLAP_TEST_EFFECT_PATH)})`,
+        `global.aux("wet").effect(${JSON.stringify(CLAP_TEST_EFFECT_PATH)})`,
         'var busStateSource = init global.seq',
         `busStateSource.audio(${JSON.stringify(sourcePath)}).chop(1).output("drum")`,
         'busStateSource.play(1, 1, 1, 1)',
@@ -1095,6 +1099,14 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
         'busStateSource.stop()',
         'global.stop()',
       ]
+      // 1-based line numbers derived from the script so edits cannot silently
+      // desynchronize the run_selection ranges below.
+      const playEndLine = dslLines.indexOf('LOOP(busStateSource)') + 1
+      const stopStartLine = dslLines.indexOf('busStateSource.stop()') + 1
+      const stopEndLine = dslLines.indexOf('global.stop()') + 1
+      expect(playEndLine).toBeGreaterThan(0)
+      expect(stopStartLine).toBe(playEndLine + 1)
+      expect(stopEndLine).toBe(stopStartLine + 1)
       fs.writeFileSync(dslPath, dslLines.join('\n') + '\n')
       const openDsl = await activeClient.call('open_file', { path: dslPath })
       expect(openDsl.isError, openDsl.text).toBe(false)
@@ -1119,7 +1131,7 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
       const stopTransportThroughDsl = async (label: string): Promise<void> => {
         const before = (await activeClient.call('get_log', { lines: 500 })).text
         const stopsBefore = (before.match(/(?:✅ Global stopped|⏹ Global)/g) ?? []).length
-        await runDslLines(10, 11)
+        await runDslLines(stopStartLine, stopEndLine)
         await waitUntil(
           async () => {
             const log = (await activeClient.call('get_log', { lines: 500 })).text
@@ -1159,9 +1171,10 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
       delete baselineStates[receiverKey]
       delete baselineStates[unprefixedDecoyKey]
       delete baselineStates[wrongKindDecoyKey]
+      delete baselineStates[auxReceiverKey]
       writeManifestStates(baselineStates)
       await startCapture(defaultWav, 'sum-bus default capture engine running')
-      await runDslLines(1, 9)
+      await runDslLines(1, playEndLine)
       await sleep(4000)
       await stopTransportThroughDsl('sum-bus default transport stopped')
       await stopEngine('sum-bus default capture engine stopped')
@@ -1184,7 +1197,7 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
 
       // 1. .orbs の sum bus insert を、ユーザーと同じ run_selection で評価する。
       await startCapture(changedWav, 'sum-bus changed capture engine running')
-      await runDslLines(1, 9)
+      await runDslLines(1, playEndLine)
       await sleep(4000)
 
       // 2. 正しい receiver key から非既定 gain が適用済み。bootstrap key を消してから
@@ -1195,11 +1208,29 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
       await stopTransportThroughDsl('sum-bus changed transport stopped before state save')
 
       // 3. 自動記録される。
-      // INTERIM(#577): 自動記録が未実装のため明示保存で代替。#577 完了時にこの行を削除すると
-      // そのまま受け入れテストになる。
-      await activeClient.call('save_plugin_state', { sequence: 'sum:drum', index: 1 })
+      // INTERIM(#577): 自動記録が未実装のため明示保存で代替。
+      // この明示保存の行を削除できる条件は「#577 の停止時 snapshot が dirty ゲートを
+      // かけず、loaded 全プラグインを対象にする」こと（#577 受け入れ基準に明記済み）。
+      // この E2E ではパラメータ編集が一度も起きない（非既定 gain は state ファイルの
+      // load で入る）ため、setState だけで dirty にならないプラグインは dirty ゲート付き
+      // snapshot の対象外になり、行を消すとテストは赤になる。また、このテストは稼働中に
+      // manifest から正解キーを外科的に削除しているので、#577 の checkpoint が削除より
+      // 前に発火する設計になった場合はこの削除手順ごと #577 側で引き取って書き直すこと。
+      const savedSum = await activeClient.call('save_plugin_state', {
+        sequence: 'sum:drum',
+        index: 1,
+      })
+      expect(savedSum.isError, savedSum.text).toBe(false)
+      // aux 側の軽量チェック: 音声オラクルは張らず、保存 → 再起動 → restore ログ行で
+      // daemon 往復まで実機証明する。
+      const savedAux = await activeClient.call('save_plugin_state', {
+        sequence: 'aux:wet',
+        index: 1,
+      })
+      expect(savedAux.isError, savedAux.text).toBe(false)
       const registeredStates = readManifestStates()
       expect(registeredStates[receiverKey]).toMatch(/^states\//)
+      expect(registeredStates[auxReceiverKey]).toMatch(/^states\//)
       expect(registeredStates[unprefixedDecoyKey]).toBe(unprefixedDecoyPath)
       expect(registeredStates[wrongKindDecoyKey]).toBe(wrongKindDecoyPath)
 
@@ -1208,8 +1239,17 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
       await startCapture(restoredWav, 'sum-bus restored capture engine running')
 
       // 5. 同じ .orbs を run_selection で再評価し、capture で音の一致を確認する。
-      await runDslLines(1, 9)
+      await runDslLines(1, playEndLine)
       await sleep(4000)
+      // aux 側は restore が daemon まで往復した証拠として engine ログの
+      // `[plugin-state] restoring 'aux:wet/…'` 行を確認する。
+      await waitUntil(
+        async () => {
+          const log = (await activeClient.call('get_log', { lines: 1000 })).text
+          return log.includes(`[plugin-state] restoring '${auxReceiverKey}'`)
+        },
+        { intervalMs: 200, timeoutMs: 10_000, label: 'aux-bus insert restored from prefixed key' },
+      )
       await stopTransportThroughDsl('sum-bus restored transport stopped')
       await stopEngine('sum-bus restored capture engine stopped')
 

--- a/tests/e2e/orbitstudio-mcp-gated.spec.ts
+++ b/tests/e2e/orbitstudio-mcp-gated.spec.ts
@@ -45,6 +45,7 @@ import * as os from 'os'
 import * as path from 'path'
 
 import { describe, it, expect, afterAll } from 'vitest'
+import { parse, stringify } from 'yaml'
 
 import {
   analyzeWavBuffer,
@@ -1059,6 +1060,191 @@ describe.skipIf(!gated)('OrbitStudio Agent Bridge MCP E2E (gated, real app)', ()
         Math.abs(restoredMeasured - expectedShiftedHz) / expectedShiftedHz,
         `restored ${restoredMeasured.toFixed(2)}Hz must be offset-7 pitch ${expectedShiftedHz.toFixed(2)}Hz`,
       ).toBeLessThanOrEqual(0.02)
+    },
+    TEST_TIMEOUT_MS,
+  )
+
+  it.skipIf(!appAvailable)(
+    'restores a non-default sum-bus insert across restart through its prefixed receiver identity',
+    async () => {
+      expect(client, 'main gated phase must initialize the MCP client first').toBeDefined()
+      expect(tmpRoot, 'main gated phase must initialize the scratch root first').toBeDefined()
+      if (!client || !tmpRoot) throw new Error('main gated phase did not initialize suite state')
+      const activeClient = client
+      const root = tmpRoot
+      const projectFile = path.join(root, 'project.yaml')
+      const sourcePath = path.join(root, 'test-assets/audio/kick.wav')
+      const dslPath = path.join(root, 'sum-bus-state.orbs')
+      const defaultWav = path.join(root, 'sum-bus-default.wav')
+      const changedWav = path.join(root, 'sum-bus-changed.wav')
+      const restoredWav = path.join(root, 'sum-bus-restored.wav')
+      const receiverKey = 'sum:drum/effect/CLAPTestEffect/0'
+      const unprefixedDecoyKey = 'drum/effect/CLAPTestEffect/0'
+      const wrongKindDecoyKey = 'aux:drum/effect/CLAPTestEffect/0'
+
+      const dslLines = [
+        'var global = init GLOBAL',
+        'global.tempo(120)',
+        'global.beat(4 by 4)',
+        `global.sum("drum").effect(${JSON.stringify(CLAP_TEST_EFFECT_PATH)})`,
+        'var busStateSource = init global.seq',
+        `busStateSource.audio(${JSON.stringify(sourcePath)}).chop(1).output("drum")`,
+        'busStateSource.play(1, 1, 1, 1)',
+        'global.start()',
+        'LOOP(busStateSource)',
+        'busStateSource.stop()',
+        'global.stop()',
+      ]
+      fs.writeFileSync(dslPath, dslLines.join('\n') + '\n')
+      const openDsl = await activeClient.call('open_file', { path: dslPath })
+      expect(openDsl.isError, openDsl.text).toBe(false)
+
+      const runDslLines = async (startLine: number, endLine: number): Promise<void> => {
+        const selected = await activeClient.call('set_selection', {
+          start_line: startLine,
+          start_char: 1,
+          end_line: endLine,
+          end_char: 999_999,
+        })
+        expect(selected.isError, selected.text).toBe(false)
+        const run = await activeClient.call('run_selection')
+        expect(run.isError, run.text).toBe(false)
+      }
+      const startCapture = async (wavPath: string, label: string): Promise<void> => {
+        const started = await activeClient.call('start_engine', { capture_wav: wavPath })
+        expect(started.isError, started.text).toBe(false)
+        await waitForEngine(true, 15_000, label)
+        await sleep(2500)
+      }
+      const stopTransportThroughDsl = async (label: string): Promise<void> => {
+        const before = (await activeClient.call('get_log', { lines: 500 })).text
+        const stopsBefore = (before.match(/(?:✅ Global stopped|⏹ Global)/g) ?? []).length
+        await runDslLines(10, 11)
+        await waitUntil(
+          async () => {
+            const log = (await activeClient.call('get_log', { lines: 500 })).text
+            return (log.match(/(?:✅ Global stopped|⏹ Global)/g) ?? []).length > stopsBefore
+          },
+          { intervalMs: 200, timeoutMs: 5_000, label },
+        )
+      }
+      const stopEngine = async (label: string): Promise<void> => {
+        const stopped = await activeClient.call('stop_engine')
+        expect(stopped.isError, stopped.text).toBe(false)
+        await waitForEngine(false, 15_000, label)
+        await sleep(1500)
+      }
+      const readManifestStates = (): Record<string, string> => {
+        if (!fs.existsSync(projectFile)) return {}
+        const manifest = parse(fs.readFileSync(projectFile, 'utf8')) as {
+          states?: Record<string, string>
+        }
+        return { ...(manifest.states ?? {}) }
+      }
+      const writeManifestStates = (states: Record<string, string>): void => {
+        fs.writeFileSync(projectFile, stringify({ version: 1, states }))
+      }
+      const writeEffectState = (relativePath: string, gain: number): void => {
+        const absolutePath = path.resolve(root, relativePath)
+        fs.mkdirSync(path.dirname(absolutePath), { recursive: true })
+        const bytes = Buffer.alloc(12)
+        bytes.writeUInt32LE(0x4f52_4531, 0)
+        bytes.writeDoubleLE(gain, 4)
+        fs.writeFileSync(absolutePath, bytes)
+      }
+
+      // Baseline oracle: the same DSL and source through the effect's default
+      // gain (0.5), captured before any receiver-specific state is registered.
+      const baselineStates = readManifestStates()
+      delete baselineStates[receiverKey]
+      delete baselineStates[unprefixedDecoyKey]
+      delete baselineStates[wrongKindDecoyKey]
+      writeManifestStates(baselineStates)
+      await startCapture(defaultWav, 'sum-bus default capture engine running')
+      await runDslLines(1, 9)
+      await sleep(4000)
+      await stopTransportThroughDsl('sum-bus default transport stopped')
+      await stopEngine('sum-bus default capture engine stopped')
+
+      // Bootstrap the non-default 0.125 gain plus two measurable decoys. The
+      // correct prefixed key is removed after load below, so only state recording
+      // can make the subsequent restart reproduce this sound.
+      const correctRelativePath = 'states/e2e-sum-gain-0125.state'
+      const unprefixedDecoyPath = 'states/e2e-unprefixed-gain-0900.state'
+      const wrongKindDecoyPath = 'states/e2e-aux-gain-0800.state'
+      writeEffectState(correctRelativePath, 0.125)
+      writeEffectState(unprefixedDecoyPath, 0.9)
+      writeEffectState(wrongKindDecoyPath, 0.8)
+      writeManifestStates({
+        ...readManifestStates(),
+        [receiverKey]: correctRelativePath,
+        [unprefixedDecoyKey]: unprefixedDecoyPath,
+        [wrongKindDecoyKey]: wrongKindDecoyPath,
+      })
+
+      // 1. .orbs の sum bus insert を、ユーザーと同じ run_selection で評価する。
+      await startCapture(changedWav, 'sum-bus changed capture engine running')
+      await runDslLines(1, 9)
+      await sleep(4000)
+
+      // 2. 正しい receiver key から非既定 gain が適用済み。bootstrap key を消してから
+      // DSL で停止し、保存経路だけが restart 用の登記を作れる状態にする。
+      const loadedStates = readManifestStates()
+      delete loadedStates[receiverKey]
+      writeManifestStates(loadedStates)
+      await stopTransportThroughDsl('sum-bus changed transport stopped before state save')
+
+      // 3. 自動記録される。
+      // INTERIM(#577): 自動記録が未実装のため明示保存で代替。#577 完了時にこの行を削除すると
+      // そのまま受け入れテストになる。
+      await activeClient.call('save_plugin_state', { sequence: 'sum:drum', index: 1 })
+      const registeredStates = readManifestStates()
+      expect(registeredStates[receiverKey]).toMatch(/^states\//)
+      expect(registeredStates[unprefixedDecoyKey]).toBe(unprefixedDecoyPath)
+      expect(registeredStates[wrongKindDecoyKey]).toBe(wrongKindDecoyPath)
+
+      // 4. エンジンを再起動する。
+      await stopEngine('sum-bus changed capture engine stopped')
+      await startCapture(restoredWav, 'sum-bus restored capture engine running')
+
+      // 5. 同じ .orbs を run_selection で再評価し、capture で音の一致を確認する。
+      await runDslLines(1, 9)
+      await sleep(4000)
+      await stopTransportThroughDsl('sum-bus restored transport stopped')
+      await stopEngine('sum-bus restored capture engine stopped')
+
+      const defaultAnalysis = analyzeWavBuffer(fs.readFileSync(defaultWav))
+      const changedAnalysis = analyzeWavBuffer(fs.readFileSync(changedWav))
+      const restoredAnalysis = analyzeWavBuffer(fs.readFileSync(restoredWav))
+      expect(defaultAnalysis.soundDetected, JSON.stringify(defaultAnalysis)).toBe(true)
+      expect(changedAnalysis.soundDetected, JSON.stringify(changedAnalysis)).toBe(true)
+      expect(restoredAnalysis.soundDetected, JSON.stringify(restoredAnalysis)).toBe(true)
+
+      const peakRatioFromDefault = changedAnalysis.peak / defaultAnalysis.peak
+      const rmsRatioFromDefault = changedAnalysis.rms / defaultAnalysis.rms
+      expect(
+        peakRatioFromDefault,
+        `non-default peak ratio ${peakRatioFromDefault} must reflect gain 0.125 / default 0.5`,
+      ).toBeGreaterThan(0.15)
+      expect(peakRatioFromDefault).toBeLessThan(0.35)
+      expect(
+        rmsRatioFromDefault,
+        `non-default RMS ratio ${rmsRatioFromDefault} must reflect gain 0.125 / default 0.5`,
+      ).toBeGreaterThan(0.12)
+      expect(rmsRatioFromDefault).toBeLessThan(0.4)
+
+      const restoredPeakDelta =
+        Math.abs(restoredAnalysis.peak - changedAnalysis.peak) / changedAnalysis.peak
+      const restoredRmsDelta =
+        Math.abs(restoredAnalysis.rms - changedAnalysis.rms) / changedAnalysis.rms
+      expect(
+        restoredPeakDelta,
+        `restored peak ${restoredAnalysis.peak} must match pre-restart ${changedAnalysis.peak}`,
+      ).toBeLessThanOrEqual(0.08)
+      expect(
+        restoredRmsDelta,
+        `restored RMS ${restoredAnalysis.rms} must match pre-restart ${changedAnalysis.rms}`,
+      ).toBeLessThanOrEqual(0.15)
     },
     TEST_TIMEOUT_MS,
   )

--- a/tests/interpreter/signal-chain-dispatch.spec.ts
+++ b/tests/interpreter/signal-chain-dispatch.spec.ts
@@ -743,6 +743,8 @@ describe('Signal Chain runtime resolver dispatch (S2)', () => {
       'resolvePluginStateTarget',
       // private だが Object.getOwnPropertyNames には現れる（他の private 同様に除外）。
       'pluginIndexError',
+      // resolvePluginStateTarget の bus 分岐（master / sum: / aux:）を担う private ヘルパー。
+      'pluginStateBusChain',
       // MIDI, chord, pattern, and mode registries.
       'getMidiManager',
       'importChords',

--- a/tests/vscode-extension/mcp-server.spec.ts
+++ b/tests/vscode-extension/mcp-server.spec.ts
@@ -430,16 +430,16 @@ describe('OrbitScore MCP server (real HTTP, stub handlers)', () => {
     expect(call?.args[0]).toBe(code)
   })
 
-  it('registers save_plugin_state with (sequence,index) and returns the saved project result', async () => {
+  it('keeps the compatible sequence field and passes a prefixed receiver through unchanged', async () => {
     const saved = {
-      identityKey: 'lead/instrument/Synth/0',
-      path: '/songs/states/lead.state',
+      identityKey: 'sum:drum/effect/GlueComp/0',
+      path: '/songs/states/sum-drum.state',
       bytesWritten: 12,
     }
     const { handlers } = createStubHandlers({
       savePluginState: (sequence, index) => {
-        expect(sequence).toBe('lead one')
-        expect(index).toBe(0)
+        expect(sequence).toBe('sum:drum')
+        expect(index).toBe(1)
         return { ok: true, saved }
       },
     })
@@ -448,12 +448,17 @@ describe('OrbitScore MCP server (real HTTP, stub handlers)', () => {
     await client.connect()
 
     const listed = await client.toolsList()
-    const listBody = listed.json as JsonRpcOk<{ tools: Array<{ name: string }> }>
+    const listBody = listed.json as JsonRpcOk<{
+      tools: Array<{ name: string; description?: string }>
+    }>
     expect(listBody.result.tools.map((tool) => tool.name)).toContain('save_plugin_state')
+    expect(
+      listBody.result.tools.find((tool) => tool.name === 'save_plugin_state')?.description,
+    ).toContain('sum:<name>')
 
     const response = await client.toolsCall('save_plugin_state', {
-      sequence: 'lead one',
-      index: 0,
+      sequence: 'sum:drum',
+      index: 1,
     })
     const body = response.json as JsonRpcOk<ToolCallResult>
     expect(body.result.isError).toBeFalsy()


### PR DESCRIPTION
Closes #564

## 何が変わるか

**`global.sum("drum").effect("Pro-Q 4")` の音色が、再起動しても戻ってくるようになります。**

| レシーバ | before | after |
|---|---|---|
| sequence / master | ✅ 保存できる | ✅ |
| **sum / aux** | ❌ **`not supported` エラー** | ✅ **保存・復元できる** |

DSL 上は挿せて音も出るのに、`resolvePluginStateTarget` が `master` だけを特別扱いしており、
sum/aux 名に到達できませんでした。**手動でも保存できない**状態です。

## 接頭辞方式

```
save_plugin_state("sum:drum", 1)     // sum バスの drum
save_plugin_state("aux:reverb", 1)   // aux バスの reverb
save_plugin_state("drum", 1)         // 従来どおり sequence（後方互換）
```

**DSL の見た目は変わりません。** `savePluginState` は DSL に存在せず、露出面は
MCP tool と REPL メタ行のみです。`.orbs` に書くのは従来どおり
`global.sum("drum").effect("Pro-Q 4")` です。

採用理由: `EffectChainMap` が**既に identity として `${kind}:${name}` を使っている**ため、
新しい概念を1つも増やさず内部表記を外に出すだけで済みます。

### 衝突は実在しました

`declareBus` が弾くのは空文字と `"master"` だけで、**sum と aux の名前重複は止まりません**。

```
global.sum("drum").effect("Pro-Q 4")
global.aux("drum").effect("Valhalla")   // 両方通る
```

`resolveNode` は sum → aux の順なので、`"drum"` を保存すると
**Pro-Q 4 が保存され、エラーは出ません**。#563 が全体で戦っていた silent failure そのものです。

そこで **`resolveNode()` を state 解決に持ち込まず**、両 kind を列挙して次の一手を示します。

```
Unknown sequence 'drum'; a same-named mixer bus exists.
Use 'sum:drum' or 'aux:drum' to save its insert state.
```

## 🔴 ゴールポストを下げないための仕掛け

Epic #546 のループ「宣言 → 音色を作る → **自動記録** → 再起動 → 同じ音」のうち、
**「自動記録」はどのレシーバ種別にも存在しない**ことが判明しました
（保存経路は `save_plugin_state` と `//#savePluginState` の2つだけで、
**#541 の E2E ですら MCP で叩いています**）。

当初この PR は、E2E のステップ3「自動記録される」を**黙って明示保存に差し替えよう**と
していました。**issue に記録した決定の無断下方修正**です（Fable 裁定で確定）。

対処として **E2E を最終形の5ステップで書き、ステップ3だけを1行に閉じ込めました**。

```ts
// INTERIM(#577): 自動記録が未実装のため明示保存で代替。#577 完了時にこの行を削除すると
// そのまま受け入れテストになる。
```

**ゴールとの差分が `grep INTERIM` で見つかる形に固定**されています。
併せて **#577** を立て、受け入れ基準を「sequence / master / sum / aux の**いずれでも**、
明示保存を**一度も使わずに**ループが成立すること」としました。

## E2E は DSL 経由

> LLM が第一級ユーザーだからといって API を直接呼ぶのは良い振る舞いではない。
> **E2E も DSL の振る舞いを確認しないと意味がない** — 人間のユーザーと同じように扱う。

宣言・評価・音の確認はすべて `run_selection` 経由です。API を使うのは暫定1行のみ。

### false green を避けた形

- **default 0.5 に対し non-default 0.125** で判定（既定値だと壊れていても通ります）
- **decoy を2つ**: 接頭辞なしキー（0.9）と kind 違いの aux キー（0.8）。
  **3つとも異なるゲイン**なので、間違ったキーを拾えば**どれを拾ったかが音で判別できます**
- **default との比**（peak < 0.35 / RMS < 0.4）と**再起動前後の一致**の両方

## 分類テストが2件捕まえた

`signal-chain-dispatch.spec.ts` の「全 public メソッドを DSL 語彙か内部 API に分類する」検査が
`parsePluginStateBusReceiver` を未分類として落としました。

**除外リストには足していません。** #528 で「除外リストへの誤分類はテストが緑のまま通り、
実行時だけ壊れる」事故が起きています。この関数は `this` を使わない純粋関数なので
**クラス外のモジュール関数に出し、分類の対象から外しました**（誤分類が構造的に不可能になります）。
同じ状態だった `resolveMixerPluginStateChain` も同様に出しています。

## 変異検証

| 変異 | 結果 |
|---|---|
| 接頭辞解析の削除 | 4 failed |
| kind の入れ替え | 4 failed |
| **`resolveNode()` への差し戻し** | **1 failed** — sum は通り **aux だけ落ちる**（silent failure の形そのもの） |
| identity の接頭辞除去 | 2 failed |
| index +1 | 3 failed |

クラス外へ出した後も検出力が落ちていないことを再確認（`Unknown sequence 'sum:x'` で 5 failed）。

## 検証（すべて sandbox 外で実行）

- `cargo test --workspace --locked`: **410 passed / 0 failed**（**Rust は1行も触っていません**）
- outproc-effect 143 / outproc-instrument 118 / both 186（すべて 0 failed）
- `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings`: pass
- `npm test`: **1811 passed / 32 skipped / 0 failed**（1806 から **+5**）

### マージ前ゲート: ビルド + 実機 E2E

```
✓ restores a non-default sum-bus insert across restart through its prefixed receiver identity  24.8s
✓ restores an MCP-saved non-default instrument state across an engine restart with the same measured pitch
✓ rescans catalog v2 through MCP, reports a broken bundle, and preserves a known CLAP fixture
✓ drives real OrbitStudio end-to-end: diagnostics-on-open, run_selection, live edit, capture verification
Test Files 1 passed / Tests 4 passed
```

**E2E 実行後の残留プロセスも 0**（OrbitStudio / repl / daemon）。

## 残ること

**この PR は #564 を閉じますが、ループの「自動記録」は #577 に残ります。**
sum/aux が sequence と同じ土俵に乗っただけで、**自動記録はどのレシーバでも未実装**です。
