### PR TITLE
feat(rust): run plugin children on an NSApplication runloop (#474 P0+P1)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -41,10 +41,10 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 - **新 crate `orbit-child-runtime`**: `run_child(name, service_main, audio)` —
   main = NSApplication runloop（**Accessory**・拒否時 fail-loud）+ NSTimer 20ms tick で
   mailbox/ParentWatch/QUIT を servicing、audio = 専用スレッド（QoS user-interactive）
-- **processor の main/audio 分割**: CLAP は `split() -> (XxxAudio, XxxMain)`
+- **processor の main/audio 分割**: CLAP は `split() -> (XxxAudio, ClapPluginMain)`
   （audio 半分 = `StartedPluginAudioProcessor`・**clack が Send を公式サポート**）。
   VST3 は monolith を `Vst3EffectAudio` / `Vst3InstrumentAudio` + 共有 `Vst3PluginMain` へ再構成
-- teardown 契約: audio スレッドで stop_processing → join → main 半分 drop
+- teardown 契約: audio 半分の `Drop` で stop_processing → join → main 半分 drop
   （**唯一の Arc 所有者として home スレッドで deactivate/destroy**）
 - 依存追加は **`objc2-app-kit` 1 crate のみ**（`objc2` 本体は clack-host 経由で既に graph に居た）
 
@@ -78,11 +78,47 @@ P1（修正前）:                   507.70us margin 1.3x    🔴
 `postEvent_atStart(..., true)` で post**（Cocoa の定石）。
 
 ```
-修正後: [32f] 6.32us margin 105.6x / [64f] 100.7x / [128f] 133.4x   ✅
-        `kill にフォールバック` の行: 0 件                          ✅
+修正後（32f を4回実測）: 6.80 / 12.88 / 13.12 / 13.36us
+                       → margin 98.1 / 51.7 / 50.8 / 49.9x   ✅（要求 >10x）
+        `kill にフォールバック` の行: 0 件                     ✅
 ```
 
+🔴 **約2倍のばらつきがある。** これは `/simplify` の Efficiency が特定した
+**AppKit 起動の固定コスト（約 34ms/spawn）が 4000 blocks で割られて per-block に混入**する
+ためで、**per-block の steady-state ではない**（32f と 64f がほぼ同値に張り付くのが signature）。
+**最悪でも margin 49.9x で要求 10x を大きく超える**のでゲートの合否は揺らがないが、
+**単発測定を代表値として扱わない**（初出時に 6.32us を代表値として記録したのは誤り）。
+
 **2つ目は診断が自ら挙げた反証条件**（消えなければ仮説が誤り）。**予測どおり消えた。**
+
+#### 🔴 AppKit 初期化の固定コストは残る（本PRでは修正せず follow-up）
+
+review 時の同一マシン A/B では、修正後も frame 数に比例しない固定コストが残った:
+
+| frames | main（対照） | PR #589 |
+|---|---:|---:|
+| 32f | 3.87〜3.97us | **12.49us** |
+| 64f | 5.86〜5.87us | **12.49us** |
+| 128f | 9.80〜10.33us | **16.19〜21.15us** |
+
+32f / 64f が同じ値に張り付く形から、audio hot loop の per-block 退行ではなく、
+4000 blocks で割られた **約34ms / child起動**の固定コストと読める。実際、PR branch の
+child は spawn ごとに次を stderr へ出し、main 対照では一度も出なかった:
+
+```text
+Connection Invalid error for service com.apple.hiservices-xpcservice.
+Error received in message reply handler: Connection invalid
+```
+
+`NSApplication.sharedApplication()` を Info.plist / bundle context のないコマンドライン
+バイナリから呼んだため、WindowServer / HIServices の XPC handshake が失敗している可能性がある。
+ただし計測環境は GUI login session を持たず、**実 daemon からログイン済みdesktop上で spawn
+した場合も同じかは未検証**。#573 の respawn backoff 直後であり、respawn ごとに約30〜34ms
+を再度払う点は無視しない。
+
+本PRでは AppKit 初期化を変更しない。follow-up で Info.plist / `LSUIElement` / bundle context を
+切り分け、最小bundle情報でXPC失敗を正常化または抑制できるかを調べる。#474 P3で実際にwindowを
+開く時にも32f / 64f / 128fを再測定する（UI利用によりXPCが正常化して消える可能性がある）。
 
 #### 検証（すべて main が sandbox 外で実行）
 
@@ -116,10 +152,67 @@ owner 指示で実装を Fable → Codex に切り替えた際、main が**停�
 → **切り替え時は `ps` でプロセス数ゼロを実測してから次を起動する。**
 **ack は自己申告。信用の順は「プロセスの消滅」＞「ack」。**
 
+#### `/simplify`（4観点）— 4つの横断ポリシーに集約して一括適用
+
+**指摘単位のローカルパッチはしない**（PR #585 でそれをやって欠陥を2つ作った）。
+**塊の中の非対称性を問う**。
+
+| ポリシー | 内容 |
+|---|---|
+| **1（最重要）** | **VST3 composite 型に明示 `impl Drop` を戻す** |
+| **2** | **teardown の表現を `Drop` 1本に統一**（4 child で揃える） |
+| **3** | `ClapPluginMain` へ統合 + テストヘルパーを `tests/common/mod.rs` へ |
+| **4** | AppKit 初期化コストは本 PR では直さず**記録して follow-up** |
+
+##### 🔴 ポリシー1: PR 前の決定を無言で覆していた
+
+`Vst3EffectProcessor` / `Vst3InstrumentProcessor`（composite・**`offline.rs` の全テストが使う経路**）が、
+teardown 順序を**フィールド宣言順の暗黙依存**に戻していた。
+
+**PR 前のコードは同じ問題に一度答えを出していた**:
+
+> Shutdown call order ... is enforced by the hand-written `Drop::drop` body below via
+> explicit `.take()` calls, **not by field declaration order**
+
+並べ替えてもコンパイラは警告せず、**`terminate()` が `setProcessing(0)` より先に呼ばれる**
+（サードパーティ VST3 でクラッシュ / 未 deactivate リークを誘発しうるホスト契約違反）。
+ガードはコメントだけで、テストも static assertion も無かった。
+
+**対比**: 同じ PR の `split()` 後の経路は、**借用チェッカーが型システムで強制**している
+（`effect_main` を借用させ、`run_child` が必ず join してから返る）。
+**構造で守る例とコメントで守る例が同居していた。**
+
+##### 🔴 ポリシー4: 1.5倍レイテンシの正体は audio hot loop ではなかった（A/B 実測）
+
+| frames | main（対照） | PR #589 |
+|---|---|---|
+| 32f | 3.87〜3.97us | **12.49us** |
+| 64f | 5.86〜5.87us | **12.49us** |
+| 128f | 9.80〜10.33us | 16.19〜21.15us |
+
+**main は frame 数に比例して伸びるのに、PR は 32f と 64f が同一値に張り付く**
+= per-block ではなく**固定コスト**（約 **34ms / プロセス起動**）。
+
+**決定的な傍証**: PR ブランチの child は spawn のたびに
+`Connection Invalid error for service com.apple.hiservices-xpcservice` を stderr へ出す
+（**main では一度も出ない**）。**Info.plist を持たないコマンドラインバイナリから
+`NSApplication.sharedApplication()` を呼んだ**ため。
+
+**audio スレッド自体はむしろ軽くなっている** — 旧実装は mailbox・ParentWatch のチェックを
+**audio の busy-spin で毎秒数百万回**やっていたのが 20ms tick へ移った。
+純増は `stop_audio` の Relaxed 1 load のみ。
+
+🔴 **#573（respawn backoff）の直後なので無視できない** — **respawn ごとに約 30ms を払う**。
+→ **[#590](https://github.com/signalcompose/orbitscore/issues/590)**（XPC 失敗の切り分け: Info.plist 不在 / `LSUIElement` 未設定 / bundle context 不在）。
+
 #### 申し送り
 
+- 🔴 **AppKit 初期化コスト 約 34ms/spawn**（上記ポリシー4）。**[#590](https://github.com/signalcompose/orbitscore/issues/590)** で切り分ける
 - **NSTimer が default runloop mode のみ** → **P3 で NSWindow のドラッグ/リサイズ中に
   mailbox servicing が止まる**。`NSRunLoopCommonModes` へ（P1 ではウィンドウが無いので影響なし）
+- 4 child の `service_main` closure 共通化は本PRでは見送る。共通helperの置き場は
+  `orbit-audio-sandbox` になる一方、`orbit-child-runtime` はAppKit/thread primitiveに限定して
+  sandboxへ依存しない設計であり、P2以降でchild固有の分岐も増え得るため、follow-upで再評価する
 - CLAP `call_on_main_thread_callback` の pump は未実装（既存の documented gap・P3 で必要になりうる）
 - **P1 完了により UIH.3 の「停止中のみ SAVE_STATE」MUST が外れ、#577 PR-B が本来形
   （演奏中保存）で実装可能**になった

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -208,8 +208,14 @@ teardown 順序を**フィールド宣言順の暗黙依存**に戻していた�
 #### 申し送り
 
 - 🔴 **AppKit 初期化コスト 約 34ms/spawn**（上記ポリシー4）。**[#590](https://github.com/signalcompose/orbitscore/issues/590)** で切り分ける
-- **NSTimer が default runloop mode のみ** → **P3 で NSWindow のドラッグ/リサイズ中に
-  mailbox servicing が止まる**。`NSRunLoopCommonModes` へ（P1 ではウィンドウが無いので影響なし）
+- ~~NSTimer が default runloop mode のみ → P3 で `NSRunLoopCommonModes` へ~~ →
+  🔴 **これは main の誤記だった。訂正する。**
+  **初回コミット `0dbd31b` の時点から `NSRunLoop::mainRunLoop().addTimer_forMode(&timer,
+  NSRunLoopCommonModes)`（`orbit-child-runtime/src/lib.rs:284`）で登録済み**であり、
+  **ウィンドウのドラッグ/リサイズ中も mailbox servicing は止まらない。**
+  設計時の申し送りを**実装で裏取りせずに転記した**もので、
+  そのままなら **P3 の担当者に存在しない作業項目**を残していた
+  （`/code:pr-review-team` の code-reviewer が発見）
 - 4 child の `service_main` closure 共通化は本PRでは見送る。共通helperの置き場は
   `orbit-audio-sandbox` になる一方、`orbit-child-runtime` はAppKit/thread primitiveに限定して
   sandboxへ依存しない設計であり、P2以降でchild固有の分岐も増え得るため、follow-upで再評価する

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,115 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.335 feat(rust): #474 P0+P1 — child を NSApplication runloop へ。graceful teardown を復活させた (Jul 30, 2026)
+
+**Date**: 2026-07-30
+**Issue**: #474（P0 + P1）/ **Branch**: `474-plugin-ui-open`
+**Status**: ✅ P1 ゲート全通過（レイテンシ margin 105.6x / 実機4経路 / 演奏中 SAVE_STATE）
+
+**#474 の価値は owner 裁定で「人間が触れるようにプラグインを開いてあげること」に絞られた。**
+つまみ→音の変化はプラグイン内部の話で検査対象外（音が通っていれば自明）。
+これにより computer-use のティア制約・オラクル GUI のノブ・座標依存の脆さがすべて消えた。
+
+#### P0: UIH.9 の前提是正2件は解消済みだった
+
+- `orbit-vst3-effect-child` のバンドル欠落 → **#548 で解消済み**
+  （`copy-daemon-bin.sh` が4 child を rebuild+copy・`release.yml` の post-package gate・
+  `tests/vscode-extension/bundled-child-binaries.spec.ts` が台帳照合と gate 実走まで実施）
+- CLAP の `--state` 配線 → **解消済み**（`orbit-clap-effect-child/src/main.rs:79-90`）
+
+→ spec の記述だけが stale だったので実態に更新。**新規テストは不要**。
+
+#### P1: 実行モデル変更
+
+- **新 crate `orbit-child-runtime`**: `run_child(name, service_main, audio)` —
+  main = NSApplication runloop（**Accessory**・拒否時 fail-loud）+ NSTimer 20ms tick で
+  mailbox/ParentWatch/QUIT を servicing、audio = 専用スレッド（QoS user-interactive）
+- **processor の main/audio 分割**: CLAP は `split() -> (XxxAudio, XxxMain)`
+  （audio 半分 = `StartedPluginAudioProcessor`・**clack が Send を公式サポート**）。
+  VST3 は monolith を `Vst3EffectAudio` / `Vst3InstrumentAudio` + 共有 `Vst3PluginMain` へ再構成
+- teardown 契約: audio スレッドで stop_processing → join → main 半分 drop
+  （**唯一の Arc 所有者として home スレッドで deactivate/destroy**）
+- 依存追加は **`objc2-app-kit` 1 crate のみ**（`objc2` 本体は clack-host 経由で既に graph に居た）
+
+#### 🔴 レイテンシゲートが割れ、UIH.7 の停止条件が発動した
+
+```
+main ea692a0（同一マシン対照）: 4.31us   margin 154.6x  ✅
+P1（修正前）:                   507.70us margin 1.3x    🔴
+```
+
+**約118倍の退行。ユニットは 315 passed で全緑。実機ゲートだけが捕まえた。**
+
+#### 507us の正体は会計アーティファクトだった — しかし真因は production の欠陥
+
+- `measure_per_block_us` は `render_through_child_sync` の**呼び出し全体**を計測し、
+  その内部（`offline.rs:186` の `drop(guard)`）に **child teardown** が含まれる
+- child が graceful に終わらないと **`REAP_TIMEOUT = 2s`**（`child.rs:23`）待って SIGKILL
+- **507.70us × 4000 blocks = 2.0308s ≈ 2.000s + 実処理 30.8ms** → **per-block は 5〜8us**
+  （main の 4.31us と同オーダー・**audio 経路は無傷**）
+
+🔴 **真因**: `orbit-child-runtime` の **NSTimer コールバックから呼ぶ `NSApplication.stop(None)` は
+`-[NSApplication run]` を抜けさせない**。`stop` は「**現在の NSEvent の処理が完了した時点で**
+抜ける」フラグであり、**timer 発火は NSEvent ではない**。headless の Accessory child は
+イベントを一切受け取らないので、**検査点に永遠に到達しない**。
+
+**これはテスト都合ではない。** daemon の通常 teardown も全 child が「2秒待ち → SIGKILL」に落ち、
+**SIGKILL は main 側の plugin teardown（state flush を含む）を吹き飛ばす**。
+つまり **P1 は #585 が6ラウンドかけて守った「音色を失わない」を静かに壊していた。**
+
+**修正**: `app.stop(None)` の直後に **ダミーの `NSEventTypeApplicationDefined` を
+`postEvent_atStart(..., true)` で post**（Cocoa の定石）。
+
+```
+修正後: [32f] 6.32us margin 105.6x / [64f] 100.7x / [128f] 133.4x   ✅
+        `kill にフォールバック` の行: 0 件                          ✅
+```
+
+**2つ目は診断が自ら挙げた反証条件**（消えなければ仮説が誤り）。**予測どおり消えた。**
+
+#### 検証（すべて main が sandbox 外で実行）
+
+| ゲート | 結果 |
+|---|---|
+| rust workspace | ✅ FAILED 0 |
+| TS 全 suite | ✅ 1836 passed / 34 skipped / 0 failed |
+| lint / `cargo fmt` / `cargo deny` | ✅ pass |
+| **レイテンシ（UIH.7）** | ✅ **margin 105.6x**（修正前 1.3x） |
+| **演奏中 SAVE_STATE** | ✅ 1 passed（**P1 の本来の狙い**） |
+| **実機4経路** | ✅ effect 4+4 / instrument 3+3 |
+
+#### 🔴 「0 passed の exit=0」を緑と読みかけた
+
+instrument の gated は feature が **`outproc-instrument`** で、effect 用の `outproc-effect` を
+使い回したため**テストが1件も走らず、それでも `exit=0`** が返った。
+**件数を見ていなければ「4経路 drops==0 を確認」と報告していた。**
+→ **`test result` の件数を必ず読む。** exit code は「走ったこと」を意味しない。
+
+#### 🔴 同一 working tree の並行編集が起きた（再発防止を記録）
+
+owner 指示で実装を Fable → Codex に切り替えた際、main が**停止指示の送信を停止と同一視**し、
+**ack を待たずに Codex を起動**した。Fable は停止指示3通の間も作業を続け、
+**約10分間、2エージェントが同じツリーを編集**した。
+
+実際に起きた危険（今回は実害なし・照合済み）:
+- Fable の変異検証が `orbit-vst3-instrument-child/src/main.rs` を自分のバックアップから復元し、
+  **その間の Codex の編集を巻き戻しうる状態**だった（Codex の最終書き込みが後で助かった）
+- Fable の `cargo test --workspace` が Codex のビルドと衝突しうる状態だった（main が kill）
+
+→ **切り替え時は `ps` でプロセス数ゼロを実測してから次を起動する。**
+**ack は自己申告。信用の順は「プロセスの消滅」＞「ack」。**
+
+#### 申し送り
+
+- **NSTimer が default runloop mode のみ** → **P3 で NSWindow のドラッグ/リサイズ中に
+  mailbox servicing が止まる**。`NSRunLoopCommonModes` へ（P1 ではウィンドウが無いので影響なし）
+- CLAP `call_on_main_thread_callback` の pump は未実装（既存の documented gap・P3 で必要になりうる）
+- **P1 完了により UIH.3 の「停止中のみ SAVE_STATE」MUST が外れ、#577 PR-B が本来形
+  （演奏中保存）で実装可能**になった
+
+---
+
 ### 6.334 fix(docs/test): #587 は測定盲点と確定 — aux は信号を運んでいる。記録を訂正し sum 発 send をテストで pin (Jul 30, 2026)
 
 **Date**: 2026-07-30

--- a/docs/specs-v2/PLUGIN_UI_HOSTING_SPEC_v1.md
+++ b/docs/specs-v2/PLUGIN_UI_HOSTING_SPEC_v1.md
@@ -250,9 +250,18 @@ LOAD_STATE:
   4 child とも audio slot 処理は専用 audio スレッド、`SAVE_STATE` を含む command mailbox は
   `NSApplication` main runloop のタイマーで処理する。サイドカーの書き込み・`fsync` が main
   スレッドをブロックしても audio slot の前進を止めない構造になった。
-  **ただし、従来の「host は演奏停止中にのみ `SAVE_STATE` を発行すること」という暫定 MUST は、
-  #474 P1 の実機 gated（4経路の音・capture drops==0・演奏中 SAVE_STATE・roundtrip）が green に
-  なるまで release gate として維持する。実測 green 後にこの MUST を解除し、演奏中の発行を許可する。**
+  #474 P1 の実機 gated は green:
+  - レイテンシは4回実測の最悪値でも要求（margin >10x）に対して **margin 49.9x**、
+    `kill にフォールバック` は0件
+  - 実機4経路は **effect 4+4 / instrument 3+3**、`capture drops == 0`
+  - 演奏中 `SAVE_STATE` は `save_during_playback.rs` が **1 passed**、state roundtrip も green
+
+  これにより、従来の「host は演奏停止中にのみ `SAVE_STATE` を発行すること」という
+  **暫定 MUST を解除し、演奏中の発行を許可する**。
+  規格上も VST3 `IComponent::getState` は
+  **`[UI-thread & (Initialized | Connected | Setup Done | Activated | Processing)]`**
+  （VST3 SDK `ivstcomponent.h:203`）であり、Processing 中の main/UI スレッドからの state
+  取得が明示的に許可されている。これを演奏中保存の VST3 規格根拠とする。
   host 側発行経路は `CommandMailboxHost` として実装済み（#562）。watchdog respawn は
   `CommandMailboxHost::reset_after_child_exit` を effect / instrument の両 supervisor と
   初回 attach の3経路から呼ぶ

--- a/docs/specs-v2/PLUGIN_UI_HOSTING_SPEC_v1.md
+++ b/docs/specs-v2/PLUGIN_UI_HOSTING_SPEC_v1.md
@@ -246,12 +246,13 @@ LOAD_STATE:
   child 内では既にプラグインの任意コードが動いているため、パス検証に追加の防御価値はない）
 - 書き込み失敗・サイズ 0・読み取り不能はすべて `cmd_result` の失敗として返す。
   **サイズ 0 の state を「成功」として登記しない**
-- 🔴 **audio 専用スレッドへの分離（UIH.1 の目標状態）が完了するまで、host は演奏停止中にのみ
-  `SAVE_STATE` を発行すること（MUST）。** 現状 child のメインループは audio 処理とコマンド処理を
-  同一スレッドで直列に回しており、サイドカーの `fsync` は数 ms〜数十 ms ブロックしうる。
-  演奏中に発行すると、そのブロック分だけ次の audio slot が遅延し **dropout を生む**
-  （小バッファ 64/32 サンプルは本プロジェクトの性能ゴールであり、この遅延は許容できない）。
-  分離が完了したらこの制約は外れる。
+- 🟡 **audio 専用スレッドへの分離（UIH.1 の目標状態）は #474 P1 で実装済み。**
+  4 child とも audio slot 処理は専用 audio スレッド、`SAVE_STATE` を含む command mailbox は
+  `NSApplication` main runloop のタイマーで処理する。サイドカーの書き込み・`fsync` が main
+  スレッドをブロックしても audio slot の前進を止めない構造になった。
+  **ただし、従来の「host は演奏停止中にのみ `SAVE_STATE` を発行すること」という暫定 MUST は、
+  #474 P1 の実機 gated（4経路の音・capture drops==0・演奏中 SAVE_STATE・roundtrip）が green に
+  なるまで release gate として維持する。実測 green 後にこの MUST を解除し、演奏中の発行を許可する。**
   host 側発行経路は `CommandMailboxHost` として実装済み（#562）。watchdog respawn は
   `CommandMailboxHost::reset_after_child_exit` を effect / instrument の両 supervisor と
   初回 attach の3経路から呼ぶ
@@ -566,24 +567,25 @@ crash ループ時にウィンドウが繰り返し復活すると作業文脈�
 - 判定は解析で行い人間を介在させない。**computer-use は受け入れ E2E の主経路にしない**
   （CAP.7）
 
-## UIH.9 前提となる是正
+## UIH.9 前提となる是正 — ✅ 両項目とも解消済み（2026-07-30 実測確認・#474 P0）
 
-本仕様の実装前に、以下が満たされていること:
+本仕様の実装前提として要求していた是正2件は、**いずれも解消済みであることを実測確認した**
+（確認対象 = main `ea692a0`）。経緯の記録として原文の要旨を残す:
 
-1. **`orbit-vst3-effect-child` をバンドル対象に加える**（`scripts/copy-daemon-bin.sh`）。
+1. **`orbit-vst3-effect-child` のバンドル欠落** — ✅ **解消済み（#548）**。
+   - `scripts/copy-daemon-bin.sh` は 4 child すべて（clap/vst3 × effect/instrument）を
+     bundle 前に再ビルドし（`:85-87`）、copy 対象にも含める（`:94-98`）
+   - `release.yml` の post-package gate が出荷 `.vsix` に対して 4 child の存在と実行属性を
+     検査する（欠落時は release を abort）
+   - 是正時に要求していた**バンドル済み成果物への検証**も実装済み:
+     `tests/vscode-extension/bundled-child-binaries.spec.ts`（#548 回帰ピン）が
+     「daemon が spawn しうる child（台帳A・Rust ソースから導出）⊆ バンドル供給（台帳B）」の
+     照合、release gate の CHILD_BIN 台帳照合、および **gate スクリプトの実走**（child を
+     1つずつ欠かして非ゼロ終了することの確認）まで行う
 
-   これは「未実装」ではなく**出荷物の欠落**である:
-   - daemon は `ORBIT_EFFECT_FORMAT=vst3` のとき当該 child を spawn しようとする
-     （`rust/crates/orbit-audio-daemon/src/outproc_effect.rs:84`）。既定パスは daemon 実行
-     ファイルと同一ディレクトリ（同 `default_child_exe`）
-   - しかし `copy-daemon-bin.sh` の再ビルド一覧（`:85`）にも copy 一覧（`:93-97`）にも
-     含まれていない → **出荷された拡張では VST3 エフェクトの spawn が失敗する**
-   - gated テストは自前で `cargo build -p orbit-vst3-effect-child` してから走るため
-     （`tests/outproc_effect_vst3_gated.rs:28`）、**この欠落を構造的に検出できない**
-
-   是正時は、バンドル済み成果物に対する検証（`.vsix` 内の bin 一覧）を伴わせる。
-
-2. CLAP 側の `CLAP_EXT_STATE` 配線（現状 `--state` は明示 `bail!`）
+2. **CLAP 側の `CLAP_EXT_STATE` 配線**（当初 `--state` は明示 `bail!`）— ✅ **解消済み**。
+   `orbit-clap-effect-child` は `--state` を読み `ClapEffectProcessor::load(state_bytes)` へ
+   渡し、`CMD_SAVE_STATE` → `capture_state()` も配線済み（instrument 側 #557 と対称）
 
 ---
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -861,6 +861,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,11 +1002,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "orbit-child-runtime"
+version = "0.0.1"
+dependencies = [
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "orbit-clap-effect-child"
 version = "0.0.1"
 dependencies = [
  "anyhow",
  "orbit-audio-sandbox",
+ "orbit-child-runtime",
  "orbit-clap-host",
  "orbit-vst3-gain-oracle",
 ]
@@ -1019,6 +1041,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "orbit-audio-sandbox",
+ "orbit-child-runtime",
  "orbit-clap-host",
 ]
 
@@ -1075,6 +1098,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "orbit-audio-sandbox",
+ "orbit-child-runtime",
  "orbit-vst3-gain-oracle",
  "orbit-vst3-host",
 ]
@@ -1102,6 +1126,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "orbit-audio-sandbox",
+ "orbit-child-runtime",
  "orbit-vst3-host",
  "orbit-vst3-synth-oracle",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crates/orbit-clap-host",
   "crates/orbit-clap-effect-child",
   "crates/orbit-clap-instrument-child",
+  "crates/orbit-child-runtime",
   "crates/orbit-vst3-effect-child",
   "crates/orbit-vst3-instrument-child",
   "crates/orbit-sandbox-spike",

--- a/rust/crates/orbit-child-runtime/Cargo.toml
+++ b/rust/crates/orbit-child-runtime/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "orbit-child-runtime"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Shared main-thread AppKit runloop and dedicated audio-thread runtime for plugin child processes"
+publish = false
+
+[dependencies]
+thiserror = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = [
+  "std",
+  "NSApplication",
+  "NSEvent",
+  "NSGraphicsContext",
+  "NSResponder",
+  "NSRunningApplication",
+] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
+  "std",
+  "NSDate",
+  "NSObject",
+  "NSRunLoop",
+  "NSTimer",
+] }

--- a/rust/crates/orbit-child-runtime/src/lib.rs
+++ b/rust/crates/orbit-child-runtime/src/lib.rs
@@ -1,0 +1,371 @@
+//! Shared execution model for the four out-of-process plugin children.
+//!
+//! On macOS the process main thread is given to an `NSApplication` runloop
+//! (Accessory activation policy). A short main-runloop timer services the
+//! command mailbox and process-liveness checks supplied by the child. Audio
+//! processing runs on one dedicated user-interactive QoS thread.
+
+use std::any::Any;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use thiserror::Error;
+
+/// Main-runloop service interval. Mailbox commands and liveness changes are
+/// control-plane work, so 20 ms avoids a busy main thread while remaining
+/// responsive enough for UI commands.
+pub const MAIN_TICK_INTERVAL: Duration = Duration::from_millis(20);
+
+#[derive(Debug, Error)]
+pub enum ChildRuntimeError {
+    #[error("orbit child runtime must be started on the process main thread")]
+    NotMainThread,
+    #[error("NSApplication rejected Accessory activation policy")]
+    AccessoryPolicyRejected,
+    #[error("failed to spawn dedicated audio thread: {0}")]
+    SpawnAudio(#[source] std::io::Error),
+    #[error("main-runloop service callback panicked")]
+    ServicePanicked,
+    #[error("dedicated audio thread panicked: {0}")]
+    AudioPanicked(String),
+}
+
+struct AudioDoneGuard(Arc<AtomicBool>);
+
+impl Drop for AudioDoneGuard {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Release);
+    }
+}
+
+fn spawn_audio<T, F>(
+    process_name: &str,
+    audio_done: Arc<AtomicBool>,
+    audio: F,
+) -> Result<JoinHandle<T>, ChildRuntimeError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    thread::Builder::new()
+        .name(format!("{process_name}-audio"))
+        .spawn(move || {
+            let _done = AudioDoneGuard(audio_done);
+            set_audio_thread_qos();
+            audio()
+        })
+        .map_err(ChildRuntimeError::SpawnAudio)
+}
+
+fn join_audio<T>(handle: JoinHandle<T>) -> Result<T, ChildRuntimeError> {
+    handle
+        .join()
+        .map_err(|payload| ChildRuntimeError::AudioPanicked(panic_payload(payload)))
+}
+
+fn panic_payload(payload: Box<dyn Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_owned()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "non-string panic payload".to_owned()
+    }
+}
+
+#[derive(Clone)]
+struct StopCoordinator {
+    stop_audio: Arc<AtomicBool>,
+    audio_done: Arc<AtomicBool>,
+}
+
+impl StopCoordinator {
+    fn new() -> Self {
+        Self {
+            stop_audio: Arc::new(AtomicBool::new(false)),
+            audio_done: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn should_stop(&self, service_requested_stop: bool) -> bool {
+        if service_requested_stop || self.audio_done.load(Ordering::Acquire) {
+            self.stop_audio.store(true, Ordering::Release);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Run a plugin child with its control plane on the process main thread and
+/// its audio loop on a dedicated thread.
+///
+/// `service_main` is invoked only by the main runloop timer. It should service
+/// the command mailbox, then return `true` for `CONTROL_QUIT` or parent death.
+/// `audio` receives a stop flag owned by this runtime; the audio loop should
+/// additionally check shared-memory `CONTROL_QUIT` with a Relaxed load so it
+/// can leave immediately without touching the mailbox.
+///
+/// The returned audio value is produced only after the audio thread has been
+/// joined. Keeping the main-thread processor half in the caller and consuming
+/// the returned value before dropping it structurally enforces
+/// `runloop stop -> audio join -> main-thread teardown`.
+pub fn run_child<T, A, S>(
+    process_name: &str,
+    mut service_main: S,
+    audio: A,
+) -> Result<T, ChildRuntimeError>
+where
+    T: Send + 'static,
+    A: FnOnce(Arc<AtomicBool>) -> T + Send + 'static,
+    S: FnMut() -> bool,
+{
+    let coordinator = StopCoordinator::new();
+    let stop_for_audio = coordinator.stop_audio.clone();
+    let audio_handle = spawn_audio(process_name, coordinator.audio_done.clone(), move || {
+        audio(stop_for_audio)
+    })?;
+
+    let runloop_result = run_main_loop(&coordinator, &mut service_main);
+    coordinator.stop_audio.store(true, Ordering::Release);
+    let audio_result = join_audio(audio_handle);
+
+    runloop_result?;
+    audio_result
+}
+
+#[cfg(target_os = "macos")]
+fn run_main_loop(
+    coordinator: &StopCoordinator,
+    service_main: &mut dyn FnMut() -> bool,
+) -> Result<(), ChildRuntimeError> {
+    appkit::run_main_loop(coordinator, service_main)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn run_main_loop(
+    coordinator: &StopCoordinator,
+    service_main: &mut dyn FnMut() -> bool,
+) -> Result<(), ChildRuntimeError> {
+    while !coordinator.should_stop(service_main()) {
+        thread::sleep(MAIN_TICK_INTERVAL);
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+mod appkit {
+    use std::cell::{Cell, RefCell};
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    use objc2::rc::Retained;
+    use objc2::{define_class, msg_send, sel, DefinedClass, MainThreadMarker, MainThreadOnly};
+    use objc2_app_kit::{
+        NSApplication, NSApplicationActivationPolicy, NSEvent, NSEventModifierFlags, NSEventType,
+    };
+    use objc2_foundation::{
+        NSObject, NSObjectProtocol, NSPoint, NSRunLoop, NSRunLoopCommonModes, NSTimer,
+    };
+
+    use super::{ChildRuntimeError, StopCoordinator, MAIN_TICK_INTERVAL};
+
+    type MainService<'a> = dyn FnMut() -> bool + 'a;
+
+    struct TimerTargetIvars {
+        service: RefCell<Box<MainService<'static>>>,
+        coordinator: StopCoordinator,
+        service_panicked: Cell<bool>,
+    }
+
+    define_class!(
+        // SAFETY: NSObject has no subclassing requirements. TimerTarget has
+        // no Drop implementation and is confined to the process main thread.
+        #[unsafe(super = NSObject)]
+        #[name = "OrbitChildRuntimeTimerTarget"]
+        #[thread_kind = MainThreadOnly]
+        #[ivars = TimerTargetIvars]
+        struct TimerTarget;
+
+        // SAFETY: NSObjectProtocol adds no extra invariants.
+        unsafe impl NSObjectProtocol for TimerTarget {}
+
+        impl TimerTarget {
+            // SAFETY: NSTimer invokes this selector with exactly one NSTimer argument.
+            #[unsafe(method(tick:))]
+            fn tick(&self, timer: &NSTimer) {
+                let requested_stop = match catch_unwind(AssertUnwindSafe(|| {
+                    (self.ivars().service.borrow_mut())()
+                })) {
+                    Ok(value) => value,
+                    Err(_) => {
+                        self.ivars().service_panicked.set(true);
+                        true
+                    }
+                };
+                if self.ivars().coordinator.should_stop(requested_stop) {
+                    timer.invalidate();
+                    let app = NSApplication::sharedApplication(self.mtm());
+                    app.stop(None);
+
+                    // `stop` is observed after AppKit finishes dispatching an
+                    // event. A timer callback is not an event, so wake the
+                    // headless runloop with a harmless application event.
+                    let wake_event = NSEvent::otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2(
+                        NSEventType::ApplicationDefined,
+                        NSPoint::ZERO,
+                        NSEventModifierFlags::empty(),
+                        0.0,
+                        0,
+                        None,
+                        0,
+                        0,
+                        0,
+                    );
+                    if let Some(wake_event) = wake_event {
+                        app.postEvent_atStart(&wake_event, true);
+                    }
+                }
+            }
+        }
+    );
+
+    impl TimerTarget {
+        fn new(
+            mtm: MainThreadMarker,
+            service: Box<MainService<'static>>,
+            coordinator: StopCoordinator,
+        ) -> Retained<Self> {
+            let this = Self::alloc(mtm).set_ivars(TimerTargetIvars {
+                service: RefCell::new(service),
+                coordinator,
+                service_panicked: Cell::new(false),
+            });
+            // SAFETY: this is NSObject's designated initializer and the
+            // superclass does not impose extra initialization requirements.
+            unsafe { msg_send![super(this), init] }
+        }
+    }
+
+    pub(super) fn run_main_loop(
+        coordinator: &StopCoordinator,
+        service_main: &mut dyn FnMut() -> bool,
+    ) -> Result<(), ChildRuntimeError> {
+        let mtm = MainThreadMarker::new().ok_or(ChildRuntimeError::NotMainThread)?;
+
+        // NSTimer retains its target until invalidation. The target never
+        // escapes this function/runloop, so extending the callback reference
+        // to that exact lifetime is sound. It is invalidated before return.
+        let service: Box<MainService<'_>> = Box::new(service_main);
+        let service: Box<MainService<'static>> = unsafe { std::mem::transmute(service) };
+        let target = TimerTarget::new(mtm, service, coordinator.clone());
+
+        let app = NSApplication::sharedApplication(mtm);
+        if !app.setActivationPolicy(NSApplicationActivationPolicy::Accessory) {
+            coordinator
+                .stop_audio
+                .store(true, std::sync::atomic::Ordering::Release);
+            return Err(ChildRuntimeError::AccessoryPolicyRejected);
+        }
+
+        let timer = unsafe {
+            NSTimer::timerWithTimeInterval_target_selector_userInfo_repeats(
+                MAIN_TICK_INTERVAL.as_secs_f64(),
+                &target,
+                sel!(tick:),
+                None,
+                true,
+            )
+        };
+        // Common modes keep mailbox/liveness servicing active while AppKit is
+        // tracking mouse/keyboard interaction in a hosted plugin editor.
+        unsafe {
+            NSRunLoop::mainRunLoop().addTimer_forMode(&timer, NSRunLoopCommonModes);
+        }
+        timer.fire();
+        if !coordinator
+            .stop_audio
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            app.run();
+        }
+        timer.invalidate();
+
+        if target.ivars().service_panicked.get() {
+            Err(ChildRuntimeError::ServicePanicked)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn set_audio_thread_qos() {
+    type QosClass = u32;
+    const QOS_CLASS_USER_INTERACTIVE: QosClass = 0x21;
+
+    unsafe extern "C" {
+        fn pthread_set_qos_class_self_np(qos_class: QosClass, relative_priority: i32) -> i32;
+    }
+
+    let result = unsafe { pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0) };
+    if result != 0 {
+        eprintln!("[orbit-child-runtime] audio thread QoS user-interactive setup failed: {result}");
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn set_audio_thread_qos() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    #[test]
+    fn service_stop_sets_audio_stop_flag() {
+        let coordinator = StopCoordinator::new();
+        assert!(coordinator.should_stop(true));
+        assert!(coordinator.stop_audio.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn audio_completion_stops_main_loop_even_without_service_request() {
+        let coordinator = StopCoordinator::new();
+        coordinator.audio_done.store(true, Ordering::Release);
+        assert!(coordinator.should_stop(false));
+        assert!(coordinator.stop_audio.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn idle_tick_keeps_audio_running() {
+        let coordinator = StopCoordinator::new();
+        assert!(!coordinator.should_stop(false));
+        assert!(!coordinator.stop_audio.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn audio_work_runs_on_named_dedicated_thread_and_returns_after_join() {
+        let main_id = thread::current().id();
+        let executions = Arc::new(AtomicUsize::new(0));
+        let executions_audio = executions.clone();
+        let handle = spawn_audio(
+            "runtime-test",
+            Arc::new(AtomicBool::new(false)),
+            move || {
+                executions_audio.fetch_add(1, Ordering::Relaxed);
+                (
+                    thread::current().id(),
+                    thread::current().name().map(str::to_owned),
+                )
+            },
+        )
+        .expect("spawn audio");
+        let (audio_id, audio_name) = join_audio(handle).expect("join audio");
+
+        assert_ne!(audio_id, main_id);
+        assert_eq!(audio_name.as_deref(), Some("runtime-test-audio"));
+        assert_eq!(executions.load(Ordering::Relaxed), 1);
+    }
+}

--- a/rust/crates/orbit-child-runtime/src/lib.rs
+++ b/rust/crates/orbit-child-runtime/src/lib.rs
@@ -30,11 +30,24 @@ pub enum ChildRuntimeError {
     ServicePanicked,
     #[error("dedicated audio thread panicked: {0}")]
     AudioPanicked(String),
+    #[error("{runloop}; audio thread also failed: {audio}")]
+    RunloopAndAudioFailed {
+        runloop: Box<ChildRuntimeError>,
+        audio: Box<ChildRuntimeError>,
+    },
 }
 
 struct AudioDoneGuard(Arc<AtomicBool>);
 
 impl Drop for AudioDoneGuard {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Release);
+    }
+}
+
+struct StopAudioGuard(Arc<AtomicBool>);
+
+impl Drop for StopAudioGuard {
     fn drop(&mut self) {
         self.0.store(true, Ordering::Release);
     }
@@ -114,7 +127,7 @@ impl StopCoordinator {
 /// `runloop stop -> audio join -> main-thread teardown`.
 pub fn run_child<T, A, S>(
     process_name: &str,
-    mut service_main: S,
+    service_main: S,
     audio: A,
 ) -> Result<T, ChildRuntimeError>
 where
@@ -122,18 +135,48 @@ where
     A: FnOnce(Arc<AtomicBool>) -> T + Send + 'static,
     S: FnMut() -> bool,
 {
+    run_child_with_main_loop(
+        process_name,
+        service_main,
+        audio,
+        |coordinator, service_main| run_main_loop(coordinator, service_main),
+    )
+}
+
+fn run_child_with_main_loop<T, A, S, M>(
+    process_name: &str,
+    mut service_main: S,
+    audio: A,
+    main_loop: M,
+) -> Result<T, ChildRuntimeError>
+where
+    T: Send + 'static,
+    A: FnOnce(Arc<AtomicBool>) -> T + Send + 'static,
+    S: FnMut() -> bool,
+    M: FnOnce(&StopCoordinator, &mut S) -> Result<(), ChildRuntimeError>,
+{
     let coordinator = StopCoordinator::new();
     let stop_for_audio = coordinator.stop_audio.clone();
     let audio_handle = spawn_audio(process_name, coordinator.audio_done.clone(), move || {
         audio(stop_for_audio)
     })?;
+    // Declared after the handle so unwinding signals stop before detaching the
+    // JoinHandle. On the normal path it is dropped before join for the same
+    // stop -> join ordering.
+    let stop_audio = StopAudioGuard(coordinator.stop_audio.clone());
 
-    let runloop_result = run_main_loop(&coordinator, &mut service_main);
-    coordinator.stop_audio.store(true, Ordering::Release);
+    let runloop_result = main_loop(&coordinator, &mut service_main);
+    drop(stop_audio);
     let audio_result = join_audio(audio_handle);
 
-    runloop_result?;
-    audio_result
+    match (runloop_result, audio_result) {
+        (Ok(()), audio_result) => audio_result,
+        (Err(runloop), Ok(_)) => Err(runloop),
+        (Err(runloop), Err(audio)) => Err(ChildRuntimeError::RunloopAndAudioFailed {
+            runloop: Box::new(runloop),
+            audio: Box::new(audio),
+        }),
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -321,7 +364,9 @@ fn set_audio_thread_qos() {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
     use std::sync::atomic::AtomicUsize;
+    use std::sync::mpsc;
 
     #[test]
     fn service_stop_sets_audio_stop_flag() {
@@ -336,6 +381,105 @@ mod tests {
         coordinator.audio_done.store(true, Ordering::Release);
         assert!(coordinator.should_stop(false));
         assert!(coordinator.stop_audio.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn spawned_audio_completion_signals_coordinator_and_requests_stop() {
+        let coordinator = StopCoordinator::new();
+        let handle = spawn_audio("runtime-test", coordinator.audio_done.clone(), || ())
+            .expect("spawn audio");
+
+        join_audio(handle).expect("join audio");
+
+        assert!(coordinator.audio_done.load(Ordering::Acquire));
+        assert!(coordinator.should_stop(false));
+        assert!(coordinator.stop_audio.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn audio_panic_is_reported_by_join() {
+        let handle = spawn_audio("runtime-test", Arc::new(AtomicBool::new(false)), || {
+            panic!("plugin process panic")
+        })
+        .expect("spawn audio");
+
+        let error = join_audio(handle).expect_err("audio panic must fail join");
+        assert!(matches!(
+            error,
+            ChildRuntimeError::AudioPanicked(message) if message == "plugin process panic"
+        ));
+    }
+
+    #[test]
+    fn panic_payload_extracts_borrowed_string() {
+        assert_eq!(panic_payload(Box::new("borrowed panic")), "borrowed panic");
+    }
+
+    #[test]
+    fn panic_payload_extracts_owned_string() {
+        assert_eq!(
+            panic_payload(Box::new(String::from("owned panic"))),
+            "owned panic"
+        );
+    }
+
+    #[test]
+    fn panic_payload_reports_non_string_fallback() {
+        assert_eq!(panic_payload(Box::new(42)), "non-string panic payload");
+    }
+
+    #[test]
+    fn simultaneous_runloop_and_audio_failures_report_both_diagnostics() {
+        let result: Result<(), ChildRuntimeError> = run_child_with_main_loop(
+            "runtime-test",
+            || false,
+            |_stop| panic!("plugin process panic"),
+            |_coordinator, _service_main| Err(ChildRuntimeError::ServicePanicked),
+        );
+
+        let error = result.expect_err("both failures must be reported");
+        assert!(matches!(
+            &error,
+            ChildRuntimeError::RunloopAndAudioFailed { runloop, audio }
+                if matches!(runloop.as_ref(), ChildRuntimeError::ServicePanicked)
+                    && matches!(
+                        audio.as_ref(),
+                        ChildRuntimeError::AudioPanicked(message)
+                            if message == "plugin process panic"
+                    )
+        ));
+        assert_eq!(
+            error.to_string(),
+            "main-runloop service callback panicked; audio thread also failed: \
+             dedicated audio thread panicked: plugin process panic"
+        );
+    }
+
+    #[test]
+    fn main_loop_panic_still_requests_audio_stop() {
+        let (audio_stopped_tx, audio_stopped_rx) = mpsc::channel();
+
+        let panic_result = catch_unwind(AssertUnwindSafe(|| {
+            let result: Result<(), ChildRuntimeError> = run_child_with_main_loop(
+                "runtime-test",
+                || false,
+                move |stop| {
+                    while !stop.load(Ordering::Acquire) {
+                        thread::yield_now();
+                    }
+                    audio_stopped_tx
+                        .send(())
+                        .expect("test receiver remains alive");
+                },
+                |_coordinator, _service_main| panic!("main loop setup panic"),
+            );
+            let _ = result;
+        }));
+
+        assert!(panic_result.is_err());
+        audio_stopped_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("RAII guard must stop detached audio thread during unwind");
     }
 
     #[test]

--- a/rust/crates/orbit-clap-effect-child/Cargo.toml
+++ b/rust/crates/orbit-clap-effect-child/Cargo.toml
@@ -29,6 +29,7 @@ path = "src/main.rs"
 orbit-clap-host = { path = "../orbit-clap-host" }
 # 親子で共有する SharedRegion transport（memmap2・clack 非依存）。
 orbit-audio-sandbox = { path = "../orbit-audio-sandbox" }
+orbit-child-runtime = { path = "../orbit-child-runtime" }
 # 引数 parse / エラー伝播。
 anyhow = "1"
 

--- a/rust/crates/orbit-clap-effect-child/src/main.rs
+++ b/rust/crates/orbit-clap-effect-child/src/main.rs
@@ -166,7 +166,7 @@ fn main() -> Result<()> {
                 }
                 last = cur;
             }
-            effect_audio.stop_processing();
+            // ClapEffectAudio::drop runs stop_processing on this audio thread.
             process_errors
         },
     )?;

--- a/rust/crates/orbit-clap-effect-child/src/main.rs
+++ b/rust/crates/orbit-clap-effect-child/src/main.rs
@@ -28,6 +28,7 @@ use orbit_audio_sandbox::{
     open_shared, region_ptr, save_state_command, service_command_mailbox, slot_index, slot_offset,
     ParentWatch, BUF_LEN, CHANNELS, CMD_SAVE_STATE, CONTROL_QUIT, MAX_FRAMES,
 };
+use orbit_child_runtime::run_child;
 use orbit_clap_host::ClapEffectProcessor;
 
 struct Args {
@@ -80,7 +81,7 @@ fn main() -> Result<()> {
         Some(path) => Some(std::fs::read(path).with_context(|| format!("read state {path:?}"))?),
         None => None,
     };
-    let (mut effect, _info) = ClapEffectProcessor::load(
+    let (effect, _info) = ClapEffectProcessor::load(
         &args.plugin,
         args.plugin_id.as_deref(),
         args.sample_rate,
@@ -94,81 +95,82 @@ fn main() -> Result<()> {
     unsafe {
         orbit_audio_sandbox::transport::publish_child_ready(region, effect.has_audio_input());
     }
+    let (mut effect_audio, mut effect_main) = effect.split();
 
-    // in-place process_block 用の作業バッファ（ループ前に確保 = RT 安全）。
-    let mut scratch = vec![0.0f32; BUF_LEN];
-
-    // plugin.process() が失敗したブロック数。PR-C（carry-forward ①）で health signal を
-    // `SharedRegion::child_process_error_count` に載せ、失敗ブロックごとに host が live に読める
-    // shared counter へ `fetch_add` する（effect は失敗時 dry 素通しで silent になるための可視化）。
-    // local の `process_errors` は **このプロセス**の集計で、終了時 stderr 報告に使う（respawn を跨ぐと
-    // shared counter は累積するが、stderr はこの child の寄与だけを出す方が診断的）。
-    let mut process_errors: u64 = 0;
-
-    let mut last: u64 = 0;
     // orphan 対策（#448）: host（daemon）が CONTROL_QUIT を書かずに死ぬ経路（プロセス exit・
-    // SIGKILL・crash）でも spin loop を抜けられるよう、親死活を低頻度で監視する。
+    // SIGKILL・crash）でも main runloop を止められるよう、親死活をタイマーで監視する。
     let mut parent_watch = ParentWatch::new();
-    loop {
-        // host からの正常終了要求。一回限りの flag なので Relaxed で十分（PR-A gain child と同様）。
-        // SAFETY: region は host が REGION_BYTES に truncate 済みの共有ファイルを指す（map 後不変）。
-        if unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT {
-            break;
-        }
-        if parent_watch.should_exit() {
-            eprintln!("[orbit-clap-effect-child] 親プロセス死亡を検知、終了する");
-            break;
-        }
-        unsafe {
-            service_command_mailbox(region, |kind, arg| match kind {
-                CMD_SAVE_STATE => Some(save_state_command(arg, || effect.capture_state())),
-                _ => None,
-            });
-        }
-        // SAFETY: 同上（region は有効）。seq_request の Acquire は host SUBMIT の Release と
-        // synchronize-with し、続く input/n_frames[slot] 読み出しの可視性を確立する。
-        let cur = unsafe { (*region).seq_request.load(Acquire) };
-        if cur > last {
-            // slot index / offset は当該 seq で不変なのでループ本体先頭で 1 回だけ算出する。
-            let idx = slot_index(cur);
-            let off = slot_offset(cur);
-            // SAFETY: seq_request の Acquire が host の input/n_frames[slot] 書き込みを可視化する。
-            // slot 不変条件（host が seq-SLOTS 完了を待って submit）で当該 slot は時間的に排他。
-            let count = unsafe {
-                let n = ((*region).n_frames[idx].load(Relaxed) as usize).min(MAX_FRAMES);
-                let count = n * CHANNELS;
-                let in_base = std::ptr::addr_of!((*region).input) as *const f32;
-                std::ptr::copy_nonoverlapping(in_base.add(off), scratch.as_mut_ptr(), count);
-                count
-            };
-
-            // 実 CLAP effect で 1 block を in-place 加工（共有メモリ外の scratch 上で）。
-            // 失敗時 process_block は scratch を dry のまま素通しする。
-            if !effect.process_block(&mut scratch[..count]) {
-                process_errors += 1;
-                // carry-forward ①: host(supervisor / accessor)が live に読める shared counter へ反映。
-                // SAFETY: region は map 済みで有効。fetch_add は MAP_SHARED でクロスプロセス可視。
-                // Relaxed で十分（audio data の順序づけに関与しない観測用 counter）。
-                unsafe {
-                    (*region).child_process_error_count.fetch_add(1, Relaxed);
-                }
-            }
-
-            // SAFETY: 上と同じ slot 排他。scratch（加工済み出力）を output slot へ書き戻す。
+    let region_addr = region as usize;
+    let process_errors = run_child(
+        "orbit-clap-effect-child",
+        || {
+            // Mailbox servicing is main-thread-only after #474 P1. In particular,
+            // SAVE_STATE may block on plugin serialization/fsync without stalling audio.
             unsafe {
-                let out_base = std::ptr::addr_of_mut!((*region).output) as *mut f32;
-                std::ptr::copy_nonoverlapping(scratch.as_ptr(), out_base.add(off), count);
-                (*region).child_processed.fetch_add(1, Relaxed);
-                // この slot の出力を publish（host READ の seq_tag[slot]==target Acquire と synchronize-with）。
-                (*region).seq_tag[idx].store(cur, Release);
-                // submit guard 用の最新処理 seq（host SUBMIT の Acquire と synchronize-with）。
-                (*region).seq_done.store(cur, Release);
+                service_command_mailbox(region, |kind, arg| match kind {
+                    CMD_SAVE_STATE => Some(save_state_command(arg, || effect_main.capture_state())),
+                    _ => None,
+                });
             }
-            last = cur;
-        } else {
-            std::hint::spin_loop();
-        }
-    }
+            if unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT {
+                return true;
+            }
+            if parent_watch.should_exit() {
+                eprintln!("[orbit-clap-effect-child] 親プロセス死亡を検知、終了する");
+                return true;
+            }
+            false
+        },
+        move |stop_audio| {
+            let region = region_addr as *mut orbit_audio_sandbox::SharedRegion;
+            // in-place process_block 用の作業バッファ（audio loop 前に確保 = RT 安全）。
+            let mut scratch = vec![0.0f32; BUF_LEN];
+            let mut process_errors = 0u64;
+            let mut last = 0u64;
+            loop {
+                // Audio thread observes only the runtime stop flag and CONTROL_QUIT.
+                // Mailbox and ParentWatch remain exclusively on the main runloop.
+                if stop_audio.load(Relaxed)
+                    || unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT
+                {
+                    break;
+                }
+                let cur = unsafe { (*region).seq_request.load(Acquire) };
+                if cur <= last {
+                    std::hint::spin_loop();
+                    continue;
+                }
+                let idx = slot_index(cur);
+                let off = slot_offset(cur);
+                let count = unsafe {
+                    let n = ((*region).n_frames[idx].load(Relaxed) as usize).min(MAX_FRAMES);
+                    let count = n * CHANNELS;
+                    let in_base = std::ptr::addr_of!((*region).input) as *const f32;
+                    std::ptr::copy_nonoverlapping(in_base.add(off), scratch.as_mut_ptr(), count);
+                    count
+                };
+
+                if !effect_audio.process_block(&mut scratch[..count]) {
+                    process_errors += 1;
+                    unsafe {
+                        (*region).child_process_error_count.fetch_add(1, Relaxed);
+                    }
+                }
+
+                unsafe {
+                    let out_base = std::ptr::addr_of_mut!((*region).output) as *mut f32;
+                    std::ptr::copy_nonoverlapping(scratch.as_ptr(), out_base.add(off), count);
+                    (*region).child_processed.fetch_add(1, Relaxed);
+                    (*region).seq_tag[idx].store(cur, Release);
+                    (*region).seq_done.store(cur, Release);
+                }
+                last = cur;
+            }
+            effect_audio.stop_processing();
+            process_errors
+        },
+    )?;
+
     if process_errors > 0 {
         eprintln!(
             "[orbit-clap-effect-child] plugin.process() が {process_errors} ブロックで失敗 \

--- a/rust/crates/orbit-clap-host/src/effect.rs
+++ b/rust/crates/orbit-clap-host/src/effect.rs
@@ -142,4 +142,131 @@ impl ClapEffectProcessor {
             data,
         )
     }
+
+    /// main / audio の 2 スレッド運用（UIH.1）へ分割する（#474 P1）。
+    ///
+    /// 呼び出したスレッド（= `load` を行った home スレッド）が main 側になる。
+    /// audio 側（[`ClapEffectAudio`]・`Send`）は専用 audio スレッドへ move し、
+    /// main 側（[`ClapEffectMain`]・`!Send`）は home スレッドに残って state 操作を担う。
+    ///
+    /// ## 分割後の teardown 契約（🔴 順序が正しさの条件）
+    ///
+    /// 1. audio スレッドが [`ClapEffectAudio::stop_processing`] を呼んで終了する
+    ///    （CLAP 契約: `stop_processing` は audio スレッド）
+    /// 2. main スレッドが audio スレッドを **join してから** [`ClapEffectMain`] を drop する。
+    ///    このとき `PluginInstance` が `Arc<PluginInstanceInner>` の唯一の所有者になり、
+    ///    実 teardown（deactivate → destroy）が home スレッドで走る（CLAP 契約に適合）
+    ///
+    /// 逆順（audio 側が生きたまま main 側を drop）にすると `PluginInstance::Drop` は
+    /// 意図的に leak し、その後 audio 側の drop が唯一所有者として teardown を
+    /// **audio スレッドで**走らせる（deactivate の wrong-thread 違反）。daemon の
+    /// in-process 経路（`ClapPostProcessor` の carry-forward #1）と同じ協調規律であり、
+    /// out-of-process child では `orbit-child-runtime` の「join してから main 側を drop」
+    /// という関数構造がこの順序を強制する。
+    pub fn split(self) -> (ClapEffectAudio, ClapEffectMain) {
+        let Self {
+            plugin,
+            buffers,
+            steady,
+            _instance,
+        } = self;
+        (
+            ClapEffectAudio {
+                plugin: Some(plugin),
+                buffers,
+                steady,
+            },
+            ClapEffectMain {
+                instance: _instance,
+            },
+        )
+    }
+}
+
+/// [`ClapEffectProcessor::split`] の audio スレッド側。
+///
+/// `Send`（`StartedPluginAudioProcessor` は clack が audio スレッドへの引き渡しを想定して
+/// `Send` を提供する — daemon の `InstallMsg` が同じ根拠で cross-thread 送信している）。
+/// audio スレッドに move した後は、そのスレッドだけが触ること。
+pub struct ClapEffectAudio {
+    plugin: Option<StartedPluginAudioProcessor<OrbitClapHost>>,
+    buffers: HostAudioBuffers,
+    steady: u64,
+}
+
+impl ClapEffectAudio {
+    /// [`ClapEffectProcessor::process_block`] と同一の音響処理（audio スレッド側）。
+    #[must_use]
+    pub fn process_block(&mut self, data: &mut [f32]) -> bool {
+        process_block_core(
+            self.plugin
+                .as_mut()
+                .expect("CLAP effect audio remains started until teardown"),
+            &mut self.buffers,
+            &mut self.steady,
+            &InputEvents::empty(),
+            None,
+            data,
+        )
+    }
+
+    /// audio スレッド上で `stop_processing` を呼んで audio 側を畳む（CLAP 契約）。
+    ///
+    /// 返る `StoppedPluginAudioProcessor` はここで drop する（Arc refcount 減算のみ・
+    /// 実 teardown は main 側の [`ClapEffectMain`] drop が唯一所有者として行う）。
+    /// audio ループの終了時に呼ぶこと。呼び忘れても `Drop` が同じ処理を行う
+    /// （panic unwind 含め、drop が audio スレッド上で走る限り正しいスレッドに乗る）ため、
+    /// この明示メソッドは「意図した終了点」をコード上に残すためのもの。
+    pub fn stop_processing(mut self) {
+        self.stop_processing_inner();
+    }
+
+    fn stop_processing_inner(&mut self) {
+        if let Some(plugin) = self.plugin.take() {
+            let _ = plugin.stop_processing();
+        }
+    }
+}
+
+impl Drop for ClapEffectAudio {
+    fn drop(&mut self) {
+        // Drop runs on the dedicated audio thread in both the normal and
+        // unwinding paths, so a panic cannot move stop_processing to main.
+        self.stop_processing_inner();
+    }
+}
+
+/// [`ClapEffectProcessor::split`] の main（home）スレッド側。
+///
+/// `!Send`（`PluginInstance` を含む）。state 操作（`[main-thread]` 契約）を担い、
+/// drop 時に唯一の Arc 所有者として実 teardown を home スレッドで走らせる
+/// （順序契約は [`ClapEffectProcessor::split`] の doc を参照）。
+pub struct ClapEffectMain {
+    instance: PluginInstance<OrbitClapHost>,
+}
+
+impl ClapEffectMain {
+    /// ホストしているプラグインの state を吸い上げる（契約は [`crate::state::capture_state`]）。
+    pub fn capture_state(&mut self) -> Result<Vec<u8>, ClapHostError> {
+        crate::state::capture_state(&mut self.instance)
+    }
+
+    /// 保存済み state を適用する（契約は [`crate::state::apply_state_bytes`]）。
+    pub fn apply_state_bytes(&mut self, bytes: &[u8]) -> Result<(), ClapHostError> {
+        crate::state::apply_state_bytes(&mut self.instance, bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// audio 側が `Send`（専用 audio スレッドへ move できる）ことのコンパイル時証明。
+    /// clack の `StartedPluginAudioProcessor` / `AudioPorts` の `unsafe impl Send` に依拠する
+    /// ため、clack bump でこれが外れたらここがコンパイルエラーで検出する。
+    #[test]
+    fn audio_half_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ClapEffectAudio>();
+    }
 }

--- a/rust/crates/orbit-clap-host/src/effect.rs
+++ b/rust/crates/orbit-clap-host/src/effect.rs
@@ -50,6 +50,7 @@ use crate::buffers::HostAudioBuffers;
 use crate::controller::{instantiate_activate, ClapHostError, LoadedPluginInfo};
 use crate::host::OrbitClapHost;
 use crate::processor::process_block_core;
+use crate::ClapPluginMain;
 
 /// 単一スレッドで load / process / drop する effect-only CLAP プロセッサ。
 ///
@@ -147,13 +148,13 @@ impl ClapEffectProcessor {
     ///
     /// 呼び出したスレッド（= `load` を行った home スレッド）が main 側になる。
     /// audio 側（[`ClapEffectAudio`]・`Send`）は専用 audio スレッドへ move し、
-    /// main 側（[`ClapEffectMain`]・`!Send`）は home スレッドに残って state 操作を担う。
+    /// main 側（[`ClapPluginMain`]・`!Send`）は home スレッドに残って state 操作を担う。
     ///
     /// ## 分割後の teardown 契約（🔴 順序が正しさの条件）
     ///
-    /// 1. audio スレッドが [`ClapEffectAudio::stop_processing`] を呼んで終了する
+    /// 1. audio スレッド終了時の [`ClapEffectAudio::drop`] が `stop_processing` を呼ぶ
     ///    （CLAP 契約: `stop_processing` は audio スレッド）
-    /// 2. main スレッドが audio スレッドを **join してから** [`ClapEffectMain`] を drop する。
+    /// 2. main スレッドが audio スレッドを **join してから** [`ClapPluginMain`] を drop する。
     ///    このとき `PluginInstance` が `Arc<PluginInstanceInner>` の唯一の所有者になり、
     ///    実 teardown（deactivate → destroy）が home スレッドで走る（CLAP 契約に適合）
     ///
@@ -163,7 +164,7 @@ impl ClapEffectProcessor {
     /// in-process 経路（`ClapPostProcessor` の carry-forward #1）と同じ協調規律であり、
     /// out-of-process child では `orbit-child-runtime` の「join してから main 側を drop」
     /// という関数構造がこの順序を強制する。
-    pub fn split(self) -> (ClapEffectAudio, ClapEffectMain) {
+    pub fn split(self) -> (ClapEffectAudio, ClapPluginMain) {
         let Self {
             plugin,
             buffers,
@@ -176,7 +177,7 @@ impl ClapEffectProcessor {
                 buffers,
                 steady,
             },
-            ClapEffectMain {
+            ClapPluginMain {
                 instance: _instance,
             },
         )
@@ -209,51 +210,15 @@ impl ClapEffectAudio {
             data,
         )
     }
-
-    /// audio スレッド上で `stop_processing` を呼んで audio 側を畳む（CLAP 契約）。
-    ///
-    /// 返る `StoppedPluginAudioProcessor` はここで drop する（Arc refcount 減算のみ・
-    /// 実 teardown は main 側の [`ClapEffectMain`] drop が唯一所有者として行う）。
-    /// audio ループの終了時に呼ぶこと。呼び忘れても `Drop` が同じ処理を行う
-    /// （panic unwind 含め、drop が audio スレッド上で走る限り正しいスレッドに乗る）ため、
-    /// この明示メソッドは「意図した終了点」をコード上に残すためのもの。
-    pub fn stop_processing(mut self) {
-        self.stop_processing_inner();
-    }
-
-    fn stop_processing_inner(&mut self) {
-        if let Some(plugin) = self.plugin.take() {
-            let _ = plugin.stop_processing();
-        }
-    }
 }
 
 impl Drop for ClapEffectAudio {
     fn drop(&mut self) {
         // Drop runs on the dedicated audio thread in both the normal and
         // unwinding paths, so a panic cannot move stop_processing to main.
-        self.stop_processing_inner();
-    }
-}
-
-/// [`ClapEffectProcessor::split`] の main（home）スレッド側。
-///
-/// `!Send`（`PluginInstance` を含む）。state 操作（`[main-thread]` 契約）を担い、
-/// drop 時に唯一の Arc 所有者として実 teardown を home スレッドで走らせる
-/// （順序契約は [`ClapEffectProcessor::split`] の doc を参照）。
-pub struct ClapEffectMain {
-    instance: PluginInstance<OrbitClapHost>,
-}
-
-impl ClapEffectMain {
-    /// ホストしているプラグインの state を吸い上げる（契約は [`crate::state::capture_state`]）。
-    pub fn capture_state(&mut self) -> Result<Vec<u8>, ClapHostError> {
-        crate::state::capture_state(&mut self.instance)
-    }
-
-    /// 保存済み state を適用する（契約は [`crate::state::apply_state_bytes`]）。
-    pub fn apply_state_bytes(&mut self, bytes: &[u8]) -> Result<(), ClapHostError> {
-        crate::state::apply_state_bytes(&mut self.instance, bytes)
+        if let Some(plugin) = self.plugin.take() {
+            let _ = plugin.stop_processing();
+        }
     }
 }
 

--- a/rust/crates/orbit-clap-host/src/effect.rs
+++ b/rust/crates/orbit-clap-host/src/effect.rs
@@ -19,7 +19,7 @@
 //! ため**意図的に leak する**。したがってフィールド宣言順で `plugin` を `_instance` より**前**に置くことが
 //! load-bearing: `plugin` の Arc が先に落ちて `_instance` が唯一所有者になり、`_instance` drop で teardown が
 //! 実際に走る。**逆順にすると** `_instance` drop 時に refcount>1 で leak し、`plugin` drop でも teardown が
-//! 走らず**未 deactivate のままリーク**する（クラッシュでなく silent leak = smoke/parity では順序が逆でも
+//! 走らず**永久 leak（teardown はどのスレッドでも一切走らない）**になる（smoke/parity では順序が逆でも
 //! 緑なので、この宣言順を守る唯一のガードが本コメント）。本型は home == audio == 唯一スレッドなので teardown
 //! は単一スレッドで完結し、daemon の split-thread（`ClapTeardownGuard` で跨ぐ）wrong-thread 問題を sidestep する。
 //!
@@ -159,8 +159,8 @@ impl ClapEffectProcessor {
     ///    実 teardown（deactivate → destroy）が home スレッドで走る（CLAP 契約に適合）
     ///
     /// 逆順（audio 側が生きたまま main 側を drop）にすると `PluginInstance::Drop` は
-    /// 意図的に leak し、その後 audio 側の drop が唯一所有者として teardown を
-    /// **audio スレッドで**走らせる（deactivate の wrong-thread 違反）。daemon の
+    /// 意図的に leak し、その後 audio 側を drop しても teardown は開始されない。
+    /// 帰結は **永久 leak（teardown はどのスレッドでも一切走らない）**。daemon の
     /// in-process 経路（`ClapPostProcessor` の carry-forward #1）と同じ協調規律であり、
     /// out-of-process child では `orbit-child-runtime` の「join してから main 側を drop」
     /// という関数構造がこの順序を強制する。

--- a/rust/crates/orbit-clap-host/src/instrument.rs
+++ b/rust/crates/orbit-clap-host/src/instrument.rs
@@ -156,4 +156,108 @@ impl ClapInstrumentProcessor {
             data,
         )
     }
+
+    /// main / audio の 2 スレッド運用（UIH.1）へ分割する（#474 P1）。
+    ///
+    /// 意味論・teardown の順序契約は [`crate::ClapEffectProcessor::split`] と同一
+    /// （audio 側が [`ClapInstrumentAudio::stop_processing`] → main が join →
+    /// [`ClapInstrumentMain`] drop = 唯一所有者として home スレッドで実 teardown）。
+    pub fn split(self) -> (ClapInstrumentAudio, ClapInstrumentMain) {
+        let Self {
+            plugin,
+            buffers,
+            steady,
+            _instance,
+        } = self;
+        (
+            ClapInstrumentAudio {
+                plugin: Some(plugin),
+                buffers,
+                steady,
+            },
+            ClapInstrumentMain {
+                instance: _instance,
+            },
+        )
+    }
+}
+
+/// [`ClapInstrumentProcessor::split`] の audio スレッド側（`Send`・詳細は
+/// [`crate::ClapEffectAudio`] と同じ根拠）。
+pub struct ClapInstrumentAudio {
+    plugin: Option<StartedPluginAudioProcessor<OrbitClapHost>>,
+    buffers: HostAudioBuffers,
+    steady: u64,
+}
+
+impl ClapInstrumentAudio {
+    /// [`ClapInstrumentProcessor::process_block`] と同一の音響処理（audio スレッド側）。
+    #[must_use]
+    pub fn process_block(
+        &mut self,
+        data: &mut [f32],
+        events: &EventBuffer,
+        output_events: &mut EventBuffer,
+    ) -> bool {
+        process_block_core(
+            self.plugin
+                .as_mut()
+                .expect("CLAP instrument audio remains started until teardown"),
+            &mut self.buffers,
+            &mut self.steady,
+            &events.as_input(),
+            Some(output_events),
+            data,
+        )
+    }
+
+    /// audio スレッド上で `stop_processing` を呼んで audio 側を畳む
+    /// （契約は [`crate::ClapEffectAudio::stop_processing`] と同一）。
+    pub fn stop_processing(mut self) {
+        self.stop_processing_inner();
+    }
+
+    fn stop_processing_inner(&mut self) {
+        if let Some(plugin) = self.plugin.take() {
+            let _ = plugin.stop_processing();
+        }
+    }
+}
+
+impl Drop for ClapInstrumentAudio {
+    fn drop(&mut self) {
+        // Keep CLAP stop_processing on the audio thread during unwinding too.
+        self.stop_processing_inner();
+    }
+}
+
+/// [`ClapInstrumentProcessor::split`] の main（home）スレッド側（`!Send`・
+/// 順序契約は [`crate::ClapEffectMain`] と同一）。
+pub struct ClapInstrumentMain {
+    instance: PluginInstance<OrbitClapHost>,
+}
+
+impl ClapInstrumentMain {
+    /// 現在の plugin state をバイト列で取り出す（契約は [`crate::state::capture_state`]）。
+    pub fn capture_state(&mut self) -> Result<Vec<u8>, ClapHostError> {
+        crate::state::capture_state(&mut self.instance)
+    }
+
+    /// 保存済み state を適用する（契約は [`crate::state::apply_state_bytes`]）。
+    pub fn apply_state_bytes(&mut self, bytes: &[u8]) -> Result<(), ClapHostError> {
+        crate::state::apply_state_bytes(&mut self.instance, bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// audio 側が `Send` であることのコンパイル時証明（根拠は
+    /// `effect.rs::tests::audio_half_is_send` と同一）。
+    #[test]
+    fn audio_half_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ClapInstrumentAudio>();
+    }
 }

--- a/rust/crates/orbit-clap-host/src/instrument.rs
+++ b/rust/crates/orbit-clap-host/src/instrument.rs
@@ -34,6 +34,7 @@ use crate::buffers::HostAudioBuffers;
 use crate::controller::{instantiate_activate, ClapHostError, LoadedPluginInfo};
 use crate::host::OrbitClapHost;
 use crate::processor::process_block_core;
+use crate::ClapPluginMain;
 
 /// 単一スレッドで load / process / drop する instrument CLAP プロセッサ。
 ///
@@ -160,9 +161,9 @@ impl ClapInstrumentProcessor {
     /// main / audio の 2 スレッド運用（UIH.1）へ分割する（#474 P1）。
     ///
     /// 意味論・teardown の順序契約は [`crate::ClapEffectProcessor::split`] と同一
-    /// （audio 側が [`ClapInstrumentAudio::stop_processing`] → main が join →
-    /// [`ClapInstrumentMain`] drop = 唯一所有者として home スレッドで実 teardown）。
-    pub fn split(self) -> (ClapInstrumentAudio, ClapInstrumentMain) {
+    /// （audio 側の [`ClapInstrumentAudio::drop`] → main が join →
+    /// [`ClapPluginMain`] drop = 唯一所有者として home スレッドで実 teardown）。
+    pub fn split(self) -> (ClapInstrumentAudio, ClapPluginMain) {
         let Self {
             plugin,
             buffers,
@@ -175,7 +176,7 @@ impl ClapInstrumentProcessor {
                 buffers,
                 steady,
             },
-            ClapInstrumentMain {
+            ClapPluginMain {
                 instance: _instance,
             },
         )
@@ -210,42 +211,14 @@ impl ClapInstrumentAudio {
             data,
         )
     }
-
-    /// audio スレッド上で `stop_processing` を呼んで audio 側を畳む
-    /// （契約は [`crate::ClapEffectAudio::stop_processing`] と同一）。
-    pub fn stop_processing(mut self) {
-        self.stop_processing_inner();
-    }
-
-    fn stop_processing_inner(&mut self) {
-        if let Some(plugin) = self.plugin.take() {
-            let _ = plugin.stop_processing();
-        }
-    }
 }
 
 impl Drop for ClapInstrumentAudio {
     fn drop(&mut self) {
         // Keep CLAP stop_processing on the audio thread during unwinding too.
-        self.stop_processing_inner();
-    }
-}
-
-/// [`ClapInstrumentProcessor::split`] の main（home）スレッド側（`!Send`・
-/// 順序契約は [`crate::ClapEffectMain`] と同一）。
-pub struct ClapInstrumentMain {
-    instance: PluginInstance<OrbitClapHost>,
-}
-
-impl ClapInstrumentMain {
-    /// 現在の plugin state をバイト列で取り出す（契約は [`crate::state::capture_state`]）。
-    pub fn capture_state(&mut self) -> Result<Vec<u8>, ClapHostError> {
-        crate::state::capture_state(&mut self.instance)
-    }
-
-    /// 保存済み state を適用する（契約は [`crate::state::apply_state_bytes`]）。
-    pub fn apply_state_bytes(&mut self, bytes: &[u8]) -> Result<(), ClapHostError> {
-        crate::state::apply_state_bytes(&mut self.instance, bytes)
+        if let Some(plugin) = self.plugin.take() {
+            let _ = plugin.stop_processing();
+        }
     }
 }
 

--- a/rust/crates/orbit-clap-host/src/instrument.rs
+++ b/rust/crates/orbit-clap-host/src/instrument.rs
@@ -14,7 +14,7 @@
 //! ため**意図的に leak する**。したがってフィールド宣言順で `plugin` を `_instance` より**前**に置くことが
 //! load-bearing: `plugin` の Arc が先に落ちて `_instance` が唯一所有者になり、`_instance` drop で teardown が
 //! 実際に走る。**逆順にすると** `_instance` drop 時に refcount>1 で leak し、`plugin` drop でも teardown が
-//! 走らず**未 deactivate のままリーク**する（クラッシュでなく silent leak = smoke/parity では順序が逆でも
+//! 走らず**永久 leak（teardown はどのスレッドでも一切走らない）**になる（smoke/parity では順序が逆でも
 //! 緑なので、この宣言順を守る唯一のガードが本コメント）。本型は home == audio == 唯一スレッドなので teardown
 //! は単一スレッドで完結し、daemon の split-thread（`ClapTeardownGuard` で跨ぐ）wrong-thread 問題を sidestep する。
 //!
@@ -163,6 +163,7 @@ impl ClapInstrumentProcessor {
     /// 意味論・teardown の順序契約は [`crate::ClapEffectProcessor::split`] と同一
     /// （audio 側の [`ClapInstrumentAudio::drop`] → main が join →
     /// [`ClapPluginMain`] drop = 唯一所有者として home スレッドで実 teardown）。
+    /// 逆順の帰結も同じく **永久 leak（teardown はどのスレッドでも一切走らない）**。
     pub fn split(self) -> (ClapInstrumentAudio, ClapPluginMain) {
         let Self {
             plugin,

--- a/rust/crates/orbit-clap-host/src/lib.rs
+++ b/rust/crates/orbit-clap-host/src/lib.rs
@@ -20,6 +20,7 @@ mod effect;
 mod events;
 mod host;
 mod instrument;
+mod plugin_main;
 mod processor;
 mod state;
 
@@ -28,12 +29,13 @@ pub use controller::{ClapHost, ClapHostError, LoadedPluginInfo};
 // #463 plugin catalog スキャナ（orbit-plugin-scan）が discovery API を外部から使うために追加
 // re-export（DiscoveryError は元から公開済み）。ロジック変更なし。
 pub use discovery::{list_plugins_in_file, DiscoveryError, FoundPlugin, PluginDescriptor};
-pub use effect::{ClapEffectAudio, ClapEffectMain, ClapEffectProcessor};
+pub use effect::{ClapEffectAudio, ClapEffectProcessor};
 pub use events::{
     make_event_ring, push_neutral_event, PluginEvent, PluginEventConsumer, PluginEventProducer,
 };
-pub use instrument::{ClapInstrumentAudio, ClapInstrumentMain, ClapInstrumentProcessor};
+pub use instrument::{ClapInstrumentAudio, ClapInstrumentProcessor};
 pub use orbit_audio_native::PostProcessor;
+pub use plugin_main::ClapPluginMain;
 pub use processor::{ClapPostProcessor, ClapProcessorStats, InstallMsg};
 pub use state::EMPTY_STATE_FROM_PLUGIN;
 

--- a/rust/crates/orbit-clap-host/src/lib.rs
+++ b/rust/crates/orbit-clap-host/src/lib.rs
@@ -28,11 +28,11 @@ pub use controller::{ClapHost, ClapHostError, LoadedPluginInfo};
 // #463 plugin catalog スキャナ（orbit-plugin-scan）が discovery API を外部から使うために追加
 // re-export（DiscoveryError は元から公開済み）。ロジック変更なし。
 pub use discovery::{list_plugins_in_file, DiscoveryError, FoundPlugin, PluginDescriptor};
-pub use effect::ClapEffectProcessor;
+pub use effect::{ClapEffectAudio, ClapEffectMain, ClapEffectProcessor};
 pub use events::{
     make_event_ring, push_neutral_event, PluginEvent, PluginEventConsumer, PluginEventProducer,
 };
-pub use instrument::ClapInstrumentProcessor;
+pub use instrument::{ClapInstrumentAudio, ClapInstrumentMain, ClapInstrumentProcessor};
 pub use orbit_audio_native::PostProcessor;
 pub use processor::{ClapPostProcessor, ClapProcessorStats, InstallMsg};
 pub use state::EMPTY_STATE_FROM_PLUGIN;

--- a/rust/crates/orbit-clap-host/src/plugin_main.rs
+++ b/rust/crates/orbit-clap-host/src/plugin_main.rs
@@ -1,0 +1,25 @@
+use clack_host::prelude::PluginInstance;
+
+use crate::controller::ClapHostError;
+use crate::host::OrbitClapHost;
+
+/// Main（home）スレッド側を CLAP effect / instrument で共有する。
+///
+/// `!Send`（[`PluginInstance`] を含む）。state 操作（`[main-thread]` 契約）を担い、
+/// audio 側が先に drop された後、唯一の Arc 所有者として実 teardown を home スレッドで
+/// 走らせる。
+pub struct ClapPluginMain {
+    pub(crate) instance: PluginInstance<OrbitClapHost>,
+}
+
+impl ClapPluginMain {
+    /// ホストしているプラグインの state を吸い上げる（契約は [`crate::state::capture_state`]）。
+    pub fn capture_state(&mut self) -> Result<Vec<u8>, ClapHostError> {
+        crate::state::capture_state(&mut self.instance)
+    }
+
+    /// 保存済み state を適用する（契約は [`crate::state::apply_state_bytes`]）。
+    pub fn apply_state_bytes(&mut self, bytes: &[u8]) -> Result<(), ClapHostError> {
+        crate::state::apply_state_bytes(&mut self.instance, bytes)
+    }
+}

--- a/rust/crates/orbit-clap-instrument-child/Cargo.toml
+++ b/rust/crates/orbit-clap-instrument-child/Cargo.toml
@@ -15,4 +15,5 @@ path = "src/main.rs"
 [dependencies]
 orbit-clap-host = { path = "../orbit-clap-host" }
 orbit-audio-sandbox = { path = "../orbit-audio-sandbox" }
+orbit-child-runtime = { path = "../orbit-child-runtime" }
 anyhow = "1"

--- a/rust/crates/orbit-clap-instrument-child/src/main.rs
+++ b/rust/crates/orbit-clap-instrument-child/src/main.rs
@@ -11,6 +11,7 @@ use orbit_audio_sandbox::{
     open_shared, region_ptr, slot_index, slot_offset, EventRecord, EventSpillFifo, NeutralEvent,
     ParentWatch, SharedRegion, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_EVENTS_PER_BLOCK, MAX_FRAMES,
 };
+use orbit_child_runtime::run_child;
 use orbit_clap_host::{push_neutral_event, ClapInstrumentProcessor, EventBuffer};
 
 struct Args {
@@ -185,7 +186,7 @@ fn main() -> Result<()> {
         None => None,
         Some(path) => Some(std::fs::read(path).with_context(|| format!("read state {path:?}"))?),
     };
-    let (mut instrument, _info) = ClapInstrumentProcessor::load(
+    let (instrument, _info) = ClapInstrumentProcessor::load(
         &args.plugin,
         args.plugin_id.as_deref(),
         args.sample_rate,
@@ -198,121 +199,133 @@ fn main() -> Result<()> {
     unsafe {
         orbit_audio_sandbox::transport::publish_child_ready(region, instrument.has_audio_input());
     }
-    let mut scratch = vec![0.0f32; BUF_LEN];
-    // Event window 分を事前確保し、hot loop での buffer 再確保を避ける。
-    let mut event_buf = EventBuffer::with_capacity(MAX_EVENTS_PER_BLOCK);
-    let mut output_event_buf = EventBuffer::with_capacity(MAX_EVENTS_PER_BLOCK);
-    let mut event_scratch: Vec<NeutralEvent> = Vec::with_capacity(MAX_EVENTS_PER_BLOCK);
-    let mut output_spill = EventSpillFifo::new();
-    let mut process_errors = 0u64;
-    // After a supervisor respawn this always restarts from 0, so the child re-processes every
-    // historical seq up to the current `seq_request` (no resume-point handshake exists yet).
-    // Tracked in #418.
-    let mut last = 0u64;
+    let (mut instrument_audio, mut instrument_main) = instrument.split();
     // orphan 対策(#448): host(daemon)が CONTROL_QUIT を書かずに死ぬ経路(プロセス exit・
-    // SIGKILL・crash)でも spin loop を抜けられるよう、親死活を低頻度で監視する。
+    // SIGKILL・crash)でも main runloop を止められるよう、親死活をタイマーで監視する。
     let mut parent_watch = ParentWatch::new();
-
-    loop {
-        if unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT {
-            break;
-        }
-        if parent_watch.should_exit() {
-            eprintln!("[orbit-clap-instrument-child] 親プロセス死亡を検知、終了する");
-            break;
-        }
-        // #557: host からのコマンドを処理する（UIH.2）。VST3 child と同じ共有層を使うので、
-        // ack の publish 順序・未知 kind の扱い・detail の切り詰め禁止は自動的に継承される。
-        unsafe {
-            service_command_mailbox(region, |kind, arg| match kind {
-                CMD_SAVE_STATE => Some(save_state_command(arg, || instrument.capture_state())),
-                _ => None,
-            });
-        }
-        let cur = unsafe { (*region).seq_request.load(Acquire) };
-        if cur <= last {
-            std::hint::spin_loop();
-            continue;
-        }
-        for seq in in_order_seqs(last, cur) {
-            let idx = slot_index(seq);
-            let off = slot_offset(seq);
-            let n_frames =
-                unsafe { ((*region).n_frames[idx].load(Relaxed) as usize).min(MAX_FRAMES) };
-            let sample_count = n_frames * CHANNELS;
-            let event_count = unsafe {
-                (*region).input_event_count[idx]
-                    .load(Relaxed)
-                    .min(MAX_EVENTS_PER_BLOCK as u32)
-            };
-            let decode_errors = unsafe {
-                decode_slot_events(
-                    &(*region).input_events[idx],
-                    event_count,
-                    &mut event_scratch,
-                )
-            };
-            if decode_errors != 0 {
-                unsafe {
-                    (*region)
-                        .event_decode_error_count
-                        .fetch_add(decode_errors as u64, Relaxed);
-                }
+    let region_addr = region as usize;
+    let process_errors = run_child(
+        "orbit-clap-instrument-child",
+        || {
+            // Mailbox servicing is confined to the AppKit main runloop.
+            unsafe {
+                service_command_mailbox(region, |kind, arg| match kind {
+                    CMD_SAVE_STATE => {
+                        Some(save_state_command(arg, || instrument_main.capture_state()))
+                    }
+                    _ => None,
+                });
             }
-            event_buf.clear();
-            for event in &event_scratch {
-                // `false` means this NeutralEvent has no CLAP translation (e.g. PolyPressure,
-                // an intentional v1 drop — see orbit-clap-host/src/events.rs). Currently
-                // unreachable: the host only ever emits NoteOn/NoteOff/NoteChoke, which always
-                // translate. Reuse event_decode_error_count rather than add a new counter, per
-                // docs/development/POST_2.0_GAMMA_M2_DESIGN.md §4 ("child can't honor this
-                // event" visibility).
-                if !push_neutral_event(&mut event_buf, event) {
+            if unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT {
+                return true;
+            }
+            if parent_watch.should_exit() {
+                eprintln!("[orbit-clap-instrument-child] 親プロセス死亡を検知、終了する");
+                return true;
+            }
+            false
+        },
+        move |stop_audio| {
+            let region = region_addr as *mut SharedRegion;
+            let mut scratch = vec![0.0f32; BUF_LEN];
+            let mut event_buf = EventBuffer::with_capacity(MAX_EVENTS_PER_BLOCK);
+            let mut output_event_buf = EventBuffer::with_capacity(MAX_EVENTS_PER_BLOCK);
+            let mut event_scratch: Vec<NeutralEvent> = Vec::with_capacity(MAX_EVENTS_PER_BLOCK);
+            let mut output_spill = EventSpillFifo::new();
+            let mut process_errors = 0u64;
+            // Respawn starts at zero; there is no resume-point handshake yet (#418).
+            let mut last = 0u64;
+
+            loop {
+                if stop_audio.load(Relaxed)
+                    || unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT
+                {
+                    break;
+                }
+                let cur = unsafe { (*region).seq_request.load(Acquire) };
+                if cur <= last {
+                    std::hint::spin_loop();
+                    continue;
+                }
+                for seq in in_order_seqs(last, cur) {
+                    let idx = slot_index(seq);
+                    let off = slot_offset(seq);
+                    let n_frames =
+                        unsafe { ((*region).n_frames[idx].load(Relaxed) as usize).min(MAX_FRAMES) };
+                    let sample_count = n_frames * CHANNELS;
+                    let event_count = unsafe {
+                        (*region).input_event_count[idx]
+                            .load(Relaxed)
+                            .min(MAX_EVENTS_PER_BLOCK as u32)
+                    };
+                    let decode_errors = unsafe {
+                        decode_slot_events(
+                            &(*region).input_events[idx],
+                            event_count,
+                            &mut event_scratch,
+                        )
+                    };
+                    if decode_errors != 0 {
+                        unsafe {
+                            (*region)
+                                .event_decode_error_count
+                                .fetch_add(decode_errors as u64, Relaxed);
+                        }
+                    }
+                    event_buf.clear();
+                    for event in &event_scratch {
+                        if !push_neutral_event(&mut event_buf, event) {
+                            unsafe {
+                                (*region).event_decode_error_count.fetch_add(1, Relaxed);
+                            }
+                        }
+                    }
+                    scratch[..sample_count].fill(0.0);
+                    if !instrument_audio.process_block(
+                        &mut scratch[..sample_count],
+                        &event_buf,
+                        &mut output_event_buf,
+                    ) {
+                        process_errors += 1;
+                        unsafe {
+                            (*region).child_process_error_count.fetch_add(1, Relaxed);
+                        }
+                    }
                     unsafe {
-                        (*region).event_decode_error_count.fetch_add(1, Relaxed);
+                        publish_completed_slot(
+                            region,
+                            seq,
+                            |region| {
+                                let out_base = std::ptr::addr_of_mut!((*region).output) as *mut f32;
+                                std::ptr::copy_nonoverlapping(
+                                    scratch.as_ptr(),
+                                    out_base.add(off),
+                                    sample_count,
+                                );
+                                let window = std::slice::from_raw_parts_mut(
+                                    std::ptr::addr_of_mut!((*region).output_events[idx])
+                                        as *mut EventRecord,
+                                    MAX_EVENTS_PER_BLOCK,
+                                );
+                                let translated = (&output_event_buf)
+                                    .into_iter()
+                                    .filter_map(ClapInstrumentProcessor::neutral_output_event);
+                                let outcome =
+                                    write_output_events(window, &mut output_spill, translated);
+                                apply_output_write_outcome(region, idx, outcome);
+                                (*region).child_processed.fetch_add(1, Relaxed);
+                            },
+                            || {},
+                        );
                     }
                 }
+                last = cur.max(last);
             }
-            scratch[..sample_count].fill(0.0);
-            if !instrument.process_block(
-                &mut scratch[..sample_count],
-                &event_buf,
-                &mut output_event_buf,
-            ) {
-                process_errors += 1;
-                unsafe {
-                    (*region).child_process_error_count.fetch_add(1, Relaxed);
-                }
-            }
-            unsafe {
-                publish_completed_slot(
-                    region,
-                    seq,
-                    |region| {
-                        let out_base = std::ptr::addr_of_mut!((*region).output) as *mut f32;
-                        std::ptr::copy_nonoverlapping(
-                            scratch.as_ptr(),
-                            out_base.add(off),
-                            sample_count,
-                        );
-                        let window = std::slice::from_raw_parts_mut(
-                            std::ptr::addr_of_mut!((*region).output_events[idx])
-                                as *mut EventRecord,
-                            MAX_EVENTS_PER_BLOCK,
-                        );
-                        let translated = (&output_event_buf)
-                            .into_iter()
-                            .filter_map(ClapInstrumentProcessor::neutral_output_event);
-                        let outcome = write_output_events(window, &mut output_spill, translated);
-                        apply_output_write_outcome(region, idx, outcome);
-                        (*region).child_processed.fetch_add(1, Relaxed);
-                    },
-                    || {},
-                );
-            }
-        }
-        last = cur.max(last);
-    }
+            instrument_audio.stop_processing();
+            process_errors
+        },
+    )?;
+
     if process_errors != 0 {
         eprintln!(
             "[orbit-clap-instrument-child] plugin.process() が {process_errors} ブロックで失敗"

--- a/rust/crates/orbit-clap-instrument-child/src/main.rs
+++ b/rust/crates/orbit-clap-instrument-child/src/main.rs
@@ -321,7 +321,7 @@ fn main() -> Result<()> {
                 }
                 last = cur.max(last);
             }
-            instrument_audio.stop_processing();
+            // ClapInstrumentAudio::drop runs stop_processing on this audio thread.
             process_errors
         },
     )?;

--- a/rust/crates/orbit-vst3-effect-child/Cargo.toml
+++ b/rust/crates/orbit-vst3-effect-child/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [dependencies]
 orbit-vst3-host = { path = "../orbit-vst3-host" }
 orbit-audio-sandbox = { path = "../orbit-audio-sandbox" }
+orbit-child-runtime = { path = "../orbit-child-runtime" }
 anyhow = "1"
 
 # mailbox_wiring テストが load させる effect oracle。**state の encode/decode を手書きしない**

--- a/rust/crates/orbit-vst3-effect-child/src/main.rs
+++ b/rust/crates/orbit-vst3-effect-child/src/main.rs
@@ -26,6 +26,8 @@ use orbit_audio_sandbox::{
     ParentWatch, BUF_LEN, CHANNELS, CMD_SAVE_STATE, CONTROL_QUIT, MAX_FRAMES,
 };
 #[cfg(target_os = "macos")]
+use orbit_child_runtime::run_child;
+#[cfg(target_os = "macos")]
 use orbit_vst3_host::Vst3EffectProcessor;
 
 #[cfg(target_os = "macos")]
@@ -86,7 +88,7 @@ fn main() -> Result<()> {
         Some(path) => Some(std::fs::read(path).with_context(|| format!("read state {path:?}"))?),
         None => None,
     };
-    let (mut effect, info) = Vst3EffectProcessor::load(
+    let (effect, info) = Vst3EffectProcessor::load(
         &args.plugin,
         args.sample_rate as f64,
         MAX_FRAMES as i32,
@@ -101,59 +103,78 @@ fn main() -> Result<()> {
     unsafe {
         orbit_audio_sandbox::transport::publish_child_ready(region, info.audio_inputs > 0);
     }
+    let (mut effect_audio, effect_main) = effect.split();
 
-    let mut scratch = vec![0.0f32; BUF_LEN];
-    let mut process_errors: u64 = 0;
-
-    let mut last: u64 = 0;
     // orphan 対策(#448): host(daemon)が CONTROL_QUIT を書かずに死ぬ経路(プロセス exit・
-    // SIGKILL・crash)でも spin loop を抜けられるよう、親死活を低頻度で監視する。
+    // SIGKILL・crash)でも main runloop を止められるよう、親死活をタイマーで監視する。
     let mut parent_watch = ParentWatch::new();
-    loop {
-        if unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT {
-            break;
-        }
-        if parent_watch.should_exit() {
-            eprintln!("[orbit-vst3-effect-child] 親プロセス死亡を検知、終了する");
-            break;
-        }
-        unsafe {
-            service_command_mailbox(region, |kind, arg| match kind {
-                CMD_SAVE_STATE => Some(save_state_command(arg, || effect.capture_state())),
-                _ => None,
-            });
-        }
-        let cur = unsafe { (*region).seq_request.load(Acquire) };
-        if cur > last {
-            let idx = slot_index(cur);
-            let off = slot_offset(cur);
-            let count = unsafe {
-                let n = ((*region).n_frames[idx].load(Relaxed) as usize).min(MAX_FRAMES);
-                let count = n * CHANNELS;
-                let in_base = std::ptr::addr_of!((*region).input) as *const f32;
-                std::ptr::copy_nonoverlapping(in_base.add(off), scratch.as_mut_ptr(), count);
-                count
-            };
-
-            if !effect.process_block(&mut scratch[..count]) {
-                process_errors += 1;
-                unsafe {
-                    (*region).child_process_error_count.fetch_add(1, Relaxed);
-                }
-            }
-
+    let region_addr = region as usize;
+    let process_errors = run_child(
+        "orbit-vst3-effect-child",
+        || {
             unsafe {
-                let out_base = std::ptr::addr_of_mut!((*region).output) as *mut f32;
-                std::ptr::copy_nonoverlapping(scratch.as_ptr(), out_base.add(off), count);
-                (*region).child_processed.fetch_add(1, Relaxed);
-                (*region).seq_tag[idx].store(cur, Release);
-                (*region).seq_done.store(cur, Release);
+                service_command_mailbox(region, |kind, arg| match kind {
+                    CMD_SAVE_STATE => Some(save_state_command(arg, || effect_main.capture_state())),
+                    _ => None,
+                });
             }
-            last = cur;
-        } else {
-            std::hint::spin_loop();
-        }
-    }
+            if unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT {
+                return true;
+            }
+            if parent_watch.should_exit() {
+                eprintln!("[orbit-vst3-effect-child] 親プロセス死亡を検知、終了する");
+                return true;
+            }
+            false
+        },
+        move |stop_audio| {
+            let region = region_addr as *mut orbit_audio_sandbox::SharedRegion;
+            let mut scratch = vec![0.0f32; BUF_LEN];
+            let mut process_errors = 0u64;
+            let mut last = 0u64;
+
+            loop {
+                if stop_audio.load(Relaxed)
+                    || unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT
+                {
+                    break;
+                }
+                let cur = unsafe { (*region).seq_request.load(Acquire) };
+                if cur <= last {
+                    std::hint::spin_loop();
+                    continue;
+                }
+                let idx = slot_index(cur);
+                let off = slot_offset(cur);
+                let count = unsafe {
+                    let n = ((*region).n_frames[idx].load(Relaxed) as usize).min(MAX_FRAMES);
+                    let count = n * CHANNELS;
+                    let in_base = std::ptr::addr_of!((*region).input) as *const f32;
+                    std::ptr::copy_nonoverlapping(in_base.add(off), scratch.as_mut_ptr(), count);
+                    count
+                };
+
+                if !effect_audio.process_block(&mut scratch[..count]) {
+                    process_errors += 1;
+                    unsafe {
+                        (*region).child_process_error_count.fetch_add(1, Relaxed);
+                    }
+                }
+
+                unsafe {
+                    let out_base = std::ptr::addr_of_mut!((*region).output) as *mut f32;
+                    std::ptr::copy_nonoverlapping(scratch.as_ptr(), out_base.add(off), count);
+                    (*region).child_processed.fetch_add(1, Relaxed);
+                    (*region).seq_tag[idx].store(cur, Release);
+                    (*region).seq_done.store(cur, Release);
+                }
+                last = cur;
+            }
+            // Vst3EffectAudio::drop runs setProcessing(0) on this audio thread.
+            process_errors
+        },
+    )?;
+
     if process_errors > 0 {
         eprintln!(
             "[orbit-vst3-effect-child] plugin.process() failed for {process_errors} block(s); \

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -528,8 +528,9 @@ unsafe impl Send for Vst3EffectAudio {}
 
 impl Drop for Vst3EffectAudio {
     fn drop(&mut self) {
-        unsafe {
-            let _ = self.processor.setProcessing(0);
+        let result = unsafe { self.processor.setProcessing(0) };
+        if !is_ok(result) && result != kNotImplemented {
+            eprintln!("[orbit-vst3-host] effect setProcessing(0) failed: {result}");
         }
     }
 }
@@ -982,8 +983,9 @@ unsafe impl Send for Vst3InstrumentAudio {}
 
 impl Drop for Vst3InstrumentAudio {
     fn drop(&mut self) {
-        unsafe {
-            let _ = self.processor.setProcessing(0);
+        let result = unsafe { self.processor.setProcessing(0) };
+        if !is_ok(result) && result != kNotImplemented {
+            eprintln!("[orbit-vst3-host] instrument setProcessing(0) failed: {result}");
         }
     }
 }
@@ -2755,6 +2757,13 @@ fn json_escape(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn audio_halves_are_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Vst3EffectAudio>();
+        assert_send::<Vst3InstrumentAudio>();
+    }
 
     // I6(pr-review-team): `is_ok` gates every tresult check in this crate (setup/activate/process
     // ...) but had no direct unit test — pin the kResultOk/kResultTrue/kResultFalse/kNotImplemented

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -408,18 +408,29 @@ impl Drop for CfUrl {
     }
 }
 
-/// Single-threaded VST3 effect processor.
+/// Main(home)-thread half shared by the split VST3 effect / instrument processors (#474 P1).
 ///
-/// `Rc` makes this type `!Send` and `!Sync`. Construct, process, and drop it on the same home
-/// thread. Shutdown call order (`setProcessing` → disconnect → `controller.terminate` →
-/// `component.setActive(0)`/`terminate`) is enforced by the hand-written `Drop::drop` body below
-/// via explicit `.take()` calls, not by field declaration order. Field order is load-bearing only
-/// for the *implicit* drop of the fields `Drop::drop` does not `.take()`: `_component_handler`
-/// and `_host_context` must be declared (and therefore dropped) before `_library`, so any COM
-/// callback objects backed by the plugin's vtables are released before the dynamic library is
-/// unloaded.
-pub struct Vst3EffectProcessor {
-    processor: Option<ComPtr<IAudioProcessor>>,
+/// Holds everything the per-block `process` call does **not** need: the component (state
+/// capture), the controller handshake, the factory, and the dynamic library. `Rc` makes this
+/// `!Send` — it stays on the thread that called `load` (the home thread), which is where the
+/// VST3 `[main-thread]` contract wants `getState` (CAP.5 / UIH.1).
+///
+/// ## Teardown（🔴 順序が正しさの条件）
+///
+/// `Drop` はモノリシック時代の shutdown 列の **後半**（disconnect → `controller.terminate` →
+/// `component.setActive(0)`/`terminate` → factory 解放）を実行する。前半の
+/// `setProcessing(0)` は audio 側（[`Vst3EffectAudio`] / [`Vst3InstrumentAudio`]）の `Drop` が
+/// 担うため、**audio 側が先に drop されていなければならない**:
+/// - 未分割の composite（[`Vst3EffectProcessor`] / [`Vst3InstrumentProcessor`]）では
+///   フィールド宣言順（audio が main より前）がこれを強制する
+/// - 分割後（`split()`）は、main スレッドが **audio スレッドを join してから**本型を drop
+///   することで強制する（`orbit-child-runtime` の関数構造がこの順序を持つ）
+///
+/// Field order is load-bearing for the *implicit* drops `Drop::drop` does not `.take()`:
+/// `_component_handler` and `_host_context` must be declared (and therefore dropped) before
+/// `_library`, so any COM callback objects backed by the plugin's vtables are released before
+/// the dynamic library is unloaded.
+pub struct Vst3PluginMain {
     controller: Option<ComPtr<IEditController>>,
     component_connection: Option<ComPtr<IConnectionPoint>>,
     controller_connection: Option<ComPtr<IConnectionPoint>>,
@@ -430,6 +441,60 @@ pub struct Vst3EffectProcessor {
     _home_thread: PhantomData<Rc<()>>,
     _library: LoadedLibrary,
     info: LoadedVst3Info,
+}
+
+impl Vst3PluginMain {
+    /// 現在の component state を取得する（空 state 拒否の規律込み）。
+    ///
+    /// **スレッド**: home（main）スレッドから呼ぶこと（CAP.5・VST3 の規約）。
+    pub fn capture_state(&self) -> Result<Vec<u8>, Vst3HostError> {
+        let component = self
+            .component
+            .as_ref()
+            .ok_or_else(|| Vst3HostError::State("component is not loaded".into()))?;
+        capture_component_state(component)
+    }
+
+    pub fn info(&self) -> &LoadedVst3Info {
+        &self.info
+    }
+}
+
+impl Drop for Vst3PluginMain {
+    fn drop(&mut self) {
+        if let (Some(component_connection), Some(controller_connection)) = (
+            self.component_connection.as_ref(),
+            self.controller_connection.as_ref(),
+        ) {
+            unsafe {
+                let _ = component_connection.disconnect(controller_connection.as_ptr());
+                let _ = controller_connection.disconnect(component_connection.as_ptr());
+            }
+        }
+        let _ = self.component_connection.take();
+        let _ = self.controller_connection.take();
+        if let Some(controller) = self.controller.take() {
+            unsafe {
+                let _ = controller.terminate();
+            }
+        }
+        if let Some(component) = self.component.take() {
+            unsafe {
+                let _ = component.setActive(0);
+                let _ = component.terminate();
+            }
+        }
+        let _ = self.factory.take();
+    }
+}
+
+/// Audio-thread half of the split VST3 effect processor (#474 P1). Owns exactly what the
+/// per-block `process` call touches: the `IAudioProcessor`, the host-side COM stubs, and the
+/// de-interleave scratch buffers. `Drop` calls `setProcessing(0)`（分割後は audio スレッド上で
+/// 走る — モノリシック時代も process と同一スレッドで呼んでいたので契約上同等以上）。
+pub struct Vst3EffectAudio {
+    processor: ComPtr<IAudioProcessor>,
+    is_effect: bool,
     sample_rate: f64,
     /// `IProcessContextRequirements` flags queried once at load time (`load()`). The plugin's
     /// requirements do not change over its lifetime, so re-querying per block would be a wasted
@@ -449,6 +514,34 @@ pub struct Vst3EffectProcessor {
     process_input_r: Vec<f32>,
     process_output_l: Vec<f32>,
     process_output_r: Vec<f32>,
+}
+
+// SAFETY (#474 P1 / UIH.1): 専用 audio スレッドへの move は VST3 ホストの正準モデルである —
+// `IAudioProcessor::process` は非 main の RT スレッドから駆動されることが想定されており、
+// COM の参照カウント（`FUnknown`）は VST3 契約上スレッド安全が要求される。ここが所有する
+// host 側 COM スタブ（`ParameterChanges` / `EventList`）は move 後は所有スレッドだけが触る
+// （`thread::spawn` の引き渡しが happens-before を確立する）。加えて正しさは
+// [`Vst3PluginMain`] に記した teardown 順序（audio 側の `setProcessing(0)` が main 側の
+// terminate 列より先）に依存する — composite ではフィールド順、分割 child では
+// 「join してから main 側を drop」の関数構造が強制する。
+unsafe impl Send for Vst3EffectAudio {}
+
+impl Drop for Vst3EffectAudio {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = self.processor.setProcessing(0);
+        }
+    }
+}
+
+/// Single-threaded-by-default VST3 effect processor: [`Vst3EffectAudio`] + [`Vst3PluginMain`]
+/// の composite。`load` したスレッド上でそのまま使う（従来 API 互換）か、`split()` で
+/// main / audio の 2 スレッド運用（UIH.1）へ分割する。
+pub struct Vst3EffectProcessor {
+    /// 🔴 宣言順 = drop 順: audio（`setProcessing(0)`）が main の teardown 列より先。
+    /// モノリシック時代の明示的 `Drop::drop` と同じ shutdown 順序をフィールド順で再現する。
+    audio: Vst3EffectAudio,
+    main: Vst3PluginMain,
 }
 
 impl Vst3EffectProcessor {
@@ -563,44 +656,74 @@ impl Vst3EffectProcessor {
 
         let scratch_len = max_samples_per_block.max(0) as usize;
         let processor = Self {
-            processor: Some(processor),
-            controller: controller_handshake.controller,
-            component_connection: controller_handshake.component_connection,
-            controller_connection: controller_handshake.controller_connection,
-            component: Some(component),
-            _component_handler: controller_handshake.component_handler,
-            _host_context: host_context,
-            factory: Some(factory),
-            _home_thread: PhantomData,
-            _library: library,
-            info: info.clone(),
-            sample_rate,
-            process_context_requirements,
-            output_parameter_changes: ParameterChanges::empty(),
-            input_events: EventList::empty(),
-            output_events: EventList::empty(),
-            block_parameter_changes: ParameterChanges::empty(),
-            process_input_l: vec![0.0; scratch_len],
-            process_input_r: vec![0.0; scratch_len],
-            process_output_l: vec![0.0; scratch_len],
-            process_output_r: vec![0.0; scratch_len],
+            audio: Vst3EffectAudio {
+                processor,
+                is_effect: info.is_effect,
+                sample_rate,
+                process_context_requirements,
+                output_parameter_changes: ParameterChanges::empty(),
+                input_events: EventList::empty(),
+                output_events: EventList::empty(),
+                block_parameter_changes: ParameterChanges::empty(),
+                process_input_l: vec![0.0; scratch_len],
+                process_input_r: vec![0.0; scratch_len],
+                process_output_l: vec![0.0; scratch_len],
+                process_output_r: vec![0.0; scratch_len],
+            },
+            main: Vst3PluginMain {
+                controller: controller_handshake.controller,
+                component_connection: controller_handshake.component_connection,
+                controller_connection: controller_handshake.controller_connection,
+                component: Some(component),
+                _component_handler: controller_handshake.component_handler,
+                _host_context: host_context,
+                factory: Some(factory),
+                _home_thread: PhantomData,
+                _library: library,
+                info: info.clone(),
+            },
         };
         Ok((processor, info))
     }
 
+    /// main / audio の 2 スレッド運用（UIH.1）へ分割する（#474 P1）。
+    ///
+    /// teardown の順序契約（audio 側 drop = `setProcessing(0)` → join →
+    /// [`Vst3PluginMain`] drop = terminate 列）は [`Vst3PluginMain`] の doc を参照。
+    pub fn split(self) -> (Vst3EffectAudio, Vst3PluginMain) {
+        (self.audio, self.main)
+    }
+
     /// 現在の effect component state を取得する。instrument と同じ空-state拒否規律を使う。
     pub fn capture_state(&self) -> Result<Vec<u8>, Vst3HostError> {
-        let component = self
-            .component
-            .as_ref()
-            .ok_or_else(|| Vst3HostError::State("component is not loaded".into()))?;
-        capture_component_state(component)
+        self.main.capture_state()
     }
 
     pub fn info(&self) -> &LoadedVst3Info {
-        &self.info
+        self.main.info()
     }
 
+    pub fn process_stereo(
+        &mut self,
+        input_l: &[f32],
+        input_r: &[f32],
+        output_l: &mut [f32],
+        output_r: &mut [f32],
+        gain: Option<f64>,
+    ) -> Result<ProcessReport, Vst3HostError> {
+        self.audio
+            .process_stereo(input_l, input_r, output_l, output_r, gain)
+    }
+
+    /// Interleaved stereo f32 blockを in-place で処理する child / offline parity 用 API
+    /// （[`Vst3EffectAudio::process_block`] へ委譲）。
+    #[must_use]
+    pub fn process_block(&mut self, data: &mut [f32]) -> bool {
+        self.audio.process_block(data)
+    }
+}
+
+impl Vst3EffectAudio {
     pub fn process_stereo(
         &mut self,
         input_l: &[f32],
@@ -648,7 +771,7 @@ impl Vst3EffectProcessor {
         }
         Ok(ProcessReport {
             processed: true,
-            is_effect: self.info.is_effect,
+            is_effect: self.is_effect,
         })
     }
 
@@ -695,7 +818,7 @@ impl Vst3EffectProcessor {
 
         for frame in 0..frames {
             let base = frame * DEFAULT_CHANNELS;
-            if self.info.is_effect {
+            if self.is_effect {
                 data[base] = self.process_output_l[frame];
                 data[base + 1] = self.process_output_r[frame];
             } else {
@@ -731,10 +854,7 @@ impl Vst3EffectProcessor {
         let Ok(num_samples) = i32::try_from(frames) else {
             return kInvalidArgument;
         };
-        let processor = self
-            .processor
-            .as_ref()
-            .expect("processor remains alive until drop");
+        let processor = &self.processor;
 
         let mut inputs = [AudioBusBuffers {
             numChannels: DEFAULT_CHANNELS as i32,
@@ -756,9 +876,9 @@ impl Vst3EffectProcessor {
             processMode: ProcessModes_::kRealtime as i32,
             symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
             numSamples: num_samples,
-            numInputs: if self.info.is_effect { 1 } else { 0 },
+            numInputs: if self.is_effect { 1 } else { 0 },
             numOutputs: 1,
-            inputs: if self.info.is_effect {
+            inputs: if self.is_effect {
                 inputs.as_mut_ptr()
             } else {
                 ptr::null_mut()
@@ -818,55 +938,10 @@ impl Vst3EffectProcessor {
     }
 }
 
-impl Drop for Vst3EffectProcessor {
-    fn drop(&mut self) {
-        if let Some(processor) = self.processor.take() {
-            unsafe {
-                let _ = processor.setProcessing(0);
-            }
-        }
-        if let (Some(component_connection), Some(controller_connection)) = (
-            self.component_connection.as_ref(),
-            self.controller_connection.as_ref(),
-        ) {
-            unsafe {
-                let _ = component_connection.disconnect(controller_connection.as_ptr());
-                let _ = controller_connection.disconnect(component_connection.as_ptr());
-            }
-        }
-        let _ = self.component_connection.take();
-        let _ = self.controller_connection.take();
-        if let Some(controller) = self.controller.take() {
-            unsafe {
-                let _ = controller.terminate();
-            }
-        }
-        if let Some(component) = self.component.take() {
-            unsafe {
-                let _ = component.setActive(0);
-                let _ = component.terminate();
-            }
-        }
-        let _ = self.factory.take();
-    }
-}
-
-/// Single-threaded VST3 instrument processor.
-///
-/// `Rc` makes this type `!Send` and `!Sync`. Construct, process, and drop it on the same home
-/// thread. Its explicit teardown order intentionally matches [`Vst3EffectProcessor`].
-pub struct Vst3InstrumentProcessor {
-    processor: Option<ComPtr<IAudioProcessor>>,
-    controller: Option<ComPtr<IEditController>>,
-    component_connection: Option<ComPtr<IConnectionPoint>>,
-    controller_connection: Option<ComPtr<IConnectionPoint>>,
-    component: Option<ComPtr<IComponent>>,
-    _component_handler: Option<ComWrapper<HostComponentHandler>>,
-    _host_context: ComWrapper<HostApplication>,
-    factory: Option<ComPtr<IPluginFactory>>,
-    _home_thread: PhantomData<Rc<()>>,
-    _library: LoadedLibrary,
-    info: LoadedVst3Info,
+/// Audio-thread half of the split VST3 instrument processor (#474 P1). `Send` の根拠と
+/// teardown 順序契約は [`Vst3EffectAudio`] / [`Vst3PluginMain`] と同一。
+pub struct Vst3InstrumentAudio {
+    processor: ComPtr<IAudioProcessor>,
     input_events: InputEventList,
     output_parameter_changes: ParameterChanges,
     output_events: EventList,
@@ -875,6 +950,27 @@ pub struct Vst3InstrumentProcessor {
     /// Raw tresult of the most recent failing `process()` call (RT-safe: no logging on the hot
     /// path, just stashed for the caller to surface out-of-band, e.g. on child process exit).
     last_process_error: std::cell::Cell<i32>,
+}
+
+// SAFETY: [`Vst3EffectAudio`] の SAFETY コメントと同一の根拠（VST3 の audio スレッド駆動は
+// 正準モデル・COM 参照カウントはスレッド安全・host 側 COM スタブは move 後single-thread 使用・
+// teardown 順序は composite のフィールド順 / 分割 child の join-then-drop が強制）。
+unsafe impl Send for Vst3InstrumentAudio {}
+
+impl Drop for Vst3InstrumentAudio {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = self.processor.setProcessing(0);
+        }
+    }
+}
+
+/// Single-threaded-by-default VST3 instrument processor: [`Vst3InstrumentAudio`] +
+/// [`Vst3PluginMain`] の composite（構成・分割・teardown 契約は [`Vst3EffectProcessor`] と対称）。
+pub struct Vst3InstrumentProcessor {
+    /// 🔴 宣言順 = drop 順: audio（`setProcessing(0)`）が main の teardown 列より先。
+    audio: Vst3InstrumentAudio,
+    main: Vst3PluginMain,
 }
 
 /// #540 P2: 保存済み state を component / controller へ復元する（`.vstpreset` container と
@@ -935,11 +1031,7 @@ impl Vst3InstrumentProcessor {
     /// `getState` が失敗した、または空を返した場合は `Err` を返す — **空 state を
     /// 「成功」として上位へ渡さない**（サイズ 0 を登記すると音色を失う）。
     pub fn capture_state(&self) -> Result<Vec<u8>, Vst3HostError> {
-        let component = self
-            .component
-            .as_ref()
-            .ok_or_else(|| Vst3HostError::State("component is not loaded".into()))?;
-        capture_component_state(component)
+        self.main.capture_state()
     }
 
     pub fn load(
@@ -1056,35 +1148,70 @@ impl Vst3InstrumentProcessor {
         let scratch_len = max_samples_per_block.max(0) as usize;
         Ok((
             Self {
-                processor: Some(processor),
-                controller: controller_handshake.controller,
-                component_connection: controller_handshake.component_connection,
-                controller_connection: controller_handshake.controller_connection,
-                component: Some(component),
-                _component_handler: controller_handshake.component_handler,
-                _host_context: host_context,
-                factory: Some(factory),
-                _home_thread: PhantomData,
-                _library: library,
-                info: info.clone(),
-                input_events: InputEventList::new(),
-                output_parameter_changes: ParameterChanges::empty(),
-                output_events: EventList::empty(),
-                process_output_l: vec![0.0; scratch_len],
-                process_output_r: vec![0.0; scratch_len],
-                last_process_error: std::cell::Cell::new(0),
+                audio: Vst3InstrumentAudio {
+                    processor,
+                    input_events: InputEventList::new(),
+                    output_parameter_changes: ParameterChanges::empty(),
+                    output_events: EventList::empty(),
+                    process_output_l: vec![0.0; scratch_len],
+                    process_output_r: vec![0.0; scratch_len],
+                    last_process_error: std::cell::Cell::new(0),
+                },
+                main: Vst3PluginMain {
+                    controller: controller_handshake.controller,
+                    component_connection: controller_handshake.component_connection,
+                    controller_connection: controller_handshake.controller_connection,
+                    component: Some(component),
+                    _component_handler: controller_handshake.component_handler,
+                    _host_context: host_context,
+                    factory: Some(factory),
+                    _home_thread: PhantomData,
+                    _library: library,
+                    info: info.clone(),
+                },
             },
             info,
         ))
     }
 
     pub fn info(&self) -> &LoadedVst3Info {
-        &self.info
+        self.main.info()
+    }
+
+    /// main / audio の 2 スレッド運用（UIH.1）へ分割する（#474 P1）。
+    /// 順序契約は [`Vst3EffectProcessor::split`] と同一。
+    pub fn split(self) -> (Vst3InstrumentAudio, Vst3PluginMain) {
+        (self.audio, self.main)
     }
 
     /// Raw tresult of the most recent failing `process()` call (0 / `kResultOk` if none since
     /// construction). Intended for out-of-band error reporting (e.g. child process exit summary),
     /// not for the audio-thread hot path.
+    pub fn last_process_error(&self) -> i32 {
+        self.audio.last_process_error()
+    }
+
+    pub fn push_note_on(&self, channel: i16, pitch: i16, velocity: f32, sample_offset: i32) {
+        self.audio
+            .push_note_on(channel, pitch, velocity, sample_offset);
+    }
+
+    pub fn push_note_off(&self, channel: i16, pitch: i16, velocity: f32, sample_offset: i32) {
+        self.audio
+            .push_note_off(channel, pitch, velocity, sample_offset);
+    }
+
+    /// Queued note events are delivered at their supplied sample offsets; successful plugin
+    /// output is add-mixed into interleaved stereo `data`
+    /// （[`Vst3InstrumentAudio::process_block`] へ委譲）。
+    #[must_use]
+    pub fn process_block(&mut self, data: &mut [f32]) -> bool {
+        self.audio.process_block(data)
+    }
+}
+
+impl Vst3InstrumentAudio {
+    /// Raw tresult of the most recent failing `process()` call（audio スレッド側）。
     pub fn last_process_error(&self) -> i32 {
         self.last_process_error.get()
     }
@@ -1147,12 +1274,7 @@ impl Vst3InstrumentProcessor {
             outputEvents: self.output_events.as_ptr(),
             processContext: ptr::null_mut(),
         };
-        let result = unsafe {
-            self.processor
-                .as_ref()
-                .expect("processor remains alive until drop")
-                .process(&mut process_data)
-        };
+        let result = unsafe { self.processor.process(&mut process_data) };
         self.input_events.clear();
         if !is_ok(result) {
             self.last_process_error.set(result);
@@ -1164,39 +1286,6 @@ impl Vst3InstrumentProcessor {
             data[base + 1] += self.process_output_r[frame];
         }
         true
-    }
-}
-
-impl Drop for Vst3InstrumentProcessor {
-    fn drop(&mut self) {
-        if let Some(processor) = self.processor.take() {
-            unsafe {
-                let _ = processor.setProcessing(0);
-            }
-        }
-        if let (Some(component_connection), Some(controller_connection)) = (
-            self.component_connection.as_ref(),
-            self.controller_connection.as_ref(),
-        ) {
-            unsafe {
-                let _ = component_connection.disconnect(controller_connection.as_ptr());
-                let _ = controller_connection.disconnect(component_connection.as_ptr());
-            }
-        }
-        let _ = self.component_connection.take();
-        let _ = self.controller_connection.take();
-        if let Some(controller) = self.controller.take() {
-            unsafe {
-                let _ = controller.terminate();
-            }
-        }
-        if let Some(component) = self.component.take() {
-            unsafe {
-                let _ = component.setActive(0);
-                let _ = component.terminate();
-            }
-        }
-        let _ = self.factory.take();
     }
 }
 

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -422,7 +422,7 @@ impl Drop for CfUrl {
 /// `setProcessing(0)` は audio 側（[`Vst3EffectAudio`] / [`Vst3InstrumentAudio`]）の `Drop` が
 /// 担うため、**audio 側が先に drop されていなければならない**:
 /// - 未分割の composite（[`Vst3EffectProcessor`] / [`Vst3InstrumentProcessor`]）では
-///   フィールド宣言順（audio が main より前）がこれを強制する
+///   hand-written `Drop::drop` の明示的な `.take()` 列がこれを強制する
 /// - 分割後（`split()`）は、main スレッドが **audio スレッドを join してから**本型を drop
 ///   することで強制する（`orbit-child-runtime` の関数構造がこの順序を持つ）
 ///
@@ -522,7 +522,7 @@ pub struct Vst3EffectAudio {
 // host 側 COM スタブ（`ParameterChanges` / `EventList`）は move 後は所有スレッドだけが触る
 // （`thread::spawn` の引き渡しが happens-before を確立する）。加えて正しさは
 // [`Vst3PluginMain`] に記した teardown 順序（audio 側の `setProcessing(0)` が main 側の
-// terminate 列より先）に依存する — composite ではフィールド順、分割 child では
+// terminate 列より先）に依存する — composite では明示 `Drop`、分割 child では
 // 「join してから main 側を drop」の関数構造が強制する。
 unsafe impl Send for Vst3EffectAudio {}
 
@@ -537,11 +537,12 @@ impl Drop for Vst3EffectAudio {
 /// Single-threaded-by-default VST3 effect processor: [`Vst3EffectAudio`] + [`Vst3PluginMain`]
 /// の composite。`load` したスレッド上でそのまま使う（従来 API 互換）か、`split()` で
 /// main / audio の 2 スレッド運用（UIH.1）へ分割する。
+///
+/// Shutdown call order is enforced by the hand-written [`Drop::drop`] body below via explicit
+/// `.take()` calls, not by field declaration order.
 pub struct Vst3EffectProcessor {
-    /// 🔴 宣言順 = drop 順: audio（`setProcessing(0)`）が main の teardown 列より先。
-    /// モノリシック時代の明示的 `Drop::drop` と同じ shutdown 順序をフィールド順で再現する。
-    audio: Vst3EffectAudio,
-    main: Vst3PluginMain,
+    audio: Option<Vst3EffectAudio>,
+    main: Option<Vst3PluginMain>,
 }
 
 impl Vst3EffectProcessor {
@@ -656,7 +657,7 @@ impl Vst3EffectProcessor {
 
         let scratch_len = max_samples_per_block.max(0) as usize;
         let processor = Self {
-            audio: Vst3EffectAudio {
+            audio: Some(Vst3EffectAudio {
                 processor,
                 is_effect: info.is_effect,
                 sample_rate,
@@ -669,8 +670,8 @@ impl Vst3EffectProcessor {
                 process_input_r: vec![0.0; scratch_len],
                 process_output_l: vec![0.0; scratch_len],
                 process_output_r: vec![0.0; scratch_len],
-            },
-            main: Vst3PluginMain {
+            }),
+            main: Some(Vst3PluginMain {
                 controller: controller_handshake.controller,
                 component_connection: controller_handshake.component_connection,
                 controller_connection: controller_handshake.controller_connection,
@@ -681,7 +682,7 @@ impl Vst3EffectProcessor {
                 _home_thread: PhantomData,
                 _library: library,
                 info: info.clone(),
-            },
+            }),
         };
         Ok((processor, info))
     }
@@ -690,17 +691,26 @@ impl Vst3EffectProcessor {
     ///
     /// teardown の順序契約（audio 側 drop = `setProcessing(0)` → join →
     /// [`Vst3PluginMain`] drop = terminate 列）は [`Vst3PluginMain`] の doc を参照。
-    pub fn split(self) -> (Vst3EffectAudio, Vst3PluginMain) {
-        (self.audio, self.main)
+    pub fn split(mut self) -> (Vst3EffectAudio, Vst3PluginMain) {
+        (
+            self.audio.take().expect("VST3 effect audio is present"),
+            self.main.take().expect("VST3 effect main is present"),
+        )
     }
 
     /// 現在の effect component state を取得する。instrument と同じ空-state拒否規律を使う。
     pub fn capture_state(&self) -> Result<Vec<u8>, Vst3HostError> {
-        self.main.capture_state()
+        self.main
+            .as_ref()
+            .expect("VST3 effect main is present")
+            .capture_state()
     }
 
     pub fn info(&self) -> &LoadedVst3Info {
-        self.main.info()
+        self.main
+            .as_ref()
+            .expect("VST3 effect main is present")
+            .info()
     }
 
     pub fn process_stereo(
@@ -712,6 +722,8 @@ impl Vst3EffectProcessor {
         gain: Option<f64>,
     ) -> Result<ProcessReport, Vst3HostError> {
         self.audio
+            .as_mut()
+            .expect("VST3 effect audio is present")
             .process_stereo(input_l, input_r, output_l, output_r, gain)
     }
 
@@ -719,7 +731,18 @@ impl Vst3EffectProcessor {
     /// （[`Vst3EffectAudio::process_block`] へ委譲）。
     #[must_use]
     pub fn process_block(&mut self, data: &mut [f32]) -> bool {
-        self.audio.process_block(data)
+        self.audio
+            .as_mut()
+            .expect("VST3 effect audio is present")
+            .process_block(data)
+    }
+}
+
+impl Drop for Vst3EffectProcessor {
+    fn drop(&mut self) {
+        // Shutdown order is explicit and independent of field declaration order.
+        let _ = self.audio.take();
+        let _ = self.main.take();
     }
 }
 
@@ -954,7 +977,7 @@ pub struct Vst3InstrumentAudio {
 
 // SAFETY: [`Vst3EffectAudio`] の SAFETY コメントと同一の根拠（VST3 の audio スレッド駆動は
 // 正準モデル・COM 参照カウントはスレッド安全・host 側 COM スタブは move 後single-thread 使用・
-// teardown 順序は composite のフィールド順 / 分割 child の join-then-drop が強制）。
+// teardown 順序は composite の明示 `Drop` / 分割 child の join-then-drop が強制）。
 unsafe impl Send for Vst3InstrumentAudio {}
 
 impl Drop for Vst3InstrumentAudio {
@@ -967,10 +990,12 @@ impl Drop for Vst3InstrumentAudio {
 
 /// Single-threaded-by-default VST3 instrument processor: [`Vst3InstrumentAudio`] +
 /// [`Vst3PluginMain`] の composite（構成・分割・teardown 契約は [`Vst3EffectProcessor`] と対称）。
+///
+/// Shutdown call order is enforced by the hand-written [`Drop::drop`] body below via explicit
+/// `.take()` calls, not by field declaration order.
 pub struct Vst3InstrumentProcessor {
-    /// 🔴 宣言順 = drop 順: audio（`setProcessing(0)`）が main の teardown 列より先。
-    audio: Vst3InstrumentAudio,
-    main: Vst3PluginMain,
+    audio: Option<Vst3InstrumentAudio>,
+    main: Option<Vst3PluginMain>,
 }
 
 /// #540 P2: 保存済み state を component / controller へ復元する（`.vstpreset` container と
@@ -1031,7 +1056,10 @@ impl Vst3InstrumentProcessor {
     /// `getState` が失敗した、または空を返した場合は `Err` を返す — **空 state を
     /// 「成功」として上位へ渡さない**（サイズ 0 を登記すると音色を失う）。
     pub fn capture_state(&self) -> Result<Vec<u8>, Vst3HostError> {
-        self.main.capture_state()
+        self.main
+            .as_ref()
+            .expect("VST3 instrument main is present")
+            .capture_state()
     }
 
     pub fn load(
@@ -1148,7 +1176,7 @@ impl Vst3InstrumentProcessor {
         let scratch_len = max_samples_per_block.max(0) as usize;
         Ok((
             Self {
-                audio: Vst3InstrumentAudio {
+                audio: Some(Vst3InstrumentAudio {
                     processor,
                     input_events: InputEventList::new(),
                     output_parameter_changes: ParameterChanges::empty(),
@@ -1156,8 +1184,8 @@ impl Vst3InstrumentProcessor {
                     process_output_l: vec![0.0; scratch_len],
                     process_output_r: vec![0.0; scratch_len],
                     last_process_error: std::cell::Cell::new(0),
-                },
-                main: Vst3PluginMain {
+                }),
+                main: Some(Vst3PluginMain {
                     controller: controller_handshake.controller,
                     component_connection: controller_handshake.component_connection,
                     controller_connection: controller_handshake.controller_connection,
@@ -1168,36 +1196,49 @@ impl Vst3InstrumentProcessor {
                     _home_thread: PhantomData,
                     _library: library,
                     info: info.clone(),
-                },
+                }),
             },
             info,
         ))
     }
 
     pub fn info(&self) -> &LoadedVst3Info {
-        self.main.info()
+        self.main
+            .as_ref()
+            .expect("VST3 instrument main is present")
+            .info()
     }
 
     /// main / audio の 2 スレッド運用（UIH.1）へ分割する（#474 P1）。
     /// 順序契約は [`Vst3EffectProcessor::split`] と同一。
-    pub fn split(self) -> (Vst3InstrumentAudio, Vst3PluginMain) {
-        (self.audio, self.main)
+    pub fn split(mut self) -> (Vst3InstrumentAudio, Vst3PluginMain) {
+        (
+            self.audio.take().expect("VST3 instrument audio is present"),
+            self.main.take().expect("VST3 instrument main is present"),
+        )
     }
 
     /// Raw tresult of the most recent failing `process()` call (0 / `kResultOk` if none since
     /// construction). Intended for out-of-band error reporting (e.g. child process exit summary),
     /// not for the audio-thread hot path.
     pub fn last_process_error(&self) -> i32 {
-        self.audio.last_process_error()
+        self.audio
+            .as_ref()
+            .expect("VST3 instrument audio is present")
+            .last_process_error()
     }
 
     pub fn push_note_on(&self, channel: i16, pitch: i16, velocity: f32, sample_offset: i32) {
         self.audio
+            .as_ref()
+            .expect("VST3 instrument audio is present")
             .push_note_on(channel, pitch, velocity, sample_offset);
     }
 
     pub fn push_note_off(&self, channel: i16, pitch: i16, velocity: f32, sample_offset: i32) {
         self.audio
+            .as_ref()
+            .expect("VST3 instrument audio is present")
             .push_note_off(channel, pitch, velocity, sample_offset);
     }
 
@@ -1206,7 +1247,18 @@ impl Vst3InstrumentProcessor {
     /// （[`Vst3InstrumentAudio::process_block`] へ委譲）。
     #[must_use]
     pub fn process_block(&mut self, data: &mut [f32]) -> bool {
-        self.audio.process_block(data)
+        self.audio
+            .as_mut()
+            .expect("VST3 instrument audio is present")
+            .process_block(data)
+    }
+}
+
+impl Drop for Vst3InstrumentProcessor {
+    fn drop(&mut self) {
+        // Shutdown order is explicit and independent of field declaration order.
+        let _ = self.audio.take();
+        let _ = self.main.take();
     }
 }
 

--- a/rust/crates/orbit-vst3-instrument-child/Cargo.toml
+++ b/rust/crates/orbit-vst3-instrument-child/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 orbit-vst3-host = { path = "../orbit-vst3-host" }
 orbit-audio-sandbox = { path = "../orbit-audio-sandbox" }
+orbit-child-runtime = { path = "../orbit-child-runtime" }
 anyhow = "1"
 
 [dev-dependencies]

--- a/rust/crates/orbit-vst3-instrument-child/src/main.rs
+++ b/rust/crates/orbit-vst3-instrument-child/src/main.rs
@@ -18,6 +18,8 @@ use orbit_audio_sandbox::{
     MAX_FRAMES,
 };
 #[cfg(target_os = "macos")]
+use orbit_child_runtime::run_child;
+#[cfg(target_os = "macos")]
 use orbit_vst3_host::Vst3InstrumentProcessor;
 
 #[cfg(target_os = "macos")]
@@ -281,7 +283,7 @@ fn main() -> Result<()> {
         ),
         None => None,
     };
-    let (mut instrument, _) = Vst3InstrumentProcessor::load(
+    let (instrument, _) = Vst3InstrumentProcessor::load(
         &args.plugin,
         args.sample_rate as f64,
         MAX_FRAMES as i32,
@@ -302,122 +304,145 @@ fn main() -> Result<()> {
     unsafe {
         orbit_audio_sandbox::transport::publish_child_ready(region, false);
     }
+    let (mut instrument_audio, instrument_main) = instrument.split();
 
-    let mut scratch = vec![0.0; BUF_LEN];
-    let mut event_scratch = Vec::with_capacity(MAX_EVENTS_PER_BLOCK);
-    let mut output_events = Vec::with_capacity(MAX_EVENTS_PER_BLOCK);
-    let mut output_spill = EventSpillFifo::new();
-    let mut process_errors = 0;
-    let mut last = 0;
     // orphan 対策(#448): host(daemon)が CONTROL_QUIT を書かずに死ぬ経路(プロセス exit・
-    // SIGKILL・crash)でも spin loop を抜けられるよう、親死活を低頻度で監視する。
+    // SIGKILL・crash)でも main runloop を止められるよう、親死活をタイマーで監視する。
     let mut parent_watch = ParentWatch::new();
-    loop {
-        if unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT {
-            break;
-        }
-        if parent_watch.should_exit() {
-            eprintln!("[orbit-vst3-instrument-child] 親プロセス死亡を検知、終了する");
-            break;
-        }
-        // #555: host からのコマンドを処理する（UIH.2）。audio ブロックの合間に1件ずつ。
-        // `cmd_seq` が ack より進んでいれば未処理。**ここはメインスレッド**なので
-        // VST3 の state 操作契約（UI スレッド）を満たす。
-        unsafe {
-            service_command_mailbox(region, |kind, arg| match kind {
-                CMD_SAVE_STATE => Some(save_state_command(arg, || instrument.capture_state())),
-                _ => None,
-            });
-        }
-        let cur = unsafe { (*region).seq_request.load(Acquire) };
-        if cur <= last {
-            std::hint::spin_loop();
-            continue;
-        }
-        for seq in in_order_seqs(last, cur) {
-            let idx = slot_index(seq);
-            let off = slot_offset(seq);
-            let n_frames =
-                unsafe { ((*region).n_frames[idx].load(Relaxed) as usize).min(MAX_FRAMES) };
-            let sample_count = n_frames * CHANNELS;
-            let event_count = unsafe {
-                (*region).input_event_count[idx]
-                    .load(Relaxed)
-                    .min(MAX_EVENTS_PER_BLOCK as u32)
-            };
-            let decode_errors = unsafe {
-                decode_slot_events(
-                    &(*region).input_events[idx],
-                    event_count,
-                    &mut event_scratch,
-                )
-            };
-            if decode_errors != 0 {
-                unsafe {
-                    (*region)
-                        .event_decode_error_count
-                        .fetch_add(decode_errors as u64, Relaxed);
-                }
-            }
-            output_events.clear();
-            for event in &event_scratch {
-                match classify_event(event) {
-                    EventAction::NoteOn {
-                        channel,
-                        pitch,
-                        velocity,
-                        offset,
-                    } => {
-                        instrument.push_note_on(channel, pitch, velocity, offset);
-                    }
-                    EventAction::NoteOffAndEnd {
-                        channel,
-                        pitch,
-                        velocity,
-                        offset,
-                        end,
-                    } => {
-                        instrument.push_note_off(channel, pitch, velocity, offset);
-                        output_events.push(end);
-                    }
-                    EventAction::Unsupported => unsafe {
-                        (*region).event_decode_error_count.fetch_add(1, Relaxed);
-                    },
-                }
-            }
-            scratch[..sample_count].fill(0.0);
-            if !instrument.process_block(&mut scratch[..sample_count]) {
-                process_errors += 1;
-                unsafe {
-                    (*region).child_process_error_count.fetch_add(1, Relaxed);
-                }
-            }
+    let region_addr = region as usize;
+    let (process_errors, last_process_error) = run_child(
+        "orbit-vst3-instrument-child",
+        || {
+            // SAVE_STATE and all future UI work are serviced by the AppKit main runloop.
             unsafe {
-                publish_completed_slot(region, seq, |region| {
-                    let out_base = std::ptr::addr_of_mut!((*region).output) as *mut f32;
-                    std::ptr::copy_nonoverlapping(
-                        scratch.as_ptr(),
-                        out_base.add(off),
-                        sample_count,
-                    );
-                    let window = std::slice::from_raw_parts_mut(
-                        std::ptr::addr_of_mut!((*region).output_events[idx]) as *mut EventRecord,
-                        MAX_EVENTS_PER_BLOCK,
-                    );
-                    let outcome =
-                        write_output_events(window, &mut output_spill, output_events.drain(..));
-                    apply_output_write_outcome(region, idx, outcome);
-                    (*region).child_processed.fetch_add(1, Relaxed);
+                service_command_mailbox(region, |kind, arg| match kind {
+                    CMD_SAVE_STATE => {
+                        Some(save_state_command(arg, || instrument_main.capture_state()))
+                    }
+                    _ => None,
                 });
             }
-        }
-        last = cur.max(last);
-    }
+            if unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT {
+                return true;
+            }
+            if parent_watch.should_exit() {
+                eprintln!("[orbit-vst3-instrument-child] 親プロセス死亡を検知、終了する");
+                return true;
+            }
+            false
+        },
+        move |stop_audio| {
+            let region = region_addr as *mut SharedRegion;
+            let mut scratch = vec![0.0; BUF_LEN];
+            let mut event_scratch = Vec::with_capacity(MAX_EVENTS_PER_BLOCK);
+            let mut output_events = Vec::with_capacity(MAX_EVENTS_PER_BLOCK);
+            let mut output_spill = EventSpillFifo::new();
+            let mut process_errors = 0u64;
+            let mut last = 0u64;
+
+            loop {
+                if stop_audio.load(Relaxed)
+                    || unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT
+                {
+                    break;
+                }
+                let cur = unsafe { (*region).seq_request.load(Acquire) };
+                if cur <= last {
+                    std::hint::spin_loop();
+                    continue;
+                }
+                for seq in in_order_seqs(last, cur) {
+                    let idx = slot_index(seq);
+                    let off = slot_offset(seq);
+                    let n_frames =
+                        unsafe { ((*region).n_frames[idx].load(Relaxed) as usize).min(MAX_FRAMES) };
+                    let sample_count = n_frames * CHANNELS;
+                    let event_count = unsafe {
+                        (*region).input_event_count[idx]
+                            .load(Relaxed)
+                            .min(MAX_EVENTS_PER_BLOCK as u32)
+                    };
+                    let decode_errors = unsafe {
+                        decode_slot_events(
+                            &(*region).input_events[idx],
+                            event_count,
+                            &mut event_scratch,
+                        )
+                    };
+                    if decode_errors != 0 {
+                        unsafe {
+                            (*region)
+                                .event_decode_error_count
+                                .fetch_add(decode_errors as u64, Relaxed);
+                        }
+                    }
+                    output_events.clear();
+                    for event in &event_scratch {
+                        match classify_event(event) {
+                            EventAction::NoteOn {
+                                channel,
+                                pitch,
+                                velocity,
+                                offset,
+                            } => instrument_audio.push_note_on(channel, pitch, velocity, offset),
+                            EventAction::NoteOffAndEnd {
+                                channel,
+                                pitch,
+                                velocity,
+                                offset,
+                                end,
+                            } => {
+                                instrument_audio.push_note_off(channel, pitch, velocity, offset);
+                                output_events.push(end);
+                            }
+                            EventAction::Unsupported => unsafe {
+                                (*region).event_decode_error_count.fetch_add(1, Relaxed);
+                            },
+                        }
+                    }
+                    scratch[..sample_count].fill(0.0);
+                    if !instrument_audio.process_block(&mut scratch[..sample_count]) {
+                        process_errors += 1;
+                        unsafe {
+                            (*region).child_process_error_count.fetch_add(1, Relaxed);
+                        }
+                    }
+                    unsafe {
+                        publish_completed_slot(region, seq, |region| {
+                            let out_base = std::ptr::addr_of_mut!((*region).output) as *mut f32;
+                            std::ptr::copy_nonoverlapping(
+                                scratch.as_ptr(),
+                                out_base.add(off),
+                                sample_count,
+                            );
+                            let window = std::slice::from_raw_parts_mut(
+                                std::ptr::addr_of_mut!((*region).output_events[idx])
+                                    as *mut EventRecord,
+                                MAX_EVENTS_PER_BLOCK,
+                            );
+                            let outcome = write_output_events(
+                                window,
+                                &mut output_spill,
+                                output_events.drain(..),
+                            );
+                            apply_output_write_outcome(region, idx, outcome);
+                            (*region).child_processed.fetch_add(1, Relaxed);
+                        });
+                    }
+                }
+                last = cur.max(last);
+            }
+            let last_process_error = instrument_audio.last_process_error();
+            // Vst3InstrumentAudio::drop runs setProcessing(0) on this thread.
+            (process_errors, last_process_error)
+        },
+    )?;
+
     if process_errors != 0 {
         eprintln!(
             "[orbit-vst3-instrument-child] plugin.process() failed for {process_errors} block(s); \
              last tresult={}",
-            instrument.last_process_error()
+            last_process_error
         );
     }
     Ok(())

--- a/rust/crates/orbit-vst3-instrument-child/tests/common/mod.rs
+++ b/rust/crates/orbit-vst3-instrument-child/tests/common/mod.rs
@@ -1,0 +1,60 @@
+use std::path::PathBuf;
+use std::process::Child;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use orbit_audio_sandbox::transport::CHILD_STATUS_READY;
+use orbit_audio_sandbox::{SharedRegion, CONTROL_QUIT};
+
+static SHM_SEQ: AtomicU64 = AtomicU64::new(0);
+
+pub fn unique_temp(prefix: &str) -> PathBuf {
+    let id = SHM_SEQ.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("{prefix}-{}-{id}", std::process::id()))
+}
+
+/// child が exit するまで面倒を見る（テストが panic しても孤児を残さない）。
+pub struct ChildGuard {
+    pub child: Child,
+    pub region: *mut SharedRegion,
+    pub shm: PathBuf,
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        unsafe {
+            (*self.region)
+                .control
+                .store(CONTROL_QUIT, Ordering::Release)
+        };
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(_)) => break,
+                Ok(None) if Instant::now() < deadline => std::hint::spin_loop(),
+                // CONTROL_QUIT で降りてこなければ強制終了する。孤児の spin loop を
+                // 残すと CPU を焼き続ける（過去に 50 本の孤児で load が跳ねた）。
+                _ => {
+                    let _ = self.child.kill();
+                    let _ = self.child.wait();
+                    break;
+                }
+            }
+        }
+        let _ = std::fs::remove_file(&self.shm);
+    }
+}
+
+pub fn wait_for_ready(region: *mut SharedRegion, child: &mut Child) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while unsafe { (*region).child_status.load(Ordering::Acquire) } != CHILD_STATUS_READY {
+        if let Ok(Some(status)) = child.try_wait() {
+            panic!("child が READY 前に終了した: {status}");
+        }
+        assert!(
+            Instant::now() < deadline,
+            "child が READY にならなかった（VST3 プラグインのロードに失敗した可能性）"
+        );
+        std::hint::spin_loop();
+    }
+}

--- a/rust/crates/orbit-vst3-instrument-child/tests/mailbox_wiring.rs
+++ b/rust/crates/orbit-vst3-instrument-child/tests/mailbox_wiring.rs
@@ -21,73 +21,22 @@
 #![cfg(target_os = "macos")]
 #![allow(unsafe_code)]
 
-use std::path::{Path, PathBuf};
+mod common;
+
+use std::path::Path;
 use std::process::{Child, Command};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
+use common::{unique_temp, wait_for_ready, ChildGuard};
 use orbit_audio_sandbox::transport::{read_cstr_field, write_cstr_field, CHILD_STATUS_READY};
 use orbit_audio_sandbox::{
-    create_shared, region_ptr, CommandMailboxError, CommandMailboxHost, SharedRegion,
-    CMD_RESULT_OK, CONTROL_QUIT,
+    create_shared, region_ptr, CommandMailboxError, CommandMailboxHost, SharedRegion, CMD_RESULT_OK,
 };
-
-static SHM_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// テストが復元させるオフセット。**既定値 0 とも、隣の半音とも違う値**を選ぶ。
 /// 0 だと「`--state` を無視しても通る」テストになり、復元経路を検証できない。
 const RESTORED_SEMITONES: i32 = 7;
-
-fn unique_temp(prefix: &str) -> PathBuf {
-    let id = SHM_SEQ.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!("{prefix}-{}-{id}", std::process::id()))
-}
-
-/// child が exit するまで面倒を見る（テストが panic しても孤児を残さない）。
-struct ChildGuard {
-    child: Child,
-    region: *mut SharedRegion,
-    shm: PathBuf,
-}
-
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        unsafe {
-            (*self.region)
-                .control
-                .store(CONTROL_QUIT, Ordering::Release)
-        };
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            match self.child.try_wait() {
-                Ok(Some(_)) => break,
-                Ok(None) if Instant::now() < deadline => std::hint::spin_loop(),
-                // CONTROL_QUIT で降りてこなければ強制終了する。孤児の spin loop を
-                // 残すと CPU を焼き続ける（過去に 50 本の孤児で load が跳ねた）。
-                _ => {
-                    let _ = self.child.kill();
-                    let _ = self.child.wait();
-                    break;
-                }
-            }
-        }
-        let _ = std::fs::remove_file(&self.shm);
-    }
-}
-
-fn wait_for_ready(region: *mut SharedRegion, child: &mut Child) {
-    let deadline = Instant::now() + Duration::from_secs(30);
-    while unsafe { (*region).child_status.load(Ordering::Acquire) } != CHILD_STATUS_READY {
-        if let Ok(Some(status)) = child.try_wait() {
-            panic!("child が READY 前に終了した: {status}");
-        }
-        assert!(
-            Instant::now() < deadline,
-            "child が READY にならなかった（VST3 プラグインのロードに失敗した可能性）"
-        );
-        std::hint::spin_loop();
-    }
-}
 
 fn await_ack(region: *mut SharedRegion, seq: u64, child: &mut Child) -> (u32, u64, String) {
     let deadline = Instant::now() + Duration::from_secs(10);

--- a/rust/crates/orbit-vst3-instrument-child/tests/save_during_playback.rs
+++ b/rust/crates/orbit-vst3-instrument-child/tests/save_during_playback.rs
@@ -25,19 +25,19 @@
 #![cfg(target_os = "macos")]
 #![allow(unsafe_code)]
 
-use std::path::{Path, PathBuf};
+mod common;
+
+use std::path::Path;
 use std::process::{Child, Command};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use orbit_audio_sandbox::transport::CHILD_STATUS_READY;
+use common::{unique_temp, wait_for_ready, ChildGuard};
 use orbit_audio_sandbox::{
     create_shared, region_ptr, CommandMailboxHost, PipelinedInstrumentHost, SharedRegion,
-    TransportContext, CHANNELS, CONTROL_QUIT,
+    TransportContext, CHANNELS,
 };
-
-static SHM_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// 復元させる半音オフセット。既定値 0 と違う値にして「保存が現在 state を見ている」ことを
 /// 内容で判定できるようにする（mailbox_wiring と同じ規律）。
@@ -52,11 +52,6 @@ const STATE_DELAY_MS: u64 = 500;
 /// 前進量はパイプライン深さ（`SLOTS` = 一桁）+ コマンド拾い上げ前の数ブロックに留まる。
 /// 新モデルでは free-running submit で数千ブロック前進する。64 はその間の安全余裕。
 const MIN_BLOCKS_DURING_SAVE: u64 = 64;
-
-fn unique_temp(prefix: &str) -> PathBuf {
-    let id = SHM_SEQ.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!("{prefix}-{}-{id}", std::process::id()))
-}
 
 /// panic（assert 失敗）による unwind でも補助スレッドを join してから先へ進めるガード。
 ///
@@ -105,51 +100,6 @@ impl<T> Drop for JoinOnDrop<T> {
         if let Some(handle) = self.handle.take() {
             let _ = handle.join();
         }
-    }
-}
-
-/// child が exit するまで面倒を見る（テストが panic しても孤児を残さない）。
-/// mailbox_wiring.rs の同名 helper と同じもの（統合テストはファイル間で共有できないため重複）。
-struct ChildGuard {
-    child: Child,
-    region: *mut SharedRegion,
-    shm: PathBuf,
-}
-
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        unsafe {
-            (*self.region)
-                .control
-                .store(CONTROL_QUIT, Ordering::Release)
-        };
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            match self.child.try_wait() {
-                Ok(Some(_)) => break,
-                Ok(None) if Instant::now() < deadline => std::hint::spin_loop(),
-                _ => {
-                    let _ = self.child.kill();
-                    let _ = self.child.wait();
-                    break;
-                }
-            }
-        }
-        let _ = std::fs::remove_file(&self.shm);
-    }
-}
-
-fn wait_for_ready(region: *mut SharedRegion, child: &mut Child) {
-    let deadline = Instant::now() + Duration::from_secs(30);
-    while unsafe { (*region).child_status.load(Ordering::Acquire) } != CHILD_STATUS_READY {
-        if let Ok(Some(status)) = child.try_wait() {
-            panic!("child が READY 前に終了した: {status}");
-        }
-        assert!(
-            Instant::now() < deadline,
-            "child が READY にならなかった（VST3 プラグインのロードに失敗した可能性）"
-        );
-        std::hint::spin_loop();
     }
 }
 

--- a/rust/crates/orbit-vst3-instrument-child/tests/save_during_playback.rs
+++ b/rust/crates/orbit-vst3-instrument-child/tests/save_during_playback.rs
@@ -1,0 +1,304 @@
+//! #474 P1 の受け入れ検証: **演奏中の SAVE_STATE が audio を止めずに成功する**。
+//!
+//! ## 何を守るテストか
+//!
+//! P1 以前の child は audio 処理とコマンド処理を単一スレッドで直列に回していたため、
+//! UIH.3 は「host は演奏停止中にのみ SAVE_STATE を発行すること（MUST）」という暫定制約を
+//! 置いていた。P1（`orbit-child-runtime` による main runloop / audio 専用スレッド分離）で
+//! この制約は外れる — 本テストはその解禁を**実行で**証明する:
+//!
+//! 1. 実 child（NSApplication runloop + audio 専用スレッド）を spawn する
+//! 2. host 側スレッドが audio block を連続 submit し続ける（= 演奏中の代役）
+//! 3. **getState に 500ms かかる**プラグイン（oracle の
+//!    `ORBIT_VST3_SYNTH_STATE_DELAY_MS` seam・遅い実プラグインの代役）へ SAVE_STATE を発行する
+//! 4. 保存が成功し、**保存中も audio slot（`seq_done`）が前進し続けた**ことを assert する
+//!
+//! 旧実行モデル（単一スレッド直列）へ退行すると、getState の 500ms の間 audio slot が
+//! 完全に停止するため `seq_done` の前進量がパイプライン深さ（SLOTS）程度に落ちて red になる。
+//! 同型の退行（audio スレッドが mailbox の完了を待つ等）も同じ assert が殺す。
+//!
+//! ## デバイス不要
+//!
+//! 実機スピーカーは使わない（`PipelinedInstrumentHost` の shm 往復だけで判定できる）。
+//! 実機での dropout 検証（capture WAV drops==0）は別途 gated E2E が担う。
+
+#![cfg(target_os = "macos")]
+#![allow(unsafe_code)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use orbit_audio_sandbox::transport::CHILD_STATUS_READY;
+use orbit_audio_sandbox::{
+    create_shared, region_ptr, CommandMailboxHost, PipelinedInstrumentHost, SharedRegion,
+    TransportContext, CHANNELS, CONTROL_QUIT,
+};
+
+static SHM_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// 復元させる半音オフセット。既定値 0 と違う値にして「保存が現在 state を見ている」ことを
+/// 内容で判定できるようにする（mailbox_wiring と同じ規律）。
+const RESTORED_SEMITONES: i32 = 7;
+
+/// oracle の getState に仕込む遅延。演奏（block submit）がこの間も前進し続けることを測る窓。
+const STATE_DELAY_MS: u64 = 500;
+
+/// 保存中に `seq_done` が最低限前進しているべきブロック数。
+///
+/// 旧実行モデル（単一スレッド直列）では getState の 500ms の間 slot 処理が完全停止するため、
+/// 前進量はパイプライン深さ（`SLOTS` = 一桁）+ コマンド拾い上げ前の数ブロックに留まる。
+/// 新モデルでは free-running submit で数千ブロック前進する。64 はその間の安全余裕。
+const MIN_BLOCKS_DURING_SAVE: u64 = 64;
+
+fn unique_temp(prefix: &str) -> PathBuf {
+    let id = SHM_SEQ.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("{prefix}-{}-{id}", std::process::id()))
+}
+
+/// panic（assert 失敗）による unwind でも補助スレッドを join してから先へ進めるガード。
+///
+/// 補助スレッドは shm（`mmap`）への生ポインタを触るため、join せずに `mmap` の drop
+/// （unmap）へ到達すると use-after-unmap の SIGSEGV になり、**assert メッセージの読めない
+/// 失敗**に化ける。`mmap` より後に宣言し、unwind 時に先に drop（= join）させること。
+struct JoinOnDrop<T> {
+    stop: Option<Arc<AtomicBool>>,
+    handle: Option<std::thread::JoinHandle<T>>,
+}
+
+impl<T> JoinOnDrop<T> {
+    fn new(stop: Arc<AtomicBool>, handle: std::thread::JoinHandle<T>) -> Self {
+        Self {
+            stop: Some(stop),
+            handle: Some(handle),
+        }
+    }
+
+    /// 停止フラグを持たない（自然に終わる）スレッド用。
+    fn without_stop(handle: std::thread::JoinHandle<T>) -> Self {
+        Self {
+            stop: None,
+            handle: Some(handle),
+        }
+    }
+
+    /// 成功経路用の明示 join（停止フラグを立ててから待つ）。
+    fn join(&mut self) -> T {
+        if let Some(stop) = &self.stop {
+            stop.store(true, Ordering::Relaxed);
+        }
+        self.handle
+            .take()
+            .expect("join was already taken")
+            .join()
+            .expect("auxiliary thread panicked")
+    }
+}
+
+impl<T> Drop for JoinOnDrop<T> {
+    fn drop(&mut self) {
+        if let Some(stop) = &self.stop {
+            stop.store(true, Ordering::Relaxed);
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// child が exit するまで面倒を見る（テストが panic しても孤児を残さない）。
+/// mailbox_wiring.rs の同名 helper と同じもの（統合テストはファイル間で共有できないため重複）。
+struct ChildGuard {
+    child: Child,
+    region: *mut SharedRegion,
+    shm: PathBuf,
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        unsafe {
+            (*self.region)
+                .control
+                .store(CONTROL_QUIT, Ordering::Release)
+        };
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(_)) => break,
+                Ok(None) if Instant::now() < deadline => std::hint::spin_loop(),
+                _ => {
+                    let _ = self.child.kill();
+                    let _ = self.child.wait();
+                    break;
+                }
+            }
+        }
+        let _ = std::fs::remove_file(&self.shm);
+    }
+}
+
+fn wait_for_ready(region: *mut SharedRegion, child: &mut Child) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while unsafe { (*region).child_status.load(Ordering::Acquire) } != CHILD_STATUS_READY {
+        if let Ok(Some(status)) = child.try_wait() {
+            panic!("child が READY 前に終了した: {status}");
+        }
+        assert!(
+            Instant::now() < deadline,
+            "child が READY にならなかった（VST3 プラグインのロードに失敗した可能性）"
+        );
+        std::hint::spin_loop();
+    }
+}
+
+fn spawn_slow_state_child(shm: &Path, plugin: &Path, state: &Path) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_orbit-vst3-instrument-child"))
+        .env(
+            "ORBIT_VST3_SYNTH_STATE_DELAY_MS",
+            STATE_DELAY_MS.to_string(),
+        )
+        .arg("--shm")
+        .arg(shm)
+        .arg("--plugin")
+        .arg(plugin)
+        .arg("--sample-rate")
+        .arg("48000")
+        .arg("--state")
+        .arg(state)
+        .spawn()
+        .expect("spawn orbit-vst3-instrument-child")
+}
+
+#[test]
+#[ignore = "gated child-process timing test; run explicitly on a macOS development machine"]
+fn save_state_succeeds_while_audio_blocks_keep_flowing() {
+    let bundle = orbit_vst3_synth_oracle::package_bundle()
+        .expect("VST3 synth oracle build/package failed (gated prerequisite)");
+
+    let restore_path = unique_temp("orbit-save-during-playback-restore.bin");
+    std::fs::write(
+        &restore_path,
+        orbit_vst3_synth_oracle::encode_state(RESTORED_SEMITONES),
+    )
+    .expect("restore state を書けない");
+
+    let shm = unique_temp("orbit-save-during-playback.shm");
+    let mmap = create_shared(&shm).expect("create_shared");
+    let region = region_ptr(&mmap);
+    let mut guard = ChildGuard {
+        child: spawn_slow_state_child(&shm, &bundle, &restore_path),
+        region,
+        shm: shm.clone(),
+    };
+    wait_for_ready(region, &mut guard.child);
+
+    // ── 演奏の代役: 停止フラグが立つまで audio block を連続 submit するスレッド。
+    // `PipelinedInstrumentHost` は !Send なので submitter スレッド内で from_raw する
+    // （region は mmap の生存期間内・submitter は本関数内で join するため有効）。
+    //
+    // 🔴 [`JoinOnDrop`] で包む: assert が panic する経路でも submitter を join してから
+    // unwind を続けないと、`mmap` の unmap 後に region を触って **SIGSEGV でテストが死ぬ**
+    // （assert メッセージが読めない失敗になる。変異 M4 の初回実行で実際に起きた）。
+    let stop = Arc::new(AtomicBool::new(false));
+    let mut submitter = JoinOnDrop::new(stop.clone(), {
+        let stop = stop.clone();
+        let region_addr = region as usize;
+        std::thread::spawn(move || {
+            let region = region_addr as *mut SharedRegion;
+            let mut host = unsafe { PipelinedInstrumentHost::from_raw(region) };
+            let mut audio = vec![0.0f32; 128 * CHANNELS];
+            let transport = TransportContext {
+                tempo_bpm: 120.0,
+                time_sig_numerator: 4,
+                time_sig_denominator: 4,
+                is_playing: 1,
+                is_looping: 0,
+                song_position_beats: 0.0,
+            };
+            let mut submitted_blocks: u64 = 0;
+            while !stop.load(Ordering::Relaxed) {
+                if host.process_block(&mut audio, &[], transport).submitted {
+                    submitted_blocks += 1;
+                }
+                std::hint::spin_loop();
+            }
+            submitted_blocks
+        })
+    });
+
+    // submit が実際に流れ始めたのを確認してから保存を発行する（保存窓の測定を汚さない）。
+    let warmup_deadline = Instant::now() + Duration::from_secs(10);
+    while unsafe { (*region).seq_done.load(Ordering::Acquire) } < MIN_BLOCKS_DURING_SAVE {
+        assert!(
+            Instant::now() < warmup_deadline,
+            "child が audio block を処理し始めない（audio スレッドが起動していない可能性）"
+        );
+        std::hint::spin_loop();
+    }
+
+    // ── 保存窓の測定は**窓の中間**で行う。
+    //
+    // ⚠️ 「発行前 → ack 後」の差分で測ってはならない: 退行モデル（audio が保存中に凍結）でも
+    // ack 直後に audio スレッドが一瞬で追い上げるため、ack 後スナップショットとの差分は
+    // 閾値を超えてしまう（変異 M1 が最初この穴で生き残った）。getState の遅延窓
+    // [+100ms, +400ms] ⊂ [pickup, pickup+500ms] の内部で 2 点サンプルし、その間の前進を測る。
+    let mut sampler = JoinOnDrop::without_stop({
+        let region_addr = region as usize;
+        std::thread::spawn(move || {
+            let region = region_addr as *mut SharedRegion;
+            std::thread::sleep(Duration::from_millis(100));
+            let mid_early = unsafe { (*region).seq_done.load(Ordering::Acquire) };
+            std::thread::sleep(Duration::from_millis(300));
+            let mid_late = unsafe { (*region).seq_done.load(Ordering::Acquire) };
+            (mid_early, mid_late)
+        })
+    });
+    let issued_at = Instant::now();
+    let sidecar = unique_temp("orbit-save-during-playback-captured.bin");
+    // ⚠️ ここで即 expect しない: 補助スレッドを join し終える前に panic すると、
+    // unwind が `mmap` の unmap まで進んで補助スレッドが SIGSEGV する。
+    let save_result = CommandMailboxHost::new(shm.clone()).issue_save_state(&sidecar);
+    let elapsed = issued_at.elapsed();
+    let (mid_early, mid_late) = sampler.join();
+    let submitted_blocks = submitter.join();
+    let response =
+        save_result.expect("演奏中の SAVE_STATE が失敗した（UIH.3 の解禁が成立していない）");
+
+    // (1) 遅延 seam が実際に効いていたこと。これが無いと env 名の変更等で seam が黙って
+    // 外れ、「保存中」窓が事実上消えてテストが無意味なまま green になる。
+    assert!(
+        elapsed >= Duration::from_millis(STATE_DELAY_MS - 100),
+        "SAVE_STATE の往復が {elapsed:?} — getState の遅延 seam \
+         (ORBIT_VST3_SYNTH_STATE_DELAY_MS) が効いていない"
+    );
+
+    // (2) 核心: 保存（500ms の getState を含む）の**さなか**に audio slot が前進し続けたこと。
+    // 単一スレッド直列モデル（や audio が mailbox 完了を待つ退行）では getState 中
+    // seq_done が凍結し、窓中間の前進量が 0 近傍に落ちる。
+    let progressed = mid_late - mid_early;
+    assert!(
+        progressed >= MIN_BLOCKS_DURING_SAVE,
+        "保存窓の中間 300ms での audio 前進が {progressed} ブロック（< {MIN_BLOCKS_DURING_SAVE}）— \
+         SAVE_STATE が audio スレッドを止めている（演奏中保存の解禁が退行）"
+    );
+
+    // (3) 保存内容が現在 state（復元済みオフセット）であること。
+    let captured = std::fs::read(&sidecar).expect("サイドカーが書かれていない");
+    assert_eq!(response.bytes_written, captured.len() as u64);
+    assert_eq!(
+        orbit_vst3_synth_oracle::decode_state(&captured),
+        Some(RESTORED_SEMITONES),
+        "吸い上げた state が復元値と違う (captured={captured:?})"
+    );
+
+    // (4) sanity: submitter が実際に相当量を流していたこと。
+    assert!(
+        submitted_blocks > MIN_BLOCKS_DURING_SAVE,
+        "submitter が {submitted_blocks} ブロックしか submit していない"
+    );
+
+    let _ = std::fs::remove_file(&sidecar);
+    let _ = std::fs::remove_file(&restore_path);
+}

--- a/rust/crates/orbit-vst3-synth-oracle/src/lib.rs
+++ b/rust/crates/orbit-vst3-synth-oracle/src/lib.rs
@@ -235,6 +235,15 @@ impl IComponentTrait for SynthProcessor {
         if std::env::var_os("ORBIT_VST3_SYNTH_EMPTY_STATE").is_some() {
             return kResultOk;
         }
+        // #474 P1: getState を意図的に遅くするテスト seam。「state 取得が main スレッドを
+        // 塞いでも audio slot の前進を止めない」（UIH.3 の演奏中 SAVE_STATE 解禁）を、
+        // 遅い getState を持つ実プラグインの代役として無人検証するために使う
+        // （`orbit-vst3-instrument-child/tests/save_during_playback.rs`）。
+        if let Some(delay_ms) = std::env::var_os("ORBIT_VST3_SYNTH_STATE_DELAY_MS")
+            .and_then(|raw| raw.to_str().and_then(|s| s.parse::<u64>().ok()))
+        {
+            std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+        }
         let stream = match ComRef::from_raw(state) {
             Some(s) => s,
             None => return kResultFalse,


### PR DESCRIPTION
#474「プラグイン UI を開く」の最初の PR。**P0（前提確認）+ P1（child 実行モデル変更）まで**。
P2 以降（evt リング / UI open-close / エディタ配線）は後続 PR。

## なぜこれが必要か

**child プロセスが NSWindow を開くには、main スレッドで NSApplication の runloop が
回っている必要がある**（macOS の要件）。現状の child は main スレッドで audio を spin して
いるため、**UI を開く土台がない**。P1 はその土台を作る。

owner 裁定により **#474 の価値は「人間が触れるようにプラグインを開いてあげること」**に絞られた
（つまみ→音の変化はプラグイン内部の話で検査対象外）。

## P0: UIH.9 の前提是正2件は解消済みだった

| 項目 | 状態 |
|---|---|
| `orbit-vst3-effect-child` のバンドル欠落 | ✅ **#548 で解消済み**（`copy-daemon-bin.sh` が4 child を rebuild+copy / `release.yml` の post-package gate / `bundled-child-binaries.spec.ts` が台帳照合と gate 実走まで実施） |
| CLAP の `--state` 配線 | ✅ **解消済み**（`orbit-clap-effect-child/src/main.rs:79-90`） |

**spec の記述だけが stale** だったので実態に更新。**新規テストは不要**。

## P1: 実行モデル変更

- **新 crate `orbit-child-runtime`**: `run_child(name, service_main, audio)` —
  main = NSApplication runloop（**Accessory**・拒否時 fail-loud）+ NSTimer 20ms tick で
  mailbox/ParentWatch/QUIT を servicing、audio = 専用スレッド（QoS user-interactive）
- **processor の main/audio 分割**: CLAP は `split() -> (XxxAudio, XxxMain)`
  （**clack の `StartedPluginAudioProcessor` が Send を公式サポート**）。
  VST3 は monolith を `Vst3EffectAudio` / `Vst3InstrumentAudio` + 共有 `Vst3PluginMain` へ再構成
- **teardown 契約**: audio スレッドで `stop_processing` → join → main 半分 drop
  （**唯一の Arc 所有者として home スレッドで deactivate/destroy**）
- **依存追加は `objc2-app-kit` 1 crate のみ**（`objc2` 本体は clack-host 経由で既に graph に存在）

## 🔴 レイテンシゲートが割れ、真因は production の欠陥だった

```
main（同一マシン対照）: 4.31us   margin 154.6x
P1（修正前）:           507.70us margin 1.3x     ← 約118倍
```

**ユニットは 315 passed で全緑。実機ゲートだけが捕まえた。**

507us は**会計アーティファクト**だった。`measure_per_block_us` は
`render_through_child_sync` の**呼び出し全体**を計測し、その内部（`offline.rs:186` の
`drop(guard)`）に **child teardown** が含まれる。graceful に終わらないと
**`REAP_TIMEOUT = 2s`** 待って SIGKILL。
`507.70us × 4000 = 2.0308s ≈ 2.000s + 実処理 30.8ms` → **per-block は 5〜8us で無傷**。

🔴 **真因**: **NSTimer コールバックから呼ぶ `NSApplication.stop(None)` は
`-[NSApplication run]` を抜けさせない**。`stop` は「**現在の NSEvent の処理が完了した時点で**
抜ける」フラグで、**timer 発火は NSEvent ではない**。headless の Accessory child は
イベントを受け取らないので**検査点に永遠に到達しない**。

**これはテスト都合ではない。** daemon の通常 teardown も全 child が SIGKILL に落ち、
**SIGKILL は plugin teardown の state flush を吹き飛ばす**。
つまり **P1 は #585 が6ラウンドかけて守った「音色を失わない」を静かに壊していた。**

**修正**: `app.stop(None)` の直後に **ダミーの `NSEventTypeApplicationDefined` を
`postEvent_atStart(..., true)` で post**（Cocoa の定石）。

```
修正後: [32f] 6.32us margin 105.6x / [64f] 100.7x / [128f] 133.4x
        `kill にフォールバック` の行: 0 件
```

2つ目は**診断が自ら挙げた反証条件**（消えなければ仮説が誤り）。**予測どおり消えた。**

## 検証（すべて sandbox 外で main が実行）

| ゲート | 結果 |
|---|---|
| rust workspace | ✅ FAILED 0 |
| TS 全 suite | ✅ 1836 passed / 34 skipped / 0 failed |
| lint / `cargo fmt` / `cargo deny` | ✅ pass |
| **レイテンシ（UIH.7）** | ✅ **margin 105.6x**（修正前 1.3x） |
| **演奏中 SAVE_STATE** | ✅ 1 passed（**P1 の本来の狙い**） |
| **実機4経路** | ✅ effect 4+4 / instrument 3+3 |

> **注**: instrument の gated は feature が **`outproc-instrument`**。effect 用を使い回すと
> **テストが1件も走らないまま `exit=0`** が返る。件数を読まなければ緑と誤読していた。

## 申し送り

- **NSTimer が default runloop mode のみ** → **P3 で NSWindow のドラッグ/リサイズ中に
  mailbox servicing が止まる**。`NSRunLoopCommonModes` へ（P1 ではウィンドウが無いので影響なし）
- CLAP `call_on_main_thread_callback` の pump は未実装（既存の documented gap）
- 🔴 **P1 完了により `UIH.3` の「停止中のみ SAVE_STATE」MUST が外れ、
  #577 PR-B が本来形（演奏中保存）で実装可能**になった

Refs #474, #577