### PR TITLE
feat(rust): plugin UI endpoint layers and the NSWindow shell (#474 P3b)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,102 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.344 feat(rust): #474 P3b-2 — NSWindow を実配線し、実在を OS に問い合わせて証明した (Jul 31, 2026)
+
+**Date**: 2026-07-31
+**Issue**: #474（P3b-2）/ **Branch**: `474-plugin-ui-p3b1-gui-endpoint`
+**Status**: `cargo test --workspace`（**sandbox 外**）= **462 passed / 0 failed**
+
+**ここで初めてウィンドウが画面に出る。** P3a（AppKit 非依存の状態機械）と
+P3b-1（フォーマット GUI エンドポイント）を AppKit で繋ぐ層。
+
+#### 実装
+
+- `orbit-child-runtime/src/window.rs`（新規）: `NSWindow` 生成・delegate・リサイズ。
+  🔴 `windowShouldClose` は**常に `NO`** を返す（AppKit にフェーズ B より前に壊させない）。
+  破棄は `close()`（**`performClose:` 禁止** — 使うと AppKit が `windowShouldClose` を再照会し、
+  機械はまだ `Closing` なので取り消され、ウィンドウが永遠に残る）
+- `orbit-child-runtime/src/ui_service.rs`（新規）: 状態機械 + evt リング + WindowShell +
+  `PluginUiEndpoint` を束ね `UiHostActions` を実装。`CMD_OPEN_UI` = **完了時 ack** /
+  `CMD_CLOSE_UI` = **受理時 ack**（UIH.2a ポリシー2）
+- 4 child への追加は各 **+14〜15行**（実質 +2〜+5）。述語も `child_should_quit` に集約し、
+  「GUI コードを4回書く」を回避した
+- **`ParentWatch` の再入時ギャップを封鎖**（P3a で trait doc に登記した完了条件）。
+  `ParentWatch` を `&self` + `Cell` 化し、`should_quit` 述語に合流。
+  🔴 `abortModal` / 強制 exit のエスカレーションは**前提未検証のためスコープ外**とした
+
+#### 🔴 ウィンドウの実在を OS に問い合わせて証明した（4層の切り分け）
+
+gated テストが実機で落ちた。**「テストが落ちた」で終わらせず層を1つずつ剥がした**結果、
+**設計の前提に関わる事実**が出た。
+
+| 仮説 | 実測 |
+|---|---|
+| ウィンドウが生成されていない | ❌ `NSWindow #993` は採番済み |
+| runloop を回していない | ❌（この時点では）変わらず |
+| pid / window number の突合ミス | ❌ 定数も比較も正しい |
+| **API 自体が NULL を返している** | ✅ |
+| **Screen Recording 権限が無い** | ✅ **`CGPreflightScreenCaptureAccess() == false`** |
+
+さらに**このセッションは SSH 経由**（`sshd-session` の子）で、Ghostty に権限があっても
+**TCC は責任プロセス単位なので伝播しない**ことが系譜の実測で判明した。
+owner が **MBA10 のローカル GUI タブ**で実行して権限を通過。
+
+すると**別の欠陥が露出した** — `wait_for_window_state` が `sleep` するだけで
+**runloop を一度も回していなかった**。`makeKeyAndOrderFront` は順序付けを予約するだけで、
+window server へ届くのは runloop が次にイベントを処理したとき。
+🔴 **最初の runloop 仮説検証は、権限が無く NULL が返っていたため仮説を試せていなかった。**
+
+#### 🔴 独立性の証明（owner が実機で実行）
+
+| 段階 | 結果 |
+|---|---|
+| baseline | `ok. 1 passed` |
+| **`makeKeyAndOrderFront` 削除**（残存数 0 で反映確認） | `FAILED` + **`owned by this process: []`** |
+| 復元（`cmp` 一致） | `ok. 1 passed` |
+
+`NSWindow #1128` は**採番されている**のに CG は画面上のウィンドウを**0枚**と報告した。
+つまりこの検査は「オブジェクトが作られたか」ではなく「**実際に画面に出たか**」を見ている。
+child の自己申告なら変異段階も「作った」で通っていた。
+
+**権限が無いときは skip せず失敗させる**（`require_screen_capture_permission`）。
+黙って skip すると「一度も検証していないのに緑」になり、しかもこれは
+**child の自己申告から独立した唯一の証拠**なので、緩めると二重経路が片翼になる。
+
+#### 🔴 `child_should_quit` の配線ギャップ（main が変異で発見・main が実装）
+
+Codex の変異は `should_quit_with_parent`（**純関数**）を突いていた。
+main が**合成箇所**（`|| parent_watch.should_exit()` → `false`）を突いたところ、
+**21 件全部が緑のまま通った**。既存テストは自前のクロージャを注入しており、
+`child_should_quit` が本物の `ParentWatch` を渡すことは誰も縛っていなかった。
+
+**CLAP の `HostCallbackConfig` と同種だが深刻度が違う** — あちらは消費者が居ないので
+到達不能（P3b-2 の完了条件として登記）。こちらは **4 child すべての production 経路**で、
+壊れれば孤児 child が生き残る（#448）。
+
+対処: `ParentWatch::orphaned_for_tests()` を追加（ありえない pid を記録して
+「親が死んだ」分岐を到達可能にする）。テストは `control` を `CONTROL_RUN` のままにするので、
+**真になりうるのは parent-watch の項だけ**。3つの独立表明を置いた
+（孤児→true / 生存→false / QUIT→true）。2番目が無いと「常に true」でも通る。
+
+**同じ変異が修正前は 21 件緑 → 修正後は狙った1件だけ FAILED。** 復元は `cmp` で一致確認。
+
+#### Codex が2度停滞した
+
+P3a fix R1 で68分、本タスクで34分、いずれも**出力ゼロ・ファイル書き込みゼロ**。
+2度目は停止して **main が直接実装**した。CLAUDE.md の
+「4ラウンド目でも収束しなければ main が直す」の趣旨（**main はコンテキストを持っており、
+ブリーフを書き起こすコストの方が高い**）がそのまま当てはまる。
+ギャップを見つけたのも変異を設計したのも main だった。
+
+**変更ファイル**: `orbit-child-runtime/{Cargo.toml,src/lib.rs,src/window.rs,src/ui_service.rs,tests/window_shell_gated.rs}` /
+`orbit-audio-sandbox/{src/parent_watch.rs,src/transport.rs,src/bin/parent-watch-probe.rs}` /
+4 child の `main.rs` / `orbit-clap-host/src/{effect.rs,instrument.rs}` / `orbit-vst3-host/src/view.rs` / `Cargo.lock`
+
+**Commit**: `474-plugin-ui-p3b1-gui-endpoint`（PR 作成予定）
+
+---
+
 ### 6.343 feat(rust): #474 P3b-1 — VST3 の UI エンドポイント層（順序が仕様） (Jul 31, 2026)
 
 **Date**: 2026-07-31

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -103,8 +103,54 @@ CLAP 原文（`gui.h`・`CLAP_WINDOW_API_COCOA` の直上）:
 cocoa は論理サイズなのでホストがスケールを押し付けると二重適用になる。
 main が一次ソースを逐語確認して修正（commit `b05538c`）。
 
+#### CLAP 側（同じ層の残り半分）
+
+**構造が VST3 と違う。** VST3 の oracle は同一プロセス内の Rust crate なので static で
+トレースを共有できたが、**CLAP プラグインは dlopen される別ビルドの dylib** で Rust の
+static はホストと共有されない。→ **トレースは env で指定したファイル経由**にした
+（`ORBIT_CLAP_GUI_TRACE` 未設定なら何も書かない）。
+
+- `orbit-clap-host/src/gui.rs`（新規）+ `host.rs` 拡張。`clack-extensions` に `"gui"` を追加
+- `closed(was_destroyed)` / `request_resize` は **`[thread-safe]`** なので atomic で受けて
+  main の tick で consume（`GuiSize::pack_to_u64` は atomic 運搬用に clack が用意している）
+- **in-process daemon 経路の挙動を変えない**ため `HostCallbackConfig` を導入。
+  `declare_extensions` は `shared.gui_callbacks.is_some()` のときだけ `HostGui` を register
+- `rust-spike/clap-test-synth` は変更しない → 「GUI 拡張なしで loud 失敗」の負の経路が
+  追加作業ゼロで書ける（VST3 で gain oracle を据え置いたのと同じ狙い）
+
+変異5種すべて red: `is_api_supported` 省略 / `set_parent`↔`show` 交換 /
+`was_destroyed=true` でも `hide` / **floating で再試行** / cocoa で `set_scale`。
+
+**検証（main 実測）**: `cargo test --workspace`（sandbox 外）= **449 passed / 0 failed**。
+CLAP 順序テストは `#[ignore]` ゲートなので workspace の件数に入らない →
+**main が別途 `--ignored` で実行し 4 passed**。件数だけ見ていたら未実行に気づけなかった。
+
+#### 🔴 配線テストは半分しか守っていなかった（main が変異で実証）
+
+`HostCallbackConfig::in_process` と `::child` は**同じ型を返す2つのコンストラクタ**で、
+取り違えてもコンパイルが通る。Codex に配線テストを追加させ、変異3種が red になった:
+
+| 変異 | 結果 |
+|---|---|
+| `controller.rs` / `effect.rs` / `instrument.rs` の**関数の中身**を差し替え | red |
+
+**しかし main が当てた「呼び出し箇所のバイパス」変異**
+（`load` の引数を `child_host_callback_config()` から
+`HostCallbackConfig::in_process(Default::default(), Default::default())` へ直接置換）は
+**28 テスト全部が緑のまま通った**。
+
+Codex が試したのは helper の中身だけで、**本番の呼び出し箇所が helper を使うことは
+誰も縛っていなかった**。#527 の `setPlayingStatus` / `setReadyStatus` 取り違えと同じ構造。
+
+**直さずに回収先を固定した**: ホスト側 GUI コールバックを消費するコードがまだ無いので
+**今日は到達不能**。P3b-2 が `closed()` / `request_resize()` を状態機械へ配線し、
+その「プラグイン起点のクローズが状態機械に届く」テストは**本物の `load` 経路を通る**ので
+初めて呼び出し箇所を縛る。→ `effect.rs` / `instrument.rs` の当該関数の doc に
+**P3b-2 の完了条件として**変異確認日つきで記載した。
+
 **変更ファイル**: `orbit-child-ui/src/lib.rs` / `orbit-vst3-host/{Cargo.toml,src/lib.rs,src/view.rs,tests/ui_endpoint.rs}` /
-`orbit-vst3-synth-oracle/src/lib.rs` / `Cargo.lock` / `PLUGIN_UI_HOSTING_SPEC_v1.md`
+`orbit-vst3-synth-oracle/src/lib.rs` / `orbit-clap-host/{Cargo.toml,src/gui.rs,src/host.rs,src/controller.rs,src/effect.rs,src/instrument.rs,src/lib.rs,src/plugin_main.rs,tests/ui_endpoint_gated.rs}` /
+`rust-spike/clap-test-effect/{Cargo.toml,src/lib.rs}` / `Cargo.lock` / `PLUGIN_UI_HOSTING_SPEC_v1.md`
 
 **Commit**: `474-plugin-ui-p3b1-gui-endpoint`（PR 作成予定）
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,97 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.345 chore(rust): #474 P3b — CI 5往復・/simplify・レビューラウンド1 (Jul 31, 2026)
+
+**Date**: 2026-07-31
+**Issue**: #474 / **PR**: #596 / **Branch**: `474-plugin-ui-p3b1-gui-endpoint`
+**Status**: `cargo test --workspace`（sandbox 外）= **462 passed / 0 failed / 26 ignored**・CI 全緑
+
+6.343 / 6.344 の後に積んだ9コミット分。**個々の commit が WORK_LOG に無い状態を作っていた**
+（comment-analyzer の指摘 I2）。以下に集約する。
+
+| commit | 内容 |
+|---|---|
+| `b05538c` | spec: cocoa で `set_scale` を呼ばない（CLAP 原文を逐語確認） |
+| `373e3bc` | `/simplify` 適用 |
+| `4e6c66c` `9f2b494` `9d727fa` `335ee50` `0871898` | CI（Linux）5往復の修正 |
+| `b1f1fe3` | 先送り2件を消せる条件つきで登記 |
+| `6cb4b05` | レビューラウンド1 の Important 2件 |
+
+#### `/simplify`（4観点・適用3件）
+
+- **4 child の tick クロージャが一字一句同一** → `service_child_main` に集約（各13行 → 3行）。
+  同じ PR で `child_should_quit` は集約済みだったのに tick 本体は複製のままで一貫していなかった
+- **`child_host_callback_config()` の重複** → `HostCallbackConfig::child()` の doc に統合
+  （reuse / altitude / simplification の**3観点が独立に指摘**）。
+  🔴 **2つの doc は既に drift していた** — 片方に変異の実測結果、もう片方は「同じ注記を見よ」
+- 統合テストを**両方向**に強化（元は child 側しか見ておらず「常に有効を返す」実装でも通った）
+
+見送り6件は理由つきで commit に記録（`core-foundation-sys` 置換は対応する sys crate が
+無く手書き FFI が残るため等）。
+
+#### 🔴 CI が5回落ちた — すべて**先行するエラーに隠されていた別の層**
+
+| 回 | 失敗 | 見えなかった理由 |
+|---|---|---|
+| 1 | `orbit-child-runtime` の Linux 死にコード3件 | — |
+| 2 | CLAP child に cfg ゲートが1つも無い | 1回目が**依存クレートで止まり** child まで到達せず |
+| 3 | CLAP のテストモジュールが `#[cfg(test)]` のみ | 2回目が**非テストビルドで止まり**テストまで到達せず |
+| 4 | `unsafe fn` の項目2件が未ゲート | 3回目で止まっていた |
+| 5 | gated テストの `#![cfg]` でカスタム `main` が消える | 4回目で止まっていた |
+
+**私の修正で壊れたものは1つも無い。** P3b-2 の時点から Linux で壊れており、
+CI が1件目で止まるため往復1回につき1件しか見えなかった。
+
+#### 🔴 往復の真因は「ローカルで Linux を再現できていなかった」こと
+
+正しい形は
+
+```
+cargo clippy -p orbit-child-runtime --all-targets --target x86_64-unknown-linux-gnu --locked -- -D warnings
+```
+
+これで**1回で2件同時に見えた**。それまでの検証はすべて弱かった:
+
+| 試み | なぜ無効だったか |
+|---|---|
+| workspace 全体を Linux ターゲットで | `alsa-sys` で止まり対象まで到達しない |
+| `-p orbit-child-runtime --lib` | 🔴 **`--lib` はテストを含まない**。テスト側の失敗はそこに出ない |
+| 静的な cfg 照合「4 child すべて 0 件」 | 🔴 照合式が `unsafe fn` / `unsafe extern` を捉えていなかった |
+
+🔴 **0 件という結果は、「対象が無い」と「対象を見ていない」を区別しない。**
+同様に、macOS で回した clippy は `-D warnings` も `--locked` も feature 別も無く、
+**CI より弱い条件での測定**だった。
+
+#### レビューラウンド1（`/code:pr-review-team` + Fable 監査を並行）
+
+**Fable**（差分に**無い**もの）:
+- A-1 `resize_hints_changed` の no-op。コメントの「P3b-2 で実装」という期限が
+  **この PR の中で満了**していた → owner 裁定で**実装せず、消せる条件つきで登記**
+- A-2 ウィンドウタイトル（Q6・承認済み）未実装 → 同上（P4 で `cmd_arg` に載せる）
+- 🔴 **残余登記2件が実態より古い**と指摘 → 確認すると**どちらもこの PR 自身で履行済み**だった
+
+**silent-failure-hunter**:
+- 🔴 **孤児検知の stderr 出力が4 child すべてから消えていた**。`child_should_quit` への
+  共通化で移植されなかった。child には `tracing` subscriber が無く **stderr が唯一の観測経路**
+  なので、唯一の観測経路を削っていた。
+  → 根本原因は `bool` を返していたことなので `QuitReason { HostRequested, ParentDied }` に変更。
+  **型で区別されていなければ、落ちてもコンパイラは何も言わない**
+
+**code-reviewer**:
+- 🔴 gain oracle フィクスチャの**固定パス競合**（素の workspace で2回・並行で **8/8 中 5** 再現）。
+  対策（pid 付きスロットの `package_bundle()`）は**既に存在**し synth oracle は使っていたが、
+  この PR の新テストだけが直叩きしていた
+- レビュー中に**私が作業ツリーを編集した**ことも正しく指摘された。次から指摘が出揃うまで触らない
+
+**comment-analyzer**:
+- Critical 3件は**すべて WORK_LOG の記述**（本エントリで是正）。
+  一方 **SDK 引用（`iplugview.h:146` 等）と Rust ソース内のコメントは全件正確**と確認された
+
+**変更ファイル**: 上表の9コミット分
+
+---
+
 ### 6.344 feat(rust): #474 P3b-2 — NSWindow を実配線し、実在を OS に問い合わせて証明した (Jul 31, 2026)
 
 **Date**: 2026-07-31
@@ -86,9 +177,15 @@ main が**合成箇所**（`|| parent_watch.should_exit()` → `false`）を突�
 **21 件全部が緑のまま通った**。既存テストは自前のクロージャを注入しており、
 `child_should_quit` が本物の `ParentWatch` を渡すことは誰も縛っていなかった。
 
-**CLAP の `HostCallbackConfig` と同種だが深刻度が違う** — あちらは消費者が居ないので
-到達不能（P3b-2 の完了条件として登記）。こちらは **4 child すべての production 経路**で、
+**CLAP の `HostCallbackConfig` と同種**。こちらは **4 child すべての production 経路**で、
 壊れれば孤児 child が生き残る（#448）。
+
+> 🔴 **執筆時この節は CLAP 側を「消費者が居ないので到達不能・P3b-2 の完了条件として登記」と
+> 書いていたが誤り**（Fable 監査で判明・commit `9d727fa` で是正）。**その P3b-2 は本エントリが
+> 記述しているコミット自身**で、`take_closed` / `take_requested_size` を実 `load` 経路へ配線し
+> `real_load_path_delivers_plugin_initiated_close_to_main_half` も同時に追加している。
+> つまり**同じコミットが埋めたギャップを「未解決」と書いていた**。
+> 変異で裏取り済み（`effect.rs` の call site を `in_process` に差し替えると当該1件だけ FAILED）。
 
 対処: `ParentWatch::orphaned_for_tests()` を追加（ありえない pid を記録して
 「親が死んだ」分岐を到達可能にする）。テストは `control` を `CONTROL_RUN` のままにするので、
@@ -138,7 +235,7 @@ VST3 の editor 取得は**順序そのものが規格要件**である。SDK �
 
 - `orbit-child-ui`: `PluginUiEndpoint` trait + `UiSize`。**依存ゼロを維持**し、
   親ビューは `*mut c_void` で受ける（AppKit も vst3 crate も入れない）
-- `orbit-vst3-host/src/view.rs`（新規 292行）: `IPlugView` + `IPlugFrame`。
+- `orbit-vst3-host/src/view.rs`（新規 299行）: `IPlugView` + `IPlugFrame`。
   `resizeView` を受けたら**同一 callstack 内で** `onSize` を呼び返す（`iplugview.h:112-114`）
 - `orbit-vst3-synth-oracle`: 呼び出しを順序込みで記録する `IPlugView` スタブ（+208行）。
   NSView は作らない（`attached` は記録して `kResultOk` を返すだけで足りる）
@@ -340,8 +437,25 @@ failed to load oracle bundle .../GainOracle.vst3: missing symbol: GetPluginFacto
 - **単独実行 ×3 はすべて 11 passed**
 - **workspace 再実行は 440 passed / 0 failed**
 
-Codex が変異検証で `cargo clean -p` を繰り返した結果、**VST3 フィクスチャの再生成と使用が
-競合**したもの。実装起因ではない。
+当時は「Codex が変異検証で `cargo clean -p` を繰り返した結果、VST3 フィクスチャの再生成と
+使用が競合したもの。実装起因ではない」と結論した。
+
+#### 🔴 上の診断は誤りだった（同日中にレビューで判明・commit `6cb4b05`）
+
+**真因はこの PR が持ち込んだ固定パス競合**。`ui_endpoint.rs` の `gain_oracle_bundle()` が
+`package-oracle.sh` を**引数なしで**叩き、固定パス `target/vst3-fixtures/GainOracle.vst3` へ
+`rm -rf` / `cp` していた。同じパスを別クレートのテストが**別プロセス**から叩くため、
+一方の `rm -rf` が他方の `cp` を追い越す。
+
+code-reviewer が素の `cargo test --workspace` で2回再現し、3バイナリ並行実行で
+**8回中5回**失敗させた。
+
+🔴 **「単独3回 green だから環境起因」という切り分けが誤りだった。**
+単独実行では**原理的に起きない**競合なので、その観測は仮説を否定できない。
+「再現しない = 環境のせい」と読んだのが誤りで、正しくは「その実験は競合を検出できない」。
+
+対策は既に存在していた（`orbit_vst3_gain_oracle::package_bundle()` の pid 付きスロット・
+synth oracle 側は使用済み）。この PR の新テストだけが使っていなかった。
 
 #### レビューラウンド1（PR #594）と fix R1
 

--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,99 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.343 feat(rust): #474 P3b-1 — VST3 の UI エンドポイント層（順序が仕様） (Jul 31, 2026)
+
+**Date**: 2026-07-31
+**Issue**: #474（P3b-1）/ **Branch**: `474-plugin-ui-p3b1-gui-endpoint`
+**Status**: `cargo test --workspace`（**sandbox 外**）= **447 passed / 0 failed**（P3a 時点 442 → 新規5本）
+
+P3b も分割した。**P3b-1 = AppKit を混ぜないフォーマット GUI エンドポイント層**。
+P3a が「AppKit 非依存の純 Rust に切り出したから変異検証が成立した」分割を踏襲している。
+**今回は VST3 のみ**（CLAP は別タスク）。
+
+#### 🔴 この層の責務は「呼ぶこと」ではなく「正しい順序で呼ぶこと」
+
+VST3 の editor 取得は**順序そのものが規格要件**である。SDK 原文（`iplugview.h:146`・
+`attached()` の doc）: *"Note that in this call the plug-in could call a IPlugFrame::resizeView ()!"*
+— **attach の最中にプラグインがリサイズを要求しうる**ので、`setFrame` を後回しにすると
+その要求を取りこぼす。
+
+したがって**テストは順序を検証しなければ意味がない**。ブリーフでは oracle スタブに
+**「attach の最中に `resizeView` を呼ぶモード」を必須**にした。これが無いと順序を
+間違えても全テストが緑のまま通る。
+
+#### 実装
+
+- `orbit-child-ui`: `PluginUiEndpoint` trait + `UiSize`。**依存ゼロを維持**し、
+  親ビューは `*mut c_void` で受ける（AppKit も vst3 crate も入れない）
+- `orbit-vst3-host/src/view.rs`（新規 292行）: `IPlugView` + `IPlugFrame`。
+  `resizeView` を受けたら**同一 callstack 内で** `onSize` を呼び返す（`iplugview.h:112-114`）
+- `orbit-vst3-synth-oracle`: 呼び出しを順序込みで記録する `IPlugView` スタブ（+208行）。
+  NSView は作らない（`attached` は記録して `kResultOk` を返すだけで足りる）
+- 🔴 **`orbit-vst3-gain-oracle` は変更しない**。`createView` が null を返すままなので、
+  「GUI 非対応プラグインで loud に失敗する」負の経路が**追加作業ゼロで検証できる**
+
+#### 🔴 view の生存を controller より短く保つのをコードで強制した
+
+`ivsteditcontroller.h:535-536`: *"The life time of the editor view will never exceed the
+life time of this controller instance."*
+
+**フィールドの宣言順に頼らない**。`Drop` は `release_view()` → `release_controller()` の順で
+明示的に呼び、`release_view` は `removed()` →  view 解放 → frame 解放、
+`release_controller` には `debug_assert!(self.view.is_none())` を置いた。
+
+#### 変異検証（Codex 4種 + main の独立再現）
+
+テストは `contains` ではなく **trace 全体の等値比較**。さらに `canResize`（規格上は
+任意の位置でよい）を除いた「規範シーケンス」を別途厳密比較する二段構えにした。
+
+| 変異 | 結果 |
+|---|---|
+| `attached` ↔ `setFrame` 交換 | red（`left`/`right` に順序差） |
+| `removed()` を2回 | red（`["removed","removed","viewDropped"]`） |
+| `onSize` 呼び返しを削除 | red（`resizeView` の後が欠ける） |
+| null view で `Ok` を返す | red（負の経路が loud 失敗を保証） |
+
+🔴 **4種すべてがコンパイルエラーではなく assertion failure で red**。
+
+main が独立に `setFrame` を `getSize` の後ろへ移す変異を当てて再現した（2 tests failed・
+`left: [..., "canResize", "getSize", "setFrame", ...]`）。復元は `cmp` で一致確認。
+
+#### 🔴 Codex の rescue 経路が read-only に倒れていた
+
+`rescue`（companion → broker → app-server）が2回とも書き込みを拒否した:
+
+```
+patch rejected: writing is blocked by read-only sandbox;
+rejected by user approval settings
+```
+
+**1回目は `completed` / `Phase: done` を返しながら作業ツリーは完全に空だった。**
+完了通知だけを見ていたら実装済みと誤読していた。
+
+切り分け: `codex exec --sandbox workspace-write` を直接叩くと**書ける**（プローブで実証）。
+broker（15時間39分稼働）を再起動しても直らず、同じ手を3回目は打たずに
+**`codex exec` 直叩き**へ切り替えた。memory の
+`codex-rescue-sandbox-broker-gotcha` の「当座は companion を直叩き」は**今回効かなかった**ので
+記録の更新が要る。
+
+Codex 本体・契約枠は正常。壊れているのは rescue の JSON-RPC 経路だけ。
+
+#### spec 修正（先行）
+
+`UIH.4b` の「`set_scale` も同様にメインスレッドで扱う」が CLAP 規格と矛盾していた。
+CLAP 原文（`gui.h`・`CLAP_WINDOW_API_COCOA` の直上）:
+*"uses logical size, don't call `clap_plugin_gui->set_scale()`"*。
+cocoa は論理サイズなのでホストがスケールを押し付けると二重適用になる。
+main が一次ソースを逐語確認して修正（commit `b05538c`）。
+
+**変更ファイル**: `orbit-child-ui/src/lib.rs` / `orbit-vst3-host/{Cargo.toml,src/lib.rs,src/view.rs,tests/ui_endpoint.rs}` /
+`orbit-vst3-synth-oracle/src/lib.rs` / `Cargo.lock` / `PLUGIN_UI_HOSTING_SPEC_v1.md`
+
+**Commit**: `474-plugin-ui-p3b1-gui-endpoint`（PR 作成予定）
+
+---
+
 ### 6.342 feat(rust): #474 P3a — クローズ状態機械を AppKit 非依存の純 Rust で実装した (Jul 31, 2026)
 
 **Date**: 2026-07-31

--- a/docs/specs-v2/PLUGIN_UI_HOSTING_SPEC_v1.md
+++ b/docs/specs-v2/PLUGIN_UI_HOSTING_SPEC_v1.md
@@ -429,7 +429,13 @@ child がウィンドウを所有する以上、**プラグイン起点のリサ
 | VST3 | `IPlugView::onSize` — SDK 原文（`iplugview.h:177-178`）: *"Note that if the plug-in requests a resize (IPlugFrame::resizeView ()) onSize has to be called afterward."* | **`resizeView` を受理したら NSWindow をリサイズし、`onSize` を呼び返す** |
 | CLAP | `clap_host_gui.request_resize` / `resize_hints_changed`（`[thread-safe]`） | 受理してメインスレッドで NSWindow をリサイズ |
 
-`set_scale` / `get_resize_hints` も同様にメインスレッドで扱う。
+`get_resize_hints` も同様にメインスレッドで扱う。
+
+> 🔴 **CLAP の `set_scale` は cocoa では呼んではならない。** CLAP 原文（`gui.h`・
+> `CLAP_WINDOW_API_COCOA` 定義の直上）: *"uses logical size, don't call
+> `clap_plugin_gui->set_scale()`"* — cocoa は論理サイズを使うため、ホストが
+> スケールを押し付けると二重適用になる。win32（physical size）のみ `set_scale` の対象。
+> 本仕様は cocoa 埋め込みに統一している（UIH.4）ので、**`set_scale` は使わない**。
 
 ### UIH.4c クローズの状態機械（経路条件つき・冪等）
 

--- a/docs/specs-v2/PLUGIN_UI_IMPLEMENTATION_DESIGN_474.md
+++ b/docs/specs-v2/PLUGIN_UI_IMPLEMENTATION_DESIGN_474.md
@@ -1,0 +1,610 @@
+# #474 プラグイン UI open/close — 実装設計（Fable 設計・2026-07-30・**v2**）
+
+> **リポジトリへの永続化について（2026-07-31）**: 本書は `/private/tmp` にのみ存在していた。
+> フェーズ P0〜P6 の定義・分割の根拠・§8 の設計判断 Q1〜Q8 がすべてこの1ファイルに載っており、
+> tmp の掃除で消える位置にあった。owner の「先送りが負の遺産にならないか」という問いへの
+> 点検で判明したため repo へ移した。**分割して別 issue にした機能は §8 Q4 を参照**。
+>
+> **owner 裁定の反映状況（2026-07-31 時点）**:
+> Q1 = (b) 全 receiver へ一般化（確定）/ Q2 = (b) `dirty_epoch`（**spec 反映済み** `9dea05e`）/
+> Q3 = objc2 系（P1 で導入済み）/ **Q4 = §8 の「別 issue に分割」は失効**（下記）/ Q5 = REPL メタ行を**足す**（承認）/
+> Q6 = `<plugin name> — <receiver>[<index>]`（承認）/ Q7 = CAP 改訂済み（`9dea05e`）/
+> Q8 = 合成判定を承認（統合 E2E は capture WAV のアサーションまで通すこと）
+>
+> 🔴 **§8 Q4 の「別 issue に分割する」は失効している。** owner が個別に裁定し、
+> `docs/development/WORK_LOG.md`（commit `9dea05e`）に記録済み:
+> **Show info / Reveal in Finder = 不要**（owner 裁定）/ **右クリック挿入 = 不要**
+> （挿入トリガーは #522・#506 と同時設計。現行 `.effect("` 前提で作ると #522 で作り直しになる）/
+> **階層ブラウズ = 補完 #495 で満たす** / **Rescan catalog = 3面すべて実装済み**
+> （コマンドパレット / `editor/context` / MCP `rescan_plugins`）。
+> **つまり分割先の issue は不要。** 2026-07-31 に誤って #595 を作成し、同日クローズした。
+>
+> **実装時に効く既存資産**: `editor/context` メニューは既に存在する
+> （`packages/vscode-extension/package.json:232`・`when: resourceExtname == .orbs`・
+> `group: "orbitscore"`）。P5 の「Open Plugin UI」/「Close Plugin UI」は
+> **メニューを新設せず既存グループに足す**形になる。
+
+対象リポジトリ: `/Users/yamato/Src/proj_orbitscore/orbitscore`
+設計者: Fable subagent（team lead 発注）
+正本仕様: `docs/specs-v2/PLUGIN_UI_HOSTING_SPEC_v1.md`（UIH）/ `PROJECT_FILE_SPEC_v1.md`（PRJ）/
+`PLUGIN_CAPABILITY_ABSTRACTION_v1.md`（CAP）
+
+> **v2 改訂（owner 裁定 2026-07-30 の反映）**:
+> 1. **#474 の検証範囲 = 「プラグイン UI が実際に開き、人間が触れる状態になること」まで**。
+>    つまみ→音の変化はプラグイン内部の自明事項でありホストの検査対象ではない
+> 2. **音色操作は2本足**: 人間 = GUI つまみ（→ state スナップショット = #577）、
+>    人間+LLM = オートメーション（→ **DSL に残る**・#506 方向）。
+>    **オートメーション値はスナップショットに保存しない — DSL が担保する**（owner 決着済み）
+> 3. **computer-use は主経路から外す**（LLM 経路でも人間側検証道具でもない）
+>
+> これにより v1 §6 の「オラクル GUI へのつまみ・GUI 起点 state 変更を『UI 編集』と主張する
+> フック・computer-use ティア調査」は不要または降格。§5b（新設）・§6・P6・§8 を改訂。
+
+---
+
+## 0. 要旨
+
+**設計の大半はすでに UIH スペックが規範として確定している**（UIH.0〜UIH.9・owner 確定
+2026-07-28）。本文書の仕事は「何を新しく決めるか」ではなく、
+
+1. スペックを **6 フェーズの実装計画**（依存・受け入れ基準・検証方法つき）に落とすこと
+2. スペックとコード実測の**乖離・空白**を列挙すること（→ §7 spec 更新一覧・§8 owner 確認事項）
+3. **「ウィンドウが実際に開いた」を child の自己申告以外の経路で無人確認する**設計（§6）と、
+   **#577 受け入れへの波及の判定**（§5b-3）を書くこと
+
+**フェーズ列**（直列が基本・矢印 = ハード依存）:
+
+```
+P1 実行モデル変更（child main = Cocoa runloop / audio = 専用スレッド）
+ → P2 イベント欄（evt リング）+ host 側ポンプ
+ → P3 child の UI open/close（NSWindow 所有・クローズ状態機械）
+ → P4 daemon/engine/MCP 配線（open_plugin_ui / close_plugin_ui・セーフポイント(b)）
+ → P5 エディタ右クリック（テキスト位置 → (receiver, chain index) 解決）
+ → P6 oracle 最小ウィンドウ + 無人 E2E（P3 完了後に oracle 側は並行着手可）
+```
+
+LLM の足（オートメーション DSL・#506）は**本計画のスコープ外**（§5b で線引き）。
+
+---
+
+## 1. 現状のコード実測(2026-07-30・本設計で確認した事実)
+
+| 項目 | 実測 | 含意 |
+|---|---|---|
+| child 実行モデル | 4 child とも**単一スレッド spin loop**。audio 処理・`service_command_mailbox`・`ParentWatch`・`CONTROL_QUIT` 監視を同一ループで直列に回す（`orbit-vst3-instrument-child/src/main.rs:315-415`, `orbit-clap-effect-child/src/main.rs:112-171`） | UIH.0 の「現状」欄と一致。P1 は 4 child 全部に及ぶ |
+| コマンドメールボックス | **実装済み**（#555/#562）。ただし `cmd_kind` は `CMD_SAVE_STATE=1` のみ（`orbit-audio-sandbox/src/transport.rs:244`）。`CommandMailboxHost` に単一 in-flight・exact-ack・generation 照合・`reset_after_child_exit` あり | UIH.2 の骨格は既設。OPEN_UI / CLOSE_UI の kind 追加と「ack=受理」型コマンドへの拡張が P3/P4 の仕事 |
+| イベント欄（evt_*） | **未実装**（transport.rs に `evt_` 系フィールドなし） | UIH.2a は丸ごと P2 の新規実装 |
+| CLAP state 配線 | **済み**。`orbit-clap-effect-child` は `--state` を読み `ClapEffectProcessor::load(state_bytes)`・`capture_state()` も CMD_SAVE_STATE で配線済み | **UIH.9 前提是正(2) は解消済み** → spec の当該行は事実の更新が必要 |
+| vst3-effect-child バンドル | **済み**。`scripts/copy-daemon-bin.sh:85-98` が 4 child 全部を build & copy | **UIH.9 前提是正(1) も解消済み**。ただし「.vsix 内 bin 一覧の検証」が積まれているかは要確認（P0 で確認） |
+| daemon プロトコル | JSON request/response + **event frame の push 経路あり**（`daemon-client.ts` が event を EventEmitter に dispatch） | UI_CLOSED → engine への通知に新チャネル不要。既存 event frame に載る |
+| daemon → child の宛先 | `GetPluginState {role, bus?, instance?}` 形式で解決済み（`daemon-client.ts:407-427`） | OpenPluginUI / ClosePluginUI は**同じ宛先語彙**で追加できる |
+| state 保存の全経路 | engine(TS) が sidecar パス決定 → daemon → `CommandMailboxHost` → child、atomic rename と `project.yaml` 登記は engine 側（`project-state-store.ts`） | **UIH の「host」は実際には daemon+engine の 2 プロセス**に分かれている。セーフポイント(b) の evt_ack 前進条件はこの跨ぎを含む（§4 P4 参照） |
+| oracle 資産 | VST3: `orbit-vst3-gain-oracle` / `orbit-vst3-synth-oracle`。CLAP: `CLAPTestEffect.clap`（テストが自前 package）。**いずれも GUI なし** | P6 で gui 拡張を oracle に実装する |
+| macOS binding 依存 | workspace に objc2 / cocoa 系 crate **なし**（core-foundation-sys のみ） | NSApplication/NSWindow 用に新規依存が要る（§8 Q3） |
+| MCP | `save_plugin_state` 等は `packages/vscode-extension/src/mcp-server.ts` に登録。`open_plugin_ui` / `close_plugin_ui` は**未実装**（spec の記載どおり） | P4 で追加 |
+
+---
+
+## 2. 全体アーキテクチャ（確定スペックの再掲 + 層の割り当て）
+
+```
+[エディタ右クリック]                [LLM / MCP]
+  テキスト位置 → (receiver, chain index) 解決      open_plugin_ui(receiver, index)
+        └──────────────┬───────────────┘
+                       ▼
+   extension mcp-server / command  ──→  engine(TS)
+      ・(receiver, index) を検証（chain 実在・期待名照合）
+      ・daemon target (role, bus|instance) へ解決          【UIH.5 の層分離】
+                       ▼
+   daemon: OpenPluginUI / ClosePluginUI request
+      ・CommandMailboxHost で OPEN_UI / CLOSE_UI を child へ投函
+      ・evt リングをポンプ → UI_CLOSED / UI_CLOSED_DONE を event frame で engine へ push
+                       ▼
+   child（メイン = Cocoa runloop / audio = 専用スレッド）
+      ・OPEN_UI: NSWindow 生成 → VST3 IPlugView attach / CLAP gui embed 【UIH.4】
+      ・クローズ 3 経路 → 状態機械（Closed→Open→Closing→Closed）【UIH.4c】
+      ・UI_CLOSED 投函 → host の保存完了 ack を待って解放 → UI_CLOSED_DONE
+```
+
+セーフポイント (b)（PRJ.3）は「UI_CLOSED 観測 → engine が既存の save+登記フローを実行 →
+daemon が evt_ack 前進」で実現する。**#577 PR-A（停止時 snapshot）・PR-B（dirty 通知）と同じ
+保存・登記コードに合流し、新しい永続化機構は作らない。**
+
+---
+
+## 3. フェーズ分割
+
+### P0: 前提確認（半日・コード変更ほぼなし）
+
+- UIH.9(1)(2) が解消済みであることの裏取りを完了させる:
+  - `.vsix` 内 bin 一覧の検証テスト（UIH.9 が要求）が存在するか確認、なければ追加
+  - `outproc_effect_vst3_gated` 等の gated テストを実機で回して green を確認
+- **受け入れ基準**: 4 child すべてが bundled path から spawn 成功（実機）。spec UIH.9 の
+  記述を実状に合わせて更新（§7-1）
+
+### P1: 実行モデル変更 — child main を Cocoa runloop に（最重リスク・全 child 共通）
+
+**内容**（UIH.0 / UIH.1 / CAP.5 に従う）:
+
+- 新 crate `orbit-child-runtime`（4 child 共有）:
+  - main: `NSApplication` 生成（activation policy = **Accessory**・Dock アイコンなし）、
+    runloop 開始。数十 ms 周期のタイマーで `service_command_mailbox`・`ParentWatch`・
+    `CONTROL_QUIT` を監視
+  - audio: 専用スレッドへ退避（現行 spin loop をそのまま移設）。スレッド優先度は
+    QoS user-interactive、必要なら `thread_policy_set`（time-constraint）。
+    audio スレッドは `CONTROL_QUIT` の Relaxed load **のみ**を追加で見る（メールボックス・
+    イベント欄には触れない = UIH.2 規律1）
+  - 終了系: QUIT / 親死亡検知 → runloop 停止 → audio join → teardown
+- `service_command_mailbox` 呼び出しを audio ループから**撤去**し main タイマーへ移す
+- **UIH.3 の「演奏停止中のみ SAVE_STATE」MUST を撤廃**できる状態になる（spec 側の
+  制約解除は実測確認後に行う・§7-2）
+
+**受け入れ基準**:
+- 既存全テスト green + `roundtrip_latency_gated` に退行なし（UIH.7 故障モード表の要求）
+- 実機 E2E: 4 経路（clap/vst3 × effect/instrument）で音が出る・capture drops==0
+- **演奏中の `save_plugin_state` が成功する**（新規 gated テスト。従来は禁止だった挙動の解禁を
+  実測で確認）
+
+**リスクと対策**: 小バッファ（64/32）は性能ゴール。audio スレッド化でレイテンシ退行が出たら
+**この時点で設計を見直す**（UIH.7 に明記された停止条件）。P1 は単独 PR とし、後続を積む前に
+実機確認を完了させる。
+
+### P2: イベント欄（evt リング）+ host 側イベントポンプ
+
+**内容**（UIH.2a を忠実に実装）:
+
+- `transport.rs`: `EVT_SLOTS = 3`、`evt_seq` / `evt_kind[]` / `evt_arg[][]` / `evt_ack_seq`。
+  publish/read の Release/Acquire 対、slot 再利用不変条件（`evt_ack_seq >= s - EVT_SLOTS`）、
+  取りこぼし不可イベントの child 側再試行
+- child 側: 投函 API（状態保持 + runloop 再試行）。host 側: `EventRingHost`
+  （seq 順処理・追い越し禁止・ack 前進）。`reset_after_child_exit` に evt リングのリセットを追加
+  （UIH.2a 故障表の respawn 行）
+- **検証**: UIH.8 の変異検証リスト該当分（seq 順処理・未 ack slot 上書き・単一スロット化・
+  Relaxed 化 → loom による in-process モデル検証。TSan は cross-process shm を追えないため）
+
+**受け入れ基準**: 変異検証込みユニット + loom green。この時点で UI イベントの消費者はまだ
+いない（P4 で接続）が、リングの正しさは単独で検証を完結させる。
+
+**#577 PR-B との整合**: PR-B は「既存 shm に `dirty_epoch` 1語追加」で設計されている。
+**推奨: STATE_DIRTY はリングに載せず `dirty_epoch`（合流カウンタ）で恒久化し、リングは
+取りこぼし不可の UI_CLOSED / UI_CLOSED_DONE 専用とする**（§8 Q2・spec 改訂要）。
+これで UIH.2a が STATE_DIRTY のために規定していた pending フラグ・in-flight 1 件制限・
+「dirty の ack でフェーズ B が誤発火する」ハザードのクラスが**構造的に消える**。
+owner が現行 spec（STATE_DIRTY もリング）を維持する判断ならそのまま実装する（実装可能・
+規定は完備している）。
+
+### P3: child の UI open/close（NSWindow 所有・クローズ状態機械）
+
+**内容**（UIH.4 / UIH.4a / UIH.4b / UIH.4c）:
+
+- 新 crate `orbit-child-ui`（4 child 共有・AppKit 依存はここに閉じ込める）:
+  - **クローズ状態機械を AppKit 非依存の純 Rust モジュール**として実装
+    （`Closed→Open→Closing→Closed`・3 経路合流・再入ガード・フェーズ A/B・
+    「フェーズ B は UI_CLOSED 自身の seq 到達で開始」）。UIH.8 の変異検証 14 項目の大半は
+    このモジュールのユニットテストで殺す（AppKit 呼び出しと evt 投函は trait で差し替え）
+  - NSWindow 生成・delegate（`windowShouldClose` で NO → 状態機械へ・`windowWillClose` 禁止）・
+    リサイズ応答（VST3 `IPlugFrame::resizeView`→`onSize` / CLAP `request_resize`）
+- VST3: `createView("editor")` → `setFrame`（**attached より前**）→ `getSize` → NSWindow →
+  `attached(nsview, "NSView")`。解放は `removed()` を親破棄より前に
+- CLAP: `is_api_supported(cocoa, false)` false なら **loud 失敗**（UIH.4a・floating へ
+  フォールバックしない）。`closed(was_destroyed)` は main へ marshal して経路③に合流
+- `cmd_kind` に `CMD_OPEN_UI` / `CMD_CLOSE_UI` を追加:
+  - OPEN_UI: main スレッド内で完結するため**完了時 ack**（結果コードで失敗を運ぶ）
+  - CLOSE_UI: **受理時 ack**（UIH.2a ポリシー2。完了は UI_CLOSED_DONE イベント）
+  - `Closing`/`Closed` 中の OPEN_UI = failure ack（"closing-in-progress"）、
+    CLOSE_UI = 成功 ack（"already-closing"）— UIH.2a 故障表どおり
+
+**受け入れ基準**: 状態機械の変異検証（UIH.8 リストの該当項目、特に「規律3 を忠実に守る host
+モックで経路②が hang しないこと」）。実プラグイン（UI を持つ CLAP/VST3 各1）で
+open→close が手元確認できること（この段階では手動確認可・無人化は P6）。
+
+**新規依存**: `objc2` + `objc2-app-kit`（§8 Q3・owner 承認事項）。
+
+### P4: daemon / engine / MCP 配線 + セーフポイント (b)
+
+**内容**:
+
+- daemon protocol: `OpenPluginUI` / `ClosePluginUI` request（宛先語彙は `GetPluginState` と
+  同一: `{role, bus?, instance?}` + chain 由来の対象特定）。
+- daemon: 各 child host に UI イベントポンプ（P2 の `EventRingHost` を既存のポーリングループへ
+  接続）。`UI_CLOSED` / `UI_CLOSED_DONE` / respawn 由来のウィンドウ消失を **event frame** で
+  engine へ push
+- **セーフポイント (b) の 2 プロセス跨ぎ**（本フェーズの核心）:
+
+  ```
+  child: UI_CLOSED 投函
+  daemon: 観測 → event frame "plugin-ui-closed" {target} を engine へ
+  engine: 既存 save フロー実行（GetPluginState → sidecar → atomic rename → project.yaml 登記）
+  engine: daemon へ AckUiSafepoint {target, evt_seq} request
+  daemon: evt_ack_seq を前進（= UIH.2a ポリシー3 の「host 側処理の完結」）
+  child: フェーズ B（解放）→ UI_CLOSED_DONE
+  daemon → engine → MCP: close 完了
+  ```
+
+  - engine 停止・未接続・保存失敗時: daemon は**タイムアウトで evt_ack を進めない**。child 側の
+    Closing タイムアウトが「保存なしでクローズ完遂 + UI_CLOSED_DONE(timeout)」で脱出する
+    （UIH.2a 故障表）。保存失敗は登記を更新せず loud（PRJ.4）
+  - `CONTROL_QUIT` 前に in-flight クローズ手続きを解決する（UIH.2a 故障表の最終行）—
+    daemon の teardown 順序に組み込む
+- MCP tool: `open_plugin_ui(receiver, index)` / `close_plugin_ui(receiver, index)`
+  - close の完了判定 = **UI_CLOSED_DONE の受信**（ack ではない・UIH.4c 注記）。タイムアウトつき
+  - 存在しない index / 未ロード / UI 非対応（CAP-UI-OPEN なし）はすべて **loud エラー**で、
+    当該レシーバの有効 index 一覧（role・正規化名つき）を返す（UIH.5 規則3 — LLM の自己修正用）
+  - **誤爆ガード**: 呼び出しに `expectedName`（正規化名）を任意で渡せるようにし、
+    (receiver, index) の実体と不一致なら開かず loud エラー（「index がずれて別のプラグインの
+    UI を開けた」silent failure の防止。エディタ経路は常に付与する）
+- UIH.6 ライフサイクル: 停止時 = セーフポイント(c) の後に child ごと消える（既存）。
+  respawn = 再オープンせず「respawn により UI が閉じた」を event frame → 拡張 output channel
+  へ **loud 通知**
+- REPL メタ行 `//#openPluginUi <receiver> <index>` / `//#closePluginUi`（`//#savePluginState`
+  と対称・実装コスト小。§8 Q5）
+
+**受け入れ基準**: MCP から open→close→登記→復元が通ること（実機・実プラグイン手動確認 +
+oracle は P6 で無人化）。close 完了が DONE 受信であることの変異検証（ack で完了を名乗る変異
+→ red）。
+
+### P5: エディタ右クリック（人間の面）
+
+**内容**（issue 本文 + owner 優先度確定コメント 2026-07-18: 本命 = Open UI のみ。
+挿入系・階層ブラウズは**別 issue に分割**する — §8 Q4）:
+
+- context menu（`editorLangId == orbitscore`）: **「Open Plugin UI」「Close Plugin UI」**
+  - 🟢 **`editor/context` メニューは既に存在する**（実測 2026-07-31・
+    `packages/vscode-extension/package.json:232`）。`when: resourceExtname == .orbs` /
+    `group: "orbitscore"` で `orbitscore.rescanPlugins` が登録済み。
+    **メニューを新設せず、この既存グループに2項目を足す**
+  - 🔴 挿入系・階層ブラウズ・Show info / Reveal in Finder は **§8 Q4 の裁定により作らない**
+- テキスト位置 → `(receiver, chain index)` 解決は**エディタ層に閉じる**（UIH.5）:
+  - v1 は regex: カーソルが乗っている `.effect("...")` / `.instrument("...")` 呼び出しを検出、
+    文頭のレシーバ識別子 + 同一文内のチェーン位置から index を算出
+    （instrument = 0・effect は 1 始まり・UIH.5 の割り当て規則）
+  - 解決した `(receiver, index, expectedName)` を P4 の同一経路へ渡す。engine 側の
+    expectedName 照合が regex 誤りの安全網（不一致 = loud エラー + 現在のチェーン一覧提示）
+  - #495 言語サービス導入時にこの regex を構文木ベースへ載せ替える（engine 以下は無変更 —
+    UIH.5 の層分離の狙いどおり）
+- 「ロード済みか」の事前検知は v1 では**しない**: メニューは常に出し、未ロードなら
+  loud エラーを通知する（グレーアウトのための状態同期機構は作らない。loud 失敗原則と
+  実装コストの均衡）
+
+**受け入れ基準**: 実機で右クリック → UI が開く。カーソル位置が曖昧・プラグイン呼び出し外なら
+説明つきエラー。engine 側照合の変異検証（expectedName 照合を外す変異 → red）。
+
+### P6: oracle 最小ウィンドウ + 無人 E2E（§6 に詳細）
+
+**内容**: oracle プラグイン（VST3 synth・CLAP test effect。必要なら CLAP synth）に
+**最小 GUI（開くだけのウィンドウ・つまみ不要**・owner 裁定）を実装し、
+gated E2E `tests/e2e/orbitstudio-mcp-gated.spec.ts` に受け入れシナリオを積む。
+
+**受け入れ基準**（= #474 全体の完成条件・UIH.8 / owner 裁定で確定した範囲）:
+- VST3 / CLAP の両方で「宣言 → **open_plugin_ui → ウィンドウが実在** → 閉じる（3 経路）→
+  セーフポイント発火 → ウィンドウ消滅」が無人 green
+- **ウィンドウの実在/消滅は child の自己申告と独立の経路（CGWindowList）の両方で assert**（§6）
+- UI を開いている間・閉じる往復中の capture WAV に dropout なし（drops==0）
+- クローズ 3 経路それぞれでセーフポイントちょうど 1 回（変異: 0 回・2 回で red）
+- 「つまみ → 音の変化」の E2E は**作らない**（プラグイン内部の自明事項・検査対象外）
+
+---
+
+## 4. team lead の設計 5 論点への回答
+
+### (1) GUI ホスティングの所有者・macOS runloop 要件
+
+**child が開く設計で確定済み**（UIH.4・owner 確定）。runloop 要件は P1 の実行モデル変更で満たす:
+`NSApplication` はプロセス先頭スレッド必須 → audio を専用スレッドへ退避し、main を runloop に
+明け渡す。これは 4 child 全部に及ぶ変更なので**単独フェーズ（P1）として先に出荷し、レイテンシ
+退行がないことを gated テストで確定させてから** UI 本体（P3）に進む。activation policy は
+Accessory（Dock に出さない・ウィンドウ表示とキー入力は可能）。
+
+### (2) daemon 経由の OpenUI/CloseUI IPC
+
+**新チャネル不要**。既存の 3 経路に載る:
+- host→child コマンド: 既存 `CommandMailboxHost`（#562）に kind を 2 つ追加
+- child→host イベント: UIH.2a の evt リングを**新設**（P2）— これが唯一の新機構
+- daemon→engine: 既存 event frame push
+
+**PR-B との整合**: `dirty_epoch` 1 語追加の設計とは**競合しない**。推奨はむしろ
+「STATE_DIRTY はリングに載せず dirty_epoch で恒久化」（P2 の項・§8 Q2）。この場合
+リングは UI_CLOSED / UI_CLOSED_DONE 専用になり、spec が STATE_DIRTY のために規定した
+合流規則が不要になって単純化する。
+
+### (3) エディタ側 + LLM 対称
+
+MCP `open_plugin_ui` / `close_plugin_ui` が正面（P4）。エディタ右クリックは
+「テキスト位置 → (receiver, chain index) の解決だけ」を担う薄い層（P5・UIH.5 の層分離）。
+両面は engine 内の同一関数に合流し、expectedName 照合・loud エラー（有効 index 一覧つき）で
+LLM が自己修正できる形にする。
+
+### (4) UIH.4 の 3 つの閉じる経路
+
+P3 のクローズ状態機械が 3 経路を同一ハンドシェイクに合流させる（スペック完備・
+実装は忠実に）。**状態機械を AppKit 非依存の純 Rust モジュールに切り出す**のが実装上の鍵で、
+UIH.8 の変異検証リスト（特に「規律3 準拠 host モックで hang しない」= 最重要項目）を
+ユニットで殺せる形にする。
+
+### (5) E2E — §6 参照（最大の難所・正直に書く）
+
+---
+
+## 5. #577 との順序関係
+
+- **PR-A（停止時 snapshot・PR #585）**: #474 と独立にマージ可。P6 で E2E の「manifest 手書き
+  登記」を UI 操作に差し替える（PR-A の機構自体は無変更）
+- **PR-B（dirty 通知）**: P1 完了で「演奏中の保存禁止」が外れ、PR-B の debounce checkpoint が
+  本来の形（演奏中も保存）で実装可能になる。**PR-B は P1 の後に置くのが得**（先行させると
+  停止中限定の暫定形を一度作って作り直すことになる）
+- セーフポイント (b) は P4 で初めて存在し、PRJ.3 表の「(b) 未実装 → #474」が解消する
+
+---
+
+## 5b. 2本足アーキテクチャ・スコープの線引き・#577 への判定（v2 新設）
+
+### 5b-1. 2本足の確定形（owner 決着済み・2026-07-30）
+
+| 操作 | 使う人 | DSL に残るか | スナップショット |
+|---|---|---|---|
+| **GUI のつまみ**（#474 が開くウィンドウ） | **人間のみ** | 残らない | **必要** — これが #577 の存在理由 |
+| **オートメーション**（プラグイン公開のパラメータ面） | **人間 + LLM** | **残る**（`.orbs`・#506 の DSL 表面） | **不要 — DSL が担保する** |
+
+- LLM の第一級経路は **DSL を書いて評価させる**こと。MCP がパラメータを直接叩く設計にしない
+  （「LLM も DSL 経由で使う」の既存原則のパラメータ層への適用）
+- computer-use は主経路にしない（LLM 経路でもなく、人間側検証の道具としても owner は不採用）
+- 「正本が2つ」問題（v1 §8 で owner 裁定候補としていた分岐）は**この決着で消滅**:
+  オートメーション値は state に保存しない。ただし**実装上の含意**が1つ残る —
+  プラグインの opaque state blob はパラメータ値も内包するため、復元順序は
+  **「state スナップショット適用 → その上に DSL のオートメーション宣言を再適用」**
+  （DSL 宣言が named パラメータについて常に勝つ・PRJ.6 の優先則と同型）。
+  これは #506 側の設計事項として申し送る
+
+### 5b-2. スコープの線引き（v2.1: prior art を一次確認して確定・**語彙を発明しない**）
+
+オートメーションには既存の設計資産と issue 群がある（#506 / #460 / #522 / #525 /
+#337 の成果物 = `POST_2.0_MIXER_DSL_DESIGN.html` §5）。一次確認した帰属:
+
+| 作業 | 帰属 | 根拠（一次確認済み） |
+|---|---|---|
+| ネイティブ UI の open/close・3 閉路・セーフポイント(b) | **#474（本計画 P0〜P6）** | 人間専用の足（GUI） |
+| オートメーション DSL 表面（`seq.PluginName(param: value)`・名前付きパラメータ） | **#506**（OPEN・当面「個別の数値指定」で十分 = owner） | #506 本文が「名前付きパラメータがそのまま **#460 オートメーションの入口**」と明記。**人間 + LLM の共用面**（LLM 専用ではない） |
+| オートメーションの関数化（ramp / mod・変数で値が動く） | **#460**（OPEN・3層設計） | 設計正本 = `POST_2.0_MIXER_DSL_DESIGN.html` §5（RT 安全の3層分離・effect ハンドルがパラメータの reconciliation key）。owner の「変数・関数で自動的に変わる」= これ |
+| **CLAP `params` 新設・VST3 `IEditController` のホスト API 化・param set の wire**（CAP-PARAM-LIST/GET/SET の実体） | **#522 スコープ2**（OPEN） | #522 本文が「パラメータを設定する経路が存在しない / VST3 は IEditController の土台あり、**CLAP は新設が要る**」と明記。**v1 で私が「別 issue 新設」と書いたのは誤り — 既に #522 が受け皿**。team lead の「PR-B とまとめるか」への回答: まとめない（PR-B = `clap_host_state`、params = 別拡張で #522 の領分） |
+| dirty 通知（`mark_dirty` / `setDirty` 受け口） | **#577 PR-B** | 既定どおり |
+| パラメータ MCP 面（列挙・観測） | #522（engine 受け口）+ #506（表面）。**設定系は DSL 経由が正**、列挙・読み取りは MCP でよい（LLM が「どの口があるか」を知る手段・CAP.6-4） | 対称設計 |
+| per-part preset/params（マルチティンバー） | #525 | 隣接・本計画と独立 |
+
+**#474 が負う唯一のオートメーション関連作業 = 境界の明記**:
+「**スナップショット（PRJ）の対象は GUI 由来の編集だけ。オートメーション値は保存しない —
+DSL が担保する**」を spec に規範として書く（§7 に行を追加済み）。復元順序
+（state blob 適用 → DSL 宣言の再適用・§5b-1）は #506/#460 側へ申し送る。
+
+### 5b-3. #577 への波及の判定（team lead の問いへの回答）
+
+**問い**: PR #585（#577 PR-A）は #474 完了をもって「UI で音色を作る」受け入れを満たすと
+言えるか。それとも実 UI 操作を経た記録の実機証明が別途要るか。
+
+**判定: 合成で満たされる — ただし条件3つつき**（確信度: 中〜高）。
+
+owner の裁定「つまみを動かせば音が変わるのは自明」の論理構造は
+「**プラグイン内部の配線はプラグインの契約であり、ホストの検査対象ではない**」である。
+同じ論理は「つまみの変更が `getState` の返す blob に映る」にも適用できる（これも
+プラグイン内部のシリアライズ契約）。したがって受け入れ連鎖は:
+
+```
+ウィンドウが開く（#474 が証明）
+→ 人間がつまみを回せる（自明・プラグイン内部）
+→ 変更が getState に映る（自明・プラグイン内部の契約）
+→ ホストが現在 state を捕捉・登記・復元する（#577 が証明）
+→ 再起動で同じ音（#577 が証明）
+```
+
+となり、**ホストが検査すべき環はすべて #474 + #577 のテストで覆われる**。
+
+**却下された「手書き state 登記」との違い**（ここが判定の核心）:
+手書き登記は「**ホストの捕捉機構を通さずに登記簿を直接書く**」= ホスト側の検査対象である
+捕捉・登記の環そのものをバイパスしていた。今回の合成は**すべての環をホストの実機構で
+通し**、プラグイン内部の環だけを「検査対象外」とする。バイパスと免除は別物であり、
+免除の線引きは owner 自身の「自明」裁定に一致する。**別の代替物には当たらない**と判定する。
+
+**条件**（これが欠けると判定は崩れる）:
+
+1. **#577 側の E2E で保存される state が、実 instance 内で発生した非デフォルト値であること**
+   （デフォルト state の往復だけだと「現在 state でなくデフォルトを保存する」バグを
+   検出できない。oracle の state 意味論 = 周波数オフセットで担保・E2E_HARNESS_SPEC §7）
+2. **#474 のクローズセーフポイント統合 E2E が1本あること**（P6）: UI を開いて閉じたとき、
+   その instance の現在 state（非デフォルト）が登記されること。人間の編集フローの
+   ホスト側全長をこれが覆う
+3. **Epic の最終受け入れとして、owner による実プラグイン1回のデモ**（#474 で Kontakt 等を
+   開く → つまみを回す → 停止 → 再起動 → 同じ音）を推奨する。これは「テストに人間を
+   介在させない」原則への違反ではない — テストループではなく、owner がプロダクトを使う
+   行為そのもの。無人 E2E が覆えない「実プラグインの癖」への正直な残余対応でもある
+
+**反証条件**: owner が「つまみ → getState 反映」を自明の範囲に含めない場合
+（例: 明示イベントでしかシリアライズしないプラグインの存在を懸念する場合）、条件3の
+一回デモを受け入れ必須に格上げすることで閉じる。判定に自信はあるが、受け入れ基準の
+解釈権は owner にあるため、**この判定自体を owner に一度見せることを推奨**する。
+
+---
+
+## 6. 無人 E2E の設計（v2・検証対象 = 「ウィンドウが実在する状態にできたか」）
+
+**owner 裁定により検証対象が確定した**: #474 が証明すべきは
+「**人間が触れるようにプラグインを開いてあげられたか**」。つまみ操作・音の変化は
+プラグイン内部の自明事項で検査対象外。したがって E2E の骨格は
+**開く → 実在確認 → 3 経路で閉じる → セーフポイント → 消滅確認**。
+
+### 6-1. 「開いた」の確認は二重経路（自己申告 + 独立証拠）
+
+**child の「開いた」報告だけでは「報告したが実際には開いていない」を検出できない**
+（#585 の `restoring` ログ = 「送信の証明 ≠ 適用の証明」と同型の穴）。二層にする:
+
+| 層 | 手段 | 検出するもの |
+|---|---|---|
+| **内部報告**（LLM 対称の観測面） | OPEN_UI の完了 ack + child の UI 状態を daemon 経由で MCP から観測可能にする（`open_plugin_ui` の返却 + 状態照会）。**LLM が第一級ユーザーとして結果を検証できる**面はこちら | 配線の失敗（コマンド不達・ack 欠落） |
+| **独立証拠**（E2E ゲートの物証） | `CGWindowListCopyWindowInfo` を叩く小ヘルパ（Rust・`kCGWindowOwnerPID` で child pid の on-screen window 数と bounds を確認。**Screen Recording 権限不要**の範囲 — タイトルは取らない。アプリ別権限付与も不要 = computer-use とは別物の素の OS API） | **「ack は返ったがウィンドウが無い」**（自己申告の嘘・attach 失敗の握り潰し・サイズ 0 ウィンドウ） |
+
+E2E は**両方を assert**する。変異検証: child が NSWindow 生成をスキップして成功 ack を
+返す変異 → 内部報告層は green のまま・CGWindowList 層だけが red になること（= 独立証拠が
+実際に独立であることの証明)。
+
+### 6-2. 3 つの閉じる経路の無人駆動
+
+| 経路 | 駆動方法 | 備考 |
+|---|---|---|
+| ② CLOSE_UI コマンド | MCP `close_plugin_ui`（本番経路そのまま） | 主経路 |
+| ① 閉じるボタン | env `ORBIT_UI_TEST_HOOKS=1` 限定の `CMD_UI_TEST_PERFORM_CLOSE` → main スレッドで `-[NSWindow performClose:]`。AppKit の実経路（`windowShouldClose` delegate）を通るので、delegate 以降の配線は人間クリックと同一 | クリック座標の合成はしない（脆さの源・不要） |
+| ③ CLAP `closed()` | CLAP oracle が env 指定の遅延後に `clap_host_gui.closed(false)` を呼ぶ（プラグイン起点クローズの実駆動。oracle は自前資産なので正当なテスト実装） | VST3 に経路③は存在しない（CAP.2） |
+
+### 6-3. アサーション一覧
+
+| 観測 | 手段 |
+|---|---|
+| ウィンドウ実在 / 消滅 | §6-1 の二重経路 |
+| クローズ完了の意味論 | MCP `close_plugin_ui` の返却が `UI_CLOSED_DONE` 起点（ack で返す変異 → hang/red） |
+| セーフポイント 1 回 | 観測表面 `[plugin-state] ui-close snapshot ...` ログ 1 行（PRJ.9 と同型）+ 変異（0 回 / 2 回）で red |
+| 保存内容が「現在 state」であること | oracle の state 意味論（周波数オフセット）を非デフォルト値にしておき、close 後の登記 → 再起動 → 周波数解析で一致（§5b-3 条件1・2。**「UI 編集の模擬」とは主張しない** — 検出対象は「現在 state でなくデフォルト/空を保存する」ホスト側バグ） |
+| 演奏継続 | UI open 中・close 往復中の capture WAV drops==0 |
+| respawn 時の挙動 | UI open 中に child kill → ウィンドウが復活**しない**こと（CGWindowList）+ loud 通知の存在（UIH.6） |
+
+### 6-4. 残余（正直に）
+
+1. **実プラグイン（Kontakt 等）の癖**（独自イベントループ・非標準リサイズ・スレッド不安全な
+   getState）は oracle では出ない。補完: (a) 実プラグイン smoke gated テスト
+   （open → close → crash なし・ウィンドウ実在まで。音色 assert なし・人間不要）を別枠で持つ、
+   (b) 実機で観測した問題プラグインは UIH.7 の方針どおり個別記録、
+   (c) **Epic 最終受け入れとして owner の実プラグイン 1 回デモ**（§5b-3 条件3）
+2. CGWindowList はヘッドレス CI では動かない（実機ランナー前提）。既存 gated E2E と同じ
+   実機ゲート運用に載せる
+3. computer-use は設計から外した（owner 裁定）。デバッグ時に手元で screenshot する程度の
+   道具としては禁止しないが、いかなるゲートにも据えない
+
+---
+
+## 7. spec 更新一覧（spec 先行の規約に基づき、実装フェーズごとに**先に** spec を直す）
+
+| # | ファイル | 箇所 | 内容 | タイミング |
+|---|---|---|---|---|
+| 1 | PLUGIN_UI_HOSTING_SPEC_v1 | UIH.9 | 前提是正 (1)(2) の解消を事実として反映（bundle 済み・CLAP state 配線済み）。`.vsix` bin 検証の有無を確認して記載 | P0 |
+| 2 | 同 | UIH.3 末尾の 🔴 MUST | 「audio 専用スレッド分離完了までは停止中のみ SAVE_STATE」→ P1 完了・実測確認後に制約解除の追記 | P1 完了時 |
+| 3 | 同 | UIH.2a | STATE_DIRTY の運搬を evt リングから `dirty_epoch` 語へ変更（**owner 承認が要る改訂**・§8 Q2。却下なら現行どおり実装） | P2 前 |
+| 4 | 同 | UIH.5 | open/close の v1 receiver スコープ（sequence 限定の維持 or 全 receiver 一般化・§8 Q1）。決定に応じて「未実装」注記の更新 | P4 前 |
+| 5 | 同 | UIH.8 | 無人 E2E の具体方式（**検証対象 = ウィンドウ実在まで**・二重経路確認〔自己申告 + CGWindowList〕・3 閉路の駆動法・実プラグイン smoke 別枠・「つまみ→音」は検査対象外である旨）を検証節へ反映 | P6 前 |
+| 5b | PLUGIN_CAPABILITY_ABSTRACTION_v1 | CAP.4 / CAP.6-7 | **owner の 2 本足決着との整合**: CAP.4 の LLM 面「param 列挙・設定」と CAP.6-7 の「CAP-PARAM-* の MCP tool 提供」は、**設定系 = DSL 経由（#506）が第一級**・MCP 直接設定は第一級経路でない、へ改訂が要る（列挙・観測系 MCP は維持）。**owner 承認必須の改訂** | #506 設計前 |
+| 6 | PROJECT_FILE_SPEC_v1 | PRJ.3 実装状況表 | (b) UI クローズ時 → 実装済みへ更新 + 観測表面（ui-close snapshot ログ 1 行）の規定 | P4 完了時 |
+| 6b | PROJECT_FILE_SPEC_v1 | PRJ.0 または PRJ.5 近傍 | **スナップショットの対象境界を規範化**: 「対象は GUI 由来の編集。オートメーション値（DSL 宣言）は保存対象ではない — DSL が担保する」（owner 決着 2026-07-30 の反映。#506/#460 の復元順序規則への参照つき）。**owner 承認要** | P4 前 |
+| 7 | PLUGIN_CAPABILITY_ABSTRACTION_v1 | CAP.6-7 | `open_plugin_ui` / `close_plugin_ui` の tool スキーマ確定後の反映（スキーマがコードにしか無い状態を作らない） | P4 完了時 |
+| 8 | core/INSTRUCTION_ORBITSCORE_DSL.md | フェーズゲート反映 | REPL メタ行（`//#openPluginUi` 等・採用時）と右クリックメニューのユーザー可視面 | P5 完了時 |
+
+---
+
+## 8. owner 確認事項 — **全件裁定済み（2026-07-31）**
+
+> 各項の冒頭に **🟢 裁定** を記す。裁定の一次記録は `docs/development/WORK_LOG.md`（commit `9dea05e` の「その他の裁定」節・および 2026-07-31 の owner 回答）。**本節の「推奨」は起案時点の記述であり、裁定と食い違う場合は裁定が正。**
+
+
+**Q1. open/close の v1 receiver スコープ** — UIH.5 は「v1 は sequence 限定」と明記するが、
+#577 の受け入れ基準は「sequence / master / sum / aux のいずれでも **UI で音色を作る**」を要求
+しており矛盾する。
+- (a) sequence 限定を維持（#577 受け入れはバス分だけ API 経路で満たす）
+- (b) **全 receiver へ一般化**（推奨）: 宛先解決は `save_plugin_state` が既に全 receiver で
+  実装済みの語彙（`sum:`/`aux:`/`master`）をそのまま使うため、追加コストは小さい。
+  #577 の受け入れ文言とも整合する
+- 推奨 (b)。確信度: 中〜高（実装コストの見積りは daemon の bus 側 child host が effect 用に
+  既存であることに依拠。反証条件: bus effect の mailbox 配線が sequence 側と非対称だった場合 —
+  P0 で確認する）
+
+> 🟢 **裁定（owner・2026-07-31）: (b) 全 receiver へ一般化。** 確定事項・再議論しない。
+
+**Q2. STATE_DIRTY の運搬** — UIH.2a（リング搭載・owner 確定 spec）と #577 PR-B 設計
+（`dirty_epoch` 1 語）が現時点で分岐している。
+- (a) spec どおりリングに載せる（PR-B を リング上に実装し直す）
+- (b) **`dirty_epoch` 語で恒久化し、リングは UI_CLOSED / UI_CLOSED_DONE 専用に spec 改訂**（推奨）
+- 推奨理由: dirty は定義上合流可能で、単調カウンタが正準の合流構造。リング占有・
+  「dirty の ack でフェーズ B 誤発火」ハザード・pending フラグ規則が丸ごと消える。
+  spec 自身が UI_RESIZED を同じ理由で排除している（「消費者の無い高頻度イベントは
+  リングを塞ぐ」）。確信度: 高。反証条件: dirty に「host が読むべき付随引数」が将来必要に
+  なった場合（カウンタでは運べない）
+
+> 🟢 **裁定: (b) `dirty_epoch` で恒久化。** リングは `UI_CLOSED` / `UI_CLOSED_DONE` 専用。
+> **spec 反映済み**（`9dea05e`・UIH.2a）。
+
+**Q3. 新規 Rust 依存** — NSApplication / NSWindow / delegate に `objc2` + `objc2-app-kit` を
+追加したい（メンテ活発・型付き・unsafe 最小）。代替: 生 `objc` crate（メンテ停滞）や
+自前 msg_send FFI（監査コスト大）。推奨: objc2 系。
+
+> 🟢 **裁定: moot。** `objc2` / `objc2-app-kit` / `objc2-foundation` は **P1 で導入済み**
+> （`orbit-child-runtime/Cargo.toml`）。P3b 以降で新規依存は増えない。
+
+**Q4. #474 の v1 スコープ確認** — owner 優先度コメント（2026-07-18）どおり
+「**Open/Close UI のみ**」とし、Show info / Reveal in Finder / Rescan catalog / 階層ブラウズ /
+右クリック挿入は**別 issue に分割**する。（この分割自体の確認。メニュー項目の器だけ先に
+作ることもしない）
+
+> 🟢 **裁定: v1 = Open/Close UI の追加のみ。🔴 分割先 issue は不要（本文の「別 issue に分割する」は失効）。**
+>
+> | 項目 | 裁定 |
+> |---|---|
+> | Show info / Reveal in Finder | **不要** |
+> | 右クリック挿入 | **不要**。挿入トリガーは **#522 / #506 と同時設計**。`editor.action.triggerSuggest` は<br>コードベース全体で未使用で連鎖が繋がっておらず、現行 `.effect("` 前提で作ると #522 で作り直しになる |
+> | 階層ブラウズ | **補完（#495）で満たす** |
+> | Rescan catalog | **3面すべて実装済み**（コマンドパレット / `editor/context` / MCP `rescan_plugins`） |
+>
+> 2026-07-31 に本文を鵜呑みにして issue #595 を作成し、同日クローズした。
+>
+> **実装時に効く既存資産**: `editor/context` メニューは既に存在する
+> （`packages/vscode-extension/package.json:232`・`when: resourceExtname == .orbs`・`group: "orbitscore"`）。
+> P5 の「Open Plugin UI」/「Close Plugin UI」は**メニューを新設せず既存グループに足す**。
+
+**Q5. REPL メタ行の対称性** — `//#savePluginState` と対称の `//#openPluginUi` /
+`//#closePluginUi` を P4 で足すか。推奨: 足す（コスト小・REPL 面の対称性維持）。ただし
+「メニューと MCP で十分」なら省略可。
+
+> 🟢 **裁定: 足す。** `//#openPluginUi` / `//#closePluginUi` を P4 で追加する。
+
+**Q6. ウィンドウタイトル規約**（軽微・実装時決定でも可）— `<plugin name> — <receiver>[<index>]`
+を提案（同一プラグイン複数インスタンスの識別のため）。
+
+> 🟢 **裁定: 提案どおり** `<plugin name> — <receiver>[<index>]`。
+
+**Q7. CAP.4 / CAP.6-7 の改訂**（v2 追加）— owner の 2 本足決着（オートメーション = DSL 経由が
+第一級・MCP 直接設定は第一級経路でない）は、CAP.4 の LLM 面「param 列挙・設定」と CAP.6-7 の
+「必須能力には MCP tool が対応して存在する」と**文言上衝突**する。提案: 設定系は
+「DSL 表面（#506）が第一級・MCP は列挙/観測」へ改訂。CAP spec は owner 確定文書なので承認要。
+
+> 🟢 **裁定: 改訂する。** CAP.6-7 を「**列挙・取得は MCP / 設定は DSL（#506）が第一級**」へ。
+> MCP の設定系 tool は計測・デバッグの副経路として禁じないが、**CAP.4 のループはこれに依存してはならない**。
+> **spec 反映済み**（`9dea05e`）。
+
+**Q8. #577 受け入れの合成判定の承認**（v2 追加・§5b-3）— 「#474 のウィンドウ実在証明 +
+#577 の記録復元証明 + クローズセーフポイント統合 E2E 1 本」の合成で「UI で音色を作る」を
+満たすとする判定（+ Epic 最終受け入れは owner の実プラグイン 1 回デモ）を owner に確認する。
+
+> 🟢 **裁定: 段階的に承認**（oracle で無人 E2E → 実プラグイン smoke → シナリオ化して自動 E2E へ昇格）。
+> 🔴 統合 E2E は **capture WAV のアサーションまで通す**こと（「ok が返った」で済ませない）。
+
+---
+
+## 9. 確信度と反証可能性（設計全体）
+
+| 主張 | 確信度 | 反証条件 |
+|---|---|---|
+| P1（runloop 化）が UI ホスティングの前提として必須 | 高（NSApplication のプロセス先頭スレッド要件は AppKit の確立された制約・spec UIH.0 も同旨） | Accessory ではなく別方式（CFRunLoop のみで NSWindow を回す等）で足りると実証された場合。ただし plugin GUI は NSApp イベントループ前提のものが多く、部分解は薦めない |
+| audio 専用スレッド化でレイテンシ目標を維持できる | 中 | `roundtrip_latency_gated` の退行。退行時は UIH.7 の規定どおり設計見直し（P1 に停止条件として内蔵済み） |
+| 既存 mailbox + 新 evt リングで IPC が足りる（新チャネル不要） | 高（CommandMailboxHost 実装・daemon event frame 実測に依拠） | UI 操作に高頻度・大容量の child→host 通知が必要になった場合（現 spec は resize すら载せない方針なので想定外） |
+| セーフポイント (b) の daemon↔engine 跨ぎ設計 | 中〜高 | engine 側 save フローが同期呼び出し前提で event frame 起点に載らない構造だった場合（P4 着手時に project-state-store の呼び出し規約を確認して確定させる） |
+| #577 受け入れは #474 + #577 + 統合 E2E の合成で満たされる（§5b-3） | 中〜高（owner の「自明」裁定の論理〔プラグイン内部はホストの検査対象外〕を「つまみ→getState 反映」へ一貫適用。手書き登記却下との違い = バイパスと免除の区別） | owner が「つまみ→getState 反映」を自明の範囲外とした場合（→ owner の実プラグイン 1 回デモを受け入れ必須へ格上げして閉じる） |
+| CGWindowList による独立証拠が「報告≠適用」の穴を塞ぐ | 高（pid/bounds は Screen Recording 権限なしで取得可能・変異検証で独立性自体を証明する設計） | macOS の将来バージョンで pid/bounds まで権限化された場合（→ AXUIElement 系 or child への外部プローブに差し替え） |
+| regex による cursor→(receiver, index) 解決が v1 に足りる | 中 | 複数文にまたがるチェーン構築が DSL 上可能で常用されている場合（その時は engine 側 expectedName 照合が silent 誤爆を防ぎ、loud エラーで顕在化する — 安全側に倒れる設計） |
+
+---
+
+## 10. 委譲プロファイル（参考・実装フェーズの担当想定）
+
+| フェーズ | 実装 | 備考 |
+|---|---|---|
+| P1 | Codex | ただし**レイテンシ gated・実機 E2E は main が sandbox 外で実測**（工程表どおり） |
+| P2 | Codex | loom モデル検証はユニットなので sandbox で回る |
+| P3 | Codex（状態機械）+ AppKit 部は小さく直列に | AppKit 実挙動の確認は実機必須 → main |
+| P4 | Codex | MCP/E2E 検証は main |
+| P5 | Codex | 実機右クリック確認は main |
+| P6 | Codex（oracle GUI）+ main（gated E2E 実走） | CGWindowList は実機ランナー限定 |
+
+各フェーズ 1 PR 以上に分割し、フェーズゲート（既存テスト全 green + 当該受け入れ基準）を
+越えるまで次に着手しない（プロジェクト規則 2）。

