### PR TITLE
feat(engine): save the timbre when the plugin window closes (#474 P4b)

### DIFF
--- a/docs/development/WORK_LOG.md
+++ b/docs/development/WORK_LOG.md
@@ -17,6 +17,61 @@ A design and implementation project for a new music DSL (Domain Specific Languag
 
 ## Recent Work
 
+### 6.347 feat(engine): #474 P4b — ウィンドウを閉じたら音色が保存される (Jul 31, 2026)
+
+**Date**: 2026-07-31
+**Issue**: #474 / **Branch**: `474-p4b-engine-safepoint`
+**Status**: `npm test`（sandbox 外・main 実走）= **1842 passed / 0 failed / 34 skipped**
+
+セーフポイント (b) の engine 側 conductor。P4a で daemon 側が揃っていたが、
+**engine に受け手がおらず、閉じても保存されなかった**（child が 10 秒待って
+「保存なしクローズ」に落ちる）。この一段でループが閉じる。
+
+#### 設計
+
+新しい保存機構は作らず、**既存の `ProjectStateStore.savePluginState` を event 起点で
+呼ぶだけ**にした。
+
+- UI イベントは daemon の `evt_seq` 順を保って**直列化**。保存と ack を順序どおり
+  完結させてから次へ進む
+- 🔴 **保存に失敗したら ack を送らない。** `return` して抜け、
+  「`AckUiSafepoint` was not sent: <理由>」と loud に記録する。daemon は `evt_ack` を
+  進めず、child の 10 秒タイムアウトが脱出経路になる（UIH.2a 故障表）。
+  **「失敗したのに成功したように見える」経路を作らない**
+- `generation` / `evt_seq` はそのまま返す（engine が再計算すると respawn 直後の
+  クローズで別 incarnation の safepoint を ack する）
+- teardown で in-flight の保存と ack を完了させてから daemon を落とす
+
+#### 変異検証（7種すべて red）
+
+引数差し替え / 呼び出し回数 / 順序 / 分岐反転の4種類を網羅した。
+
+| 変異 | red の実出力 |
+|---|---|
+| `generation` を 0 に | expected 37, received 0 |
+| 保存失敗でも ack | expected 0 calls, got 1 |
+| timeout 通知を 0 回に | waitFor: condition not met |
+| ack を保存より先に | expected 3 to be less than 2 |
+| ack を 2 回 | expected 1 call, got 2 |
+| respawn 後に再 open | expected 0 calls, got 1 |
+| saver 有無の分岐反転 | ack 待機が timeout |
+
+#### 🔴 差分を読んで拾ったもの
+
+`tests/interpreter/signal-chain-dispatch.spec.ts` の除外リストに
+`listPluginUiStateTargets` / `savePluginUiStateAtSafepoint` を足す変更が
+**ステージから漏れていた**。テストは緑のままなので、コミットしていたら気づけなかった。
+
+これは **#528 でエディタ評価を全滅させたのと同じ機構**（逆方向テストは「全メソッドが
+DSL 語彙か内部 API 除外リストのどちらかに分類される」ことしか見ないので、
+分類の欠落は実行時にしか出ない）。**緑は差分を読まない理由にならない**という
+既存の規律が、そのまま効いた。
+
+#### 委譲先の報告との差
+
+Codex は sandbox で「loopback bind 制限により失敗」と報告したが、
+**main の実走では全件通った**。委譲先の green も red も main が回し直す規律どおり。
+
 ### 6.346 feat(rust): #474 P4a — UI 経路を daemon に通す + 未コミット実装の消失と復旧 (Jul 31, 2026)
 
 **Date**: 2026-07-31

--- a/packages/engine/src/audio/rust-engine/daemon-client.ts
+++ b/packages/engine/src/audio/rust-engine/daemon-client.ts
@@ -426,6 +426,20 @@ export class DaemonClient extends EventEmitter {
     }
   }
 
+  async ackUiSafepoint(
+    target: PluginStateSaveTarget,
+    index: number,
+    generation: number,
+    evtSeq: number,
+  ): Promise<void> {
+    await this.request('AckUiSafepoint', {
+      target,
+      index,
+      generation,
+      evt_seq: evtSeq,
+    })
+  }
+
   /**
    * Runtime mixer bus routing change (MX.4, #459/#453 M3): (re)sets `seqBus`'s output
    * target (sum) and/or send gains (aux). `output: undefined` means "leave untouched" —
@@ -588,6 +602,12 @@ export class DaemonClient extends EventEmitter {
         return 'stream-stats'
       case 'DaemonError':
         return 'daemon-error'
+      case 'PluginUiClosed':
+        return 'plugin-ui-closed'
+      case 'PluginUiCloseDone':
+        return 'plugin-ui-close-done'
+      case 'PluginUiClosedByRespawn':
+        return 'plugin-ui-closed-by-respawn'
       default:
         return 'unknown-event'
     }

--- a/packages/engine/src/audio/rust-engine/protocol-types.ts
+++ b/packages/engine/src/audio/rust-engine/protocol-types.ts
@@ -19,6 +19,7 @@ export type CommandMethod =
   | 'LoadSample'
   | 'LoadPlugin'
   | 'GetPluginState'
+  | 'AckUiSafepoint'
   // ランタイムの mixer bus routing 変更（MX.4・#459/#453 M3）: seq_bus の output(sum)/
   // sends(aux) を非 RT で書き換える。daemon が feature `outproc-effect` 無効ビルドなら
   // OUTPROC_EFFECT_UNAVAILABLE を返す。
@@ -74,7 +75,14 @@ export type ResponseFrame = OkResponse | ErrorResponse
 
 export interface EventFrame {
   type: 'event'
-  event: 'PlayStarted' | 'PlayEnded' | 'StreamStats' | 'DaemonError'
+  event:
+    | 'PlayStarted'
+    | 'PlayEnded'
+    | 'StreamStats'
+    | 'DaemonError'
+    | 'PluginUiClosed'
+    | 'PluginUiCloseDone'
+    | 'PluginUiClosedByRespawn'
   data: Record<string, unknown>
 }
 

--- a/packages/engine/src/audio/rust-engine/rust-engine-player.ts
+++ b/packages/engine/src/audio/rust-engine/rust-engine-player.ts
@@ -41,7 +41,7 @@
 import { gainDbToAmplitude } from '../audio-gain-utils'
 import type { AudioEngineBackend } from '../engine-backend'
 import type { AudioDevice } from '../supercollider/types'
-import type { PluginLoadResult } from '../types'
+import type { PluginLoadResult, PluginStateSaveTarget, PluginUiTarget } from '../types'
 
 import { DaemonClient } from './daemon-client'
 import type { AudioDeviceListEntry } from './daemon-client'
@@ -57,6 +57,45 @@ import { DaemonConnectionError, DaemonProtocolError, DaemonQuitError } from './e
  * pan / slice 領域 / slice varispeed（rate≠1.0）は実装済みのため gap ではない。
  */
 type GapKind = 'outputChannel' | 'masterEffect' | 'linkTempo' | 'pluginNoteDrop' | 'pluginInactive'
+
+function eventRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function eventNonNegativeInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error(`${label} must be a non-negative safe integer`)
+  }
+  return Number(value)
+}
+
+function pluginUiTargetFromEvent(data: Record<string, unknown>): PluginUiTarget {
+  const target = eventRecord(data.target, 'target')
+  const index = eventNonNegativeInteger(target.index, 'target.index')
+  if (target.role === 'effect') {
+    if (target.bus !== undefined && typeof target.bus !== 'string') {
+      throw new Error('target.bus must be a string when present')
+    }
+    return {
+      role: 'effect',
+      ...(target.bus === undefined ? {} : { bus: target.bus }),
+      index,
+    }
+  }
+  if (target.role === 'instrument' && typeof target.instance === 'string') {
+    return { role: 'instrument', instance: target.instance, index }
+  }
+  throw new Error("target must identify an 'effect' or 'instrument' plugin")
+}
+
+function pluginStateTarget(target: PluginUiTarget): PluginStateSaveTarget {
+  return target.role === 'effect'
+    ? { role: 'effect', ...(target.bus === undefined ? {} : { bus: target.bus }) }
+    : { role: 'instrument', instance: target.instance }
+}
 
 /** chop slice 情報。`scheduleSliceEvent` 由来。発火時に領域（offset/duration）へ解決する。 */
 export interface SliceSpec {
@@ -222,6 +261,8 @@ export interface RustEnginePlayerOptions {
    * @internal
    */
   wsUrlOverride?: string
+  /** WebSocket を使わず protocol/event 境界を検証するための注入 seam。@internal */
+  daemonClient?: DaemonClient
   /**
    * 各 dispatch の観測コールバック（任意・副作用なしの telemetry seam）。A0 の実機
    * timing 計測 spec が lead/drift を読むのに使う。`createAudioEngine()` の production
@@ -335,11 +376,15 @@ export class RustEnginePlayer implements AudioEngineBackend {
   /** respawn の single-flight ガード（death/close/reject が同時多発しても二重 spawn させない）。 */
   private respawnPromise: Promise<void> | null = null
 
+  /** UI event は daemon の evt_seq 順を保ったまま、保存・ack まで直列に完結させる。 */
+  private pluginUiEventTail: Promise<void> = Promise.resolve()
+  private pluginUiSafepointSaver: ((target: PluginUiTarget) => Promise<void>) | undefined
+
   /** feature gap の 1 回限り warning。stopAll で再 arm する。 */
   private warned: Set<string> = freshWarned()
 
   constructor(options: RustEnginePlayerOptions = {}) {
-    this.daemon = new DaemonClient()
+    this.daemon = options.daemonClient ?? new DaemonClient()
     this.daemonPath = options.daemonPath
     this.wsUrlOverride = options.wsUrlOverride
     this.lookaheadSec = options.lookaheadSec ?? DEFAULT_LOOKAHEAD_SEC
@@ -347,6 +392,9 @@ export class RustEnginePlayer implements AudioEngineBackend {
     // daemon の予期せぬ死を supervise する（recovery floor / #300）。意図的 quit は DaemonClient が
     // intentionalClose で抑制するので、このリスナは crash（panic→exit / segfault / kill）のみ発火する。
     this.daemon.on('daemon-died', this.onDaemonDied)
+    this.daemon.on('plugin-ui-closed', this.onPluginUiClosed)
+    this.daemon.on('plugin-ui-close-done', this.onPluginUiCloseDone)
+    this.daemon.on('plugin-ui-closed-by-respawn', this.onPluginUiClosedByRespawn)
   }
 
   // --- AudioEngine surface ---
@@ -485,6 +533,70 @@ export class RustEnginePlayer implements AudioEngineBackend {
     })
   }
 
+  private enqueuePluginUiEvent(work: () => Promise<void> | void): void {
+    this.pluginUiEventTail = this.pluginUiEventTail.then(work).catch((error) => {
+      console.error(
+        `[plugin-ui] event handling failed: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    })
+  }
+
+  private readonly onPluginUiClosed = (raw: unknown): void => {
+    this.enqueuePluginUiEvent(async () => {
+      const data = eventRecord(raw, 'PluginUiClosed data')
+      const target = pluginUiTargetFromEvent(data)
+      const generation = eventNonNegativeInteger(data.generation, 'generation')
+      const evtSeq = eventNonNegativeInteger(data.evt_seq, 'evt_seq')
+      if (!this.pluginUiSafepointSaver) {
+        throw new Error(
+          `cannot save ${JSON.stringify(target)}: no project-state safepoint saver is registered`,
+        )
+      }
+      try {
+        await this.pluginUiSafepointSaver(target)
+      } catch (error) {
+        console.error(
+          `[plugin-ui] safepoint save failed for ${JSON.stringify(target)}; ` +
+            `AckUiSafepoint was not sent: ${error instanceof Error ? error.message : String(error)}`,
+        )
+        return
+      }
+      await this.daemon.ackUiSafepoint(pluginStateTarget(target), target.index, generation, evtSeq)
+    })
+  }
+
+  private readonly onPluginUiCloseDone = (raw: unknown): void => {
+    this.enqueuePluginUiEvent(() => {
+      const data = eventRecord(raw, 'PluginUiCloseDone data')
+      const target = pluginUiTargetFromEvent(data)
+      if (data.completion === 'timeout-without-save') {
+        console.error(
+          `[plugin-ui] ${JSON.stringify(target)} closed after timing out without saving state`,
+        )
+      } else if (data.completion !== 'safepoint-completed') {
+        throw new Error(`unknown PluginUiCloseDone completion: ${String(data.completion)}`)
+      }
+    })
+  }
+
+  private readonly onPluginUiClosedByRespawn = (raw: unknown): void => {
+    this.enqueuePluginUiEvent(() => {
+      const data = eventRecord(raw, 'PluginUiClosedByRespawn data')
+      const target = pluginUiTargetFromEvent(data)
+      console.error(
+        `[plugin-ui] ${JSON.stringify(target)} was closed by daemon respawn and was not reopened`,
+      )
+    })
+  }
+
+  private async settlePluginUiEvents(): Promise<void> {
+    for (;;) {
+      const pending = this.pluginUiEventTail
+      await pending
+      if (pending === this.pluginUiEventTail) return
+    }
+  }
+
   /** respawn を single-flight 化する（同時多発する death/close/reject で二重 spawn しないため）。 */
   private ensureRespawn(): Promise<void> {
     if (this.respawnPromise) return this.respawnPromise
@@ -576,7 +688,16 @@ export class RustEnginePlayer implements AudioEngineBackend {
         console.warn('[rust-engine] quit: respawn settled with an unexpected error:', err)
       }
     }
+    // CONTROL_QUIT の前に、既に受け取った UI close の保存・ack を完結させる。
+    await this.settlePluginUiEvents()
+    this.daemon.off('plugin-ui-closed', this.onPluginUiClosed)
+    this.daemon.off('plugin-ui-close-done', this.onPluginUiCloseDone)
+    this.daemon.off('plugin-ui-closed-by-respawn', this.onPluginUiClosedByRespawn)
     await this.daemon.quit()
+  }
+
+  setPluginUiSafepointSaver(saver: (target: PluginUiTarget) => Promise<void>): void {
+    this.pluginUiSafepointSaver = saver
   }
 
   getCurrentOutputDevice(): AudioDevice | undefined {

--- a/packages/engine/src/audio/types.ts
+++ b/packages/engine/src/audio/types.ts
@@ -15,6 +15,11 @@ export type PluginStateSaveTarget =
   | { role: 'effect'; bus?: string }
   | { role: 'instrument'; instance: string }
 
+/** daemon の plugin UI event が返す、chain index つきの解決済み宛先。 */
+export type PluginUiTarget =
+  | { role: 'effect'; bus?: string; index: number }
+  | { role: 'instrument'; instance: string; index: number }
+
 export interface PluginStateSaveResult {
   path: string
   bytesWritten: number
@@ -90,6 +95,9 @@ export interface AudioEngine {
     target: PluginStateSaveTarget,
     absolutePath: string,
   ): Promise<PluginStateSaveResult>
+
+  /** UI close safepoint を既存の project-state 保存フローへ接続する。 */
+  setPluginUiSafepointSaver?(saver: (target: PluginUiTarget) => Promise<void>): void
 
   pluginNoteOn?(key: number, channel: number, velocity: number, instance?: string): Promise<void>
   pluginNoteOff?(key: number, channel: number, velocity?: number, instance?: string): Promise<void>

--- a/packages/engine/src/core/global.ts
+++ b/packages/engine/src/core/global.ts
@@ -3,7 +3,7 @@
  * Represents the global transport and configuration
  */
 
-import { AudioEngine } from '../audio/types'
+import { AudioEngine, type PluginUiTarget } from '../audio/types'
 import { StackElement, PlayElement } from '../parser/types'
 import { BoundValue, ChordVoice } from '../midi/chord/types'
 import { evaluateChordDefinition } from '../midi/chord/resolve-chords'
@@ -67,6 +67,21 @@ function pluginStateTargetForSlot(receiverId: string, slot: PluginSlot): Resolve
             ...(slot.bus === undefined ? {} : { bus: slot.bus }),
           },
   }
+}
+
+function daemonTargetMatchesUiTarget(
+  target: ResolvedPluginStateTarget['daemonTarget'],
+  uiTarget: PluginUiTarget,
+): boolean {
+  if (target.role !== uiTarget.role) return false
+  if (target.role === 'effect' && uiTarget.role === 'effect') {
+    return target.bus === uiTarget.bus
+  }
+  return (
+    target.role === 'instrument' &&
+    uiTarget.role === 'instrument' &&
+    target.instance === uiTarget.instance
+  )
 }
 
 export class Global {
@@ -136,6 +151,9 @@ export class Global {
     this.transportControl = new TransportControl(
       this.globalScheduler,
       this.sequenceRegistry.getAllSequences(),
+    )
+    this.audioEngine.setPluginUiSafepointSaver?.((target) =>
+      this.savePluginUiStateAtSafepoint(target),
     )
   }
 
@@ -687,26 +705,58 @@ export class Global {
    * No receiver-name resolution or implicit mixer-kind priority participates.
    */
   listPluginStateTargets(): ResolvedPluginStateTarget[] {
-    const targets: ResolvedPluginStateTarget[] = []
-    const append = (receiverId: string, chain: readonly PluginSlot[]) => {
-      for (const slot of chain) {
-        targets.push(pluginStateTargetForSlot(receiverId, slot))
-      }
+    return this.listPluginUiStateTargets().map(({ resolved }) => resolved)
+  }
+
+  private listPluginUiStateTargets(): Array<{
+    index: number
+    resolved: ResolvedPluginStateTarget
+  }> {
+    const targets: Array<{ index: number; resolved: ResolvedPluginStateTarget }> = []
+    const append = (receiverId: string, chain: readonly PluginSlot[], firstIndex: number) => {
+      chain.forEach((slot, offset) => {
+        targets.push({
+          index: firstIndex + offset,
+          resolved: pluginStateTargetForSlot(receiverId, slot),
+        })
+      })
     }
 
-    append('master', this.pluginEffectManager.chain())
+    append('master', this.pluginEffectManager.chain(), 1)
     for (const kind of MIXER_BUS_KINDS) {
       for (const name of this.mixerManager.declaredBusNames(kind)) {
-        append(formatReceiverId(kind, name), this.mixerManager.chainFor(kind, name))
+        append(formatReceiverId(kind, name), this.mixerManager.chainFor(kind, name), 1)
       }
     }
     for (const sequenceName of this.sequenceEffectManager.keys()) {
-      append(sequenceName, this.sequenceEffectManager.chainFor(sequenceName))
+      append(sequenceName, this.sequenceEffectManager.chainFor(sequenceName), 1)
     }
     for (const sequenceName of this.pluginInstrumentManager.keys()) {
-      append(sequenceName, this.pluginInstrumentManager.chainFor(sequenceName))
+      append(sequenceName, this.pluginInstrumentManager.chainFor(sequenceName), 0)
     }
     return targets
+  }
+
+  private async savePluginUiStateAtSafepoint(target: PluginUiTarget): Promise<void> {
+    const match = this.listPluginUiStateTargets().find(
+      ({ index, resolved }) =>
+        index === target.index && daemonTargetMatchesUiTarget(resolved.daemonTarget, target),
+    )
+    if (!match) {
+      throw new Error(
+        `Plugin UI target is not present in the current chain: ${JSON.stringify(target)}`,
+      )
+    }
+    const projectDirectory = this.audioManager.getDocumentDirectory()
+    if (!projectDirectory) {
+      throw new Error(
+        'Plugin UI state cannot be saved before the document has a directory; save the .orbs file first.',
+      )
+    }
+    await this.projectStateStore(projectDirectory).save(
+      match.resolved.identity,
+      match.resolved.daemonTarget,
+    )
   }
 
   /**

--- a/tests/audio/rust-engine/mock-daemon-server.ts
+++ b/tests/audio/rust-engine/mock-daemon-server.ts
@@ -26,6 +26,7 @@ export interface MockDaemonHandlers {
   LoadSample?: MockHandler
   LoadPlugin?: MockHandler
   GetPluginState?: MockHandler
+  AckUiSafepoint?: MockHandler
   PluginNoteOn?: MockHandler
   PluginNoteOff?: MockHandler
   PlayAt?: MockHandler

--- a/tests/audio/rust-engine/plugin-ui-safepoint.spec.ts
+++ b/tests/audio/rust-engine/plugin-ui-safepoint.spec.ts
@@ -1,0 +1,206 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { parse } from 'yaml'
+
+import { DaemonClient } from '../../../packages/engine/src/audio/rust-engine/daemon-client'
+import { RustEnginePlayer } from '../../../packages/engine/src/audio/rust-engine/rust-engine-player'
+import { Global } from '../../../packages/engine/src/core/global'
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  throw new Error(`waitFor: condition not met within ${timeoutMs}ms`)
+}
+
+describe('plugin UI safepoint conductor', () => {
+  let daemon: DaemonClient
+  let player: RustEnginePlayer | null
+  let directory: string
+  let saveState: ReturnType<typeof vi.spyOn>
+  let ack: ReturnType<typeof vi.spyOn>
+  let quitDaemon: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), 'orbitscore-ui-safepoint-'))
+    daemon = new DaemonClient()
+    vi.spyOn(daemon, 'loadPlugin').mockResolvedValue({
+      pluginId: 'mock-plugin',
+      pluginName: 'Mock Plugin',
+      notePortIndex: 0,
+    })
+    saveState = vi.spyOn(daemon, 'savePluginState')
+    ack = vi.spyOn(daemon, 'ackUiSafepoint').mockResolvedValue()
+    quitDaemon = vi.spyOn(daemon, 'quit').mockResolvedValue()
+    player = new RustEnginePlayer({ daemonClient: daemon })
+  })
+
+  afterEach(async () => {
+    if (player) await player.quit()
+    fs.rmSync(directory, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  async function declaredInstrument(): Promise<Global> {
+    const global = new Global(player!)
+    global.setDocumentDirectory(directory)
+    const pluginPath = path.join(directory, 'Mock.clap')
+    fs.mkdirSync(pluginPath)
+    await global.instrument('lead', pluginPath)
+    return global
+  }
+
+  it('dispatches all three daemon event frame names and sends AckUiSafepoint wire fields unchanged', async () => {
+    const framing = new DaemonClient()
+    const closed = vi.fn()
+    const done = vi.fn()
+    const respawn = vi.fn()
+    framing.on('plugin-ui-closed', closed)
+    framing.on('plugin-ui-close-done', done)
+    framing.on('plugin-ui-closed-by-respawn', respawn)
+    const handleMessage = (framing as any).handleMessage.bind(framing) as (raw: string) => void
+    handleMessage(JSON.stringify({ type: 'event', event: 'PluginUiClosed', data: { marker: 1 } }))
+    handleMessage(
+      JSON.stringify({ type: 'event', event: 'PluginUiCloseDone', data: { marker: 2 } }),
+    )
+    handleMessage(
+      JSON.stringify({ type: 'event', event: 'PluginUiClosedByRespawn', data: { marker: 3 } }),
+    )
+    expect(closed).toHaveBeenCalledTimes(1)
+    expect(closed).toHaveBeenCalledWith({ marker: 1 })
+    expect(done).toHaveBeenCalledTimes(1)
+    expect(done).toHaveBeenCalledWith({ marker: 2 })
+    expect(respawn).toHaveBeenCalledTimes(1)
+    expect(respawn).toHaveBeenCalledWith({ marker: 3 })
+
+    const request = vi.spyOn(framing as any, 'request').mockResolvedValue({ status: 'acked' })
+    await framing.ackUiSafepoint({ role: 'instrument', instance: 'plugin:lead' }, 0, 37, 41)
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(request).toHaveBeenCalledWith('AckUiSafepoint', {
+      target: { role: 'instrument', instance: 'plugin:lead' },
+      index: 0,
+      generation: 37,
+      evt_seq: 41,
+    })
+  })
+
+  it('saves through ProjectStateStore before acking the identical generation and evt_seq once', async () => {
+    await declaredInstrument()
+    saveState.mockImplementation(async (_target, statePath) => {
+      fs.writeFileSync(statePath, 'plugin-state')
+      return { path: statePath, bytesWritten: 12 }
+    })
+
+    daemon.emit('plugin-ui-closed', {
+      target: { role: 'instrument', instance: 'plugin:lead', index: 0 },
+      generation: 37,
+      evt_seq: 41,
+    })
+    await waitFor(() => ack.mock.calls.length >= 1)
+
+    expect(saveState).toHaveBeenCalledTimes(1)
+    expect(saveState).toHaveBeenCalledWith(
+      { role: 'instrument', instance: 'plugin:lead' },
+      expect.stringMatching(/\/states\/.+\.state$/),
+    )
+    expect(ack).toHaveBeenCalledTimes(1)
+    expect(ack).toHaveBeenCalledWith({ role: 'instrument', instance: 'plugin:lead' }, 0, 37, 41)
+    expect(saveState.mock.invocationCallOrder[0]).toBeLessThan(ack.mock.invocationCallOrder[0])
+    const manifest = parse(fs.readFileSync(path.join(directory, 'project.yaml'), 'utf8')) as {
+      states: Record<string, string>
+    }
+    expect(manifest.states).toHaveProperty('lead/instrument/Mock/0')
+  })
+
+  it('does not ack when the existing project-state save fails', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await declaredInstrument()
+    saveState.mockRejectedValue(new Error('state serialization failed'))
+
+    daemon.emit('plugin-ui-closed', {
+      target: { role: 'instrument', instance: 'plugin:lead', index: 0 },
+      generation: 2,
+      evt_seq: 3,
+    })
+    await waitFor(() =>
+      error.mock.calls.some(([message]) => String(message).includes('save failed')),
+    )
+
+    expect(saveState).toHaveBeenCalledTimes(1)
+    expect(ack).toHaveBeenCalledTimes(0)
+    expect(fs.existsSync(path.join(directory, 'project.yaml'))).toBe(false)
+    expect(error).toHaveBeenCalledTimes(1)
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('AckUiSafepoint was not sent'))
+  })
+
+  it('reports timeout-without-save loudly exactly once', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    daemon.emit('plugin-ui-close-done', {
+      target: { role: 'effect', bus: 'seq-bus-2', index: 1 },
+      completion: 'timeout-without-save',
+    })
+    await waitFor(() => error.mock.calls.length === 1)
+
+    expect(error).toHaveBeenCalledTimes(1)
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining('closed after timing out without saving state'),
+    )
+  })
+
+  it('reports respawn closure loudly without issuing save, ack, or another daemon request', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const request = vi.spyOn(daemon as any, 'request')
+
+    daemon.emit('plugin-ui-closed-by-respawn', {
+      target: { role: 'instrument', instance: 'plugin:lead', index: 0 },
+    })
+    await waitFor(() => error.mock.calls.length === 1)
+
+    expect(error).toHaveBeenCalledTimes(1)
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('was not reopened'))
+    expect(saveState).toHaveBeenCalledTimes(0)
+    expect(ack).toHaveBeenCalledTimes(0)
+    expect(request).toHaveBeenCalledTimes(0)
+  })
+
+  it('waits for an in-flight save and ack before daemon teardown', async () => {
+    let finishSave: (() => void) | undefined
+    const saveGate = new Promise<void>((resolve) => {
+      finishSave = resolve
+    })
+    await declaredInstrument()
+    saveState.mockImplementation(async (_target, statePath) => {
+      await saveGate
+      fs.writeFileSync(statePath, 'plugin-state')
+      return { path: statePath, bytesWritten: 12 }
+    })
+    daemon.emit('plugin-ui-closed', {
+      target: { role: 'instrument', instance: 'plugin:lead', index: 0 },
+      generation: 7,
+      evt_seq: 8,
+    })
+    await waitFor(() => saveState.mock.calls.length === 1)
+
+    let quitSettled = false
+    const quitting = player!.quit().then(() => {
+      quitSettled = true
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(quitSettled).toBe(false)
+    expect(ack).toHaveBeenCalledTimes(0)
+    expect(quitDaemon).toHaveBeenCalledTimes(0)
+
+    finishSave!()
+    await quitting
+    player = null
+    expect(ack).toHaveBeenCalledTimes(1)
+    expect(quitDaemon).toHaveBeenCalledTimes(1)
+    expect(ack.mock.invocationCallOrder[0]).toBeLessThan(quitDaemon.mock.invocationCallOrder[0])
+  })
+})

--- a/tests/interpreter/signal-chain-dispatch.spec.ts
+++ b/tests/interpreter/signal-chain-dispatch.spec.ts
@@ -865,6 +865,10 @@ describe('Signal Chain runtime resolver dispatch (S2)', () => {
       // 各 manager を読むためクラス外へ出せない（純関数の
       // `pluginStateTargetForSlot` はモジュール関数として分類対象外にしてある）。
       'listPluginStateTargets',
+      // PluginUiClosed の daemon target/index を現在の chain に照合し、同じ保存経路へ渡す
+      // safepoint conductor 内部 API。DSL 語彙としては公開しない。
+      'listPluginUiStateTargets',
+      'savePluginUiStateAtSafepoint',
       'saveAllPluginStates',
       // 同上。`this.projectStateStores` の Map をキャッシュとして読むため純関数化できない。
       'projectStateStore',


### PR DESCRIPTION
> **stacked on #597**（P4a・daemon 側）。#597 のマージ後に base を `main` へ切り替えます。

セーフポイント (b) の **engine 側 conductor** です。P4a で daemon 側は揃っていましたが、
**engine に受け手がおらず、ウィンドウを閉じても音色は保存されませんでした**
（child が 10 秒待って「保存なしクローズ」に落ちる）。この一段でループが閉じます。

## 経路

```
daemon → engine:  PluginUiClosed { target, generation, evt_seq }
engine:           既存の ProjectStateStore.savePluginState を呼ぶ
engine → daemon:  AckUiSafepoint { target, generation, evt_seq }
daemon:           evt_ack_seq を進める → child が Phase B → UI_CLOSED_DONE
```

**新しい保存機構は作らず、既存フローを event 起点で呼ぶだけ**にしています。

## 設計

- UI イベントは daemon の `evt_seq` 順を保って**直列化**。保存と ack を順序どおり
  完結させてから次のイベントへ進みます
- 🔴 **保存に失敗したら ack を送りません。** `return` して抜け、
  `AckUiSafepoint was not sent: <理由>` と loud に記録します。daemon は `evt_ack` を
  進めず、child の 10 秒タイムアウトが「保存なしクローズ」で脱出します（UIH.2a 故障表）。
  **「失敗したのに成功したように見える」経路を作りません**
- `generation` / `evt_seq` はそのまま返します。engine が再計算すると、respawn 直後の
  クローズで**別 incarnation の safepoint を ack**してしまいます
- `timeout-without-save` は loud 通知（保存されなかったことをユーザーが知る必要がある）
- respawn による UI 消失では**再オープンしません**（UIH.6）
- teardown: in-flight の保存と ack を完了させてから daemon を落とします
  （UIH.2a 故障表の最終行）

## 変異検証（7種すべて red・実出力つき）

壊し方の4種類（引数 / 回数 / 順序 / 分岐）を網羅しました。

| 変異 | 種類 | red の実出力 |
|---|---|---|
| `generation` を 0 に差し替え | 引数 | expected 37, received 0 |
| **保存失敗でも ack を送る** | 分岐 | expected 0 calls, got 1 |
| timeout 通知を 0 回に | 回数 | waitFor: condition not met |
| **ack を保存より先に送る** | 順序 | expected 3 to be less than 2 |
| ack を 2 回送る | 回数 | expected 1 call, got 2 |
| respawn 後に再 open する | 分岐 | expected 0 calls, got 1 |
| saver 有無の分岐を反転 | 分岐 | ack 待機が timeout |

復元は全件 `cmp` で確認済みです。特に「**保存失敗でも ack**」が red であることが重要で、
ここが破れると保存できていないのに保存された扱いになり、**音色が失われたことに
誰も気づけません**。

## 🔴 差分を読んで拾ったもの

`tests/interpreter/signal-chain-dispatch.spec.ts` の除外リストに
`listPluginUiStateTargets` / `savePluginUiStateAtSafepoint` を足す変更が
**ステージから漏れていました**。テストは緑のままなので、そのままコミットしていたら
気づけません。

これは **#528 でエディタ評価を全滅させたのと同じ機構**です（逆方向テストは
「全メソッドが DSL 語彙か内部 API 除外リストのどちらかに分類される」ことしか検査しないため、
**分類の欠落は実行時にしか現れません**）。

## 検証（main が sandbox 外で実走）

- `npm test` = **1842 passed / 0 failed / 34 skipped**（Test Files 123 passed / 4 skipped）
- `npm run lint` = **エラー 0**（warning 1件は既存の `audio-slicer.spec.ts`・本差分と無関係）

Codex が sandbox で「loopback bind 制限により失敗」と報告した分は、**main の実走では
すべて通りました**。

## まだやっていないこと

- **実機 E2E は未実施**です。UI を実際に開閉する経路は **P4c（MCP tools）**が入って
  初めて外から叩けるため、そこで実施します
- MCP tool（`open_plugin_ui` / `close_plugin_ui`）は P4c の担当です

Refs #474