--- a/rust-spike/clap-test-effect/Cargo.toml
+++ b/rust-spike/clap-test-effect/Cargo.toml
@@ -20,6 +20,7 @@ clack-extensions = { git = "https://github.com/prokopyl/clack", rev = "f874e858a
   "clack-plugin",
   "audio-ports",
   "state",
+  "gui",
 ] }
 
 [dev-dependencies]

--- a/rust-spike/clap-test-effect/src/lib.rs
+++ b/rust-spike/clap-test-effect/src/lib.rs
@@ -15,9 +15,13 @@ use clack_extensions::audio_ports::{
     AudioPortFlags, AudioPortInfo, AudioPortInfoWriter, AudioPortType, PluginAudioPorts,
     PluginAudioPortsImpl,
 };
+use clack_extensions::gui::{
+    GuiApiType, GuiConfiguration, GuiSize, PluginGui, PluginGuiImpl, Window,
+};
 use clack_extensions::state::{PluginState, PluginStateImpl};
 use clack_plugin::prelude::*;
 use clack_plugin::stream::{InputStream, OutputStream};
+use std::fs::OpenOptions;
 use std::io::{Read as _, Write as _};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -70,7 +74,8 @@ impl Plugin for TestEffect {
     ) {
         builder
             .register::<PluginAudioPorts>()
-            .register::<PluginState>();
+            .register::<PluginState>()
+            .register::<PluginGui>();
     }
 }
 
@@ -116,6 +121,92 @@ pub struct TestEffectMainThread {
 }
 
 impl PluginMainThread<'_, TestEffectShared> for TestEffectMainThread {}
+
+fn trace_gui(call: &str) {
+    let Some(path) = std::env::var_os("ORBIT_CLAP_GUI_TRACE") else {
+        return;
+    };
+    let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) else {
+        return;
+    };
+    let _ = writeln!(file, "{call}");
+}
+
+impl PluginGuiImpl for TestEffectMainThread {
+    fn is_api_supported(&mut self, configuration: GuiConfiguration) -> bool {
+        trace_gui("is_api_supported");
+        let floating_only = std::env::var_os("ORBIT_CLAP_GUI_FLOATING_ONLY").is_some();
+        configuration.api_type == GuiApiType::COCOA && configuration.is_floating == floating_only
+    }
+
+    fn get_preferred_api(&mut self) -> Option<GuiConfiguration<'_>> {
+        None
+    }
+
+    fn create(&mut self, configuration: GuiConfiguration) -> Result<(), PluginError> {
+        trace_gui("create");
+        if configuration.api_type == GuiApiType::COCOA {
+            Ok(())
+        } else {
+            Err(PluginError::Message(
+                "clap-test-effect GUI only supports cocoa",
+            ))
+        }
+    }
+
+    fn destroy(&mut self) {
+        trace_gui("destroy");
+    }
+
+    fn set_scale(&mut self, _scale: f64) -> Result<(), PluginError> {
+        trace_gui("set_scale");
+        Ok(())
+    }
+
+    fn get_size(&mut self) -> Option<GuiSize> {
+        trace_gui("get_size");
+        Some(GuiSize {
+            width: 400,
+            height: 300,
+        })
+    }
+
+    fn can_resize(&mut self) -> bool {
+        trace_gui("can_resize");
+        true
+    }
+
+    fn set_size(&mut self, _size: GuiSize) -> Result<(), PluginError> {
+        trace_gui("set_size");
+        Ok(())
+    }
+
+    fn set_parent(&mut self, window: Window) -> Result<(), PluginError> {
+        trace_gui("set_parent");
+        if window.api_type() == GuiApiType::COCOA {
+            Ok(())
+        } else {
+            Err(PluginError::Message(
+                "clap-test-effect GUI parent is not cocoa",
+            ))
+        }
+    }
+
+    fn set_transient(&mut self, _window: Window) -> Result<(), PluginError> {
+        trace_gui("set_transient");
+        Ok(())
+    }
+
+    fn show(&mut self) -> Result<(), PluginError> {
+        trace_gui("show");
+        Ok(())
+    }
+
+    fn hide(&mut self) -> Result<(), PluginError> {
+        trace_gui("hide");
+        Ok(())
+    }
+}
 
 impl PluginStateImpl for TestEffectMainThread {
     fn save(&mut self, output: &mut OutputStream) -> Result<(), PluginError> {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1034,6 +1034,7 @@ dependencies = [
  "clack-host",
  "orbit-audio-native",
  "orbit-audio-sandbox",
+ "orbit-child-ui",
  "rtrb",
  "thiserror 2.0.18",
  "tracing",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1008,6 +1008,8 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "orbit-audio-sandbox",
+ "orbit-child-ui",
  "thiserror 2.0.18",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1119,6 +1119,7 @@ name = "orbit-vst3-host"
 version = "0.0.1"
 dependencies = [
  "core-foundation-sys",
+ "orbit-child-ui",
  "orbit-vst3-gain-oracle",
  "orbit-vst3-synth-oracle",
  "vst3",

--- a/rust/crates/orbit-audio-sandbox/src/bin/parent-watch-probe.rs
+++ b/rust/crates/orbit-audio-sandbox/src/bin/parent-watch-probe.rs
@@ -40,7 +40,7 @@ fn main() {
         Some("watch-parent") => {
             let marker = args.next().expect("marker_path required");
             fs::write(&marker, format!("STARTED:{}", std::process::id())).expect("write marker");
-            let mut watch = ParentWatch::with_interval(Duration::from_millis(20));
+            let watch = ParentWatch::with_interval(Duration::from_millis(20));
             let deadline = Instant::now() + Duration::from_secs(10);
             loop {
                 if watch.should_exit() {

--- a/rust/crates/orbit-audio-sandbox/src/parent_watch.rs
+++ b/rust/crates/orbit-audio-sandbox/src/parent_watch.rs
@@ -16,6 +16,7 @@
 
 #![allow(unsafe_code)]
 
+use std::cell::Cell;
 use std::time::{Duration, Instant};
 
 /// [`ParentWatch::should_exit`] のデフォルト rate-limit 間隔。
@@ -25,7 +26,7 @@ pub const DEFAULT_CHECK_INTERVAL: Duration = Duration::from_millis(250);
 pub struct ParentWatch {
     original_ppid: libc::pid_t,
     check_interval: Duration,
-    last_check: Instant,
+    last_check: Cell<Instant>,
 }
 
 impl ParentWatch {
@@ -42,7 +43,26 @@ impl ParentWatch {
         Self {
             original_ppid,
             check_interval,
-            last_check: Instant::now(),
+            last_check: Cell::new(Instant::now()),
+        }
+    }
+
+    /// 常に「親は死んだ」と報告する watch を作る(**テスト支援専用**)。
+    ///
+    /// [`should_exit`](Self::should_exit) は起動時に記録した `getppid()` との差で判定するため、
+    /// **プロセス内では本物の孤児化を演出できない**。ありえない pid を記録することで
+    /// 「親が死んだ」分岐を到達可能にする。
+    ///
+    /// 🔴 用途は**配線の検証**である。`child_should_quit` が本物の [`ParentWatch`] を
+    /// 参照していることを縛るテストが、これを使って合成箇所を通る
+    /// (`orbit-child-runtime` の `child_should_quit_consults_the_injected_parent_watch`)。
+    /// 純関数にクロージャを注入するテストでは、その合成は検証できない。
+    pub fn orphaned_for_tests() -> Self {
+        Self {
+            // getppid(2) は POSIX 上ここには到達しない値を返さない。
+            original_ppid: -1,
+            check_interval: Duration::ZERO,
+            last_check: Cell::new(Instant::now()),
         }
     }
 
@@ -50,12 +70,12 @@ impl ParentWatch {
     ///
     /// rate-limit: 前回チェックから `check_interval` 未満なら syscall を発行せず false を返す
     /// (spin loop 内で毎回呼んでも system call 頻度は interval に収まる)。
-    pub fn should_exit(&mut self) -> bool {
+    pub fn should_exit(&self) -> bool {
         let now = Instant::now();
-        if now.duration_since(self.last_check) < self.check_interval {
+        if now.duration_since(self.last_check.get()) < self.check_interval {
             return false;
         }
-        self.last_check = now;
+        self.last_check.set(now);
         // SAFETY: 同上。
         let current_ppid = unsafe { libc::getppid() };
         current_ppid != self.original_ppid
@@ -75,7 +95,7 @@ mod tests {
 
     #[test]
     fn does_not_fire_while_ppid_unchanged() {
-        let mut watch = ParentWatch::with_interval(Duration::from_millis(1));
+        let watch = ParentWatch::with_interval(Duration::from_millis(1));
         thread::sleep(Duration::from_millis(5));
         // このテストプロセスの親(テストランナー)は生きているので発火しないはず。
         assert!(!watch.should_exit());
@@ -83,7 +103,7 @@ mod tests {
 
     #[test]
     fn rate_limits_syscall_checks() {
-        let mut watch = ParentWatch::with_interval(Duration::from_secs(10));
+        let watch = ParentWatch::with_interval(Duration::from_secs(10));
         // 間隔未満の連続呼び出しは syscall を発行せず false を返し続ける
         // (ppid が変わっていたとしても検知しないのが rate-limit の定義)。
         for _ in 0..1000 {

--- a/rust/crates/orbit-audio-sandbox/src/transport.rs
+++ b/rust/crates/orbit-audio-sandbox/src/transport.rs
@@ -719,6 +719,9 @@ pub const PLUGIN_STATE_MAILBOX_TIMEOUT: Duration = Duration::from_secs(5);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandMailboxResponse {
     pub bytes_written: u64,
+    /// Command detail returned by the child. UIH.4c permits a successful no-op
+    /// `CLOSE_UI` to carry `"already-closing"`.
+    pub detail: String,
 }
 
 #[derive(Debug)]
@@ -834,7 +837,8 @@ struct InFlightCommand {
     /// 安全側に倒れる。フィールド 2 本と `&&` 3 箇所の対価としては安い。
     generation: u64,
     abandoned: bool,
-    sidecar_path: std::path::PathBuf,
+    kind: u32,
+    sidecar_path: Option<std::path::PathBuf>,
 }
 
 #[derive(Debug, Default)]
@@ -868,6 +872,14 @@ impl CommandMailboxHost {
         self.issue_save_state_with_timeout(sidecar_path, PLUGIN_STATE_MAILBOX_TIMEOUT)
     }
 
+    pub fn issue_open_ui(&self) -> Result<CommandMailboxResponse, CommandMailboxError> {
+        self.issue_command(CMD_OPEN_UI, "", None, PLUGIN_STATE_MAILBOX_TIMEOUT)
+    }
+
+    pub fn issue_close_ui(&self) -> Result<CommandMailboxResponse, CommandMailboxError> {
+        self.issue_command(CMD_CLOSE_UI, "", None, PLUGIN_STATE_MAILBOX_TIMEOUT)
+    }
+
     /// 現在の child incarnation が plugin state 復元まで終えて READY かをAcquireで確認する。
     pub fn child_is_ready(&self) -> Result<bool, CommandMailboxError> {
         let mmap = open_shared(&self.shm_path)?;
@@ -891,7 +903,16 @@ impl CommandMailboxHost {
         let sidecar = sidecar_path.to_str().ok_or_else(|| {
             CommandMailboxError::InvalidArgument("path must be valid UTF-8".into())
         })?;
+        self.issue_command(CMD_SAVE_STATE, sidecar, Some(sidecar_path), timeout)
+    }
 
+    fn issue_command(
+        &self,
+        kind: u32,
+        arg: &str,
+        sidecar_path: Option<&Path>,
+        timeout: Duration,
+    ) -> Result<CommandMailboxResponse, CommandMailboxError> {
         let mmap = open_shared(&self.shm_path)?;
         let region = region_ptr(&mmap);
         let (seq, generation) = {
@@ -910,7 +931,7 @@ impl CommandMailboxHost {
                 }
                 // SAFETY: region はこのメソッドが open_shared で得た生存 mapping を指す。
                 unsafe { warn_if_abandoned_save_succeeded(region, in_flight) };
-                let cleanup_result = remove_abandoned_sidecar(&in_flight.sidecar_path);
+                let cleanup_result = cleanup_abandoned_sidecar(in_flight);
                 state.in_flight = None;
                 cleanup_result?;
             }
@@ -920,15 +941,15 @@ impl CommandMailboxHost {
                 .checked_add(1)
                 .ok_or(CommandMailboxError::SequenceExhausted)?;
             unsafe {
-                if !write_cstr_field(&mut (*region).cmd_arg, sidecar) {
+                if !write_cstr_field(&mut (*region).cmd_arg, arg) {
                     return Err(CommandMailboxError::InvalidArgument(format!(
-                        "path must contain no NUL and fit in CMD_ARG_BYTES={CMD_ARG_BYTES}"
+                        "command argument must contain no NUL and fit in CMD_ARG_BYTES={CMD_ARG_BYTES}"
                     )));
                 }
                 let _ = write_cstr_field(&mut (*region).cmd_result_detail, "");
                 (*region).cmd_result_len.store(0, Ordering::Relaxed);
                 (*region).cmd_result.store(CMD_RESULT_OK, Ordering::Relaxed);
-                (*region).cmd_kind.store(CMD_SAVE_STATE, Ordering::Relaxed);
+                (*region).cmd_kind.store(kind, Ordering::Relaxed);
                 // Release publish: child は cmd_seq Acquire 後に kind/arg を読む。
                 (*region).cmd_seq.store(seq, Ordering::Release);
             }
@@ -937,7 +958,8 @@ impl CommandMailboxHost {
                 seq,
                 generation,
                 abandoned: false,
-                sidecar_path: sidecar_path.to_path_buf(),
+                kind,
+                sidecar_path: sidecar_path.map(Path::to_path_buf),
             });
             (seq, generation)
         };
@@ -980,7 +1002,10 @@ impl CommandMailboxHost {
                     state.in_flight = None;
                 }
                 return match result {
-                    CMD_RESULT_OK => Ok(CommandMailboxResponse { bytes_written }),
+                    CMD_RESULT_OK => Ok(CommandMailboxResponse {
+                        bytes_written,
+                        detail,
+                    }),
                     CMD_RESULT_CHILD_EXITED => {
                         Err(CommandMailboxError::ChildExited { seq, detail })
                     }
@@ -1040,7 +1065,7 @@ impl CommandMailboxHost {
         let cleanup_result = state
             .in_flight
             .as_ref()
-            .map(|in_flight| remove_abandoned_sidecar(&in_flight.sidecar_path))
+            .map(cleanup_abandoned_sidecar)
             .unwrap_or(Ok(()));
         state.in_flight = None;
         cleanup_result
@@ -1059,17 +1084,27 @@ impl CommandMailboxHost {
 /// **素の `fn` にしない** — 呼び出し側に「このポインタの有効性は誰が保証するのか」を
 /// 見せるのがこの crate の慣習で、その慣習だけがガードになっている。
 unsafe fn warn_if_abandoned_save_succeeded(region: *mut SharedRegion, in_flight: &InFlightCommand) {
-    if !in_flight.abandoned {
+    if !in_flight.abandoned || in_flight.kind != CMD_SAVE_STATE {
         return;
     }
+    let Some(sidecar_path) = in_flight.sidecar_path.as_ref() else {
+        return;
+    };
     let ack = unsafe { (*region).cmd_ack_seq.load(Ordering::Acquire) };
     let result = unsafe { (*region).cmd_result.load(Ordering::Relaxed) };
     if ack == in_flight.seq && result == CMD_RESULT_OK {
         tracing::warn!(
             seq = in_flight.seq,
-            path = %in_flight.sidecar_path.display(),
+            path = %sidecar_path.display(),
             "discarding plugin state saved after mailbox timeout"
         );
+    }
+}
+
+fn cleanup_abandoned_sidecar(in_flight: &InFlightCommand) -> Result<(), CommandMailboxError> {
+    match in_flight.sidecar_path.as_deref() {
+        Some(path) => remove_abandoned_sidecar(path),
+        None => Ok(()),
     }
 }
 
@@ -1124,7 +1159,8 @@ pub struct CommandOutcome {
     pub result: u32,
     /// 成功時に生成したバイト数（[`CMD_SAVE_STATE`] ならサイドカーの長さ）。失敗時は 0。
     pub len: u64,
-    /// 失敗理由。成功時は空。
+    /// 失敗理由。通常の成功時は空。UIH.4c の冪等 `CLOSE_UI` だけは成功時にも
+    /// `"already-closing"` を運ぶ（`orbit_child_ui::CommandAck` からの mailbox 変換）。
     pub detail: String,
 }
 
@@ -2331,6 +2367,50 @@ mod tests {
             .issue_save_state(Path::new("/tmp/orbit-mailbox-state.bin"))
             .expect("mailbox success");
         assert_eq!(response.bytes_written, 321);
+        child.join().expect("child join");
+        drop(mmap);
+        let _ = std::fs::remove_file(shm);
+    }
+
+    #[test]
+    fn command_mailbox_host_issues_open_and_close_ui_with_success_detail() {
+        let shm = mailbox_test_path("ui-commands");
+        let mmap = create_shared(&shm).expect("create");
+        let host = CommandMailboxHost::new(shm.clone());
+        let child_shm = shm.clone();
+        let child = std::thread::spawn(move || {
+            let child_mmap = open_shared(&child_shm).expect("child map");
+            let region = region_ptr(&child_mmap);
+            let mut previous_seq = 0;
+            for (expected_kind, detail) in [(CMD_OPEN_UI, ""), (CMD_CLOSE_UI, "already-closing")] {
+                let deadline = Instant::now() + Duration::from_secs(1);
+                let seq = loop {
+                    let seq = unsafe { (*region).cmd_seq.load(Ordering::Acquire) };
+                    if seq > previous_seq {
+                        break seq;
+                    }
+                    assert!(Instant::now() < deadline, "next UI command not published");
+                    std::thread::sleep(Duration::from_millis(1));
+                };
+                unsafe {
+                    assert_eq!((*region).cmd_kind.load(Ordering::Acquire), expected_kind);
+                    assert_eq!(read_cstr_field(&(*region).cmd_arg), Some(""));
+                    assert!(write_cstr_field(&mut (*region).cmd_result_detail, detail));
+                    (*region).cmd_result_len.store(0, Ordering::Relaxed);
+                    (*region).cmd_result.store(CMD_RESULT_OK, Ordering::Relaxed);
+                    (*region).cmd_ack_seq.store(seq, Ordering::Release);
+                }
+                previous_seq = seq;
+            }
+        });
+
+        let open = host.issue_open_ui().expect("OPEN_UI ack");
+        assert_eq!(open.bytes_written, 0);
+        assert_eq!(open.detail, "");
+        let close = host.issue_close_ui().expect("CLOSE_UI ack");
+        assert_eq!(close.bytes_written, 0);
+        assert_eq!(close.detail, "already-closing");
+
         child.join().expect("child join");
         drop(mmap);
         let _ = std::fs::remove_file(shm);

--- a/rust/crates/orbit-child-runtime/Cargo.toml
+++ b/rust/crates/orbit-child-runtime/Cargo.toml
@@ -8,7 +8,14 @@ authors.workspace = true
 description = "Shared main-thread AppKit runloop and dedicated audio-thread runtime for plugin child processes"
 publish = false
 
+[[test]]
+name = "window_shell_gated"
+path = "tests/window_shell_gated.rs"
+harness = false
+
 [dependencies]
+orbit-audio-sandbox = { path = "../orbit-audio-sandbox" }
+orbit-child-ui = { path = "../orbit-child-ui" }
 thiserror = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -17,9 +24,12 @@ objc2-app-kit = { version = "0.3.2", default-features = false, features = [
   "std",
   "NSApplication",
   "NSEvent",
+  "NSGraphics",
   "NSGraphicsContext",
   "NSResponder",
   "NSRunningApplication",
+  "NSView",
+  "NSWindow",
 ] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = [
   "std",

--- a/rust/crates/orbit-child-runtime/src/lib.rs
+++ b/rust/crates/orbit-child-runtime/src/lib.rs
@@ -87,7 +87,8 @@ pub const MAIN_TICK_INTERVAL: Duration = Duration::from_millis(20);
 /// [`MAIN_TICK_INTERVAL`] が 20ms なので 50 スキップ ≒ 1 秒。nested runloop が続く間、
 /// 毎 tick 書くと 1 秒あたり 50 回の未バッファ書き込みになる — 初回 + 1 秒ごとで
 /// 「今も再入している」ことは十分伝わる。
-#[cfg(any(target_os = "macos", test))]
+// Only the AppKit tick logs skipped ticks, so this has no meaning off macOS.
+#[cfg(target_os = "macos")]
 const REENTRANT_TICK_LOG_EVERY: u64 = 50;
 
 #[cfg(any(target_os = "macos", test))]

--- a/rust/crates/orbit-child-runtime/src/lib.rs
+++ b/rust/crates/orbit-child-runtime/src/lib.rs
@@ -15,6 +15,30 @@ use std::time::Duration;
 
 use thiserror::Error;
 
+mod ui_service;
+#[cfg(target_os = "macos")]
+pub mod window;
+
+pub use ui_service::{PluginMainHandle, UiCallbacks, UiService, UI_CLOSE_TIMEOUT};
+
+fn should_quit_with_parent(control_quit: bool, parent_should_exit: impl FnOnce() -> bool) -> bool {
+    control_quit || parent_should_exit()
+}
+
+/// Shared `run_child` predicate used by all plugin child binaries.
+///
+/// # Safety
+/// `region` must point to a live mapped [`orbit_audio_sandbox::SharedRegion`].
+pub unsafe fn child_should_quit(
+    region: *const orbit_audio_sandbox::SharedRegion,
+    parent_watch: &orbit_audio_sandbox::ParentWatch,
+) -> bool {
+    should_quit_with_parent(
+        (unsafe { (*region).control.load(Ordering::Relaxed) }) == orbit_audio_sandbox::CONTROL_QUIT,
+        || parent_watch.should_exit(),
+    )
+}
+
 /// Main-runloop service interval. Mailbox commands and liveness changes are
 /// control-plane work, so 20 ms avoids a busy main thread while remaining
 /// responsive enough for UI commands.
@@ -628,6 +652,84 @@ mod tests {
             "the busy service remains skipped while teardown still advances"
         );
         drop(held_by_outer_tick);
+    }
+
+    #[test]
+    fn reentrant_main_service_tick_still_evaluates_parent_watch_predicate() {
+        let service_calls = std::cell::Cell::new(0);
+        let parent_watch_checks = std::cell::Cell::new(0);
+        let service = RefCell::new(|| {
+            service_calls.set(service_calls.get() + 1);
+            false
+        });
+        let held_by_outer_tick = service.borrow_mut();
+
+        let requested_stop = try_call_main_service(&service, &|| {
+            should_quit_with_parent(false, || {
+                parent_watch_checks.set(parent_watch_checks.get() + 1);
+                // This stands for `parent_watch.should_exit()` after reparenting.
+                true
+            })
+        })
+        .expect("ParentWatch must bypass a reentrant service borrow");
+
+        assert!(requested_stop);
+        assert_eq!(parent_watch_checks.get(), 1);
+        assert_eq!(
+            service_calls.get(),
+            0,
+            "the busy service remains skipped while orphan teardown advances"
+        );
+        drop(held_by_outer_tick);
+    }
+
+    /// Zeroed shared region: `CONTROL_RUN == 0`, so control alone never requests a stop.
+    fn run_state_region() -> (*mut orbit_audio_sandbox::SharedRegion, std::alloc::Layout) {
+        let layout = std::alloc::Layout::new::<orbit_audio_sandbox::SharedRegion>();
+        let raw =
+            unsafe { std::alloc::alloc_zeroed(layout) } as *mut orbit_audio_sandbox::SharedRegion;
+        assert!(!raw.is_null(), "failed to allocate a zeroed SharedRegion");
+        (raw, layout)
+    }
+
+    /// 🔴 Binds `child_should_quit` to the **real** `ParentWatch` it is handed.
+    ///
+    /// The test above injects its own closure into `should_quit_with_parent`, so it only covers
+    /// the pure function. Replacing `|| parent_watch.should_exit()` in `child_should_quit` with
+    /// `|| false` left all tests green (measured 2026-07-31) — the orphan guard from #448 was
+    /// live in all four child binaries with nothing pinning the composition. This test is what
+    /// pins it: it goes through `child_should_quit` with control at `CONTROL_RUN`, so only the
+    /// parent-watch leg can produce `true`.
+    #[test]
+    fn child_should_quit_consults_the_injected_parent_watch() {
+        let (region, layout) = run_state_region();
+        let orphaned = orbit_audio_sandbox::ParentWatch::orphaned_for_tests();
+        let live = orbit_audio_sandbox::ParentWatch::new();
+
+        let orphan_requests_quit = unsafe { child_should_quit(region, &orphaned) };
+        let live_parent_keeps_running = unsafe { child_should_quit(region, &live) };
+
+        unsafe {
+            (*region)
+                .control
+                .store(orbit_audio_sandbox::CONTROL_QUIT, Ordering::Relaxed)
+        };
+        let control_quit_requests_quit = unsafe { child_should_quit(region, &live) };
+
+        unsafe { std::alloc::dealloc(region.cast(), layout) };
+
+        assert!(
+            orphan_requests_quit,
+            "child_should_quit must consult the ParentWatch it is given, not only CONTROL_QUIT"
+        );
+        assert!(
+            !live_parent_keeps_running,
+            "a live parent with CONTROL_RUN must not request a stop"
+        );
+        assert!(
+            control_quit_requests_quit,
+            "CONTROL_QUIT must still request a stop on its own"
+        );
     }
 
     #[test]

--- a/rust/crates/orbit-child-runtime/src/lib.rs
+++ b/rust/crates/orbit-child-runtime/src/lib.rs
@@ -39,6 +39,40 @@ pub unsafe fn child_should_quit(
     )
 }
 
+/// Shared `run_child` main-service body used by all plugin child binaries.
+///
+/// Services one mailbox command and advances the UI close state machine. Returns `false`
+/// because the mailbox never asks the child to stop — teardown arrives through
+/// [`child_should_quit`] instead.
+///
+/// Both the command vocabulary and the tick contract live here rather than in each
+/// `main.rs`: the four children differ only in how they capture plugin state, and a
+/// per-child copy of this body drifts as soon as a fifth command kind appears.
+///
+/// # Safety
+/// `region` must point to a live mapped [`orbit_audio_sandbox::SharedRegion`], and this must
+/// run on the process main thread (mailbox servicing is main-thread-only after #474 P1 —
+/// `CMD_SAVE_STATE` may block on plugin serialization and fsync without stalling audio).
+pub unsafe fn service_child_main<E: std::fmt::Display>(
+    region: *mut orbit_audio_sandbox::SharedRegion,
+    ui: &UiService,
+    capture_state: impl FnOnce() -> Result<Vec<u8>, E>,
+) -> bool {
+    unsafe {
+        orbit_audio_sandbox::service_command_mailbox(region, |kind, arg| match kind {
+            orbit_audio_sandbox::CMD_SAVE_STATE => {
+                Some(orbit_audio_sandbox::save_state_command(arg, capture_state))
+            }
+            orbit_audio_sandbox::CMD_OPEN_UI | orbit_audio_sandbox::CMD_CLOSE_UI => {
+                Some(ui.handle_command(kind, arg))
+            }
+            _ => None,
+        });
+    }
+    ui.tick(ui.now());
+    false
+}
+
 /// Main-runloop service interval. Mailbox commands and liveness changes are
 /// control-plane work, so 20 ms avoids a busy main thread while remaining
 /// responsive enough for UI commands.

--- a/rust/crates/orbit-child-runtime/src/lib.rs
+++ b/rust/crates/orbit-child-runtime/src/lib.rs
@@ -24,11 +24,34 @@ pub mod window;
 #[cfg(any(target_os = "macos", test))]
 pub use ui_service::{PluginMainHandle, UiCallbacks, UiService, UI_CLOSE_TIMEOUT};
 
-fn should_quit_with_parent(control_quit: bool, parent_should_exit: impl FnOnce() -> bool) -> bool {
-    control_quit || parent_should_exit()
+/// Why the child is shutting down. Distinguishing the two is the whole point of returning
+/// an enum instead of `bool`: they look identical from the outside (the process exits) but
+/// mean opposite things when the daemon is being debugged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuitReason {
+    /// The host wrote `CONTROL_QUIT` — an orderly shutdown.
+    HostRequested,
+    /// `getppid()` changed: the daemon died without writing `CONTROL_QUIT` (#448).
+    ParentDied,
+}
+
+fn quit_reason(
+    control_quit: bool,
+    parent_should_exit: impl FnOnce() -> bool,
+) -> Option<QuitReason> {
+    if control_quit {
+        return Some(QuitReason::HostRequested);
+    }
+    parent_should_exit().then_some(QuitReason::ParentDied)
 }
 
 /// Shared `run_child` predicate used by all plugin child binaries.
+///
+/// 🔴 Announces orphan detection on stderr. Children have no `tracing` subscriber, so stderr
+/// (inherited by the daemon) is their **only** observation channel — and once the process is
+/// gone, "the host asked us to quit" and "the daemon crashed and we noticed we were orphaned"
+/// are indistinguishable without this line. Each child used to print it; folding the predicate
+/// into one place dropped it (caught in review of #474 P3b), so it now lives with the check.
 ///
 /// # Safety
 /// `region` must point to a live mapped [`orbit_audio_sandbox::SharedRegion`].
@@ -36,10 +59,14 @@ pub unsafe fn child_should_quit(
     region: *const orbit_audio_sandbox::SharedRegion,
     parent_watch: &orbit_audio_sandbox::ParentWatch,
 ) -> bool {
-    should_quit_with_parent(
+    let reason = quit_reason(
         (unsafe { (*region).control.load(Ordering::Relaxed) }) == orbit_audio_sandbox::CONTROL_QUIT,
         || parent_watch.should_exit(),
-    )
+    );
+    if reason == Some(QuitReason::ParentDied) {
+        eprintln!("[orbit-child-runtime] 親プロセス死亡を検知、終了する");
+    }
+    reason.is_some()
 }
 
 /// Shared `run_child` main-service body used by all plugin child binaries.
@@ -705,11 +732,12 @@ mod tests {
         let held_by_outer_tick = service.borrow_mut();
 
         let requested_stop = try_call_main_service(&service, &|| {
-            should_quit_with_parent(false, || {
+            quit_reason(false, || {
                 parent_watch_checks.set(parent_watch_checks.get() + 1);
                 // This stands for `parent_watch.should_exit()` after reparenting.
                 true
             })
+            .is_some()
         })
         .expect("ParentWatch must bypass a reentrant service borrow");
 
@@ -732,9 +760,24 @@ mod tests {
         (raw, layout)
     }
 
+    /// 🔴 Keeps the two shutdown causes distinguishable.
+    ///
+    /// Both make the child exit, so a `bool` return hides which one happened — and the stderr
+    /// line that used to say so was lost when this predicate was folded into one place
+    /// (#474 P3b review). Once the process is gone, the daemon-crash case is unrecoverable
+    /// from the outside, so the distinction has to survive in the type.
+    #[test]
+    fn quit_reason_separates_host_request_from_parent_death() {
+        assert_eq!(quit_reason(true, || false), Some(QuitReason::HostRequested));
+        assert_eq!(quit_reason(false, || true), Some(QuitReason::ParentDied));
+        assert_eq!(quit_reason(false, || false), None);
+        // A live parent must not be reported as a host request either.
+        assert_eq!(quit_reason(true, || true), Some(QuitReason::HostRequested));
+    }
+
     /// 🔴 Binds `child_should_quit` to the **real** `ParentWatch` it is handed.
     ///
-    /// The test above injects its own closure into `should_quit_with_parent`, so it only covers
+    /// The test above injects its own closure into `quit_reason`, so it only covers
     /// the pure function. Replacing `|| parent_watch.should_exit()` in `child_should_quit` with
     /// `|| false` left all tests green (measured 2026-07-31) — the orphan guard from #448 was
     /// live in all four child binaries with nothing pinning the composition. This test is what

--- a/rust/crates/orbit-child-runtime/src/lib.rs
+++ b/rust/crates/orbit-child-runtime/src/lib.rs
@@ -15,10 +15,13 @@ use std::time::Duration;
 
 use thiserror::Error;
 
+// The UI service exists to drive an AppKit window; it has no meaning without one.
+#[cfg(any(target_os = "macos", test))]
 mod ui_service;
 #[cfg(target_os = "macos")]
 pub mod window;
 
+#[cfg(any(target_os = "macos", test))]
 pub use ui_service::{PluginMainHandle, UiCallbacks, UiService, UI_CLOSE_TIMEOUT};
 
 fn should_quit_with_parent(control_quit: bool, parent_should_exit: impl FnOnce() -> bool) -> bool {
@@ -53,6 +56,7 @@ pub unsafe fn child_should_quit(
 /// `region` must point to a live mapped [`orbit_audio_sandbox::SharedRegion`], and this must
 /// run on the process main thread (mailbox servicing is main-thread-only after #474 P1 —
 /// `CMD_SAVE_STATE` may block on plugin serialization and fsync without stalling audio).
+#[cfg(any(target_os = "macos", test))]
 pub unsafe fn service_child_main<E: std::fmt::Display>(
     region: *mut orbit_audio_sandbox::SharedRegion,
     ui: &UiService,
@@ -83,6 +87,7 @@ pub const MAIN_TICK_INTERVAL: Duration = Duration::from_millis(20);
 /// [`MAIN_TICK_INTERVAL`] が 20ms なので 50 スキップ ≒ 1 秒。nested runloop が続く間、
 /// 毎 tick 書くと 1 秒あたり 50 回の未バッファ書き込みになる — 初回 + 1 秒ごとで
 /// 「今も再入している」ことは十分伝わる。
+#[cfg(any(target_os = "macos", test))]
 const REENTRANT_TICK_LOG_EVERY: u64 = 50;
 
 #[cfg(any(target_os = "macos", test))]

--- a/rust/crates/orbit-child-runtime/src/ui_service.rs
+++ b/rust/crates/orbit-child-runtime/src/ui_service.rs
@@ -1,0 +1,777 @@
+use std::cell::{Cell, RefCell};
+use std::ffi::c_void;
+use std::rc::{Rc, Weak};
+use std::time::{Duration, Instant};
+
+use orbit_audio_sandbox::transport::{EventRingChild, EVT_UI_CLOSED, EVT_UI_CLOSED_DONE};
+use orbit_audio_sandbox::{
+    CommandOutcome, SharedRegion, CMD_CLOSE_UI, CMD_OPEN_UI, CMD_RESULT_PLUGIN_ERROR,
+    CMD_RESULT_UNKNOWN_KIND,
+};
+use orbit_child_ui::{
+    CloseCompletion, PluginUiEndpoint, UiCloseStateMachine, UiEvent, UiHostActions, UiSize,
+};
+
+/// Maximum time Phase B waits for the host to complete the `UI_CLOSED` safepoint.
+pub const UI_CLOSE_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub(crate) type WindowCloseCallback = Rc<dyn Fn() -> bool>;
+pub(crate) type WindowResizeCallback = Rc<dyn Fn(UiSize)>;
+
+pub(crate) trait WindowHandle {
+    fn content_view(&self) -> *mut c_void;
+    fn resize(&mut self, size: UiSize) -> Result<(), String>;
+    fn close(&mut self);
+}
+
+pub(crate) trait WindowFactory {
+    fn create(
+        &mut self,
+        size: UiSize,
+        can_resize: bool,
+        close_callback: WindowCloseCallback,
+        resize_callback: WindowResizeCallback,
+    ) -> Result<Box<dyn WindowHandle>, String>;
+}
+
+/// Thread-safe plugin GUI callbacks consumed by the main-runloop tick.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct UiCallbacks {
+    pub closed: Option<bool>,
+    pub requested_size: Option<UiSize>,
+}
+
+/// Main-thread access to the concrete plugin object also used through the UI endpoint trait.
+pub struct PluginMainHandle<E> {
+    endpoint: Rc<RefCell<E>>,
+}
+
+impl<E> PluginMainHandle<E> {
+    pub fn with_mut<T>(&self, operation: impl FnOnce(&mut E) -> T) -> T {
+        operation(&mut self.endpoint.borrow_mut())
+    }
+}
+
+struct SharedEndpoint<E> {
+    endpoint: Rc<RefCell<E>>,
+}
+
+impl<E: PluginUiEndpoint> PluginUiEndpoint for SharedEndpoint<E> {
+    fn begin_open(&mut self) -> Result<UiSize, String> {
+        self.endpoint.borrow_mut().begin_open()
+    }
+
+    fn attach(&mut self, parent: *mut c_void) -> Result<(), String> {
+        self.endpoint.borrow_mut().attach(parent)
+    }
+
+    fn release(&mut self, was_destroyed: bool) {
+        self.endpoint.borrow_mut().release(was_destroyed);
+    }
+
+    fn can_resize(&self) -> bool {
+        self.endpoint.borrow().can_resize()
+    }
+
+    fn apply_host_resize(&mut self, size: UiSize) -> Result<(), String> {
+        self.endpoint.borrow_mut().apply_host_resize(size)
+    }
+}
+
+struct UiActions {
+    region: *mut SharedRegion,
+    event_ring: EventRingChild,
+    retained_event: Option<UiEvent>,
+    endpoint: Box<dyn PluginUiEndpoint>,
+    poll_callbacks: Box<dyn FnMut() -> UiCallbacks>,
+    window_factory: Box<dyn WindowFactory>,
+    window: Option<Box<dyn WindowHandle>>,
+    close_callback: WindowCloseCallback,
+    resize_callback: WindowResizeCallback,
+}
+
+impl UiActions {
+    fn resize_window(&mut self, size: UiSize) {
+        let Some(window) = self.window.as_mut() else {
+            return;
+        };
+        if let Err(detail) = window.resize(size) {
+            eprintln!("[orbit-child-runtime] plugin UI resize failed: {detail}");
+        }
+    }
+
+    fn apply_host_resize(&mut self, size: UiSize) {
+        if let Err(detail) = self.endpoint.apply_host_resize(size) {
+            eprintln!("[orbit-child-runtime] plugin rejected host window resize: {detail}");
+        }
+    }
+}
+
+impl UiHostActions for UiActions {
+    fn open_ui(&mut self) -> Result<(), String> {
+        let (size, can_resize) = {
+            let size = self.endpoint.begin_open()?;
+            (size, self.endpoint.can_resize())
+        };
+        let mut window = match self.window_factory.create(
+            size,
+            can_resize,
+            self.close_callback.clone(),
+            self.resize_callback.clone(),
+        ) {
+            Ok(window) => window,
+            Err(detail) => {
+                self.endpoint.release(false);
+                return Err(detail);
+            }
+        };
+
+        if let Err(detail) = self.endpoint.attach(window.content_view()) {
+            // The plugin-owned view must be released before its parent is destroyed.
+            self.endpoint.release(false);
+            window.close();
+            return Err(detail);
+        }
+        self.window = Some(window);
+        Ok(())
+    }
+
+    fn try_publish_event(&mut self, event: UiEvent) -> Option<u64> {
+        match self.retained_event {
+            Some(retained) => {
+                assert_eq!(
+                    retained, event,
+                    "UI close publication must retry the retained head event"
+                );
+            }
+            None => {
+                let (kind, arg) = match event {
+                    UiEvent::UiClosed => (EVT_UI_CLOSED, ""),
+                    UiEvent::UiClosedDone(CloseCompletion::SafepointCompleted) => {
+                        (EVT_UI_CLOSED_DONE, "safepoint-completed")
+                    }
+                    UiEvent::UiClosedDone(CloseCompletion::TimedOutWithoutSave) => {
+                        (EVT_UI_CLOSED_DONE, "timeout-without-save")
+                    }
+                };
+                self.event_ring
+                    .queue(kind, arg)
+                    .expect("UiEvent always maps to a supported event-ring kind");
+                self.retained_event = Some(event);
+            }
+        }
+
+        let published = match unsafe { self.event_ring.service(self.region) } {
+            Ok(published) => published,
+            Err(error) => {
+                eprintln!("[orbit-child-runtime] plugin UI event publication failed: {error}");
+                return None;
+            }
+        };
+        if published == 0 {
+            return None;
+        }
+        debug_assert_eq!(published, 1);
+        self.retained_event = None;
+        Some(unsafe { (*self.region).evt_seq.load_own() })
+    }
+
+    fn event_ack_seq(&self) -> u64 {
+        unsafe { (*self.region).evt_ack_seq.read() }
+    }
+
+    fn is_event_ring_drained(&self) -> bool {
+        unsafe { self.event_ring.is_drained(self.region) }
+    }
+
+    fn release_plugin_ui(&mut self, was_destroyed: bool) {
+        self.endpoint.release(was_destroyed);
+    }
+
+    fn destroy_window(&mut self) {
+        if let Some(mut window) = self.window.take() {
+            window.close();
+        }
+    }
+}
+
+struct UiServiceCore {
+    machine: UiCloseStateMachine,
+    actions: UiActions,
+}
+
+fn with_machine<T>(
+    core: &mut UiServiceCore,
+    operation: impl FnOnce(&mut UiCloseStateMachine, &mut UiActions) -> T,
+) -> T {
+    operation(&mut core.machine, &mut core.actions)
+}
+
+/// Shared AppKit/plugin/transport adapter used by all four plugin child binaries.
+pub struct UiService {
+    core: Rc<RefCell<UiServiceCore>>,
+    pending_window_close: Rc<Cell<bool>>,
+    pending_host_resize: Rc<Cell<Option<UiSize>>>,
+    started_at: Instant,
+}
+
+impl UiService {
+    #[cfg(target_os = "macos")]
+    pub fn new<E, F>(
+        region: *mut SharedRegion,
+        endpoint: E,
+        poll_callbacks: F,
+    ) -> (Self, PluginMainHandle<E>)
+    where
+        E: PluginUiEndpoint + 'static,
+        F: FnMut(&E) -> UiCallbacks + 'static,
+    {
+        Self::with_window_factory(
+            region,
+            endpoint,
+            poll_callbacks,
+            Box::new(crate::window::AppKitWindowFactory),
+            UI_CLOSE_TIMEOUT,
+        )
+    }
+
+    fn with_window_factory<E, F>(
+        region: *mut SharedRegion,
+        endpoint: E,
+        mut poll_callbacks: F,
+        window_factory: Box<dyn WindowFactory>,
+        close_timeout: Duration,
+    ) -> (Self, PluginMainHandle<E>)
+    where
+        E: PluginUiEndpoint + 'static,
+        F: FnMut(&E) -> UiCallbacks + 'static,
+    {
+        let endpoint = Rc::new(RefCell::new(endpoint));
+        let endpoint_for_ui = endpoint.clone();
+        let endpoint_for_callbacks = endpoint.clone();
+        let pending_window_close = Rc::new(Cell::new(false));
+        let pending_for_callback = pending_window_close.clone();
+        let pending_host_resize = Rc::new(Cell::new(None));
+        let pending_resize_for_callback = pending_host_resize.clone();
+        let started_at = Instant::now();
+        let weak_core: Rc<RefCell<Weak<RefCell<UiServiceCore>>>> =
+            Rc::new(RefCell::new(Weak::new()));
+        let weak_for_callback = weak_core.clone();
+        let close_callback: WindowCloseCallback = Rc::new(move || {
+            let Some(core) = weak_for_callback.borrow().upgrade() else {
+                return false;
+            };
+            let Ok(mut core) = core.try_borrow_mut() else {
+                pending_for_callback.set(true);
+                return false;
+            };
+            with_machine(&mut core, |machine, actions| {
+                machine.window_should_close(started_at.elapsed(), actions)
+            })
+        });
+        let weak_for_resize = weak_core.clone();
+        let resize_callback: WindowResizeCallback = Rc::new(move |size| {
+            let Some(core) = weak_for_resize.borrow().upgrade() else {
+                return;
+            };
+            let Ok(mut core) = core.try_borrow_mut() else {
+                pending_resize_for_callback.set(Some(size));
+                return;
+            };
+            core.actions.apply_host_resize(size);
+        });
+
+        let core = Rc::new(RefCell::new(UiServiceCore {
+            machine: UiCloseStateMachine::new(close_timeout),
+            actions: UiActions {
+                region,
+                event_ring: EventRingChild::new(),
+                retained_event: None,
+                endpoint: Box::new(SharedEndpoint {
+                    endpoint: endpoint_for_ui,
+                }),
+                poll_callbacks: Box::new(move || {
+                    let endpoint = endpoint_for_callbacks.borrow();
+                    poll_callbacks(&endpoint)
+                }),
+                window_factory,
+                window: None,
+                close_callback,
+                resize_callback,
+            },
+        }));
+        *weak_core.borrow_mut() = Rc::downgrade(&core);
+
+        (
+            Self {
+                core,
+                pending_window_close,
+                pending_host_resize,
+                started_at,
+            },
+            PluginMainHandle { endpoint },
+        )
+    }
+
+    /// Elapsed time from the single monotonic clock used by this service.
+    pub fn now(&self) -> Duration {
+        self.started_at.elapsed()
+    }
+
+    /// Handle one UI mailbox command. `OPEN_UI` acks after attach; `CLOSE_UI` acks at Phase A.
+    pub fn handle_command(&self, kind: u32, _arg: Option<&str>) -> CommandOutcome {
+        let now = self.now();
+        let ack = {
+            let mut core = self.core.borrow_mut();
+            with_machine(&mut core, |machine, actions| match kind {
+                CMD_OPEN_UI => machine.open_command(actions),
+                CMD_CLOSE_UI => machine.close_command(now, actions),
+                _ => orbit_child_ui::CommandAck {
+                    success: false,
+                    detail: format!("unknown UI cmd_kind {kind}").into(),
+                },
+            })
+        };
+        CommandOutcome {
+            result: if ack.success {
+                orbit_audio_sandbox::CMD_RESULT_OK
+            } else if matches!(kind, CMD_OPEN_UI | CMD_CLOSE_UI) {
+                CMD_RESULT_PLUGIN_ERROR
+            } else {
+                CMD_RESULT_UNKNOWN_KIND
+            },
+            len: 0,
+            detail: ack.detail.into_owned(),
+        }
+    }
+
+    /// Advance callback marshaling, retained-event publication, and close Phase B.
+    pub fn tick(&self, now: Duration) {
+        let mut core = self.core.borrow_mut();
+        if self.pending_window_close.replace(false) {
+            with_machine(&mut core, |machine, actions| {
+                machine.window_should_close(now, actions);
+            });
+        }
+        if let Some(size) = self.pending_host_resize.take() {
+            core.actions.apply_host_resize(size);
+        }
+
+        let callbacks = (core.actions.poll_callbacks)();
+        if let Some(was_destroyed) = callbacks.closed {
+            with_machine(&mut core, |machine, actions| {
+                machine.clap_closed(was_destroyed, now, actions);
+            });
+        }
+        if let Some(size) = callbacks.requested_size {
+            core.actions.resize_window(size);
+        }
+        with_machine(&mut core, |machine, actions| machine.tick(now, actions));
+    }
+}
+
+impl Drop for UiService {
+    fn drop(&mut self) {
+        let Ok(mut core) = self.core.try_borrow_mut() else {
+            return;
+        };
+        if core.actions.window.is_some() {
+            core.actions.release_plugin_ui(false);
+            core.actions.destroy_window();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use orbit_audio_sandbox::{create_shared, region_ptr, CMD_RESULT_OK};
+    use orbit_child_ui::UiState;
+
+    struct TestRegion {
+        path: PathBuf,
+        region: *mut SharedRegion,
+        _mapping: Box<dyn std::any::Any>,
+    }
+
+    impl TestRegion {
+        fn new(label: &str) -> Self {
+            static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+            let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "orbit-ui-service-{label}-{}-{id}.shm",
+                std::process::id()
+            ));
+            let mmap = create_shared(&path).expect("create test shared region");
+            let region = region_ptr(&mmap);
+            Self {
+                path,
+                region,
+                _mapping: Box::new(mmap),
+            }
+        }
+
+        fn ptr(&self) -> *mut SharedRegion {
+            self.region
+        }
+    }
+
+    impl Drop for TestRegion {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+
+    #[derive(Default)]
+    struct EndpointControls {
+        attach_error: Cell<bool>,
+    }
+
+    struct MockEndpoint {
+        trace: Rc<RefCell<Vec<String>>>,
+        controls: Rc<EndpointControls>,
+    }
+
+    impl PluginUiEndpoint for MockEndpoint {
+        fn begin_open(&mut self) -> Result<UiSize, String> {
+            self.trace.borrow_mut().push("endpoint.begin_open".into());
+            Ok(UiSize {
+                width: 640,
+                height: 480,
+            })
+        }
+
+        fn attach(&mut self, parent: *mut c_void) -> Result<(), String> {
+            assert!(!parent.is_null(), "mock parent must be non-null");
+            self.trace.borrow_mut().push("endpoint.attach".into());
+            if self.controls.attach_error.get() {
+                Err("attach rejected".into())
+            } else {
+                Ok(())
+            }
+        }
+
+        fn release(&mut self, was_destroyed: bool) {
+            self.trace
+                .borrow_mut()
+                .push(format!("endpoint.release({was_destroyed})"));
+        }
+
+        fn can_resize(&self) -> bool {
+            true
+        }
+
+        fn apply_host_resize(&mut self, size: UiSize) -> Result<(), String> {
+            self.trace.borrow_mut().push(format!(
+                "endpoint.apply_host_resize({}x{})",
+                size.width, size.height
+            ));
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct WindowProbe {
+        callback: RefCell<Option<WindowCloseCallback>>,
+        resize_callback: RefCell<Option<WindowResizeCallback>>,
+        invoke_callback_on_close: Cell<bool>,
+        close_callback_result: Cell<Option<bool>>,
+        last_size: Cell<Option<UiSize>>,
+    }
+
+    struct MockWindow {
+        trace: Rc<RefCell<Vec<String>>>,
+        probe: Rc<WindowProbe>,
+    }
+
+    impl WindowHandle for MockWindow {
+        fn content_view(&self) -> *mut c_void {
+            std::ptr::dangling_mut::<c_void>()
+        }
+
+        fn resize(&mut self, size: UiSize) -> Result<(), String> {
+            self.trace
+                .borrow_mut()
+                .push(format!("window.resize({}x{})", size.width, size.height));
+            self.probe.last_size.set(Some(size));
+            Ok(())
+        }
+
+        fn close(&mut self) {
+            self.trace.borrow_mut().push("window.close".into());
+            if self.probe.invoke_callback_on_close.get() {
+                let callback = self
+                    .probe
+                    .callback
+                    .borrow()
+                    .clone()
+                    .expect("window close callback");
+                self.probe.close_callback_result.set(Some(callback()));
+            }
+        }
+    }
+
+    struct MockWindowFactory {
+        trace: Rc<RefCell<Vec<String>>>,
+        probe: Rc<WindowProbe>,
+    }
+
+    impl WindowFactory for MockWindowFactory {
+        fn create(
+            &mut self,
+            size: UiSize,
+            can_resize: bool,
+            close_callback: WindowCloseCallback,
+            resize_callback: WindowResizeCallback,
+        ) -> Result<Box<dyn WindowHandle>, String> {
+            assert_eq!(
+                size,
+                UiSize {
+                    width: 640,
+                    height: 480
+                }
+            );
+            assert!(can_resize);
+            self.trace.borrow_mut().push("window.create".into());
+            *self.probe.callback.borrow_mut() = Some(close_callback);
+            *self.probe.resize_callback.borrow_mut() = Some(resize_callback);
+            Ok(Box::new(MockWindow {
+                trace: self.trace.clone(),
+                probe: self.probe.clone(),
+            }))
+        }
+    }
+
+    struct Fixture {
+        region: TestRegion,
+        ui: UiService,
+        endpoint_controls: Rc<EndpointControls>,
+        callbacks: Rc<Cell<UiCallbacks>>,
+        window: Rc<WindowProbe>,
+        trace: Rc<RefCell<Vec<String>>>,
+    }
+
+    impl Fixture {
+        fn new(label: &str) -> Self {
+            let region = TestRegion::new(label);
+            let trace = Rc::new(RefCell::new(Vec::new()));
+            let endpoint_controls = Rc::new(EndpointControls::default());
+            let callbacks = Rc::new(Cell::new(UiCallbacks::default()));
+            let callbacks_for_poller = callbacks.clone();
+            let window = Rc::new(WindowProbe::default());
+            let (ui, _main) = UiService::with_window_factory(
+                region.ptr(),
+                MockEndpoint {
+                    trace: trace.clone(),
+                    controls: endpoint_controls.clone(),
+                },
+                move |_| callbacks_for_poller.take(),
+                Box::new(MockWindowFactory {
+                    trace: trace.clone(),
+                    probe: window.clone(),
+                }),
+                Duration::from_secs(10),
+            );
+            Self {
+                region,
+                ui,
+                endpoint_controls,
+                callbacks,
+                window,
+                trace,
+            }
+        }
+
+        fn open(&self) -> CommandOutcome {
+            self.ui.handle_command(CMD_OPEN_UI, None)
+        }
+
+        fn state(&self) -> UiState {
+            self.ui.core.borrow().machine.state()
+        }
+    }
+
+    #[test]
+    fn open_ack_waits_for_attach_and_attach_failure_destroys_the_window() {
+        let fixture = Fixture::new("attach-failure");
+        fixture.endpoint_controls.attach_error.set(true);
+
+        let outcome = fixture.open();
+
+        assert_eq!(outcome.result, CMD_RESULT_PLUGIN_ERROR);
+        assert_eq!(outcome.detail, "attach rejected");
+        assert_eq!(fixture.state(), UiState::Closed);
+        assert_eq!(
+            fixture.trace.borrow().as_slice(),
+            [
+                "endpoint.begin_open",
+                "window.create",
+                "endpoint.attach",
+                "endpoint.release(false)",
+                "window.close",
+            ],
+            "failure ack may be produced only after attach cleanup completes"
+        );
+    }
+
+    #[test]
+    fn close_acks_at_acceptance_and_duplicate_close_is_a_successful_no_op() {
+        let fixture = Fixture::new("close-ack");
+        assert_eq!(fixture.open().result, CMD_RESULT_OK);
+
+        let accepted = fixture.ui.handle_command(CMD_CLOSE_UI, None);
+
+        assert_eq!(accepted.result, CMD_RESULT_OK);
+        assert_eq!(accepted.detail, "");
+        assert_eq!(fixture.state(), UiState::Closing);
+        assert!(
+            !fixture
+                .trace
+                .borrow()
+                .iter()
+                .any(|call| call == "window.close"),
+            "CLOSE_UI must ack before Phase B destroys the window"
+        );
+
+        let duplicate = fixture.ui.handle_command(CMD_CLOSE_UI, None);
+        assert_eq!(duplicate.result, CMD_RESULT_OK);
+        assert_eq!(duplicate.detail, "already-closing");
+        assert_eq!(
+            unsafe { (*fixture.region.ptr()).evt_seq.load_own() },
+            1,
+            "duplicate close must not publish a second safepoint"
+        );
+    }
+
+    #[test]
+    fn phase_b_releases_the_plugin_before_closing_the_window() {
+        let fixture = Fixture::new("phase-b-order");
+        assert_eq!(fixture.open().result, CMD_RESULT_OK);
+        assert_eq!(
+            fixture.ui.handle_command(CMD_CLOSE_UI, None).result,
+            CMD_RESULT_OK
+        );
+        unsafe { (*fixture.region.ptr()).evt_ack_seq.publish(1) };
+
+        fixture.ui.tick(Duration::from_secs(1));
+
+        assert_eq!(fixture.state(), UiState::Closed);
+        let trace = fixture.trace.borrow();
+        let release = trace
+            .iter()
+            .position(|call| call == "endpoint.release(false)")
+            .expect("release call");
+        let close = trace
+            .iter()
+            .position(|call| call == "window.close")
+            .expect("window close call");
+        assert!(release < close);
+        assert_eq!(unsafe { (*fixture.region.ptr()).evt_seq.load_own() }, 2);
+    }
+
+    #[test]
+    fn window_should_close_always_returns_no_and_enters_the_machine() {
+        let fixture = Fixture::new("window-close");
+        assert_eq!(fixture.open().result, CMD_RESULT_OK);
+        let callback = fixture
+            .window
+            .callback
+            .borrow()
+            .clone()
+            .expect("window callback");
+
+        assert!(!callback());
+
+        assert_eq!(fixture.state(), UiState::Closing);
+        assert_eq!(unsafe { (*fixture.region.ptr()).evt_seq.load_own() }, 1);
+    }
+
+    #[test]
+    fn user_window_resize_reaches_endpoint_and_reentrant_resize_is_deferred() {
+        let fixture = Fixture::new("host-resize");
+        assert_eq!(fixture.open().result, CMD_RESULT_OK);
+        let callback = fixture
+            .window
+            .resize_callback
+            .borrow()
+            .clone()
+            .expect("window resize callback");
+        let first = UiSize {
+            width: 700,
+            height: 500,
+        };
+        callback(first);
+        assert!(fixture
+            .trace
+            .borrow()
+            .iter()
+            .any(|call| call == "endpoint.apply_host_resize(700x500)"));
+
+        let held_by_outer_tick = fixture.ui.core.borrow_mut();
+        let deferred = UiSize {
+            width: 701,
+            height: 501,
+        };
+        callback(deferred);
+        assert_eq!(fixture.ui.pending_host_resize.get(), Some(deferred));
+        drop(held_by_outer_tick);
+
+        fixture.ui.tick(Duration::from_secs(1));
+        assert_eq!(fixture.ui.pending_host_resize.get(), None);
+        assert!(fixture
+            .trace
+            .borrow()
+            .iter()
+            .any(|call| call == "endpoint.apply_host_resize(701x501)"));
+    }
+
+    #[test]
+    fn reentrant_window_should_close_returns_no_and_is_deferred_without_borrow_panic() {
+        let fixture = Fixture::new("reentrant-window-close");
+        assert_eq!(fixture.open().result, CMD_RESULT_OK);
+        assert_eq!(
+            fixture.ui.handle_command(CMD_CLOSE_UI, None).result,
+            CMD_RESULT_OK
+        );
+        unsafe { (*fixture.region.ptr()).evt_ack_seq.publish(1) };
+        fixture.window.invoke_callback_on_close.set(true);
+
+        fixture.ui.tick(Duration::from_secs(1));
+
+        assert_eq!(fixture.window.close_callback_result.get(), Some(false));
+        assert!(
+            fixture.ui.pending_window_close.get(),
+            "busy delegate entry must be retained for the next non-reentrant tick"
+        );
+        fixture.ui.tick(Duration::from_secs(2));
+        assert!(!fixture.ui.pending_window_close.get());
+    }
+
+    #[test]
+    fn callback_tick_marshals_plugin_close_and_resize_to_the_main_machine() {
+        let fixture = Fixture::new("callbacks");
+        assert_eq!(fixture.open().result, CMD_RESULT_OK);
+        let requested = UiSize {
+            width: 720,
+            height: 512,
+        };
+        fixture.callbacks.set(UiCallbacks {
+            closed: Some(true),
+            requested_size: Some(requested),
+        });
+
+        fixture.ui.tick(Duration::from_secs(1));
+
+        assert_eq!(fixture.state(), UiState::Closing);
+        assert_eq!(fixture.window.last_size.get(), Some(requested));
+        assert!(fixture
+            .trace
+            .borrow()
+            .iter()
+            .any(|call| call == "window.resize(720x512)"));
+        assert_eq!(unsafe { (*fixture.region.ptr()).evt_seq.load_own() }, 1);
+    }
+}

--- a/rust/crates/orbit-child-runtime/src/ui_service.rs
+++ b/rust/crates/orbit-child-runtime/src/ui_service.rs
@@ -319,6 +319,18 @@ impl UiService {
     }
 
     /// Handle one UI mailbox command. `OPEN_UI` acks after attach; `CLOSE_UI` acks at Phase A.
+    /// Service one `CMD_OPEN_UI` / `CMD_CLOSE_UI`.
+    ///
+    /// 🔴 `_arg` is discarded, so the **window title convention is not implemented yet**:
+    /// owner approved `<plugin name> — <receiver>[<index>]` (design §8 Q6) to tell several
+    /// instances of one plugin apart, but the child knows neither the receiver nor the index —
+    /// those live host-side.
+    ///
+    /// **This may be deleted once** P4 puts the rendered title into `cmd_arg` on `CMD_OPEN_UI`
+    /// (the field already exists and is already carried for `CMD_SAVE_STATE`) **and**
+    /// `WindowShell` calls `setTitle` with it. Ordering: strictly after P4, because the host is
+    /// the only side that can name the receiver. Until then every plugin window shows the
+    /// AppKit default, which is wrong as soon as two are open at once.
     pub fn handle_command(&self, kind: u32, _arg: Option<&str>) -> CommandOutcome {
         let now = self.now();
         let ack = {

--- a/rust/crates/orbit-child-runtime/src/ui_service.rs
+++ b/rust/crates/orbit-child-runtime/src/ui_service.rs
@@ -4,6 +4,8 @@ use std::rc::{Rc, Weak};
 use std::time::{Duration, Instant};
 
 use orbit_audio_sandbox::transport::{EventRingChild, EVT_UI_CLOSED, EVT_UI_CLOSED_DONE};
+#[cfg(test)]
+use orbit_audio_sandbox::CMD_SAVE_STATE;
 use orbit_audio_sandbox::{
     CommandOutcome, SharedRegion, CMD_CLOSE_UI, CMD_OPEN_UI, CMD_RESULT_PLUGIN_ERROR,
     CMD_RESULT_UNKNOWN_KIND,
@@ -604,6 +606,108 @@ mod tests {
         fn state(&self) -> UiState {
             self.ui.core.borrow().machine.state()
         }
+    }
+
+    /// Post one command into the real mailbox and let `service_child_main` dispatch it.
+    ///
+    /// `arg` matters for `CMD_SAVE_STATE`: without a sidecar path `save_state_command` returns
+    /// `BAD_ARG` *without* invoking the capture closure, which would make a capture-count
+    /// assertion pass for the wrong reason.
+    fn dispatch(fixture: &Fixture, kind: u32, arg: &str) {
+        let region = fixture.region.ptr();
+        unsafe {
+            (*region).cmd_kind.store(kind, Ordering::Release);
+            assert!(
+                orbit_audio_sandbox::transport::write_cstr_field(&mut (*region).cmd_arg, arg),
+                "test argument must fit cmd_arg"
+            );
+            let seq = (*region).cmd_ack_seq.load(Ordering::Relaxed) + 1;
+            (*region).cmd_seq.store(seq, Ordering::Release);
+        }
+    }
+
+    /// 🔴 Pins **which handler each command kind reaches** in [`crate::service_child_main`].
+    ///
+    /// The four children share that one body, so a swapped arm breaks all of them at once — and
+    /// the swap type-checks, since both arms return `CommandOutcome`. Nothing covered it: routing
+    /// `CMD_OPEN_UI`/`CMD_CLOSE_UI` into `save_state_command` instead left the **entire workspace
+    /// suite green** (measured 2026-07-31), while the mirror-image swap of `CMD_SAVE_STATE` was
+    /// caught by the existing real-process `mailbox_wiring` tests. Only the UI arm was unguarded.
+    ///
+    /// Asserting the capture count as well as the state matters: checking only the state would let
+    /// an implementation that runs *both* handlers pass.
+    #[test]
+    fn service_child_main_routes_each_command_kind_to_its_own_handler() {
+        let fixture = Fixture::new("dispatch");
+        let captures = Rc::new(Cell::new(0usize));
+
+        let sidecar = std::env::temp_dir().join(format!(
+            "orbit-dispatch-{}-{}.state",
+            std::process::id(),
+            line!()
+        ));
+        let run = |kind: u32, arg: &str| {
+            dispatch(&fixture, kind, arg);
+            let captures = captures.clone();
+            unsafe {
+                crate::service_child_main(fixture.region.ptr(), &fixture.ui, move || {
+                    captures.set(captures.get() + 1);
+                    Ok::<Vec<u8>, String>(vec![7])
+                })
+            }
+        };
+
+        // OPEN_UI must reach the state machine, and must not be mistaken for a state capture.
+        run(CMD_OPEN_UI, "");
+        assert_eq!(
+            fixture.state(),
+            UiState::Open,
+            "CMD_OPEN_UI must open the UI"
+        );
+        assert_eq!(
+            captures.get(),
+            0,
+            "CMD_OPEN_UI must not capture plugin state"
+        );
+
+        // CLOSE_UI likewise — and it is the same match arm, so it needs its own assertion.
+        run(CMD_CLOSE_UI, "");
+        assert_eq!(
+            fixture.state(),
+            UiState::Closing,
+            "CMD_CLOSE_UI must start the close handshake"
+        );
+        assert_eq!(
+            captures.get(),
+            0,
+            "CMD_CLOSE_UI must not capture plugin state"
+        );
+
+        // SAVE_STATE takes the other arm: it captures, and must not disturb the machine.
+        let before = fixture.state();
+        run(CMD_SAVE_STATE, sidecar.to_str().expect("utf-8 temp path"));
+        assert_eq!(
+            captures.get(),
+            1,
+            "CMD_SAVE_STATE must capture exactly once"
+        );
+        assert_eq!(
+            fixture.state(),
+            before,
+            "CMD_SAVE_STATE must not drive the UI state machine"
+        );
+
+        // An unknown kind must fall through to the mailbox's UNKNOWN_KIND result, not silently
+        // pick either handler.
+        run(9999, "");
+        assert_eq!(captures.get(), 1, "an unknown kind must not capture state");
+        let result = unsafe { (*fixture.region.ptr()).cmd_result.load(Ordering::Acquire) };
+        assert_eq!(
+            result, CMD_RESULT_UNKNOWN_KIND,
+            "an unknown kind must be reported as such"
+        );
+
+        let _ = std::fs::remove_file(&sidecar);
     }
 
     #[test]

--- a/rust/crates/orbit-child-runtime/src/window.rs
+++ b/rust/crates/orbit-child-runtime/src/window.rs
@@ -1,0 +1,232 @@
+//! AppKit-owned plugin editor window shell.
+
+use std::cell::Cell;
+use std::ffi::c_void;
+use std::rc::Rc;
+
+use objc2::rc::Retained;
+use objc2::runtime::ProtocolObject;
+use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker, MainThreadOnly};
+use objc2_app_kit::{NSBackingStoreType, NSWindow, NSWindowDelegate, NSWindowStyleMask};
+use objc2_foundation::{NSObject, NSObjectProtocol, NSPoint, NSRect, NSSize};
+use orbit_child_ui::UiSize;
+
+use crate::ui_service::{WindowCloseCallback, WindowFactory, WindowHandle, WindowResizeCallback};
+
+struct WindowDelegateIvars {
+    close_callback: WindowCloseCallback,
+    resize_callback: WindowResizeCallback,
+    programmatic_resize: Rc<Cell<bool>>,
+}
+
+define_class!(
+    // SAFETY: NSObject has no subclassing requirements. The delegate is main-thread-only
+    // and owns only a Rust callback with a 'static lifetime.
+    #[unsafe(super = NSObject)]
+    #[name = "OrbitChildRuntimeWindowDelegate"]
+    #[thread_kind = MainThreadOnly]
+    #[ivars = WindowDelegateIvars]
+    struct WindowDelegate;
+
+    // SAFETY: NSObjectProtocol adds no extra invariants.
+    unsafe impl NSObjectProtocol for WindowDelegate {}
+
+    // SAFETY: The implementation is main-thread confined and uses the generated signature.
+    unsafe impl NSWindowDelegate for WindowDelegate {
+        #[unsafe(method(windowShouldClose:))]
+        fn window_should_close(&self, _sender: &NSWindow) -> bool {
+            // The callback enters (or defers entry into) the close state machine. AppKit
+            // never owns destruction: every callback path returns NO, and Phase B later
+            // calls NSWindow::close directly.
+            (self.ivars().close_callback)()
+        }
+
+        #[unsafe(method(windowWillResize:toSize:))]
+        fn window_will_resize(&self, sender: &NSWindow, frame_size: NSSize) -> NSSize {
+            if !self.ivars().programmatic_resize.get() {
+                let frame = NSRect::new(NSPoint::ZERO, frame_size);
+                let content = sender.contentRectForFrameRect(frame).size;
+                if let (Some(width), Some(height)) = (
+                    logical_dimension(content.width),
+                    logical_dimension(content.height),
+                ) {
+                    (self.ivars().resize_callback)(UiSize { width, height });
+                }
+            }
+            frame_size
+        }
+    }
+);
+
+impl WindowDelegate {
+    fn new(
+        mtm: MainThreadMarker,
+        close_callback: WindowCloseCallback,
+        resize_callback: WindowResizeCallback,
+        programmatic_resize: Rc<Cell<bool>>,
+    ) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(WindowDelegateIvars {
+            close_callback,
+            resize_callback,
+            programmatic_resize,
+        });
+        // SAFETY: NSObject's designated initializer has the generated signature.
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+/// Host-owned AppKit window containing a plugin editor NSView.
+pub struct WindowShell {
+    window: Option<Retained<NSWindow>>,
+    delegate: Option<Retained<WindowDelegate>>,
+    programmatic_resize: Rc<Cell<bool>>,
+    window_number: u32,
+}
+
+impl WindowShell {
+    pub fn new(
+        size: UiSize,
+        can_resize: bool,
+        close_callback: impl Fn() -> bool + 'static,
+    ) -> Result<Self, String> {
+        Self::new_with_callbacks(size, can_resize, Rc::new(close_callback), Rc::new(|_| {}))
+    }
+
+    fn new_with_callbacks(
+        size: UiSize,
+        can_resize: bool,
+        close_callback: WindowCloseCallback,
+        resize_callback: WindowResizeCallback,
+    ) -> Result<Self, String> {
+        if size.width <= 0 || size.height <= 0 {
+            return Err(format!(
+                "plugin UI window creation failed: invalid size {}x{}",
+                size.width, size.height
+            ));
+        }
+        let mtm = MainThreadMarker::new()
+            .ok_or_else(|| "plugin UI window creation must run on the main thread".to_owned())?;
+        let mut style = NSWindowStyleMask::Titled | NSWindowStyleMask::Closable;
+        if can_resize {
+            style |= NSWindowStyleMask::Resizable;
+        }
+        let content_rect = NSRect::new(
+            NSPoint::new(0.0, 0.0),
+            NSSize::new(size.width as f64, size.height as f64),
+        );
+        // SAFETY: releasedWhenClosed is disabled immediately below, so the Retained owner
+        // remains authoritative until this shell calls close and drops it.
+        let window = unsafe {
+            NSWindow::initWithContentRect_styleMask_backing_defer(
+                NSWindow::alloc(mtm),
+                content_rect,
+                style,
+                NSBackingStoreType::Buffered,
+                false,
+            )
+        };
+        unsafe { window.setReleasedWhenClosed(false) };
+        let programmatic_resize = Rc::new(Cell::new(false));
+        let delegate = WindowDelegate::new(
+            mtm,
+            close_callback,
+            resize_callback,
+            programmatic_resize.clone(),
+        );
+        window.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+        window.center();
+        window.makeKeyAndOrderFront(None);
+        let window_number = u32::try_from(window.windowNumber())
+            .map_err(|_| "plugin UI window number does not fit u32".to_owned())?;
+
+        Ok(Self {
+            window: Some(window),
+            delegate: Some(delegate),
+            programmatic_resize,
+            window_number,
+        })
+    }
+
+    /// Opaque NSView pointer passed to the format-specific endpoint.
+    pub fn content_view(&self) -> *mut c_void {
+        self.window
+            .as_ref()
+            .and_then(|window| window.contentView())
+            .map_or(std::ptr::null_mut(), |view| {
+                Retained::as_ptr(&view).cast_mut().cast()
+            })
+    }
+
+    /// Apply a plugin-requested logical content size to the host window.
+    pub fn resize(&mut self, size: UiSize) -> Result<(), String> {
+        if size.width <= 0 || size.height <= 0 {
+            return Err(format!(
+                "plugin UI window resize failed: invalid size {}x{}",
+                size.width, size.height
+            ));
+        }
+        let window = self
+            .window
+            .as_ref()
+            .ok_or_else(|| "plugin UI window resize failed: window is closed".to_owned())?;
+        self.programmatic_resize.set(true);
+        window.setContentSize(NSSize::new(size.width as f64, size.height as f64));
+        self.programmatic_resize.set(false);
+        Ok(())
+    }
+
+    /// Close without consulting `windowShouldClose`; Phase B already authorized destruction.
+    pub fn close(&mut self) {
+        let Some(window) = self.window.take() else {
+            return;
+        };
+        window.setDelegate(None);
+        window.close();
+        self.delegate = None;
+    }
+
+    /// CoreGraphics window number used only for independent gated verification.
+    #[doc(hidden)]
+    pub fn window_number(&self) -> u32 {
+        self.window_number
+    }
+}
+
+impl Drop for WindowShell {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+impl WindowHandle for WindowShell {
+    fn content_view(&self) -> *mut c_void {
+        self.content_view()
+    }
+
+    fn resize(&mut self, size: UiSize) -> Result<(), String> {
+        self.resize(size)
+    }
+
+    fn close(&mut self) {
+        self.close();
+    }
+}
+
+pub(crate) struct AppKitWindowFactory;
+
+impl WindowFactory for AppKitWindowFactory {
+    fn create(
+        &mut self,
+        size: UiSize,
+        can_resize: bool,
+        close_callback: WindowCloseCallback,
+        resize_callback: WindowResizeCallback,
+    ) -> Result<Box<dyn WindowHandle>, String> {
+        WindowShell::new_with_callbacks(size, can_resize, close_callback, resize_callback)
+            .map(|window| Box::new(window) as Box<dyn WindowHandle>)
+    }
+}
+
+fn logical_dimension(value: f64) -> Option<i32> {
+    (value.is_finite() && value > 0.0 && value <= i32::MAX as f64).then(|| value.round() as i32)
+}

--- a/rust/crates/orbit-child-runtime/tests/window_shell_gated.rs
+++ b/rust/crates/orbit-child-runtime/tests/window_shell_gated.rs
@@ -1,26 +1,40 @@
 //! Independent Window Server proof for the AppKit shell.
 
-#![cfg(target_os = "macos")]
-
+#[cfg(target_os = "macos")]
 use std::ffi::c_void;
+#[cfg(target_os = "macos")]
 use std::time::{Duration, Instant};
 
+#[cfg(target_os = "macos")]
 use objc2::MainThreadMarker;
+#[cfg(target_os = "macos")]
 use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy};
+#[cfg(target_os = "macos")]
 use objc2_foundation::{NSDate, NSRunLoop};
+#[cfg(target_os = "macos")]
 use orbit_child_runtime::window::WindowShell;
+#[cfg(target_os = "macos")]
 use orbit_child_ui::UiSize;
 
+#[cfg(target_os = "macos")]
 type CFIndex = isize;
+#[cfg(target_os = "macos")]
 type CFArrayRef = *const c_void;
+#[cfg(target_os = "macos")]
 type CFDictionaryRef = *const c_void;
+#[cfg(target_os = "macos")]
 type CFNumberRef = *const c_void;
+#[cfg(target_os = "macos")]
 type CFTypeRef = *const c_void;
 
+#[cfg(target_os = "macos")]
 const K_CF_NUMBER_SINT32_TYPE: u32 = 3;
+#[cfg(target_os = "macos")]
 const K_CG_WINDOW_LIST_OPTION_ON_SCREEN_ONLY: u32 = 1;
+#[cfg(target_os = "macos")]
 const K_CG_WINDOW_LIST_EXCLUDE_DESKTOP_ELEMENTS: u32 = 1 << 4;
 
+#[cfg(target_os = "macos")]
 #[link(name = "CoreGraphics", kind = "framework")]
 unsafe extern "C" {
     fn CGWindowListCopyWindowInfo(option: u32, relative_to_window: u32) -> CFArrayRef;
@@ -40,6 +54,7 @@ unsafe extern "C" {
 ///
 /// This must **fail**, never skip: this test is the only independent evidence that a window
 /// really reached the window server, and a silent skip would turn "never verified" into green.
+#[cfg(target_os = "macos")]
 fn require_screen_capture_permission() {
     assert!(
         unsafe { CGPreflightScreenCaptureAccess() },
@@ -50,6 +65,7 @@ fn require_screen_capture_permission() {
     );
 }
 
+#[cfg(target_os = "macos")]
 #[link(name = "CoreFoundation", kind = "framework")]
 unsafe extern "C" {
     fn CFArrayGetCount(array: CFArrayRef) -> CFIndex;
@@ -59,14 +75,17 @@ unsafe extern "C" {
     fn CFRelease(value: CFTypeRef);
 }
 
+#[cfg(target_os = "macos")]
 struct OwnedWindowList(CFArrayRef);
 
+#[cfg(target_os = "macos")]
 impl Drop for OwnedWindowList {
     fn drop(&mut self) {
         unsafe { CFRelease(self.0) };
     }
 }
 
+#[cfg(target_os = "macos")]
 fn dictionary_i32(dictionary: CFDictionaryRef, key: CFTypeRef) -> Option<i32> {
     let number = unsafe { CFDictionaryGetValue(dictionary, key) };
     if number.is_null() {
@@ -83,6 +102,7 @@ fn dictionary_i32(dictionary: CFDictionaryRef, key: CFTypeRef) -> Option<i32> {
     }
 }
 
+#[cfg(target_os = "macos")]
 fn window_server_contains(window_number: u32, owner_pid: u32) -> bool {
     let list = unsafe {
         CGWindowListCopyWindowInfo(
@@ -103,6 +123,7 @@ fn window_server_contains(window_number: u32, owner_pid: u32) -> bool {
 }
 
 /// Every on-screen window this process owns, for diagnosing a failed match.
+#[cfg(target_os = "macos")]
 fn own_window_numbers() -> Vec<i32> {
     let list = unsafe {
         CGWindowListCopyWindowInfo(
@@ -132,6 +153,7 @@ fn own_window_numbers() -> Vec<i32> {
 /// when the main run loop next processes events. Sleeping instead of running the loop leaves the
 /// window permanently absent from `CGWindowListCopyWindowInfo`, which is indistinguishable from
 /// "the window was never created" — so this loop must pump, not sleep.
+#[cfg(target_os = "macos")]
 fn wait_for_window_state(window_number: u32, expected: bool) -> bool {
     let deadline = Instant::now() + Duration::from_secs(3);
     loop {
@@ -145,6 +167,7 @@ fn wait_for_window_state(window_number: u32, expected: bool) -> bool {
     }
 }
 
+#[cfg(target_os = "macos")]
 fn run_window_shell_exists_in_cgwindowlist_and_disappears_after_close() {
     require_screen_capture_permission();
 
@@ -181,10 +204,12 @@ fn run_window_shell_exists_in_cgwindowlist_and_disappears_after_close() {
 
 #[test]
 #[ignore = "requires a logged-in macOS Window Server session"]
+#[cfg(target_os = "macos")]
 fn window_shell_exists_in_cgwindowlist_and_disappears_after_close() {
     run_window_shell_exists_in_cgwindowlist_and_disappears_after_close();
 }
 
+#[cfg(target_os = "macos")]
 fn main() {
     let run_ignored = std::env::args().any(|arg| arg == "--ignored");
     println!("running 1 test");
@@ -217,4 +242,11 @@ fn main() {
             std::panic::resume_unwind(payload);
         }
     }
+}
+
+/// Off macOS there is no Window Server to witness, so this harness reports and exits 0
+/// rather than failing — the suite it belongs to is gated on a logged-in macOS session.
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    println!("window_shell_gated is macOS-only; nothing to run on this platform");
 }

--- a/rust/crates/orbit-child-runtime/tests/window_shell_gated.rs
+++ b/rust/crates/orbit-child-runtime/tests/window_shell_gated.rs
@@ -1,0 +1,220 @@
+//! Independent Window Server proof for the AppKit shell.
+
+#![cfg(target_os = "macos")]
+
+use std::ffi::c_void;
+use std::time::{Duration, Instant};
+
+use objc2::MainThreadMarker;
+use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy};
+use objc2_foundation::{NSDate, NSRunLoop};
+use orbit_child_runtime::window::WindowShell;
+use orbit_child_ui::UiSize;
+
+type CFIndex = isize;
+type CFArrayRef = *const c_void;
+type CFDictionaryRef = *const c_void;
+type CFNumberRef = *const c_void;
+type CFTypeRef = *const c_void;
+
+const K_CF_NUMBER_SINT32_TYPE: u32 = 3;
+const K_CG_WINDOW_LIST_OPTION_ON_SCREEN_ONLY: u32 = 1;
+const K_CG_WINDOW_LIST_EXCLUDE_DESKTOP_ELEMENTS: u32 = 1 << 4;
+
+#[link(name = "CoreGraphics", kind = "framework")]
+unsafe extern "C" {
+    fn CGWindowListCopyWindowInfo(option: u32, relative_to_window: u32) -> CFArrayRef;
+    /// Whether this process already holds Screen Recording (screen capture) permission.
+    /// Non-prompting, unlike `CGRequestScreenCaptureAccess`.
+    fn CGPreflightScreenCaptureAccess() -> bool;
+    static kCGWindowNumber: CFTypeRef;
+    static kCGWindowOwnerPID: CFTypeRef;
+}
+
+/// Fail loudly and actionably when the window-server query cannot work at all.
+///
+/// 🔴 Without Screen Recording permission `CGWindowListCopyWindowInfo` returns NULL, so every
+/// lookup reports "window absent" and the assertions below become **indistinguishable from a
+/// genuinely missing window** (measured 2026-07-31: `CGPreflightScreenCaptureAccess() == false`
+/// → NULL list → the test failed while `NSWindow #993` existed perfectly well).
+///
+/// This must **fail**, never skip: this test is the only independent evidence that a window
+/// really reached the window server, and a silent skip would turn "never verified" into green.
+fn require_screen_capture_permission() {
+    assert!(
+        unsafe { CGPreflightScreenCaptureAccess() },
+        "this process lacks Screen Recording permission, so CGWindowListCopyWindowInfo returns \
+         NULL and cannot witness any window. Grant it in System Settings → Privacy & Security → \
+         Screen Recording for the process running the tests, then re-run. Do not weaken this \
+         test: it is the only check independent of the child's own report."
+    );
+}
+
+#[link(name = "CoreFoundation", kind = "framework")]
+unsafe extern "C" {
+    fn CFArrayGetCount(array: CFArrayRef) -> CFIndex;
+    fn CFArrayGetValueAtIndex(array: CFArrayRef, index: CFIndex) -> *const c_void;
+    fn CFDictionaryGetValue(dictionary: CFDictionaryRef, key: *const c_void) -> *const c_void;
+    fn CFNumberGetValue(number: CFNumberRef, number_type: u32, value: *mut c_void) -> bool;
+    fn CFRelease(value: CFTypeRef);
+}
+
+struct OwnedWindowList(CFArrayRef);
+
+impl Drop for OwnedWindowList {
+    fn drop(&mut self) {
+        unsafe { CFRelease(self.0) };
+    }
+}
+
+fn dictionary_i32(dictionary: CFDictionaryRef, key: CFTypeRef) -> Option<i32> {
+    let number = unsafe { CFDictionaryGetValue(dictionary, key) };
+    if number.is_null() {
+        return None;
+    }
+    let mut value = 0i32;
+    unsafe {
+        CFNumberGetValue(
+            number,
+            K_CF_NUMBER_SINT32_TYPE,
+            std::ptr::addr_of_mut!(value).cast(),
+        )
+        .then_some(value)
+    }
+}
+
+fn window_server_contains(window_number: u32, owner_pid: u32) -> bool {
+    let list = unsafe {
+        CGWindowListCopyWindowInfo(
+            K_CG_WINDOW_LIST_OPTION_ON_SCREEN_ONLY | K_CG_WINDOW_LIST_EXCLUDE_DESKTOP_ELEMENTS,
+            0,
+        )
+    };
+    if list.is_null() {
+        return false;
+    }
+    let list = OwnedWindowList(list);
+    let count = unsafe { CFArrayGetCount(list.0) };
+    (0..count).any(|index| {
+        let dictionary = unsafe { CFArrayGetValueAtIndex(list.0, index) };
+        dictionary_i32(dictionary, unsafe { kCGWindowNumber }) == Some(window_number as i32)
+            && dictionary_i32(dictionary, unsafe { kCGWindowOwnerPID }) == Some(owner_pid as i32)
+    })
+}
+
+/// Every on-screen window this process owns, for diagnosing a failed match.
+fn own_window_numbers() -> Vec<i32> {
+    let list = unsafe {
+        CGWindowListCopyWindowInfo(
+            K_CG_WINDOW_LIST_OPTION_ON_SCREEN_ONLY | K_CG_WINDOW_LIST_EXCLUDE_DESKTOP_ELEMENTS,
+            0,
+        )
+    };
+    if list.is_null() {
+        return Vec::new();
+    }
+    let list = OwnedWindowList(list);
+    let count = unsafe { CFArrayGetCount(list.0) };
+    let me = std::process::id() as i32;
+    (0..count)
+        .filter_map(|index| {
+            let dictionary = unsafe { CFArrayGetValueAtIndex(list.0, index) };
+            (dictionary_i32(dictionary, unsafe { kCGWindowOwnerPID }) == Some(me))
+                .then(|| dictionary_i32(dictionary, unsafe { kCGWindowNumber }))
+                .flatten()
+        })
+        .collect()
+}
+
+/// Poll the window server while **letting AppKit run**.
+///
+/// 🔴 `makeKeyAndOrderFront` only schedules the ordering; the window reaches the window server
+/// when the main run loop next processes events. Sleeping instead of running the loop leaves the
+/// window permanently absent from `CGWindowListCopyWindowInfo`, which is indistinguishable from
+/// "the window was never created" — so this loop must pump, not sleep.
+fn wait_for_window_state(window_number: u32, expected: bool) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        if window_server_contains(window_number, std::process::id()) == expected {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        NSRunLoop::currentRunLoop().runUntilDate(&NSDate::dateWithTimeIntervalSinceNow(0.02));
+    }
+}
+
+fn run_window_shell_exists_in_cgwindowlist_and_disappears_after_close() {
+    require_screen_capture_permission();
+
+    let mtm = MainThreadMarker::new().expect("gated test must run on the process main thread");
+    let app = NSApplication::sharedApplication(mtm);
+    let _ = app.setActivationPolicy(NSApplicationActivationPolicy::Accessory);
+    app.finishLaunching();
+
+    let mut shell = WindowShell::new(
+        UiSize {
+            width: 360,
+            height: 220,
+        },
+        true,
+        || false,
+    )
+    .expect("create WindowShell");
+    let window_number = shell.window_number();
+
+    assert!(
+        wait_for_window_state(window_number, true),
+        "CGWindowListCopyWindowInfo did not contain this process's NSWindow #{window_number}. \
+         on-screen windows owned by this process: {:?}",
+        own_window_numbers()
+    );
+
+    shell.close();
+
+    assert!(
+        wait_for_window_state(window_number, false),
+        "CGWindowListCopyWindowInfo still contained closed NSWindow #{window_number}"
+    );
+}
+
+#[test]
+#[ignore = "requires a logged-in macOS Window Server session"]
+fn window_shell_exists_in_cgwindowlist_and_disappears_after_close() {
+    run_window_shell_exists_in_cgwindowlist_and_disappears_after_close();
+}
+
+fn main() {
+    let run_ignored = std::env::args().any(|arg| arg == "--ignored");
+    println!("running 1 test");
+    if !run_ignored {
+        println!("test window_shell_exists_in_cgwindowlist_and_disappears_after_close ... ignored");
+        println!();
+        println!("test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out");
+        return;
+    }
+
+    print!("test window_shell_exists_in_cgwindowlist_and_disappears_after_close ... ");
+    let result = std::panic::catch_unwind(|| {
+        run_window_shell_exists_in_cgwindowlist_and_disappears_after_close()
+    });
+    match result {
+        Ok(()) => {
+            println!("ok");
+            println!();
+            println!("test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out");
+        }
+        Err(payload) => {
+            println!("FAILED");
+            println!();
+            println!("failures:");
+            println!("    window_shell_exists_in_cgwindowlist_and_disappears_after_close");
+            println!();
+            println!(
+                "test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out"
+            );
+            std::panic::resume_unwind(payload);
+        }
+    }
+}

--- a/rust/crates/orbit-child-ui/src/lib.rs
+++ b/rust/crates/orbit-child-ui/src/lib.rs
@@ -5,7 +5,39 @@
 //! those dependencies into the transition logic tested here.
 
 use std::borrow::Cow;
+use std::ffi::c_void;
 use std::time::Duration;
+
+/// Logical plugin-editor size in host-view coordinates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UiSize {
+    pub width: i32,
+    pub height: i32,
+}
+
+/// AppKit- and plugin-format-independent editor-view endpoint.
+///
+/// `begin_open` deliberately stops before the parent view is created. The caller uses its
+/// returned size to create the host-owned window, then passes that window's content view to
+/// `attach`.
+pub trait PluginUiEndpoint {
+    /// Create the plugin editor and return its initial size.
+    fn begin_open(&mut self) -> Result<UiSize, String>;
+
+    /// Embed the editor into `parent`, an opaque platform parent-view pointer.
+    fn attach(&mut self, parent: *mut c_void) -> Result<(), String>;
+
+    /// Release the plugin editor before the host destroys its parent window.
+    ///
+    /// `was_destroyed` carries CLAP's `closed()` distinction. VST3 implementations ignore it.
+    fn release(&mut self, was_destroyed: bool);
+
+    /// Whether the plugin permits user-driven window resizing.
+    fn can_resize(&self) -> bool;
+
+    /// Apply a host-originated resize to the plugin editor.
+    fn apply_host_resize(&mut self, size: UiSize) -> Result<(), String>;
+}
 
 /// Detail returned when `OPEN_UI` arrives before the previous close cycle drains.
 pub const CLOSING_IN_PROGRESS_DETAIL: &str = "closing-in-progress";

--- a/rust/crates/orbit-child-ui/src/lib.rs
+++ b/rust/crates/orbit-child-ui/src/lib.rs
@@ -123,11 +123,13 @@ pub enum CloseRequestDisposition {
 ///   clock. Wall-clock values and non-monotonic values must not be used.
 /// - Opening a real window makes the main-runloop tick reentrant (modal sheets, live
 ///   resize, drag tracking). While a tick is reentrant the child's `service_main` is
-///   skipped, so `ParentWatch::should_exit` — the orphan guard from #448 — is not
-///   evaluated. `CONTROL_QUIT` already survives this via `run_child`'s `should_quit`
-///   predicate; the orphan case does not. P3b must extend that predicate to cover
-///   parent death before the first window can be shown, otherwise a daemon crash
-///   during a modal sheet leaves the child alive holding its plugin.
+///   skipped, so `ParentWatch::should_exit` — the orphan guard from #448 — would not be
+///   evaluated there. ✅ **Closed in P3b-2**: `child_should_quit` now evaluates both
+///   `CONTROL_QUIT` and `ParentWatch` outside the borrow, so a daemon crash during a modal
+///   sheet still tears the child down. Its composition (not just the pure predicate) is
+///   pinned by `child_should_quit_consults_the_injected_parent_watch`, which uses
+///   `ParentWatch::orphaned_for_tests` to make the parent-died branch reachable in-process.
+///   Keep that test whenever the predicate gains another term.
 pub trait UiHostActions {
     /// Create and show the UI. P3b supplies the format-specific implementation.
     fn open_ui(&mut self) -> Result<(), String>;

--- a/rust/crates/orbit-clap-effect-child/src/main.rs
+++ b/rust/crates/orbit-clap-effect-child/src/main.rs
@@ -20,19 +20,26 @@
 
 #![allow(unsafe_code)]
 
+#[cfg(target_os = "macos")]
 use std::path::PathBuf;
+#[cfg(target_os = "macos")]
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
+#[cfg(target_os = "macos")]
 use anyhow::{bail, Context, Result};
+#[cfg(target_os = "macos")]
 use orbit_audio_sandbox::{
     open_shared, region_ptr, slot_index, slot_offset, ParentWatch, BUF_LEN, CHANNELS, CONTROL_QUIT,
     MAX_FRAMES,
 };
+#[cfg(target_os = "macos")]
 use orbit_child_runtime::{
     child_should_quit, run_child, service_child_main, UiCallbacks, UiService,
 };
+#[cfg(target_os = "macos")]
 use orbit_clap_host::ClapEffectProcessor;
 
+#[cfg(target_os = "macos")]
 struct Args {
     shm: PathBuf,
     plugin: PathBuf,
@@ -41,6 +48,7 @@ struct Args {
     state: Option<PathBuf>,
 }
 
+#[cfg(target_os = "macos")]
 fn parse_args() -> Result<Args> {
     let mut shm: Option<PathBuf> = None;
     let mut plugin: Option<PathBuf> = None;
@@ -73,6 +81,7 @@ fn parse_args() -> Result<Args> {
     })
 }
 
+#[cfg(target_os = "macos")]
 fn main() -> Result<()> {
     let args = parse_args()?;
     let mmap = open_shared(&args.shm).with_context(|| format!("open_shared({:?})", args.shm))?;
@@ -170,4 +179,10 @@ fn main() -> Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() -> std::process::ExitCode {
+    eprintln!("orbit-clap-effect-child is macOS-only (plugin UI hosting needs AppKit)");
+    std::process::ExitCode::FAILURE
 }

--- a/rust/crates/orbit-clap-effect-child/src/main.rs
+++ b/rust/crates/orbit-clap-effect-child/src/main.rs
@@ -25,11 +25,12 @@ use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 use anyhow::{bail, Context, Result};
 use orbit_audio_sandbox::{
-    open_shared, region_ptr, save_state_command, service_command_mailbox, slot_index, slot_offset,
-    ParentWatch, BUF_LEN, CHANNELS, CMD_CLOSE_UI, CMD_OPEN_UI, CMD_SAVE_STATE, CONTROL_QUIT,
+    open_shared, region_ptr, slot_index, slot_offset, ParentWatch, BUF_LEN, CHANNELS, CONTROL_QUIT,
     MAX_FRAMES,
 };
-use orbit_child_runtime::{child_should_quit, run_child, UiCallbacks, UiService};
+use orbit_child_runtime::{
+    child_should_quit, run_child, service_child_main, UiCallbacks, UiService,
+};
 use orbit_clap_host::ClapEffectProcessor;
 
 struct Args {
@@ -109,20 +110,8 @@ fn main() -> Result<()> {
     let process_errors = run_child(
         "orbit-clap-effect-child",
         || unsafe { child_should_quit(region, &parent_watch) },
-        || {
-            // Mailbox servicing is main-thread-only after #474 P1. In particular,
-            // SAVE_STATE may block on plugin serialization/fsync without stalling audio.
-            unsafe {
-                service_command_mailbox(region, |kind, arg| match kind {
-                    CMD_SAVE_STATE => Some(save_state_command(arg, || {
-                        main.with_mut(|main| main.capture_state())
-                    })),
-                    CMD_OPEN_UI | CMD_CLOSE_UI => Some(ui.handle_command(kind, arg)),
-                    _ => None,
-                });
-            }
-            ui.tick(ui.now());
-            false
+        || unsafe {
+            service_child_main(region, &ui, || main.with_mut(|main| main.capture_state()))
         },
         move |stop_audio| {
             let region = region_addr as *mut orbit_audio_sandbox::SharedRegion;

--- a/rust/crates/orbit-clap-effect-child/src/main.rs
+++ b/rust/crates/orbit-clap-effect-child/src/main.rs
@@ -26,9 +26,10 @@ use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 use anyhow::{bail, Context, Result};
 use orbit_audio_sandbox::{
     open_shared, region_ptr, save_state_command, service_command_mailbox, slot_index, slot_offset,
-    ParentWatch, BUF_LEN, CHANNELS, CMD_SAVE_STATE, CONTROL_QUIT, MAX_FRAMES,
+    ParentWatch, BUF_LEN, CHANNELS, CMD_CLOSE_UI, CMD_OPEN_UI, CMD_SAVE_STATE, CONTROL_QUIT,
+    MAX_FRAMES,
 };
-use orbit_child_runtime::run_child;
+use orbit_child_runtime::{child_should_quit, run_child, UiCallbacks, UiService};
 use orbit_clap_host::ClapEffectProcessor;
 
 struct Args {
@@ -95,28 +96,32 @@ fn main() -> Result<()> {
     unsafe {
         orbit_audio_sandbox::transport::publish_child_ready(region, effect.has_audio_input());
     }
-    let (mut effect_audio, mut effect_main) = effect.split();
+    let (mut effect_audio, effect_main) = effect.split();
+    let (ui, main) = UiService::new(region, effect_main, |main| UiCallbacks {
+        closed: main.take_closed(),
+        requested_size: main.take_requested_size(),
+    });
 
     // orphan 対策（#448）: host（daemon）が CONTROL_QUIT を書かずに死ぬ経路（プロセス exit・
     // SIGKILL・crash）でも main runloop を止められるよう、親死活をタイマーで監視する。
-    let mut parent_watch = ParentWatch::new();
+    let parent_watch = ParentWatch::new();
     let region_addr = region as usize;
     let process_errors = run_child(
         "orbit-clap-effect-child",
-        || unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT,
+        || unsafe { child_should_quit(region, &parent_watch) },
         || {
             // Mailbox servicing is main-thread-only after #474 P1. In particular,
             // SAVE_STATE may block on plugin serialization/fsync without stalling audio.
             unsafe {
                 service_command_mailbox(region, |kind, arg| match kind {
-                    CMD_SAVE_STATE => Some(save_state_command(arg, || effect_main.capture_state())),
+                    CMD_SAVE_STATE => Some(save_state_command(arg, || {
+                        main.with_mut(|main| main.capture_state())
+                    })),
+                    CMD_OPEN_UI | CMD_CLOSE_UI => Some(ui.handle_command(kind, arg)),
                     _ => None,
                 });
             }
-            if parent_watch.should_exit() {
-                eprintln!("[orbit-clap-effect-child] 親プロセス死亡を検知、終了する");
-                return true;
-            }
+            ui.tick(ui.now());
             false
         },
         move |stop_audio| {

--- a/rust/crates/orbit-clap-host/Cargo.toml
+++ b/rust/crates/orbit-clap-host/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/lib.rs"
 
 [dependencies]
 orbit-audio-native = { path = "../orbit-audio-native" }
+orbit-child-ui = { path = "../orbit-child-ui" }
 # M2 neutral event wire 型（EventRecord/NeutralEvent）。orbit-audio-sandbox は clack-free だが、
 # こちら側から一方向に依存するのは問題ない（§4 crate 配置規約）。
 orbit-audio-sandbox = { path = "../orbit-audio-sandbox" }
@@ -30,6 +31,7 @@ clack-extensions = { git = "https://github.com/prokopyl/clack", rev = "f874e858a
   "log",
   "params",
   "state",
+  "gui",
 ] }
 rtrb = "0.3"
 thiserror = { workspace = true }

--- a/rust/crates/orbit-clap-host/src/controller.rs
+++ b/rust/crates/orbit-clap-host/src/controller.rs
@@ -81,6 +81,45 @@ pub(crate) struct InstantiatedPlugin {
     pub info: LoadedPluginInfo,
 }
 
+pub(crate) struct HostCallbackConfig {
+    callback_requested: Arc<AtomicBool>,
+    resize_count: Arc<AtomicU64>,
+    enable_gui_callbacks: bool,
+}
+
+impl HostCallbackConfig {
+    pub(crate) fn in_process(
+        callback_requested: Arc<AtomicBool>,
+        resize_count: Arc<AtomicU64>,
+    ) -> Self {
+        Self {
+            callback_requested,
+            resize_count,
+            enable_gui_callbacks: false,
+        }
+    }
+
+    pub(crate) fn child() -> Self {
+        Self {
+            callback_requested: Arc::new(AtomicBool::new(false)),
+            resize_count: Arc::new(AtomicU64::new(0)),
+            enable_gui_callbacks: true,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn gui_callbacks_enabled(&self) -> bool {
+        self.enable_gui_callbacks
+    }
+}
+
+fn daemon_host_callback_config(
+    callback_requested: Arc<AtomicBool>,
+    resize_count: Arc<AtomicU64>,
+) -> HostCallbackConfig {
+    HostCallbackConfig::in_process(callback_requested, resize_count)
+}
+
 /// .clap バンドルを discover → instantiate → activate → start_processing し、全部品を返す。
 ///
 /// CLAP 仕様: `PluginInstance::new` / `activate` / `start_processing` は同一スレッド（呼び出し元）で
@@ -92,9 +131,14 @@ pub(crate) fn instantiate_activate(
     sample_rate: u32,
     channels: usize,
     max_frames: u32,
-    callback_requested: Arc<AtomicBool>,
-    resize_count: Arc<AtomicU64>,
+    host_callbacks: HostCallbackConfig,
 ) -> Result<InstantiatedPlugin, ClapHostError> {
+    let HostCallbackConfig {
+        callback_requested,
+        resize_count,
+        enable_gui_callbacks,
+    } = host_callbacks;
+
     // プラグインを発見する。
     let found: FoundPlugin = match id {
         None => {
@@ -128,7 +172,13 @@ pub(crate) fn instantiate_activate(
     // PluginInstance を生成する（main thread 要件: 呼び出し元スレッドで実行）。
     // carry-forward #2: callback_requested Arc を closure にキャプチャして clone で共有。
     let mut instance = PluginInstance::<OrbitClapHost>::new(
-        move |_| OrbitHostShared::new(callback_requested.clone()),
+        move |_| {
+            if enable_gui_callbacks {
+                OrbitHostShared::with_gui_callbacks(callback_requested.clone())
+            } else {
+                OrbitHostShared::new(callback_requested.clone())
+            }
+        },
         |shared| OrbitHostMainThread::new(shared),
         &found.entry,
         &plugin_id,
@@ -240,8 +290,7 @@ impl ClapHost {
             sample_rate,
             channels,
             max_frames,
-            self.callback_requested.clone(),
-            self.resize_count.clone(),
+            daemon_host_callback_config(self.callback_requested.clone(), self.resize_count.clone()),
         )?;
 
         self.instance = Some(loaded.instance);
@@ -320,6 +369,16 @@ fn query_note_port_index(instance: &mut PluginInstance<OrbitClapHost>) -> u16 {
 mod tests {
     use super::*;
 
+    #[test]
+    fn daemon_path_does_not_advertise_gui_callbacks() {
+        let config = daemon_host_callback_config(
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicU64::new(0)),
+        );
+
+        assert!(!config.gui_callbacks_enabled());
+    }
+
     /// 存在しない .clap パスは panic せず `Err` を返す（discovery 失敗が型で伝播する保証）。
     /// 実 dylib も audio device も不要なので CI（`cargo test`）でそのまま実行できる。
     #[test]
@@ -330,8 +389,10 @@ mod tests {
             48_000,
             2,
             512,
-            Arc::new(AtomicBool::new(false)),
-            Arc::new(AtomicU64::new(0)),
+            daemon_host_callback_config(
+                Arc::new(AtomicBool::new(false)),
+                Arc::new(AtomicU64::new(0)),
+            ),
         );
         assert!(
             result.is_err(),

--- a/rust/crates/orbit-clap-host/src/controller.rs
+++ b/rust/crates/orbit-clap-host/src/controller.rs
@@ -101,16 +101,20 @@ impl HostCallbackConfig {
 
     /// Out-of-process children host a plugin UI, so they must advertise `HostGui`.
     ///
-    /// 🔴 **P3b-2 completion condition.** The unit test below pins this constructor's body,
-    /// but nothing pins the *call sites* to it: replacing the argument at either `load` call
-    /// with [`HostCallbackConfig::in_process`] compiles and leaves all tests green (verified
-    /// by mutation on 2026-07-31). Both constructors return the same type, so the swap is
-    /// invisible to the compiler — the sibling-swap class this project has already shipped once.
+    /// `child` and [`in_process`](Self::in_process) return the same type, so swapping them at a
+    /// call site is invisible to the compiler — the sibling-swap class this project has already
+    /// shipped once. **Two layers guard it, and each was verified by mutation on 2026-07-31:**
     ///
-    /// The gap is unreachable today because nothing consumes the host GUI callbacks yet.
-    /// P3b-2 wires `closed()` / `request_resize()` into the close state machine, and its test
-    /// that a plugin-initiated close reaches the machine must run through the real `load` path,
-    /// which binds the call sites for the first time.
+    /// 1. The unit test below pins this constructor's body. **Alone it was not enough**: swapping
+    ///    the argument at either `load` call left all 28 tests green.
+    /// 2. `real_load_path_delivers_plugin_initiated_close_to_main_half` (in `effect` and
+    ///    `instrument`, `#[ignore]`d — needs the prebuilt CLAP dylib) drives a plugin-initiated
+    ///    `closed()` through the **real `load` path**, so a call site that stops asking for
+    ///    `child()` reports `take_closed() == None`. Swapping `effect.rs`'s call site now fails
+    ///    exactly that test.
+    ///
+    /// 🔴 Layer 2 is the one that binds the call sites; keep those tests running whenever this
+    /// type gains another variant.
     pub(crate) fn child() -> Self {
         Self {
             callback_requested: Arc::new(AtomicBool::new(false)),

--- a/rust/crates/orbit-clap-host/src/controller.rs
+++ b/rust/crates/orbit-clap-host/src/controller.rs
@@ -99,6 +99,18 @@ impl HostCallbackConfig {
         }
     }
 
+    /// Out-of-process children host a plugin UI, so they must advertise `HostGui`.
+    ///
+    /// 🔴 **P3b-2 completion condition.** The unit test below pins this constructor's body,
+    /// but nothing pins the *call sites* to it: replacing the argument at either `load` call
+    /// with [`HostCallbackConfig::in_process`] compiles and leaves all tests green (verified
+    /// by mutation on 2026-07-31). Both constructors return the same type, so the swap is
+    /// invisible to the compiler — the sibling-swap class this project has already shipped once.
+    ///
+    /// The gap is unreachable today because nothing consumes the host GUI callbacks yet.
+    /// P3b-2 wires `closed()` / `request_resize()` into the close state machine, and its test
+    /// that a plugin-initiated close reaches the machine must run through the real `load` path,
+    /// which binds the call sites for the first time.
     pub(crate) fn child() -> Self {
         Self {
             callback_requested: Arc::new(AtomicBool::new(false)),
@@ -368,6 +380,20 @@ fn query_note_port_index(instance: &mut PluginInstance<OrbitClapHost>) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The child path must advertise `HostGui`; the in-process daemon path must not.
+    ///
+    /// Both assertions are needed: pinning only the child side lets a constructor that always
+    /// enables callbacks pass, which would silently start advertising GUI on the daemon path.
+    #[test]
+    fn child_enables_gui_callbacks_and_in_process_does_not() {
+        assert!(HostCallbackConfig::child().gui_callbacks_enabled());
+        assert!(!HostCallbackConfig::in_process(
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicU64::new(0))
+        )
+        .gui_callbacks_enabled());
+    }
 
     #[test]
     fn daemon_path_does_not_advertise_gui_callbacks() {

--- a/rust/crates/orbit-clap-host/src/effect.rs
+++ b/rust/crates/orbit-clap-host/src/effect.rs
@@ -244,6 +244,10 @@ impl Drop for ClapEffectAudio {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clack_extensions::gui::HostGuiImpl;
+    use std::path::PathBuf;
+
+    use crate::host::OrbitHostShared;
 
     /// audio 側が `Send`（専用 audio スレッドへ move できる）ことのコンパイル時証明。
     /// clack の `StartedPluginAudioProcessor` / `AudioPorts` の `unsafe impl Send` に依拠する
@@ -257,5 +261,30 @@ mod tests {
     #[test]
     fn child_path_advertises_gui_callbacks() {
         assert!(child_host_callback_config().gui_callbacks_enabled());
+    }
+
+    #[test]
+    #[ignore = "needs prebuilt release clap-test-effect dylib"]
+    fn real_load_path_delivers_plugin_initiated_close_to_main_half() {
+        let dylib = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../.."))
+            .join("rust-spike/clap-test-effect/target/release/libclap_test_effect.dylib");
+        assert!(dylib.exists(), "missing {}", dylib.display());
+        let (processor, _) = ClapEffectProcessor::load(
+            &dylib,
+            Some("com.signalcompose.clap-test-effect"),
+            48_000,
+            2,
+            512,
+            None,
+        )
+        .expect("load test effect through child callback configuration");
+        let (audio, main) = processor.split();
+
+        main.instance
+            .access_shared_handler(|shared: &OrbitHostShared| HostGuiImpl::closed(shared, true));
+
+        assert_eq!(main.take_closed(), Some(true));
+        drop(audio);
+        drop(main);
     }
 }

--- a/rust/crates/orbit-clap-host/src/effect.rs
+++ b/rust/crates/orbit-clap-host/src/effect.rs
@@ -40,17 +40,34 @@
 //!   `effect_processor_smoke_gated.rs::instrument_branch_add_mixes_dry_signal`）。
 
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, AtomicU64};
-use std::sync::Arc;
 
 use clack_host::events::io::InputEvents;
 use clack_host::prelude::{PluginInstance, StartedPluginAudioProcessor};
 
 use crate::buffers::HostAudioBuffers;
-use crate::controller::{instantiate_activate, ClapHostError, LoadedPluginInfo};
+use crate::controller::{
+    instantiate_activate, ClapHostError, HostCallbackConfig, LoadedPluginInfo,
+};
 use crate::host::OrbitClapHost;
 use crate::processor::process_block_core;
 use crate::ClapPluginMain;
+
+/// Child processes host a plugin UI, so they must advertise `HostGui`.
+///
+/// 🔴 **P3b-2 completion condition.** The unit test below pins this function's body, but
+/// nothing pins the *call site* to this function: replacing the argument at the `load`
+/// call with `HostCallbackConfig::in_process(..)` compiles and leaves all 28 tests green
+/// (verified by mutation on 2026-07-31). `in_process` and `child` return the same type,
+/// so the swap is invisible to the compiler — the sibling-swap class this project has
+/// already shipped once.
+///
+/// The gap is unreachable today because nothing consumes the host GUI callbacks yet.
+/// P3b-2 wires `closed()` / `request_resize()` into the close state machine, and its test
+/// that a plugin-initiated close reaches the machine must run through the real `load`
+/// path, which binds the call site for the first time.
+fn child_host_callback_config() -> HostCallbackConfig {
+    HostCallbackConfig::child()
+}
 
 /// 単一スレッドで load / process / drop する effect-only CLAP プロセッサ。
 ///
@@ -96,8 +113,7 @@ impl ClapEffectProcessor {
             sample_rate,
             channels,
             max_frames,
-            Arc::new(AtomicBool::new(false)),
-            Arc::new(AtomicU64::new(0)),
+            child_host_callback_config(),
         )?;
 
         let mut processor = Self {
@@ -179,6 +195,9 @@ impl ClapEffectProcessor {
             },
             ClapPluginMain {
                 instance: _instance,
+                plugin_gui: None,
+                gui_attached: false,
+                gui_can_resize: false,
             },
         )
     }
@@ -233,5 +252,10 @@ mod tests {
     fn audio_half_is_send() {
         fn assert_send<T: Send>() {}
         assert_send::<ClapEffectAudio>();
+    }
+
+    #[test]
+    fn child_path_advertises_gui_callbacks() {
+        assert!(child_host_callback_config().gui_callbacks_enabled());
     }
 }

--- a/rust/crates/orbit-clap-host/src/effect.rs
+++ b/rust/crates/orbit-clap-host/src/effect.rs
@@ -52,23 +52,6 @@ use crate::host::OrbitClapHost;
 use crate::processor::process_block_core;
 use crate::ClapPluginMain;
 
-/// Child processes host a plugin UI, so they must advertise `HostGui`.
-///
-/// 🔴 **P3b-2 completion condition.** The unit test below pins this function's body, but
-/// nothing pins the *call site* to this function: replacing the argument at the `load`
-/// call with `HostCallbackConfig::in_process(..)` compiles and leaves all 28 tests green
-/// (verified by mutation on 2026-07-31). `in_process` and `child` return the same type,
-/// so the swap is invisible to the compiler — the sibling-swap class this project has
-/// already shipped once.
-///
-/// The gap is unreachable today because nothing consumes the host GUI callbacks yet.
-/// P3b-2 wires `closed()` / `request_resize()` into the close state machine, and its test
-/// that a plugin-initiated close reaches the machine must run through the real `load`
-/// path, which binds the call site for the first time.
-fn child_host_callback_config() -> HostCallbackConfig {
-    HostCallbackConfig::child()
-}
-
 /// 単一スレッドで load / process / drop する effect-only CLAP プロセッサ。
 ///
 /// `!Send`（[`PluginInstance`] を含む）。生成したスレッド上でのみ使うこと。
@@ -113,7 +96,7 @@ impl ClapEffectProcessor {
             sample_rate,
             channels,
             max_frames,
-            child_host_callback_config(),
+            HostCallbackConfig::child(),
         )?;
 
         let mut processor = Self {
@@ -256,11 +239,6 @@ mod tests {
     fn audio_half_is_send() {
         fn assert_send<T: Send>() {}
         assert_send::<ClapEffectAudio>();
-    }
-
-    #[test]
-    fn child_path_advertises_gui_callbacks() {
-        assert!(child_host_callback_config().gui_callbacks_enabled());
     }
 
     #[test]

--- a/rust/crates/orbit-clap-host/src/gui.rs
+++ b/rust/crates/orbit-clap-host/src/gui.rs
@@ -1,0 +1,136 @@
+//! CLAP Cocoa editor endpoint. This module intentionally has no AppKit surface.
+
+use std::ffi::c_void;
+use std::ptr::NonNull;
+
+use clack_extensions::gui::{
+    GuiApiType, GuiConfiguration, GuiSize, PluginGui, Window as ClapWindow,
+};
+use orbit_child_ui::{PluginUiEndpoint, UiSize};
+
+use crate::ClapPluginMain;
+
+const COCOA_EMBEDDED: GuiConfiguration<'static> = GuiConfiguration {
+    api_type: GuiApiType::COCOA,
+    is_floating: false,
+};
+
+impl PluginUiEndpoint for ClapPluginMain {
+    fn begin_open(&mut self) -> Result<UiSize, String> {
+        if self.plugin_gui.is_some() {
+            return Err("CLAP UI open failed: editor GUI is already open".into());
+        }
+
+        let mut plugin = self.instance.plugin_handle();
+        let gui = plugin
+            .get_extension::<PluginGui>()
+            .ok_or_else(|| "CLAP UI open failed: plugin has no CLAP GUI extension".to_owned())?;
+
+        if !gui.is_api_supported(&mut plugin, COCOA_EMBEDDED) {
+            return Err(
+                "CLAP UI open failed: embedded cocoa GUI is unsupported; floating fallback is forbidden"
+                    .into(),
+            );
+        }
+
+        gui.create(&mut plugin, COCOA_EMBEDDED)
+            .map_err(|error| format!("CLAP UI open failed: create(cocoa, false): {error}"))?;
+
+        // Cocoa reports logical sizes. CLAP explicitly forbids set_scale for this API.
+        let can_resize = gui.can_resize(&mut plugin);
+        let size = match gui.get_size(&mut plugin) {
+            Some(size) => size,
+            None => {
+                gui.destroy(&mut plugin);
+                return Err("CLAP UI open failed: get_size returned no valid size".into());
+            }
+        };
+        let size = match ui_size(size) {
+            Ok(size) => size,
+            Err(detail) => {
+                gui.destroy(&mut plugin);
+                return Err(format!("CLAP UI open failed: {detail}"));
+            }
+        };
+
+        self.plugin_gui = Some(gui);
+        self.gui_attached = false;
+        self.gui_can_resize = can_resize;
+        Ok(size)
+    }
+
+    fn attach(&mut self, parent: *mut c_void) -> Result<(), String> {
+        let parent = NonNull::new(parent)
+            .ok_or_else(|| "CLAP UI attach failed: NSView parent is null".to_owned())?;
+        if self.gui_attached {
+            return Err("CLAP UI attach failed: editor GUI is already attached".into());
+        }
+        let gui = self
+            .plugin_gui
+            .ok_or_else(|| "CLAP UI attach failed: editor GUI is not open".to_owned())?;
+        let mut plugin = self.instance.plugin_handle();
+
+        // SAFETY: The caller owns `parent` and must keep it alive until `release`.
+        unsafe { gui.set_parent(&mut plugin, ClapWindow::from_cocoa_nsview(parent.as_ptr())) }
+            .map_err(|error| format!("CLAP UI attach failed: set_parent: {error}"))?;
+        self.gui_attached = true;
+        gui.show(&mut plugin)
+            .map_err(|error| format!("CLAP UI attach failed: show: {error}"))
+    }
+
+    fn release(&mut self, was_destroyed: bool) {
+        let Some(gui) = self.plugin_gui.take() else {
+            self.gui_attached = false;
+            self.gui_can_resize = false;
+            return;
+        };
+        let mut plugin = self.instance.plugin_handle();
+        if !was_destroyed {
+            let _ = gui.hide(&mut plugin);
+        }
+        gui.destroy(&mut plugin);
+        self.gui_attached = false;
+        self.gui_can_resize = false;
+    }
+
+    fn can_resize(&self) -> bool {
+        self.gui_can_resize
+    }
+
+    fn apply_host_resize(&mut self, size: UiSize) -> Result<(), String> {
+        let size = gui_size(size)?;
+        let gui = self
+            .plugin_gui
+            .ok_or_else(|| "CLAP UI resize failed: editor GUI is not open".to_owned())?;
+        let mut plugin = self.instance.plugin_handle();
+        gui.set_size(&mut plugin, size)
+            .map_err(|error| format!("CLAP UI resize failed: set_size: {error}"))
+    }
+}
+
+impl Drop for ClapPluginMain {
+    fn drop(&mut self) {
+        self.release(false);
+    }
+}
+
+fn ui_size(size: GuiSize) -> Result<UiSize, String> {
+    let width = i32::try_from(size.width)
+        .map_err(|_| format!("editor width {} exceeds i32", size.width))?;
+    let height = i32::try_from(size.height)
+        .map_err(|_| format!("editor height {} exceeds i32", size.height))?;
+    Ok(UiSize { width, height })
+}
+
+fn gui_size(size: UiSize) -> Result<GuiSize, String> {
+    if size.width <= 0 || size.height <= 0 {
+        return Err(format!(
+            "CLAP UI resize failed: invalid size {}x{}",
+            size.width, size.height
+        ));
+    }
+    Ok(GuiSize {
+        width: size.width as u32,
+        height: size.height as u32,
+    })
+}

--- a/rust/crates/orbit-clap-host/src/host.rs
+++ b/rust/crates/orbit-clap-host/src/host.rs
@@ -8,14 +8,21 @@
 //! - pump 側（ClapHost::pump）が `callback_requested.swap(false, AcqRel)` で読む。
 
 use clack_extensions::audio_ports::{AudioPortRescanFlags, HostAudioPortsImpl};
+use clack_extensions::gui::{GuiSize, HostGui, HostGuiImpl};
 use clack_extensions::log::{HostLog, HostLogImpl, LogSeverity};
 use clack_extensions::note_ports::{HostNotePortsImpl, NoteDialects, NotePortRescanFlags};
 use clack_extensions::params::{
     HostParams, HostParamsImplMainThread, HostParamsImplShared, ParamClearFlags, ParamRescanFlags,
 };
 use clack_host::prelude::*;
-use std::sync::atomic::{AtomicBool, Ordering};
+use orbit_child_ui::UiSize;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
+
+const NO_CLOSED_CALLBACK: u8 = 0;
+const CLOSED_NOT_DESTROYED: u8 = 1;
+const CLOSED_DESTROYED: u8 = 2;
+const NO_REQUESTED_SIZE: u64 = 0;
 
 /// ホスト型タグ — Shared / MainThread / AudioProcessor を紐付ける。
 pub struct OrbitClapHost;
@@ -25,11 +32,20 @@ impl HostHandlers for OrbitClapHost {
     type MainThread<'a> = OrbitHostMainThread<'a>;
     type AudioProcessor<'a> = ();
 
-    fn declare_extensions(builder: &mut HostExtensions<Self>, _shared: &Self::Shared<'_>) {
+    fn declare_extensions(builder: &mut HostExtensions<Self>, shared: &Self::Shared<'_>) {
         builder.register::<HostLog>().register::<HostParams>();
+        if shared.gui_callbacks.is_some() {
+            builder.register::<HostGui>();
+        }
         // audio-ports / note-ports はプラグイン側のエクステンションとして取得する
         // (ホスト提供エクステンションとしての登録は不要)。
     }
+}
+
+#[derive(Default)]
+struct GuiCallbackState {
+    closed: AtomicU8,
+    requested_size: AtomicU64,
 }
 
 /// どのスレッドからもアクセス可能なデータ。
@@ -38,11 +54,55 @@ impl HostHandlers for OrbitClapHost {
 /// audio thread から `request_callback` が呼ばれても alloc / block なし（RT 安全）。
 pub struct OrbitHostShared {
     callback_requested: Arc<AtomicBool>,
+    /// `Some` なのは out-of-process child 経路だけ。daemon の in-process 経路は
+    /// `None` のままなので、CLAP GUI host extension を広告しない。
+    gui_callbacks: Option<GuiCallbackState>,
 }
 
 impl OrbitHostShared {
+    /// GUI を使わない in-process daemon 用。
     pub fn new(callback_requested: Arc<AtomicBool>) -> Self {
-        Self { callback_requested }
+        Self {
+            callback_requested,
+            gui_callbacks: None,
+        }
+    }
+
+    /// GUI を child の main thread で扱う standalone host 用。
+    pub(crate) fn with_gui_callbacks(callback_requested: Arc<AtomicBool>) -> Self {
+        Self {
+            callback_requested,
+            gui_callbacks: Some(GuiCallbackState::default()),
+        }
+    }
+
+    pub(crate) fn take_closed(&self) -> Option<bool> {
+        let state = self
+            .gui_callbacks
+            .as_ref()?
+            .closed
+            .swap(NO_CLOSED_CALLBACK, Ordering::AcqRel);
+        match state {
+            CLOSED_NOT_DESTROYED => Some(false),
+            CLOSED_DESTROYED => Some(true),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn take_requested_size(&self) -> Option<UiSize> {
+        let packed = self
+            .gui_callbacks
+            .as_ref()?
+            .requested_size
+            .swap(NO_REQUESTED_SIZE, Ordering::AcqRel);
+        if packed == NO_REQUESTED_SIZE {
+            return None;
+        }
+        let size = GuiSize::unpack_from_u64(packed);
+        Some(UiSize {
+            width: size.width as i32,
+            height: size.height as i32,
+        })
     }
 }
 
@@ -153,6 +213,57 @@ impl HostParamsImplShared for OrbitHostShared {
     }
 }
 
+impl HostGuiImpl for OrbitHostShared {
+    fn resize_hints_changed(&self) {
+        // P3b-1 は callback の保持まで。hints の再取得と NSWindow 操作は P3b-2。
+    }
+
+    fn request_resize(&self, new_size: GuiSize) -> Result<(), HostError> {
+        if new_size.width == 0
+            || new_size.height == 0
+            || new_size.width > i32::MAX as u32
+            || new_size.height > i32::MAX as u32
+        {
+            return Err(HostError::Message(
+                "CLAP GUI requested an invalid parent size",
+            ));
+        }
+        let callbacks = self
+            .gui_callbacks
+            .as_ref()
+            .ok_or(HostError::Message("CLAP GUI callbacks are disabled"))?;
+        callbacks
+            .requested_size
+            .store(new_size.pack_to_u64(), Ordering::Release);
+        Ok(())
+    }
+
+    fn request_show(&self) -> Result<(), HostError> {
+        Err(HostError::Message(
+            "plugin-originated CLAP GUI show is unsupported",
+        ))
+    }
+
+    fn request_hide(&self) -> Result<(), HostError> {
+        Err(HostError::Message(
+            "plugin-originated CLAP GUI hide is unsupported",
+        ))
+    }
+
+    fn closed(&self, was_destroyed: bool) {
+        if let Some(callbacks) = &self.gui_callbacks {
+            callbacks.closed.store(
+                if was_destroyed {
+                    CLOSED_DESTROYED
+                } else {
+                    CLOSED_NOT_DESTROYED
+                },
+                Ordering::Release,
+            );
+        }
+    }
+}
+
 // ---- headless pump の注記 ----------------------------------------
 // pump は ClapHost::pump() として main thread で実行する — PluginInstance<OrbitClapHost>
 // は !Send なのでそのスレッド以外に移動できない。carry-forward #2: callback_requested
@@ -183,5 +294,48 @@ mod tests {
             mt.warned_rescan_unsupported,
             "再要求でも latch は true のまま"
         );
+    }
+
+    #[test]
+    fn gui_callbacks_are_marshaled_through_atomics_and_consumed_once() {
+        let shared = OrbitHostShared::with_gui_callbacks(Arc::new(AtomicBool::new(false)));
+        let requested = GuiSize {
+            width: 640,
+            height: 480,
+        };
+
+        HostGuiImpl::request_resize(&shared, requested).expect("accept resize callback");
+        assert_eq!(
+            shared.take_requested_size(),
+            Some(UiSize {
+                width: 640,
+                height: 480
+            })
+        );
+        assert_eq!(shared.take_requested_size(), None);
+
+        HostGuiImpl::closed(&shared, false);
+        assert_eq!(shared.take_closed(), Some(false));
+        assert_eq!(shared.take_closed(), None);
+        HostGuiImpl::closed(&shared, true);
+        assert_eq!(shared.take_closed(), Some(true));
+        assert_eq!(shared.take_closed(), None);
+    }
+
+    #[test]
+    fn daemon_shared_state_keeps_gui_callbacks_disabled() {
+        let shared = OrbitHostShared::new(Arc::new(AtomicBool::new(false)));
+
+        assert!(shared.gui_callbacks.is_none());
+        assert_eq!(shared.take_closed(), None);
+        assert_eq!(shared.take_requested_size(), None);
+        assert!(HostGuiImpl::request_resize(
+            &shared,
+            GuiSize {
+                width: 640,
+                height: 480
+            }
+        )
+        .is_err());
     }
 }

--- a/rust/crates/orbit-clap-host/src/host.rs
+++ b/rust/crates/orbit-clap-host/src/host.rs
@@ -214,9 +214,31 @@ impl HostParamsImplShared for OrbitHostShared {
 }
 
 impl HostGuiImpl for OrbitHostShared {
-    fn resize_hints_changed(&self) {
-        // P3b-1 は callback の保持まで。hints の再取得と NSWindow 操作は P3b-2。
-    }
+    /// Deliberately a no-op in v1 — **owner ruling 2026-07-31: not implemented, registered instead.**
+    ///
+    /// `clap_gui_resize_hints` (gui.h:92-103) carries `can_resize_horizontally` /
+    /// `can_resize_vertically` / `preserve_aspect_ratio` + the ratio, i.e. constraints on
+    /// **user-driven** window dragging. Ignoring them costs appearance only: the NSWindow follows
+    /// the drag while the plugin keeps its own ratio, so an aspect-locked editor gets letterboxed
+    /// or clipped. Audio, plugin state, and the close handshake are unaffected — which is why this
+    /// sits outside #474's acceptance ("open the plugin so a human can touch it").
+    ///
+    /// 🔴 **Do not write "implemented in <next phase>" here again.** The previous comment said
+    /// "P3b-2 で" and P3b-2 turned out to be the *second commit of the same PR*; nothing made its
+    /// author read this line, so the marker silently expired. A deferral is only honest if the
+    /// condition to delete it is written down:
+    ///
+    /// **This no-op may be deleted once all of the following hold:**
+    /// 1. `get_resize_hints` is called on the main thread (it is `[main-thread & !floating]`,
+    ///    so this callback — which is not — must only raise a flag that the tick consumes);
+    /// 2. the hints are applied to the window (`contentAspectRatio` when `preserve_aspect_ratio`,
+    ///    and a fixed extent for any axis whose `can_resize_*` is false);
+    /// 3. a gated test drives an **aspect-ratio-locked oracle**, drags the window off-ratio, and
+    ///    asserts the resulting frame stayed on-ratio — a mutation that skips step 2 must fail it.
+    ///
+    /// Ordering: independent of P4/P5 (no daemon, engine, or MCP surface), so it can land whenever
+    /// an aspect-locked oracle exists. VST3 has no counterpart, so this stays CLAP-only.
+    fn resize_hints_changed(&self) {}
 
     fn request_resize(&self, new_size: GuiSize) -> Result<(), HostError> {
         if new_size.width == 0

--- a/rust/crates/orbit-clap-host/src/host.rs
+++ b/rust/crates/orbit-clap-host/src/host.rs
@@ -318,6 +318,72 @@ mod tests {
         );
     }
 
+    /// 🔴 Rejects sizes a plugin must not be able to push through.
+    ///
+    /// `request_resize` is a plugin-driven callback, so the values are not ours. Nothing
+    /// downstream re-checks them: `take_requested_size` casts with `as i32`, so `width > i32::MAX`
+    /// arrives at `NSWindow` as a **negative** extent, and `0` passes straight through. Deleting
+    /// the guard used to leave all 27 lib tests green (measured 2026-07-31), because the existing
+    /// marshaling test only ever sends a valid 640x480.
+    ///
+    /// Each rejected call also asserts the slot stayed empty: a guard that returns `Err` *after*
+    /// storing would still corrupt the next tick.
+    #[test]
+    fn request_resize_rejects_sizes_the_window_cannot_hold() {
+        let shared = OrbitHostShared::with_gui_callbacks(Arc::new(AtomicBool::new(false)));
+
+        for (label, size) in [
+            (
+                "zero width",
+                GuiSize {
+                    width: 0,
+                    height: 480,
+                },
+            ),
+            (
+                "zero height",
+                GuiSize {
+                    width: 640,
+                    height: 0,
+                },
+            ),
+            (
+                "beyond i32",
+                GuiSize {
+                    width: u32::MAX,
+                    height: 480,
+                },
+            ),
+        ] {
+            assert!(
+                HostGuiImpl::request_resize(&shared, size).is_err(),
+                "{label} must be rejected"
+            );
+            assert_eq!(
+                shared.take_requested_size(),
+                None,
+                "{label} must not leave a pending resize behind"
+            );
+        }
+
+        // The guard must not reject everything: a usable size still gets through.
+        assert!(HostGuiImpl::request_resize(
+            &shared,
+            GuiSize {
+                width: 640,
+                height: 480
+            }
+        )
+        .is_ok());
+        assert_eq!(
+            shared.take_requested_size(),
+            Some(UiSize {
+                width: 640,
+                height: 480
+            })
+        );
+    }
+
     #[test]
     fn gui_callbacks_are_marshaled_through_atomics_and_consumed_once() {
         let shared = OrbitHostShared::with_gui_callbacks(Arc::new(AtomicBool::new(false)));

--- a/rust/crates/orbit-clap-host/src/instrument.rs
+++ b/rust/crates/orbit-clap-host/src/instrument.rs
@@ -238,6 +238,10 @@ impl Drop for ClapInstrumentAudio {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clack_extensions::gui::HostGuiImpl;
+    use std::path::PathBuf;
+
+    use crate::host::OrbitHostShared;
 
     /// audio 側が `Send` であることのコンパイル時証明（根拠は
     /// `effect.rs::tests::audio_half_is_send` と同一）。
@@ -250,5 +254,30 @@ mod tests {
     #[test]
     fn child_path_advertises_gui_callbacks() {
         assert!(child_host_callback_config().gui_callbacks_enabled());
+    }
+
+    #[test]
+    #[ignore = "needs prebuilt release clap-test-synth dylib"]
+    fn real_load_path_delivers_plugin_initiated_close_to_main_half() {
+        let dylib = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../.."))
+            .join("rust-spike/clap-test-synth/target/release/libclap_test_synth.dylib");
+        assert!(dylib.exists(), "missing {}", dylib.display());
+        let (processor, _) = ClapInstrumentProcessor::load(
+            &dylib,
+            Some("com.signalcompose.clap-test-synth"),
+            48_000,
+            2,
+            512,
+            None,
+        )
+        .expect("load test instrument through child callback configuration");
+        let (audio, main) = processor.split();
+
+        main.instance
+            .access_shared_handler(|shared: &OrbitHostShared| HostGuiImpl::closed(shared, false));
+
+        assert_eq!(main.take_closed(), Some(false));
+        drop(audio);
+        drop(main);
     }
 }

--- a/rust/crates/orbit-clap-host/src/instrument.rs
+++ b/rust/crates/orbit-clap-host/src/instrument.rs
@@ -35,17 +35,6 @@ use crate::host::OrbitClapHost;
 use crate::processor::process_block_core;
 use crate::ClapPluginMain;
 
-/// Child processes host a plugin UI, so they must advertise `HostGui`.
-///
-/// 🔴 **P3b-2 completion condition.** See the identical note on
-/// `crate::effect::child_host_callback_config`: the unit test pins this function's body,
-/// but nothing pins the call site to it, and `in_process` / `child` share a return type
-/// so the swap compiles. P3b-2's plugin-initiated-close test runs through the real `load`
-/// path and binds the call site.
-fn child_host_callback_config() -> HostCallbackConfig {
-    HostCallbackConfig::child()
-}
-
 /// 単一スレッドで load / process / drop する instrument CLAP プロセッサ。
 ///
 /// `!Send`（[`PluginInstance`] を含む）。生成したスレッド上でのみ使うこと。
@@ -118,7 +107,7 @@ impl ClapInstrumentProcessor {
             sample_rate,
             channels,
             max_frames,
-            child_host_callback_config(),
+            HostCallbackConfig::child(),
         )?;
 
         let mut processor = Self {
@@ -249,11 +238,6 @@ mod tests {
     fn audio_half_is_send() {
         fn assert_send<T: Send>() {}
         assert_send::<ClapInstrumentAudio>();
-    }
-
-    #[test]
-    fn child_path_advertises_gui_callbacks() {
-        assert!(child_host_callback_config().gui_callbacks_enabled());
     }
 
     #[test]

--- a/rust/crates/orbit-clap-host/src/instrument.rs
+++ b/rust/crates/orbit-clap-host/src/instrument.rs
@@ -21,20 +21,30 @@
 //! ⚠️ clack を bump する際は上記2つの Drop site（`plugin.rs:399` の sole-owner guard /
 //! `plugin/instance.rs:232` の teardown）の契約を再確認すること（この宣言順の正当性は library 内部実装に依存する）。
 
-use std::path::Path;
-use std::sync::atomic::{AtomicBool, AtomicU64};
-use std::sync::Arc;
-
 use clack_host::events::io::EventBuffer;
 use clack_host::events::UnknownEvent;
 use clack_host::prelude::{PluginInstance, StartedPluginAudioProcessor};
 use orbit_audio_sandbox::NeutralEvent;
+use std::path::Path;
 
 use crate::buffers::HostAudioBuffers;
-use crate::controller::{instantiate_activate, ClapHostError, LoadedPluginInfo};
+use crate::controller::{
+    instantiate_activate, ClapHostError, HostCallbackConfig, LoadedPluginInfo,
+};
 use crate::host::OrbitClapHost;
 use crate::processor::process_block_core;
 use crate::ClapPluginMain;
+
+/// Child processes host a plugin UI, so they must advertise `HostGui`.
+///
+/// 🔴 **P3b-2 completion condition.** See the identical note on
+/// `crate::effect::child_host_callback_config`: the unit test pins this function's body,
+/// but nothing pins the call site to it, and `in_process` / `child` share a return type
+/// so the swap compiles. P3b-2's plugin-initiated-close test runs through the real `load`
+/// path and binds the call site.
+fn child_host_callback_config() -> HostCallbackConfig {
+    HostCallbackConfig::child()
+}
 
 /// 単一スレッドで load / process / drop する instrument CLAP プロセッサ。
 ///
@@ -108,8 +118,7 @@ impl ClapInstrumentProcessor {
             sample_rate,
             channels,
             max_frames,
-            Arc::new(AtomicBool::new(false)),
-            Arc::new(AtomicU64::new(0)),
+            child_host_callback_config(),
         )?;
 
         let mut processor = Self {
@@ -179,6 +188,9 @@ impl ClapInstrumentProcessor {
             },
             ClapPluginMain {
                 instance: _instance,
+                plugin_gui: None,
+                gui_attached: false,
+                gui_can_resize: false,
             },
         )
     }
@@ -233,5 +245,10 @@ mod tests {
     fn audio_half_is_send() {
         fn assert_send<T: Send>() {}
         assert_send::<ClapInstrumentAudio>();
+    }
+
+    #[test]
+    fn child_path_advertises_gui_callbacks() {
+        assert!(child_host_callback_config().gui_callbacks_enabled());
     }
 }

--- a/rust/crates/orbit-clap-host/src/lib.rs
+++ b/rust/crates/orbit-clap-host/src/lib.rs
@@ -18,6 +18,7 @@ mod controller;
 mod discovery;
 mod effect;
 mod events;
+mod gui;
 mod host;
 mod instrument;
 mod plugin_main;

--- a/rust/crates/orbit-clap-host/src/plugin_main.rs
+++ b/rust/crates/orbit-clap-host/src/plugin_main.rs
@@ -1,7 +1,9 @@
+use clack_extensions::gui::PluginGui;
 use clack_host::prelude::PluginInstance;
+use orbit_child_ui::UiSize;
 
 use crate::controller::ClapHostError;
-use crate::host::OrbitClapHost;
+use crate::host::{OrbitClapHost, OrbitHostShared};
 
 /// Main（home）スレッド側を CLAP effect / instrument で共有する。
 ///
@@ -10,6 +12,9 @@ use crate::host::OrbitClapHost;
 /// 走らせる。
 pub struct ClapPluginMain {
     pub(crate) instance: PluginInstance<OrbitClapHost>,
+    pub(crate) plugin_gui: Option<PluginGui>,
+    pub(crate) gui_attached: bool,
+    pub(crate) gui_can_resize: bool,
 }
 
 impl ClapPluginMain {
@@ -21,5 +26,17 @@ impl ClapPluginMain {
     /// 保存済み state を適用する（契約は [`crate::state::apply_state_bytes`]）。
     pub fn apply_state_bytes(&mut self, bytes: &[u8]) -> Result<(), ClapHostError> {
         crate::state::apply_state_bytes(&mut self.instance, bytes)
+    }
+
+    /// Consume the most recent thread-safe CLAP `closed(was_destroyed)` callback.
+    pub fn take_closed(&self) -> Option<bool> {
+        self.instance
+            .access_shared_handler(OrbitHostShared::take_closed)
+    }
+
+    /// Consume the most recent thread-safe CLAP `request_resize` callback.
+    pub fn take_requested_size(&self) -> Option<UiSize> {
+        self.instance
+            .access_shared_handler(OrbitHostShared::take_requested_size)
     }
 }

--- a/rust/crates/orbit-clap-host/tests/ui_endpoint_gated.rs
+++ b/rust/crates/orbit-clap-host/tests/ui_endpoint_gated.rs
@@ -1,0 +1,228 @@
+//! #474 P3b-1: real-dylib CLAP GUI endpoint verification.
+//!
+//! Prebuild both test plugins:
+//!   cargo build --manifest-path rust-spike/clap-test-effect/Cargo.toml --release
+//!   cargo build --manifest-path rust-spike/clap-test-synth/Cargo.toml --release
+//! Run:
+//!   cd rust
+//!   cargo test -p orbit-clap-host --test ui_endpoint_gated -- --ignored --nocapture
+
+#![cfg(target_os = "macos")]
+
+use std::ffi::c_void;
+use std::path::PathBuf;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use orbit_child_ui::{PluginUiEndpoint, UiSize};
+use orbit_clap_host::{ClapEffectAudio, ClapEffectProcessor, ClapPluginMain};
+
+const EFFECT_PLUGIN_ID: &str = "com.signalcompose.clap-test-effect";
+const SYNTH_PLUGIN_ID: &str = "com.signalcompose.clap-test-synth";
+const INITIAL_SIZE: UiSize = UiSize {
+    width: 400,
+    height: 300,
+};
+
+fn dummy_parent() -> *mut c_void {
+    std::ptr::dangling_mut::<c_void>()
+}
+
+fn repo_path(rel: &str) -> PathBuf {
+    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../..")).join(rel)
+}
+
+fn effect_dylib() -> PathBuf {
+    repo_path("rust-spike/clap-test-effect/target/release/libclap_test_effect.dylib")
+}
+
+fn synth_dylib() -> PathBuf {
+    repo_path("rust-spike/clap-test-synth/target/release/libclap_test_synth.dylib")
+}
+
+fn scenario_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+struct TraceFile {
+    path: PathBuf,
+}
+
+impl TraceFile {
+    fn new() -> Self {
+        static NEXT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let id = NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "orbit-clap-gui-trace-{}-{id}.txt",
+            std::process::id()
+        ));
+        std::fs::write(&path, []).expect("create empty CLAP GUI trace");
+        std::env::set_var("ORBIT_CLAP_GUI_TRACE", &path);
+        std::env::remove_var("ORBIT_CLAP_GUI_FLOATING_ONLY");
+        Self { path }
+    }
+
+    fn clear(&self) {
+        std::fs::write(&self.path, []).expect("clear CLAP GUI trace");
+    }
+
+    fn read(&self) -> Vec<String> {
+        std::fs::read_to_string(&self.path)
+            .expect("read CLAP GUI trace")
+            .lines()
+            .map(str::to_owned)
+            .collect()
+    }
+}
+
+impl Drop for TraceFile {
+    fn drop(&mut self) {
+        std::env::remove_var("ORBIT_CLAP_GUI_TRACE");
+        std::env::remove_var("ORBIT_CLAP_GUI_FLOATING_ONLY");
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn load_effect_endpoint() -> (ClapEffectAudio, ClapPluginMain) {
+    let dylib = effect_dylib();
+    assert!(
+        dylib.exists(),
+        "test-effect dylib is missing: {}",
+        dylib.display()
+    );
+    ClapEffectProcessor::load(&dylib, Some(EFFECT_PLUGIN_ID), 48_000, 2, 512, None)
+        .expect("load CLAP test effect")
+        .0
+        .split()
+}
+
+#[test]
+#[ignore = "needs prebuilt release test-effect dylib (local only)"]
+fn open_calls_the_complete_required_clap_sequence_without_set_scale() {
+    let _scenario = scenario_lock();
+    let trace = TraceFile::new();
+    let (audio, mut main) = load_effect_endpoint();
+
+    assert_eq!(main.begin_open(), Ok(INITIAL_SIZE));
+    assert!(main.can_resize());
+    main.attach(dummy_parent()).expect("attach CLAP test GUI");
+
+    let calls = trace.read();
+    assert_eq!(
+        calls,
+        [
+            "is_api_supported",
+            "create",
+            "can_resize",
+            "get_size",
+            "set_parent",
+            "show",
+        ],
+        "the complete CLAP open trace must retain its exact order"
+    );
+    assert!(
+        !calls.iter().any(|call| call == "set_scale"),
+        "cocoa must never receive set_scale"
+    );
+
+    main.release(false);
+    drop(audio);
+    drop(main);
+}
+
+#[test]
+#[ignore = "needs prebuilt release test-effect dylib (local only)"]
+fn close_distinguishes_host_owned_and_already_destroyed_gui() {
+    let _scenario = scenario_lock();
+    let trace = TraceFile::new();
+
+    let (audio, mut main) = load_effect_endpoint();
+    main.begin_open().expect("open CLAP test GUI");
+    main.attach(dummy_parent()).expect("attach CLAP test GUI");
+    trace.clear();
+    main.release(false);
+    assert_eq!(
+        trace.read(),
+        ["hide", "destroy"],
+        "host-owned close must hide before destroy"
+    );
+    drop(audio);
+    drop(main);
+
+    trace.clear();
+    let (audio, mut main) = load_effect_endpoint();
+    main.begin_open().expect("open CLAP test GUI");
+    main.attach(dummy_parent()).expect("attach CLAP test GUI");
+    trace.clear();
+    main.release(true);
+    assert_eq!(
+        trace.read(),
+        ["destroy"],
+        "already-destroyed close must acknowledge with destroy only"
+    );
+    drop(audio);
+    drop(main);
+}
+
+#[test]
+#[ignore = "needs prebuilt release test-effect dylib (local only)"]
+fn floating_only_gui_fails_without_fallback() {
+    let _scenario = scenario_lock();
+    let trace = TraceFile::new();
+    std::env::set_var("ORBIT_CLAP_GUI_FLOATING_ONLY", "1");
+    let (audio, mut main) = load_effect_endpoint();
+
+    let detail = main
+        .begin_open()
+        .expect_err("floating-only GUI must fail loudly");
+    assert!(
+        detail.contains("embedded cocoa")
+            && detail.contains("unsupported")
+            && detail.contains("floating fallback"),
+        "failure detail must explain the forbidden fallback: {detail}"
+    );
+    assert_eq!(
+        trace.read(),
+        ["is_api_supported"],
+        "embedded rejection must not retry with floating configuration"
+    );
+
+    drop(audio);
+    drop(main);
+}
+
+#[test]
+#[ignore = "needs prebuilt release test-synth dylib (local only)"]
+fn plugin_without_gui_extension_fails_loudly_with_detail() {
+    let _scenario = scenario_lock();
+    let trace = TraceFile::new();
+    let dylib = synth_dylib();
+    assert!(
+        dylib.exists(),
+        "test-synth dylib is missing: {}",
+        dylib.display()
+    );
+    let (audio, mut main) =
+        ClapEffectProcessor::load(&dylib, Some(SYNTH_PLUGIN_ID), 48_000, 2, 512, None)
+            .expect("load CLAP test synth")
+            .0
+            .split();
+
+    let detail = main
+        .begin_open()
+        .expect_err("plugin without GUI extension must fail loudly");
+    assert!(
+        detail.contains("CLAP GUI extension") && detail.contains("no"),
+        "failure detail must identify the absent GUI extension: {detail}"
+    );
+    assert_eq!(
+        trace.read(),
+        Vec::<String>::new(),
+        "plugin without GUI extension must not make GUI calls"
+    );
+
+    drop(audio);
+    drop(main);
+}

--- a/rust/crates/orbit-clap-instrument-child/src/main.rs
+++ b/rust/crates/orbit-clap-instrument-child/src/main.rs
@@ -6,13 +6,13 @@ use std::path::PathBuf;
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 use anyhow::{bail, Context, Result};
-use orbit_audio_sandbox::transport::{save_state_command, service_command_mailbox, CMD_SAVE_STATE};
 use orbit_audio_sandbox::{
     open_shared, region_ptr, slot_index, slot_offset, EventRecord, EventSpillFifo, NeutralEvent,
-    ParentWatch, SharedRegion, BUF_LEN, CHANNELS, CMD_CLOSE_UI, CMD_OPEN_UI, CONTROL_QUIT,
-    MAX_EVENTS_PER_BLOCK, MAX_FRAMES,
+    ParentWatch, SharedRegion, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_EVENTS_PER_BLOCK, MAX_FRAMES,
 };
-use orbit_child_runtime::{child_should_quit, run_child, UiCallbacks, UiService};
+use orbit_child_runtime::{
+    child_should_quit, run_child, service_child_main, UiCallbacks, UiService,
+};
 use orbit_clap_host::{push_neutral_event, ClapInstrumentProcessor, EventBuffer};
 
 struct Args {
@@ -212,19 +212,8 @@ fn main() -> Result<()> {
     let process_errors = run_child(
         "orbit-clap-instrument-child",
         || unsafe { child_should_quit(region, &parent_watch) },
-        || {
-            // Mailbox servicing is confined to the AppKit main runloop.
-            unsafe {
-                service_command_mailbox(region, |kind, arg| match kind {
-                    CMD_SAVE_STATE => Some(save_state_command(arg, || {
-                        main.with_mut(|main| main.capture_state())
-                    })),
-                    CMD_OPEN_UI | CMD_CLOSE_UI => Some(ui.handle_command(kind, arg)),
-                    _ => None,
-                });
-            }
-            ui.tick(ui.now());
-            false
+        || unsafe {
+            service_child_main(region, &ui, || main.with_mut(|main| main.capture_state()))
         },
         move |stop_audio| {
             let region = region_addr as *mut SharedRegion;

--- a/rust/crates/orbit-clap-instrument-child/src/main.rs
+++ b/rust/crates/orbit-clap-instrument-child/src/main.rs
@@ -89,8 +89,8 @@ fn decode_slot_events(records: &[EventRecord], count: u32, sink: &mut Vec<Neutra
 
 /// Outcome of [`write_output_events`]: how many records landed in `window`, plus the health
 /// counter deltas the caller adds to `SharedRegion` after the closure returns.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[cfg(target_os = "macos")]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct OutputWriteOutcome {
     written: usize,
     spilled: u64,
@@ -337,7 +337,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::*;
     use orbit_audio_sandbox::{

--- a/rust/crates/orbit-clap-instrument-child/src/main.rs
+++ b/rust/crates/orbit-clap-instrument-child/src/main.rs
@@ -2,19 +2,26 @@
 
 #![allow(unsafe_code)]
 
+#[cfg(target_os = "macos")]
 use std::path::PathBuf;
+#[cfg(target_os = "macos")]
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
+#[cfg(target_os = "macos")]
 use anyhow::{bail, Context, Result};
+#[cfg(target_os = "macos")]
 use orbit_audio_sandbox::{
     open_shared, region_ptr, slot_index, slot_offset, EventRecord, EventSpillFifo, NeutralEvent,
     ParentWatch, SharedRegion, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_EVENTS_PER_BLOCK, MAX_FRAMES,
 };
+#[cfg(target_os = "macos")]
 use orbit_child_runtime::{
     child_should_quit, run_child, service_child_main, UiCallbacks, UiService,
 };
+#[cfg(target_os = "macos")]
 use orbit_clap_host::{push_neutral_event, ClapInstrumentProcessor, EventBuffer};
 
+#[cfg(target_os = "macos")]
 struct Args {
     shm: PathBuf,
     plugin: PathBuf,
@@ -24,6 +31,7 @@ struct Args {
     state: Option<PathBuf>,
 }
 
+#[cfg(target_os = "macos")]
 fn parse_args() -> Result<Args> {
     let mut shm = None;
     let mut plugin = None;
@@ -57,10 +65,12 @@ fn parse_args() -> Result<Args> {
     })
 }
 
+#[cfg(target_os = "macos")]
 fn in_order_seqs(last: u64, cur: u64) -> impl Iterator<Item = u64> {
     last.saturating_add(1)..=cur
 }
 
+#[cfg(target_os = "macos")]
 fn decode_slot_events(records: &[EventRecord], count: u32, sink: &mut Vec<NeutralEvent>) -> u32 {
     sink.clear();
     let count = (count as usize)
@@ -80,6 +90,7 @@ fn decode_slot_events(records: &[EventRecord], count: u32, sink: &mut Vec<Neutra
 /// Outcome of [`write_output_events`]: how many records landed in `window`, plus the health
 /// counter deltas the caller adds to `SharedRegion` after the closure returns.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[cfg(target_os = "macos")]
 struct OutputWriteOutcome {
     written: usize,
     spilled: u64,
@@ -95,6 +106,7 @@ struct OutputWriteOutcome {
 /// Pure and CLAP-independent (operates on `NeutralEvent`/`EventRecord` only), so it is directly
 /// unit-testable without a live plugin -- extracted from `main()`'s per-slot `write_slot` closure
 /// for exactly that reason (see `tests::output_window_and_spill_overflow_drops_and_tracks_note_end`).
+#[cfg(target_os = "macos")]
 fn write_output_events(
     window: &mut [EventRecord],
     output_spill: &mut EventSpillFifo,
@@ -176,6 +188,7 @@ unsafe fn publish_completed_slot(
     after_sequence_publish();
 }
 
+#[cfg(target_os = "macos")]
 fn main() -> Result<()> {
     let args = parse_args()?;
     let mmap = open_shared(&args.shm).with_context(|| format!("open_shared({:?})", args.shm))?;
@@ -590,4 +603,10 @@ mod tests {
             std::alloc::dealloc(region.cast(), layout);
         }
     }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() -> std::process::ExitCode {
+    eprintln!("orbit-clap-instrument-child is macOS-only (plugin UI hosting needs AppKit)");
+    std::process::ExitCode::FAILURE
 }

--- a/rust/crates/orbit-clap-instrument-child/src/main.rs
+++ b/rust/crates/orbit-clap-instrument-child/src/main.rs
@@ -143,6 +143,7 @@ fn write_output_events(
 /// pass every CI-runnable test, since the only prior coverage exercised `write_output_events`'s
 /// returned struct in isolation, never the region counters it gets mirrored into (pr-test-analyzer,
 /// PR #422 round 2 item 2). Caller must ensure `region` is valid and `idx` is in range.
+#[cfg(target_os = "macos")]
 unsafe fn apply_output_write_outcome(
     region: *mut SharedRegion,
     idx: usize,
@@ -173,6 +174,7 @@ unsafe fn apply_output_write_outcome(
 /// `write_slot` must write audio, `output_events`, and `output_event_count`. Their writes must stay
 /// before both sequence stores: the host uses `seq_tag`'s Acquire load as the publication edge for
 /// all slot payload and then revalidates the tag after reading it.
+#[cfg(target_os = "macos")]
 unsafe fn publish_completed_slot(
     region: *mut SharedRegion,
     seq: u64,

--- a/rust/crates/orbit-clap-instrument-child/src/main.rs
+++ b/rust/crates/orbit-clap-instrument-child/src/main.rs
@@ -9,9 +9,10 @@ use anyhow::{bail, Context, Result};
 use orbit_audio_sandbox::transport::{save_state_command, service_command_mailbox, CMD_SAVE_STATE};
 use orbit_audio_sandbox::{
     open_shared, region_ptr, slot_index, slot_offset, EventRecord, EventSpillFifo, NeutralEvent,
-    ParentWatch, SharedRegion, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_EVENTS_PER_BLOCK, MAX_FRAMES,
+    ParentWatch, SharedRegion, BUF_LEN, CHANNELS, CMD_CLOSE_UI, CMD_OPEN_UI, CONTROL_QUIT,
+    MAX_EVENTS_PER_BLOCK, MAX_FRAMES,
 };
-use orbit_child_runtime::run_child;
+use orbit_child_runtime::{child_should_quit, run_child, UiCallbacks, UiService};
 use orbit_clap_host::{push_neutral_event, ClapInstrumentProcessor, EventBuffer};
 
 struct Args {
@@ -199,28 +200,30 @@ fn main() -> Result<()> {
     unsafe {
         orbit_audio_sandbox::transport::publish_child_ready(region, instrument.has_audio_input());
     }
-    let (mut instrument_audio, mut instrument_main) = instrument.split();
+    let (mut instrument_audio, instrument_main) = instrument.split();
+    let (ui, main) = UiService::new(region, instrument_main, |main| UiCallbacks {
+        closed: main.take_closed(),
+        requested_size: main.take_requested_size(),
+    });
     // orphan 対策(#448): host(daemon)が CONTROL_QUIT を書かずに死ぬ経路(プロセス exit・
     // SIGKILL・crash)でも main runloop を止められるよう、親死活をタイマーで監視する。
-    let mut parent_watch = ParentWatch::new();
+    let parent_watch = ParentWatch::new();
     let region_addr = region as usize;
     let process_errors = run_child(
         "orbit-clap-instrument-child",
-        || unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT,
+        || unsafe { child_should_quit(region, &parent_watch) },
         || {
             // Mailbox servicing is confined to the AppKit main runloop.
             unsafe {
                 service_command_mailbox(region, |kind, arg| match kind {
-                    CMD_SAVE_STATE => {
-                        Some(save_state_command(arg, || instrument_main.capture_state()))
-                    }
+                    CMD_SAVE_STATE => Some(save_state_command(arg, || {
+                        main.with_mut(|main| main.capture_state())
+                    })),
+                    CMD_OPEN_UI | CMD_CLOSE_UI => Some(ui.handle_command(kind, arg)),
                     _ => None,
                 });
             }
-            if parent_watch.should_exit() {
-                eprintln!("[orbit-clap-instrument-child] 親プロセス死亡を検知、終了する");
-                return true;
-            }
+            ui.tick(ui.now());
             false
         },
         move |stop_audio| {

--- a/rust/crates/orbit-vst3-effect-child/src/main.rs
+++ b/rust/crates/orbit-vst3-effect-child/src/main.rs
@@ -22,12 +22,13 @@ use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 use anyhow::{bail, Context, Result};
 #[cfg(target_os = "macos")]
 use orbit_audio_sandbox::{
-    open_shared, region_ptr, save_state_command, service_command_mailbox, slot_index, slot_offset,
-    ParentWatch, BUF_LEN, CHANNELS, CMD_CLOSE_UI, CMD_OPEN_UI, CMD_SAVE_STATE, CONTROL_QUIT,
+    open_shared, region_ptr, slot_index, slot_offset, ParentWatch, BUF_LEN, CHANNELS, CONTROL_QUIT,
     MAX_FRAMES,
 };
 #[cfg(target_os = "macos")]
-use orbit_child_runtime::{child_should_quit, run_child, UiCallbacks, UiService};
+use orbit_child_runtime::{
+    child_should_quit, run_child, service_child_main, UiCallbacks, UiService,
+};
 #[cfg(target_os = "macos")]
 use orbit_vst3_host::Vst3EffectProcessor;
 
@@ -117,18 +118,8 @@ fn main() -> Result<()> {
     let process_errors = run_child(
         "orbit-vst3-effect-child",
         || unsafe { child_should_quit(region, &parent_watch) },
-        || {
-            unsafe {
-                service_command_mailbox(region, |kind, arg| match kind {
-                    CMD_SAVE_STATE => Some(save_state_command(arg, || {
-                        main.with_mut(|main| main.capture_state())
-                    })),
-                    CMD_OPEN_UI | CMD_CLOSE_UI => Some(ui.handle_command(kind, arg)),
-                    _ => None,
-                });
-            }
-            ui.tick(ui.now());
-            false
+        || unsafe {
+            service_child_main(region, &ui, || main.with_mut(|main| main.capture_state()))
         },
         move |stop_audio| {
             let region = region_addr as *mut orbit_audio_sandbox::SharedRegion;

--- a/rust/crates/orbit-vst3-effect-child/src/main.rs
+++ b/rust/crates/orbit-vst3-effect-child/src/main.rs
@@ -23,10 +23,11 @@ use anyhow::{bail, Context, Result};
 #[cfg(target_os = "macos")]
 use orbit_audio_sandbox::{
     open_shared, region_ptr, save_state_command, service_command_mailbox, slot_index, slot_offset,
-    ParentWatch, BUF_LEN, CHANNELS, CMD_SAVE_STATE, CONTROL_QUIT, MAX_FRAMES,
+    ParentWatch, BUF_LEN, CHANNELS, CMD_CLOSE_UI, CMD_OPEN_UI, CMD_SAVE_STATE, CONTROL_QUIT,
+    MAX_FRAMES,
 };
 #[cfg(target_os = "macos")]
-use orbit_child_runtime::run_child;
+use orbit_child_runtime::{child_should_quit, run_child, UiCallbacks, UiService};
 #[cfg(target_os = "macos")]
 use orbit_vst3_host::Vst3EffectProcessor;
 
@@ -104,25 +105,29 @@ fn main() -> Result<()> {
         orbit_audio_sandbox::transport::publish_child_ready(region, info.audio_inputs > 0);
     }
     let (mut effect_audio, effect_main) = effect.split();
+    let (ui, main) = UiService::new(region, effect_main, |main| UiCallbacks {
+        closed: None,
+        requested_size: main.take_requested_size(),
+    });
 
     // orphan 対策(#448): host(daemon)が CONTROL_QUIT を書かずに死ぬ経路(プロセス exit・
     // SIGKILL・crash)でも main runloop を止められるよう、親死活をタイマーで監視する。
-    let mut parent_watch = ParentWatch::new();
+    let parent_watch = ParentWatch::new();
     let region_addr = region as usize;
     let process_errors = run_child(
         "orbit-vst3-effect-child",
-        || unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT,
+        || unsafe { child_should_quit(region, &parent_watch) },
         || {
             unsafe {
                 service_command_mailbox(region, |kind, arg| match kind {
-                    CMD_SAVE_STATE => Some(save_state_command(arg, || effect_main.capture_state())),
+                    CMD_SAVE_STATE => Some(save_state_command(arg, || {
+                        main.with_mut(|main| main.capture_state())
+                    })),
+                    CMD_OPEN_UI | CMD_CLOSE_UI => Some(ui.handle_command(kind, arg)),
                     _ => None,
                 });
             }
-            if parent_watch.should_exit() {
-                eprintln!("[orbit-vst3-effect-child] 親プロセス死亡を検知、終了する");
-                return true;
-            }
+            ui.tick(ui.now());
             false
         },
         move |stop_audio| {

--- a/rust/crates/orbit-vst3-host/Cargo.toml
+++ b/rust/crates/orbit-vst3-host/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 
 [dependencies]
 vst3 = "0.3"
+orbit-child-ui = { path = "../orbit-child-ui" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation-sys = "0.8"

--- a/rust/crates/orbit-vst3-host/src/lib.rs
+++ b/rust/crates/orbit-vst3-host/src/lib.rs
@@ -11,6 +11,8 @@
 
 #![cfg(target_os = "macos")]
 
+mod view;
+
 use std::cell::{Cell, RefCell};
 use std::error::Error;
 use std::ffi::{c_void, CString};
@@ -30,6 +32,8 @@ use core_foundation_sys::url::{kCFURLPOSIXPathStyle, CFURLCreateWithFileSystemPa
 use vst3::Steinberg::Vst::*;
 use vst3::Steinberg::*;
 use vst3::{Class, ComPtr, ComWrapper};
+
+pub use view::Vst3UiEndpoint;
 
 const AUDIO_MODULE_CLASS: &str = "Audio Module Class";
 const DEFAULT_CHANNELS: usize = 2;
@@ -431,6 +435,7 @@ impl Drop for CfUrl {
 /// `_library`, so any COM callback objects backed by the plugin's vtables are released before
 /// the dynamic library is unloaded.
 pub struct Vst3PluginMain {
+    ui_endpoint: Vst3UiEndpoint,
     controller: Option<ComPtr<IEditController>>,
     component_connection: Option<ComPtr<IConnectionPoint>>,
     controller_connection: Option<ComPtr<IConnectionPoint>>,
@@ -444,6 +449,11 @@ pub struct Vst3PluginMain {
 }
 
 impl Vst3PluginMain {
+    /// Format-specific endpoint used by the AppKit-owning layer.
+    pub fn ui_endpoint(&mut self) -> &mut Vst3UiEndpoint {
+        &mut self.ui_endpoint
+    }
+
     /// 現在の component state を取得する（空 state 拒否の規律込み）。
     ///
     /// **スレッド**: home（main）スレッドから呼ぶこと（CAP.5・VST3 の規約）。
@@ -462,6 +472,11 @@ impl Vst3PluginMain {
 
 impl Drop for Vst3PluginMain {
     fn drop(&mut self) {
+        // UIH.4: the editor view must be removed and released before controller termination.
+        // Do not rely on field declaration order for this lifetime constraint.
+        self.ui_endpoint.release_view();
+        self.ui_endpoint.release_controller();
+
         if let (Some(component_connection), Some(controller_connection)) = (
             self.component_connection.as_ref(),
             self.controller_connection.as_ref(),
@@ -657,6 +672,7 @@ impl Vst3EffectProcessor {
         };
 
         let scratch_len = max_samples_per_block.max(0) as usize;
+        let ui_endpoint = Vst3UiEndpoint::new(controller_handshake.controller.as_ref().cloned());
         let processor = Self {
             audio: Some(Vst3EffectAudio {
                 processor,
@@ -673,6 +689,7 @@ impl Vst3EffectProcessor {
                 process_output_r: vec![0.0; scratch_len],
             }),
             main: Some(Vst3PluginMain {
+                ui_endpoint,
                 controller: controller_handshake.controller,
                 component_connection: controller_handshake.component_connection,
                 controller_connection: controller_handshake.controller_connection,
@@ -1176,6 +1193,7 @@ impl Vst3InstrumentProcessor {
             is_effect: false,
         };
         let scratch_len = max_samples_per_block.max(0) as usize;
+        let ui_endpoint = Vst3UiEndpoint::new(controller_handshake.controller.as_ref().cloned());
         Ok((
             Self {
                 audio: Some(Vst3InstrumentAudio {
@@ -1188,6 +1206,7 @@ impl Vst3InstrumentProcessor {
                     last_process_error: std::cell::Cell::new(0),
                 }),
                 main: Some(Vst3PluginMain {
+                    ui_endpoint,
                     controller: controller_handshake.controller,
                     component_connection: controller_handshake.component_connection,
                     controller_connection: controller_handshake.controller_connection,

--- a/rust/crates/orbit-vst3-host/src/view.rs
+++ b/rust/crates/orbit-vst3-host/src/view.rs
@@ -272,6 +272,13 @@ impl PluginUiEndpoint for Vst3PluginMain {
     }
 }
 
+impl Vst3PluginMain {
+    /// Consume the most recent plugin-originated `IPlugFrame::resizeView` request.
+    pub fn take_requested_size(&self) -> Option<UiSize> {
+        self.ui_endpoint.take_requested_size()
+    }
+}
+
 fn ui_size(rect: ViewRect) -> Result<UiSize, String> {
     let width = rect
         .right

--- a/rust/crates/orbit-vst3-host/src/view.rs
+++ b/rust/crates/orbit-vst3-host/src/view.rs
@@ -1,0 +1,292 @@
+//! VST3 editor-view endpoint. This module intentionally has no AppKit surface.
+
+use std::cell::Cell;
+use std::ffi::c_void;
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+use std::rc::Rc;
+
+use orbit_child_ui::{PluginUiEndpoint, UiSize};
+use vst3::Steinberg::Vst::{IEditController, IEditControllerTrait, ViewType};
+use vst3::Steinberg::{
+    kInvalidArgument, kPlatformTypeNSView, tresult, IPlugFrame, IPlugFrameTrait, IPlugView,
+    IPlugViewTrait, ViewRect,
+};
+use vst3::{Class, ComPtr, ComRef, ComWrapper};
+
+use crate::Vst3PluginMain;
+
+#[derive(Default)]
+struct PlugFrameState {
+    requested_size: Cell<Option<UiSize>>,
+}
+
+struct HostPlugFrame {
+    state: Rc<PlugFrameState>,
+}
+
+impl Class for HostPlugFrame {
+    type Interfaces = (IPlugFrame,);
+}
+
+impl IPlugFrameTrait for HostPlugFrame {
+    unsafe fn resizeView(&self, view: *mut IPlugView, new_size: *mut ViewRect) -> tresult {
+        let Some(view) = ComRef::from_raw(view) else {
+            return kInvalidArgument;
+        };
+        if new_size.is_null() {
+            return kInvalidArgument;
+        }
+        let Ok(size) = ui_size(*new_size) else {
+            return kInvalidArgument;
+        };
+
+        // UIH.4b: record the host-side resize and call onSize before returning to the plugin.
+        self.state.requested_size.set(Some(size));
+        view.onSize(new_size)
+    }
+}
+
+/// VST3 implementation of the format-independent plugin UI endpoint.
+///
+/// It owns an extra controller reference so the editor can never outlive the controller object.
+/// [`Vst3PluginMain`] additionally releases this endpoint at the very start of its `Drop`, before
+/// it calls `IEditController::terminate`.
+pub struct Vst3UiEndpoint {
+    controller: Option<ComPtr<IEditController>>,
+    view: Option<ComPtr<IPlugView>>,
+    frame: Option<ComWrapper<HostPlugFrame>>,
+    frame_state: Rc<PlugFrameState>,
+    attached: bool,
+    can_resize: bool,
+    _home_thread: PhantomData<Rc<()>>,
+}
+
+impl Vst3UiEndpoint {
+    pub(crate) fn new(controller: Option<ComPtr<IEditController>>) -> Self {
+        Self {
+            controller,
+            view: None,
+            frame: None,
+            frame_state: Rc::new(PlugFrameState::default()),
+            attached: false,
+            can_resize: false,
+            _home_thread: PhantomData,
+        }
+    }
+
+    /// Construct an endpoint around an initialized edit controller.
+    ///
+    /// This is useful when a host already owns the controller independently of
+    /// [`Vst3PluginMain`], including COM-level integration tests.
+    pub fn from_controller(controller: ComPtr<IEditController>) -> Self {
+        Self::new(Some(controller))
+    }
+
+    /// Most recent plugin-originated `IPlugFrame::resizeView` request.
+    pub fn requested_size(&self) -> Option<UiSize> {
+        self.frame_state.requested_size.get()
+    }
+
+    /// Take the most recent plugin-originated resize request.
+    pub fn take_requested_size(&self) -> Option<UiSize> {
+        self.frame_state.requested_size.take()
+    }
+
+    pub(crate) fn release_view(&mut self) {
+        if self.attached {
+            if let Some(view) = self.view.as_ref() {
+                unsafe {
+                    let _ = view.removed();
+                }
+            }
+        }
+        self.attached = false;
+        self.can_resize = false;
+
+        // Keep this explicit: the view must be released before the frame and controller.
+        let _ = self.view.take();
+        let _ = self.frame.take();
+        self.frame_state.requested_size.set(None);
+    }
+
+    pub(crate) fn release_controller(&mut self) {
+        debug_assert!(self.view.is_none());
+        let _ = self.controller.take();
+    }
+
+    fn view(&self, operation: &str) -> Result<&ComPtr<IPlugView>, String> {
+        self.view
+            .as_ref()
+            .ok_or_else(|| format!("VST3 UI {operation} failed: editor view is not open"))
+    }
+}
+
+impl PluginUiEndpoint for Vst3UiEndpoint {
+    fn begin_open(&mut self) -> Result<UiSize, String> {
+        if self.view.is_some() {
+            return Err("VST3 UI open failed: editor view is already open".into());
+        }
+        let controller = self
+            .controller
+            .as_ref()
+            .ok_or_else(|| "VST3 UI open failed: edit controller is unavailable".to_owned())?;
+
+        // UIH.4 fixes this exact order. In particular, setFrame must precede attached because
+        // the plugin may synchronously call resizeView from inside attached.
+        let raw_view = unsafe { controller.createView(ViewType::kEditor) };
+        let view = unsafe { ComPtr::from_raw(raw_view) }.ok_or_else(|| {
+            "VST3 UI open failed: IEditController::createView(\"editor\") returned null".to_owned()
+        })?;
+
+        let platform_result = unsafe { view.isPlatformTypeSupported(kPlatformTypeNSView) };
+        if !is_ok(platform_result) {
+            return Err(format!(
+                "VST3 UI open failed: NSView is unsupported ({platform_result})"
+            ));
+        }
+
+        let frame = ComWrapper::new(HostPlugFrame {
+            state: Rc::clone(&self.frame_state),
+        });
+        let frame_ptr = frame
+            .as_com_ref::<IPlugFrame>()
+            .expect("HostPlugFrame exposes IPlugFrame")
+            .as_ptr();
+        let set_frame_result = unsafe { view.setFrame(frame_ptr) };
+        if !is_ok(set_frame_result) {
+            // The plugin may have retained the frame even when returning an error.
+            drop(view);
+            drop(frame);
+            return Err(format!(
+                "VST3 UI open failed: IPlugView::setFrame failed ({set_frame_result})"
+            ));
+        }
+
+        let can_resize = is_ok(unsafe { view.canResize() });
+        let mut rect = ViewRect {
+            left: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+        };
+        let get_size_result = unsafe { view.getSize(&mut rect) };
+        if !is_ok(get_size_result) {
+            drop(view);
+            drop(frame);
+            return Err(format!(
+                "VST3 UI open failed: IPlugView::getSize failed ({get_size_result})"
+            ));
+        }
+        let size = match ui_size(rect) {
+            Ok(size) => size,
+            Err(detail) => {
+                drop(view);
+                drop(frame);
+                return Err(format!("VST3 UI open failed: {detail}"));
+            }
+        };
+
+        self.frame_state.requested_size.set(None);
+        self.frame = Some(frame);
+        self.view = Some(view);
+        self.can_resize = can_resize;
+        Ok(size)
+    }
+
+    fn attach(&mut self, parent: *mut c_void) -> Result<(), String> {
+        let parent = NonNull::new(parent)
+            .ok_or_else(|| "VST3 UI attach failed: NSView parent is null".to_owned())?;
+        if self.attached {
+            return Err("VST3 UI attach failed: editor view is already attached".into());
+        }
+        let view = self.view("attach")?;
+        let result = unsafe { view.attached(parent.as_ptr(), kPlatformTypeNSView) };
+        if !is_ok(result) {
+            return Err(format!(
+                "VST3 UI attach failed: IPlugView::attached failed ({result})"
+            ));
+        }
+        self.attached = true;
+        Ok(())
+    }
+
+    fn release(&mut self, _was_destroyed: bool) {
+        self.release_view();
+    }
+
+    fn can_resize(&self) -> bool {
+        self.can_resize
+    }
+
+    fn apply_host_resize(&mut self, size: UiSize) -> Result<(), String> {
+        if size.width <= 0 || size.height <= 0 {
+            return Err(format!(
+                "VST3 UI resize failed: invalid size {}x{}",
+                size.width, size.height
+            ));
+        }
+        let view = self.view("resize")?;
+        let mut rect = ViewRect {
+            left: 0,
+            top: 0,
+            right: size.width,
+            bottom: size.height,
+        };
+        let result = unsafe { view.onSize(&mut rect) };
+        if !is_ok(result) {
+            return Err(format!(
+                "VST3 UI resize failed: IPlugView::onSize failed ({result})"
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Vst3UiEndpoint {
+    fn drop(&mut self) {
+        self.release_view();
+        self.release_controller();
+    }
+}
+
+impl PluginUiEndpoint for Vst3PluginMain {
+    fn begin_open(&mut self) -> Result<UiSize, String> {
+        self.ui_endpoint.begin_open()
+    }
+
+    fn attach(&mut self, parent: *mut c_void) -> Result<(), String> {
+        self.ui_endpoint.attach(parent)
+    }
+
+    fn release(&mut self, was_destroyed: bool) {
+        self.ui_endpoint.release(was_destroyed);
+    }
+
+    fn can_resize(&self) -> bool {
+        self.ui_endpoint.can_resize()
+    }
+
+    fn apply_host_resize(&mut self, size: UiSize) -> Result<(), String> {
+        self.ui_endpoint.apply_host_resize(size)
+    }
+}
+
+fn ui_size(rect: ViewRect) -> Result<UiSize, String> {
+    let width = rect
+        .right
+        .checked_sub(rect.left)
+        .ok_or_else(|| "editor width overflowed".to_owned())?;
+    let height = rect
+        .bottom
+        .checked_sub(rect.top)
+        .ok_or_else(|| "editor height overflowed".to_owned())?;
+    if width <= 0 || height <= 0 {
+        return Err(format!("editor returned invalid size {width}x{height}"));
+    }
+    Ok(UiSize { width, height })
+}
+
+fn is_ok(result: tresult) -> bool {
+    crate::is_ok(result)
+}

--- a/rust/crates/orbit-vst3-host/tests/ui_endpoint.rs
+++ b/rust/crates/orbit-vst3-host/tests/ui_endpoint.rs
@@ -1,0 +1,181 @@
+#![cfg(target_os = "macos")]
+
+use std::ffi::c_void;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::OnceLock;
+
+use orbit_child_ui::{PluginUiEndpoint, UiSize};
+use orbit_vst3_host::{Vst3EffectProcessor, Vst3UiEndpoint};
+use orbit_vst3_synth_oracle::{
+    create_ui_test_controller, lock_ui_scenario, reset_ui_trace, set_resize_during_attach, ui_trace,
+};
+
+const INITIAL_SIZE: UiSize = UiSize {
+    width: 400,
+    height: 300,
+};
+const ATTACH_RESIZE: UiSize = UiSize {
+    width: 640,
+    height: 480,
+};
+
+fn dummy_parent() -> *mut c_void {
+    std::ptr::dangling_mut::<c_void>()
+}
+
+fn endpoint(resize_during_attach: bool) -> Vst3UiEndpoint {
+    reset_ui_trace();
+    set_resize_during_attach(resize_during_attach);
+    Vst3UiEndpoint::from_controller(create_ui_test_controller())
+}
+
+#[test]
+fn synth_oracle_open_calls_the_required_vst3_sequence() {
+    let _scenario = lock_ui_scenario();
+    let mut endpoint = endpoint(false);
+
+    assert_eq!(endpoint.begin_open(), Ok(INITIAL_SIZE));
+    assert!(endpoint.can_resize());
+    endpoint.attach(dummy_parent()).expect("attach oracle view");
+
+    let trace = ui_trace();
+    assert_eq!(
+        trace,
+        [
+            "createView",
+            "isPlatformTypeSupported",
+            "setFrame",
+            "canResize",
+            "getSize",
+            "attached",
+        ],
+        "the complete VST3 open trace must retain its exact order"
+    );
+    let normative_calls = trace
+        .iter()
+        .filter(|call| call.as_str() != "canResize")
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        normative_calls,
+        [
+            "createView",
+            "isPlatformTypeSupported",
+            "setFrame",
+            "getSize",
+            "attached",
+        ],
+        "UIH.4's normative sequence must be exact"
+    );
+
+    endpoint.release(false);
+}
+
+#[test]
+fn resize_requested_inside_attached_is_recorded_and_answered_with_on_size() {
+    let _scenario = lock_ui_scenario();
+    let mut endpoint = endpoint(true);
+
+    assert_eq!(endpoint.begin_open(), Ok(INITIAL_SIZE));
+    endpoint
+        .attach(dummy_parent())
+        .expect("attach-time resize must be answered");
+
+    assert_eq!(endpoint.requested_size(), Some(ATTACH_RESIZE));
+    assert_eq!(
+        ui_trace(),
+        [
+            "createView",
+            "isPlatformTypeSupported",
+            "setFrame",
+            "canResize",
+            "getSize",
+            "attached",
+            "resizeView",
+            "onSize",
+        ],
+        "resizeView must synchronously reach onSize in the attached callstack"
+    );
+
+    endpoint.release(false);
+}
+
+#[test]
+fn close_calls_removed_once_before_releasing_the_view() {
+    let _scenario = lock_ui_scenario();
+    let mut endpoint = endpoint(false);
+    endpoint.begin_open().expect("open oracle view");
+    endpoint.attach(dummy_parent()).expect("attach oracle view");
+    reset_ui_trace();
+
+    endpoint.release(false);
+
+    assert_eq!(
+        ui_trace(),
+        ["removed", "viewDropped"],
+        "removed must occur exactly once before the editor COM object is released"
+    );
+}
+
+#[test]
+fn host_resize_calls_the_open_view_on_size() {
+    let _scenario = lock_ui_scenario();
+    let mut endpoint = endpoint(false);
+    endpoint.begin_open().expect("open oracle view");
+    endpoint.attach(dummy_parent()).expect("attach oracle view");
+    reset_ui_trace();
+
+    endpoint
+        .apply_host_resize(UiSize {
+            width: 512,
+            height: 384,
+        })
+        .expect("host resize");
+
+    assert_eq!(ui_trace(), ["onSize"]);
+    endpoint.release(false);
+}
+
+#[test]
+fn gain_oracle_without_an_editor_fails_loudly_with_detail() {
+    let bundle = gain_oracle_bundle();
+    let (processor, _) = Vst3EffectProcessor::load(&bundle, 48_000.0, 512, None)
+        .unwrap_or_else(|error| panic!("failed to load gain oracle {}: {error}", bundle.display()));
+    let (audio, mut main) = processor.split();
+
+    let detail = main
+        .begin_open()
+        .expect_err("a null createView result must not fall back or succeed");
+    assert!(
+        detail.contains("createView") && detail.contains("returned null"),
+        "failure detail must identify the null editor view: {detail}"
+    );
+
+    // Preserve the production split teardown contract: audio stops before main terminates.
+    drop(audio);
+    drop(main);
+}
+
+fn gain_oracle_bundle() -> PathBuf {
+    static BUNDLE: OnceLock<PathBuf> = OnceLock::new();
+    BUNDLE
+        .get_or_init(|| {
+            let script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .expect("host crate has a parent")
+                .join("orbit-vst3-gain-oracle")
+                .join("package-oracle.sh");
+            let output = Command::new(&script)
+                .output()
+                .unwrap_or_else(|error| panic!("failed to run {}: {error}", script.display()));
+            assert!(
+                output.status.success(),
+                "gain oracle packaging failed: status={} stderr={}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            );
+            PathBuf::from(String::from_utf8_lossy(&output.stdout).trim())
+        })
+        .clone()
+}

--- a/rust/crates/orbit-vst3-host/tests/ui_endpoint.rs
+++ b/rust/crates/orbit-vst3-host/tests/ui_endpoint.rs
@@ -2,8 +2,6 @@
 
 use std::ffi::c_void;
 use std::path::PathBuf;
-use std::process::Command;
-use std::sync::OnceLock;
 
 use orbit_child_ui::{PluginUiEndpoint, UiSize};
 use orbit_vst3_host::{Vst3EffectProcessor, Vst3UiEndpoint};
@@ -157,25 +155,15 @@ fn gain_oracle_without_an_editor_fails_loudly_with_detail() {
     drop(main);
 }
 
+/// The gain oracle has no editor, so it is the negative case for `begin_open`.
+///
+/// 🔴 Goes through `orbit_vst3_gain_oracle::package_bundle()`, **not** the packaging script
+/// directly: the script writes a fixed path by default, and several test binaries across crates
+/// package this same oracle as independent processes under `cargo test --workspace`. One
+/// process's `rm -rf` then races another's `cp`, which surfaces as
+/// `missing symbol: GetPluginFactory` in whichever test happens to load mid-rewrite.
+/// `package_bundle()` already keys the output slot by pid; this test bypassed it and reintroduced
+/// the race (reproduced 5 of 8 concurrent runs in review of #474 P3b).
 fn gain_oracle_bundle() -> PathBuf {
-    static BUNDLE: OnceLock<PathBuf> = OnceLock::new();
-    BUNDLE
-        .get_or_init(|| {
-            let script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .parent()
-                .expect("host crate has a parent")
-                .join("orbit-vst3-gain-oracle")
-                .join("package-oracle.sh");
-            let output = Command::new(&script)
-                .output()
-                .unwrap_or_else(|error| panic!("failed to run {}: {error}", script.display()));
-            assert!(
-                output.status.success(),
-                "gain oracle packaging failed: status={} stderr={}",
-                output.status,
-                String::from_utf8_lossy(&output.stderr)
-            );
-            PathBuf::from(String::from_utf8_lossy(&output.stdout).trim())
-        })
-        .clone()
+    orbit_vst3_gain_oracle::package_bundle().expect("package the gain oracle bundle")
 }

--- a/rust/crates/orbit-vst3-instrument-child/src/main.rs
+++ b/rust/crates/orbit-vst3-instrument-child/src/main.rs
@@ -10,15 +10,15 @@ use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 #[cfg(target_os = "macos")]
 use anyhow::{bail, Context, Result};
 #[cfg(target_os = "macos")]
-use orbit_audio_sandbox::transport::{save_state_command, service_command_mailbox, CMD_SAVE_STATE};
-#[cfg(target_os = "macos")]
 use orbit_audio_sandbox::{
     open_shared, region_ptr, slot_index, slot_offset, EventRecord, EventSpillFifo, NeutralEvent,
-    ParentWatch, SharedRegion, VoiceAddr, BUF_LEN, CHANNELS, CMD_CLOSE_UI, CMD_OPEN_UI,
-    CONTROL_QUIT, MAX_EVENTS_PER_BLOCK, MAX_FRAMES,
+    ParentWatch, SharedRegion, VoiceAddr, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_EVENTS_PER_BLOCK,
+    MAX_FRAMES,
 };
 #[cfg(target_os = "macos")]
-use orbit_child_runtime::{child_should_quit, run_child, UiCallbacks, UiService};
+use orbit_child_runtime::{
+    child_should_quit, run_child, service_child_main, UiCallbacks, UiService,
+};
 #[cfg(target_os = "macos")]
 use orbit_vst3_host::Vst3InstrumentProcessor;
 
@@ -317,19 +317,8 @@ fn main() -> Result<()> {
     let (process_errors, last_process_error) = run_child(
         "orbit-vst3-instrument-child",
         || unsafe { child_should_quit(region, &parent_watch) },
-        || {
-            // SAVE_STATE and all future UI work are serviced by the AppKit main runloop.
-            unsafe {
-                service_command_mailbox(region, |kind, arg| match kind {
-                    CMD_SAVE_STATE => Some(save_state_command(arg, || {
-                        main.with_mut(|main| main.capture_state())
-                    })),
-                    CMD_OPEN_UI | CMD_CLOSE_UI => Some(ui.handle_command(kind, arg)),
-                    _ => None,
-                });
-            }
-            ui.tick(ui.now());
-            false
+        || unsafe {
+            service_child_main(region, &ui, || main.with_mut(|main| main.capture_state()))
         },
         move |stop_audio| {
             let region = region_addr as *mut SharedRegion;

--- a/rust/crates/orbit-vst3-instrument-child/src/main.rs
+++ b/rust/crates/orbit-vst3-instrument-child/src/main.rs
@@ -14,11 +14,11 @@ use orbit_audio_sandbox::transport::{save_state_command, service_command_mailbox
 #[cfg(target_os = "macos")]
 use orbit_audio_sandbox::{
     open_shared, region_ptr, slot_index, slot_offset, EventRecord, EventSpillFifo, NeutralEvent,
-    ParentWatch, SharedRegion, VoiceAddr, BUF_LEN, CHANNELS, CONTROL_QUIT, MAX_EVENTS_PER_BLOCK,
-    MAX_FRAMES,
+    ParentWatch, SharedRegion, VoiceAddr, BUF_LEN, CHANNELS, CMD_CLOSE_UI, CMD_OPEN_UI,
+    CONTROL_QUIT, MAX_EVENTS_PER_BLOCK, MAX_FRAMES,
 };
 #[cfg(target_os = "macos")]
-use orbit_child_runtime::run_child;
+use orbit_child_runtime::{child_should_quit, run_child, UiCallbacks, UiService};
 #[cfg(target_os = "macos")]
 use orbit_vst3_host::Vst3InstrumentProcessor;
 
@@ -305,28 +305,30 @@ fn main() -> Result<()> {
         orbit_audio_sandbox::transport::publish_child_ready(region, false);
     }
     let (mut instrument_audio, instrument_main) = instrument.split();
+    let (ui, main) = UiService::new(region, instrument_main, |main| UiCallbacks {
+        closed: None,
+        requested_size: main.take_requested_size(),
+    });
 
     // orphan 対策(#448): host(daemon)が CONTROL_QUIT を書かずに死ぬ経路(プロセス exit・
     // SIGKILL・crash)でも main runloop を止められるよう、親死活をタイマーで監視する。
-    let mut parent_watch = ParentWatch::new();
+    let parent_watch = ParentWatch::new();
     let region_addr = region as usize;
     let (process_errors, last_process_error) = run_child(
         "orbit-vst3-instrument-child",
-        || unsafe { (*region).control.load(Relaxed) } == CONTROL_QUIT,
+        || unsafe { child_should_quit(region, &parent_watch) },
         || {
             // SAVE_STATE and all future UI work are serviced by the AppKit main runloop.
             unsafe {
                 service_command_mailbox(region, |kind, arg| match kind {
-                    CMD_SAVE_STATE => {
-                        Some(save_state_command(arg, || instrument_main.capture_state()))
-                    }
+                    CMD_SAVE_STATE => Some(save_state_command(arg, || {
+                        main.with_mut(|main| main.capture_state())
+                    })),
+                    CMD_OPEN_UI | CMD_CLOSE_UI => Some(ui.handle_command(kind, arg)),
                     _ => None,
                 });
             }
-            if parent_watch.should_exit() {
-                eprintln!("[orbit-vst3-instrument-child] 親プロセス死亡を検知、終了する");
-                return true;
-            }
+            ui.tick(ui.now());
             false
         },
         move |stop_audio| {

--- a/rust/crates/orbit-vst3-synth-oracle/src/lib.rs
+++ b/rust/crates/orbit-vst3-synth-oracle/src/lib.rs
@@ -1,14 +1,66 @@
 //! Known-behavior VST3 instrument oracle: a monophonic stereo sine synth.
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::f32::consts::TAU;
-use std::ffi::{c_char, c_void, CString};
+use std::ffi::{c_char, c_void, CStr, CString};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, MutexGuard};
 use std::{ptr, slice};
 
-use vst3::{uid, Class, ComRef, ComWrapper, Steinberg::Vst::*, Steinberg::*};
+use vst3::{uid, Class, ComPtr, ComRef, ComWrapper, Steinberg::Vst::*, Steinberg::*};
 
 const PLUGIN_NAME: &str = "Orbit VST3 Synth Oracle";
+const INITIAL_UI_WIDTH: i32 = 400;
+const INITIAL_UI_HEIGHT: i32 = 300;
+const ATTACH_RESIZE_WIDTH: i32 = 640;
+const ATTACH_RESIZE_HEIGHT: i32 = 480;
+
+static UI_TRACE: Mutex<Vec<String>> = Mutex::new(Vec::new());
+static UI_SCENARIO_LOCK: Mutex<()> = Mutex::new(());
+static RESIZE_DURING_ATTACH: AtomicBool = AtomicBool::new(false);
+
+fn ui_trace_guard() -> MutexGuard<'static, Vec<String>> {
+    UI_TRACE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn record_ui_call(call: &str) {
+    ui_trace_guard().push(call.to_owned());
+}
+
+/// Serialize process-local GUI-oracle scenarios that share the trace and behavior switch.
+pub fn lock_ui_scenario() -> MutexGuard<'static, ()> {
+    UI_SCENARIO_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Clear the process-local GUI call trace.
+pub fn reset_ui_trace() {
+    ui_trace_guard().clear();
+}
+
+/// Snapshot the process-local GUI call trace.
+pub fn ui_trace() -> Vec<String> {
+    ui_trace_guard().clone()
+}
+
+/// Make `attached` synchronously request a 640x480 resize from its `IPlugFrame`.
+pub fn set_resize_during_attach(enabled: bool) {
+    RESIZE_DURING_ATTACH.store(enabled, Ordering::SeqCst);
+}
+
+/// Create the same edit-controller COM class used by the packaged synth oracle.
+///
+/// The direct constructor lets host integration tests inspect this process's trace without
+/// introducing an oracle-specific interface into the production VST3 host.
+pub fn create_ui_test_controller() -> ComPtr<IEditController> {
+    ComWrapper::new(SynthController)
+        .to_com_ptr::<IEditController>()
+        .expect("SynthController exposes IEditController")
+}
 
 fn copy_cstring(src: &str, dst: &mut [c_char]) {
     let string = CString::new(src).unwrap_or_default();
@@ -430,8 +482,154 @@ impl IEditControllerTrait for SynthController {
     unsafe fn setComponentHandler(&self, _handler: *mut IComponentHandler) -> tresult {
         kResultOk
     }
-    unsafe fn createView(&self, _name: *const c_char) -> *mut IPlugView {
-        ptr::null_mut()
+    unsafe fn createView(&self, name: *const c_char) -> *mut IPlugView {
+        record_ui_call("createView");
+        if name.is_null() || CStr::from_ptr(name).to_bytes() != b"editor" {
+            return ptr::null_mut();
+        }
+
+        let wrapper = ComWrapper::new(OraclePlugView::new());
+        let view_ptr = wrapper
+            .as_com_ref::<IPlugView>()
+            .expect("OraclePlugView exposes IPlugView")
+            .as_ptr();
+        wrapper.self_ptr.set(view_ptr);
+        wrapper
+            .to_com_ptr::<IPlugView>()
+            .expect("OraclePlugView exposes IPlugView")
+            .into_raw()
+    }
+}
+
+struct OraclePlugView {
+    frame: RefCell<Option<ComPtr<IPlugFrame>>>,
+    size: Cell<ViewRect>,
+    self_ptr: Cell<*mut IPlugView>,
+}
+
+impl OraclePlugView {
+    fn new() -> Self {
+        Self {
+            frame: RefCell::new(None),
+            size: Cell::new(ViewRect {
+                left: 0,
+                top: 0,
+                right: INITIAL_UI_WIDTH,
+                bottom: INITIAL_UI_HEIGHT,
+            }),
+            self_ptr: Cell::new(ptr::null_mut()),
+        }
+    }
+}
+
+impl Drop for OraclePlugView {
+    fn drop(&mut self) {
+        record_ui_call("viewDropped");
+    }
+}
+
+impl Class for OraclePlugView {
+    type Interfaces = (IPlugView,);
+}
+
+impl IPlugViewTrait for OraclePlugView {
+    unsafe fn isPlatformTypeSupported(&self, platform_type: FIDString) -> tresult {
+        record_ui_call("isPlatformTypeSupported");
+        if !platform_type.is_null()
+            && CStr::from_ptr(platform_type).to_bytes()
+                == CStr::from_ptr(kPlatformTypeNSView).to_bytes()
+        {
+            kResultTrue
+        } else {
+            kResultFalse
+        }
+    }
+
+    unsafe fn attached(&self, _parent: *mut c_void, platform_type: FIDString) -> tresult {
+        record_ui_call("attached");
+        if platform_type.is_null()
+            || CStr::from_ptr(platform_type).to_bytes()
+                != CStr::from_ptr(kPlatformTypeNSView).to_bytes()
+        {
+            return kInvalidArgument;
+        }
+
+        if RESIZE_DURING_ATTACH.load(Ordering::SeqCst) {
+            record_ui_call("resizeView");
+            let mut requested = ViewRect {
+                left: 0,
+                top: 0,
+                right: ATTACH_RESIZE_WIDTH,
+                bottom: ATTACH_RESIZE_HEIGHT,
+            };
+            let frame = self.frame.borrow();
+            let Some(frame) = frame.as_ref() else {
+                return kNotInitialized;
+            };
+            let result = frame.resizeView(self.self_ptr.get(), &mut requested);
+            if result != kResultOk && result != kResultTrue {
+                return result;
+            }
+        }
+        kResultOk
+    }
+
+    unsafe fn removed(&self) -> tresult {
+        record_ui_call("removed");
+        kResultOk
+    }
+
+    unsafe fn onWheel(&self, _distance: f32) -> tresult {
+        kResultFalse
+    }
+
+    unsafe fn onKeyDown(&self, _key: char16, _key_code: int16, _modifiers: int16) -> tresult {
+        kResultFalse
+    }
+
+    unsafe fn onKeyUp(&self, _key: char16, _key_code: int16, _modifiers: int16) -> tresult {
+        kResultFalse
+    }
+
+    unsafe fn getSize(&self, size: *mut ViewRect) -> tresult {
+        record_ui_call("getSize");
+        let Some(size) = size.as_mut() else {
+            return kInvalidArgument;
+        };
+        *size = self.size.get();
+        kResultOk
+    }
+
+    unsafe fn onSize(&self, new_size: *mut ViewRect) -> tresult {
+        record_ui_call("onSize");
+        let Some(new_size) = new_size.as_ref() else {
+            return kInvalidArgument;
+        };
+        self.size.set(*new_size);
+        kResultOk
+    }
+
+    unsafe fn onFocus(&self, _state: TBool) -> tresult {
+        kResultOk
+    }
+
+    unsafe fn setFrame(&self, frame: *mut IPlugFrame) -> tresult {
+        record_ui_call("setFrame");
+        *self.frame.borrow_mut() = ComRef::from_raw(frame).map(|frame| frame.to_com_ptr());
+        kResultOk
+    }
+
+    unsafe fn canResize(&self) -> tresult {
+        record_ui_call("canResize");
+        kResultTrue
+    }
+
+    unsafe fn checkSizeConstraint(&self, rect: *mut ViewRect) -> tresult {
+        if rect.is_null() {
+            kInvalidArgument
+        } else {
+            kResultOk
+        }
     }
 }
 


### PR DESCRIPTION
#474 の **P3b**。P3a（AppKit 非依存のクローズ状態機械・PR #594）の上に、
**プラグイン UI を実際に画面へ出す**層を積む。

Refs #474

## 何が入ったか

| コミット | 内容 |
|---|---|
| `b05538c` | spec 修正: cocoa で `set_scale` を呼ばない（CLAP 原文を逐語確認） |
| `5b19f35` | **P3b-1 VST3**: `PluginUiEndpoint` + `IPlugView` / `IPlugFrame` |
| `db7372e` | **P3b-1 CLAP**: `clap_plugin_gui` 経由の同じ層 |
| `9735d43` | **P3b-2**: `NSWindow` シェル + `CMD_OPEN_UI` / `CMD_CLOSE_UI` 配線 |

AppKit を混ぜない層（P3b-1）と混ぜる層（P3b-2）を分けた。P3a が
「AppKit 非依存の純 Rust に切り出したから変異検証が成立した」分割の踏襲。

## 🔴 順序が仕様である

VST3 の editor 取得は**順序そのものが規格要件**。SDK 原文（`iplugview.h:146`）:

> Note that in this call the plug-in could call a IPlugFrame::resizeView ()!

`setFrame` を `attached` の後に回すと、attach 中のリサイズ要求を取りこぼす。
したがってテストは `contains` ではなく **trace 全体の等値比較**にし、
oracle には「**attach の最中に `resizeView` を呼ぶモード**」を実装した。
これが無いと順序を間違えても全テストが緑のまま通る。

## 🔴 ウィンドウの実在を OS に問い合わせて証明した

gated テストが実機で落ち、層を1つずつ剥がした:

1. `CGWindowListCopyWindowInfo` が NULL → `CGPreflightScreenCaptureAccess() == false`
2. 開発セッションは SSH 経由（`sshd-session` の子）で、GUI アプリの権限は
   TCC の責任プロセス単位のため伝播しない
3. ローカル GUI で権限を通すと**別の欠陥が露出** — 待機ループが `sleep` するだけで
   **runloop を回していなかった**。`makeKeyAndOrderFront` は順序付けを予約するだけで、
   window server へ届くのは runloop が次にイベントを処理したとき

**独立性の証明**（実機・owner 実行）:

| 段階 | 結果 |
|---|---|
| baseline | `ok. 1 passed` |
| `makeKeyAndOrderFront` 削除 | `FAILED` + **`owned by this process: []`** |
| 復元（`cmp` 一致） | `ok. 1 passed` |

`NSWindow #1128` は**採番済み**なのに CG は画面上0枚と報告した。
つまりこの検査は「作られたか」ではなく「**画面に出たか**」を見ている。

権限が無いときは **skip せず失敗させる**。黙って skip すると「一度も検証していないのに緑」
になり、これは child の自己申告から独立した唯一の証拠なので、緩めると二重経路が片翼になる。

## 🔴 配線ギャップを2件見つけた（うち1件を修正）

同一シグネチャの兄弟は取り違えてもコンパイルが通る、という本プロジェクトで
実際に出荷された類型。

| ギャップ | 到達可能性 | 対処 |
|---|---|---|
| `child_should_quit` が本物の `ParentWatch` を渡すこと | 🔴 **4 child すべての production 経路**。壊れれば孤児 child が生き残る（#448） | **修正**。`ParentWatch::orphaned_for_tests()` を追加し、`control` を `CONTROL_RUN` のままにして「真になりうるのは parent-watch の項だけ」の形で縛った |
| `HostCallbackConfig::in_process` / `::child` の呼び出し箇所 | 消費者が居ないので**今日は到達不能** | P3b-2 完了条件として doc に登記（P3b-2 のプラグイン起点クローズテストが本物の `load` 経路を通って縛る） |

前者は合成箇所を `false` に差し替えても **21 件全部が緑のまま通っていた**（実測）。
修正後は狙った1件だけ FAILED になる。

## 検証

- `cargo test --workspace`（**sandbox 外**）= **462 passed / 0 failed**
- gated window shell（**実機 Window Server**）= **1 passed** + 独立性を実証
- CLAP 順序テスト（gated・実 dylib）= **4 passed**
- 変異検証: VST3 4種 / CLAP 5種 / P3b-2 7種 + main の独立再現3種、いずれも
  **コンパイルエラーではなく assertion failure** で red
- clippy 指摘0 / fmt OK

## 🔴 レビュー時の注意

**gated テストは SSH 経由では走らない。** `CGWindowListCopyWindowInfo` が
Screen Recording 権限を要求し、TCC は責任プロセス単位で権限を判定するため。
検証は **GUI セッションの直系**（ローカルターミナル）で行うこと。
この制約は P6 の無人 E2E にも同じくかかる。

## まだ音色は作れない

本 PR はウィンドウを出すところまで。MCP / エディタから開けるようにするのは **P4 / P5**。